### PR TITLE
Enforce consistent ordering of imports with linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,25 @@ module.exports = {
       // allow importing dev dependencies in test files
       { devDependencies: ['**/*.spec.ts', '**/*.spec.tsx'] },
     ],
+    'import/order': [
+      // require imports to be sorted like vscode automatically does with its "organize imports" feature.
+      // https://code.visualstudio.com/docs/languages/typescript#_organize-imports
+      'error',
+      {
+        alphabetize: {
+          order: 'asc',
+        },
+        'newlines-between': 'never',
+        groups: [
+          ['external', 'builtin'],
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+          'object',
+        ],
+      },
+    ],
     'react/react-in-jsx-scope': 'off', // not needed with next.js: https://stackoverflow.com/a/61160875
     'react-hooks/rules-of-hooks': 'error', // enforce best practices with react hoooks
     'react-hooks/exhaustive-deps': 'error', // enforce best practices with react hoooks: https://github.com/facebook/create-react-app/issues/6880#issuecomment-485912528

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ If you use VSCode, following plugins are recommended:
 - [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for showing linting errors within the code
 - [bradlc.vscode-tailwindcss](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) for adding Tailwind suggestions to IntelliSense
 
+It is also recommended to enable the [organize imports](https://code.visualstudio.com/docs/languages/typescript#_organize-imports) feature so that the imports will be ordered as the linter wants automatically.
+Non-VSCode users can sort imports e.g. by running `yarn lint --fix` on command line.
+(Probably there are also ways to configure other IDE's to order imports automatically or a way to make them run the linter with `--fix` flag automatically when code file is saved.)
+
 ## Docker image
 
 Docker image can be tested locally like this:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ If you want to run prettier manually for some reason you can run `yarn prettier`
 
 We have enabled `eslint` with opionated rulesets for keeping code style clean & consistent and for avoiding certain mistakes. Eslint can be run with `yarn lint`. It is highly recommended for developers to use eslint extension with their editors so that they can see linting errors instantly when writing code.
 
+Eslint can fix certain linting errors automatically when ran with `--fix` flag, e.g. `yarn lint --fix`.
+
 ### Local tests
 
 For tests we use `jest`, `ts-jest` and `@testing-library/react`.

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,6 +1,6 @@
-import { Main } from 'components/Main';
 import React, { FunctionComponent } from 'react';
 import { useParams } from 'react-router-dom';
+import { Main } from './components/Main';
 
 export enum Path {
   root = '/',


### PR DESCRIPTION
- Tried to setup this according to VSCode's organize imports feature.
  Not 100% sure if there is corner case which wasn't taken into account,
  but at least this works with current codebase.1
- If some developers use some other editor, they probably still can
  automate import ordering as `import/order` rule supports `--fix` flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/9)
<!-- Reviewable:end -->
