### PR TITLE
Hasura role-based authorization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,11 @@ module.exports = withImages({
         destination: 'http://localhost:3001/api/:path*',
       },
       {
+        // Proxy graphql requests to hasura
+        source: '/api/hasura/:path*',
+        destination: 'http://localhost:8080/:path*',
+      },
+      {
         // Rewrite everything else to `pages/index`
         source: '/:any*',
         destination: '/',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.20",
+    "@graphql-typed-document-node/core": "^3.1.0",
     "@headlessui/react": "^1.0.0",
     "@react-leaflet/core": "^1.1.0",
     "axios": "0.21.1",

--- a/src/graphql/auth.ts
+++ b/src/graphql/auth.ts
@@ -1,0 +1,36 @@
+import { ApolloLink, useQuery } from '@apollo/client';
+import { OperationVariables } from '@apollo/client/core';
+import { QueryHookOptions } from '@apollo/client/react/types/types';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { DocumentNode } from 'graphql';
+
+const REQUESTED_HASURA_ROLE_HEADER = 'x-hasura-role';
+
+export type Role = string;
+
+export const authRoleMiddleware = new ApolloLink((operation, forward) => {
+  const { role } = operation.variables;
+
+  // add the requested authorization role to the headers if it is specified
+  operation.setContext(({ headers = {} }) => ({
+    headers: {
+      ...headers,
+      ...(role && {
+        [REQUESTED_HASURA_ROLE_HEADER]: role,
+      }),
+    },
+  }));
+
+  return forward(operation);
+});
+
+export function useQueryWithRole<T>(
+  query: DocumentNode | TypedDocumentNode<T, OperationVariables>,
+  role: Role,
+  options?: QueryHookOptions<T>,
+) {
+  return useQuery(query, {
+    ...options,
+    variables: { ...options?.variables, role },
+  });
+}

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,10 +1,19 @@
-import { ApolloClient, HttpLink, InMemoryCache, split } from '@apollo/client';
+import {
+  ApolloClient,
+  concat,
+  HttpLink,
+  InMemoryCache,
+  split,
+} from '@apollo/client';
 import { WebSocketLink } from '@apollo/client/link/ws';
 import { getMainDefinition } from '@apollo/client/utilities';
+import { authRoleMiddleware } from './auth';
 
 const httpLink = new HttpLink({
-  uri: 'http://localhost:8080/v1/graphql',
+  uri: 'http://localhost:3000/api/hasura/v1/graphql',
 });
+
+const apolloLink = concat(authRoleMiddleware, httpLink);
 
 // because next.js might run this on server-side and websockets aren't
 // supported there, we have to check if we are on browser before
@@ -29,9 +38,9 @@ const link = process.browser
       },
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       wsLink!,
-      httpLink,
+      apolloLink,
     )
-  : httpLink;
+  : apolloLink;
 
 const cache = new InMemoryCache({
   typePolicies: {
@@ -51,3 +60,5 @@ const client = new ApolloClient({
 });
 
 export const GQLClient = client;
+
+export * from './auth';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,7 +1267,7 @@
     tslib "~2.2.0"
     value-or-promise "1.0.6"
 
-"@graphql-typed-document-node/core@^3.0.0":
+"@graphql-typed-document-node/core@^3.0.0", "@graphql-typed-document-node/core@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==


### PR DESCRIPTION
- proxy Hasura requests through the dev server to have the browser
  attach the session cookie to each request
- the useQueryWithRole -hook is provided to request a specific role for
  a Hasura graphql query
- the installed authRoleMiddleware will pick up the requested role and
  attach it to the graphql request as a request header

Hasura can then be configured to use the jore4-auth webhook. Hasura will
forward both the session cookie and the requested role header to the
auth backend webhook, which will authorize the request if the user has a
permission matching the specified requested role.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/21)
<!-- Reviewable:end -->
