### PR TITLE
Avoid defining baseUrl in tsconfig

### DIFF
--- a/src/components/navbar/BrandLogo.tsx
+++ b/src/components/navbar/BrandLogo.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Path, routes } from 'routes';
+import { Path, routes } from '../../routes';
 
 interface Props {
   className?: string;

--- a/src/components/navbar/LanguageDropdown.spec.tsx
+++ b/src/components/navbar/LanguageDropdown.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
-import { render } from 'test-utils';
 import { i18n } from '../../i18n';
+import { render } from '../../utils/test-utils';
 import { LanguageDropdown, testIds } from './LanguageDropdown';
 
 describe('<LanguageDropdown />', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    // "baseUrl": "src",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
@@ -17,10 +17,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
-    "paths": {
-      "test-utils": ["utils/test-utils"]
-    }
+    "jsx": "preserve"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Originally baseUrl was set in order to be able to import `render` in
test files without relative paths.
Anyway, because it was defined in project-wide tsconfig it affected
the whole project and caused unexpected errors in development:
e.g. creating `src/leaflet.ts` file in project caused
`import * as L from 'leaflet';` style imports to break, as TS tried
to find those from our local file.

Technically we could define baseUrl in `tsconfig.test.json`, but then
doing project-wide TS type checking would have to be done in two steps
(one for test files, one for everything else) instead of all at once
(as we are doing right now). So for the sake of simplicity it might
be better to do this change now and consider other options if relative
imports become too annoying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/18)
<!-- Reviewable:end -->
