### PR TITLE
Add hslSimpleStyle as map style

### DIFF
--- a/src/components/map/Maplibre.tsx
+++ b/src/components/map/Maplibre.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
 import MapGL, { MapEvent, NavigationControl } from 'react-map-gl';
+import hslSimpleStyle from './hslSimpleStyle.json';
 import rasterMapStyle from './rasterMapStyle.json';
 
 interface Props {
@@ -65,9 +66,7 @@ export const Maplibre: FunctionComponent<Props> = ({
     return undefined;
   };
 
-  const mapStyle = useVectorTilesAsBaseMap
-    ? 'https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/master/simple-style.json'
-    : rasterMapStyle;
+  const mapStyle = useVectorTilesAsBaseMap ? hslSimpleStyle : rasterMapStyle;
 
   return (
     <MapGL

--- a/src/components/map/hslSimpleStyle.json
+++ b/src/components/map/hslSimpleStyle.json
@@ -1,0 +1,3319 @@
+{
+  "version": 8,
+  "name": "HSL v1.6",
+  "metadata": {
+    "mapbox:groups": {
+      "1457010660461.3042": {
+        "name": "Routes",
+        "collapsed": true
+      },
+      "1457010208438.9548": {
+        "name": "POI–public-transport",
+        "collapsed": true
+      },
+      "1457010362398.355": {
+        "name": "POI-private-sector",
+        "collapsed": true
+      },
+      "1452776685487.2012": {
+        "name": "POI-public",
+        "collapsed": true
+      },
+      "1457010287588.8713": {
+        "name": "POI-park-and-ride",
+        "collapsed": true
+      },
+      "1460634974533.995": {
+        "name": "Kuljettajan_ohje",
+        "collapsed": true
+      },
+      "1455204550197.1404": {
+        "name": "Stops",
+        "collapsed": true
+      },
+      "1457010266398.4177": {
+        "name": "POI-citybikes",
+        "collapsed": true
+      }
+    },
+    "mapbox-groups": {}
+  },
+  "center": [24.780522192591405, 60.178648250675934],
+  "zoom": 14.051135528958179,
+  "bearing": 0,
+  "pitch": 0,
+  "sources": {
+    "vector": {
+      "url": "https://digitransit-dev-cdn-origin.azureedge.net/map/v1/hsl-vector-map/index.json",
+      "type": "vector"
+    },
+    "parkandride": {
+      "url": "https://digitransit-dev-cdn-origin.azureedge.net/map/v1/hsl-parkandride-map/index.json",
+      "type": "vector"
+    }
+  },
+  "sprite": "https://raw.githubusercontent.com/HSLdevcom/hsl-map-style/master/sprite",
+  "glyphs": "https://hslstoragestatic.azureedge.net/mapfonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": {
+          "base": 1,
+          "stops": [
+            [0, "#d3e3bb"],
+            [7, "#d3e3bb"],
+            [9, "#f0f1f2"],
+            [22, "#f0f1f2"]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landuse_hospital",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "hospital"],
+      "paint": {
+        "fill-color": "#fbe6e0"
+      }
+    },
+    {
+      "id": "landuse_school",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "school"],
+      "paint": {
+        "fill-color": "#f9f4d2"
+      }
+    },
+    {
+      "id": "landuse_park",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "park"],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#dceacc"
+      }
+    },
+    {
+      "id": "landuse_wood",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["in", "class", "scrub", "wood"],
+      "paint": {
+        "fill-color": "rgba(208,227,184,1)"
+      }
+    },
+    {
+      "id": "landuse_park_nature_reserve",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        ["==", "class", "park"],
+        ["==", "type", "nature_reserve"]
+      ],
+      "paint": {
+        "fill-color": "rgba(207,219,193,1)",
+        "fill-outline-color": "rgba(187,199,175,1)"
+      }
+    },
+    {
+      "id": "landuse_aeroway",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "aeroway",
+      "filter": ["==", "$type", "Polygon"],
+      "paint": {
+        "fill-color": "#e3e3e3",
+        "fill-outline-color": "#ccc"
+      }
+    },
+    {
+      "id": "landuse_grass",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "grass"],
+      "paint": {
+        "fill-color": "rgba(208,227,184,1)"
+      }
+    },
+    {
+      "id": "landuse_sand",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "sand"],
+      "paint": {
+        "fill-color": "rgba(224,223,204,1)"
+      }
+    },
+    {
+      "id": "landuse_scrub",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "scrub"],
+      "paint": {
+        "fill-color": "#b8d19b",
+        "fill-opacity": 0.3
+      }
+    },
+    {
+      "id": "landuse_cemetery",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "cemetery"],
+      "paint": {
+        "fill-color": "rgba(203,222,180,1)",
+        "fill-outline-color": "rgba(184,209,155,1)"
+      }
+    },
+    {
+      "id": "landuse_agriculture",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "agriculture"],
+      "paint": {
+        "fill-color": "#e3ecc5"
+      }
+    },
+    {
+      "id": "landuse_industrial",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "industrial"],
+      "paint": {
+        "fill-color": "hsl(18, 21%, 91%)"
+      }
+    },
+    {
+      "id": "landuse_athletics",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "pitch"],
+      "paint": {
+        "fill-color": "rgba(205,224,182,1)",
+        "fill-outline-color": "rgba(172,199,139,1)"
+      }
+    },
+    {
+      "id": "landuse_pitch_horseracing",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        ["==", "class", "pitch"],
+        ["==", "type", "horse_racing"]
+      ],
+      "paint": {
+        "fill-color": "#e0dfcc",
+        "fill-outline-color": "rgba(209,208,190,1)"
+      }
+    },
+    {
+      "id": "landuse_athletics_track",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["all", ["==", "class", "pitch"], ["==", "type", "track"]],
+      "paint": {
+        "fill-color": "rgba(240,194,194,1)",
+        "fill-outline-color": "rgba(204,165,165,1)"
+      }
+    },
+    {
+      "id": "landuse_parking",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "parking"],
+      "paint": {
+        "fill-color": "rgba(247,247,247,1)",
+        "fill-outline-color": "#ccc"
+      }
+    },
+    {
+      "id": "landuse_park-and-ride",
+      "type": "fill",
+      "source": "parkandride",
+      "source-layer": "facilities",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#007ac9",
+        "fill-outline-color": "#007ac9",
+        "fill-opacity": 0.2
+      }
+    },
+    {
+      "id": "aeroway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "aeroway",
+      "filter": ["==", "type", "runway"],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "square",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [10, 2.5],
+            [20, 240]
+          ]
+        }
+      }
+    },
+    {
+      "id": "aeroway_taxiway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "aeroway",
+      "filter": ["==", "type", "taxiway"],
+      "layout": {
+        "visibility": "visible",
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [10, 1],
+            [22, 8]
+          ]
+        },
+        "line-opacity": 1,
+        "line-dasharray": [1, 2]
+      }
+    },
+    {
+      "id": "waterway_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "canal", "river", "stream"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#a6d8f4",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [8, 1],
+            [20, 17]
+          ]
+        }
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "water",
+      "layout": {},
+      "paint": {
+        "fill-color": "#bee4f8",
+        "fill-outline-color": "#a6d8f4"
+      }
+    },
+    {
+      "id": "landuse_wetland",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse_overlay",
+      "filter": ["==", "class", "wetland"],
+      "paint": {
+        "fill-color": "rgba(204,230,161,1)",
+        "fill-pattern": {
+          "base": 1,
+          "stops": [
+            [0, "icon-wetland"],
+            [22, "icon-wetland"]
+          ]
+        },
+        "fill-translate": [0, 0],
+        "fill-translate-anchor": "map"
+      }
+    },
+    {
+      "id": "landuse_barrier_line",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "barrier_line",
+      "filter": [
+        "all",
+        ["==", "class", "land"],
+        ["in", "$type", "Point", "Polygon"]
+      ],
+      "paint": {
+        "fill-color": "#edf0f5",
+        "fill-outline-color": "#a6d8f4"
+      }
+    },
+    {
+      "id": "landuse_barrier_line_land",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "barrier_line",
+      "filter": ["all", ["==", "$type", "LineString"], ["==", "class", "land"]],
+      "layout": {
+        "line-cap": "butt"
+      },
+      "paint": {
+        "line-color": "#f0f1f2",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [14, 1],
+            [20, 20]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landuse_barrier_line_cliff",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "barrier_line",
+      "filter": [
+        "all",
+        ["==", "class", "cliff"],
+        ["in", "$type", "LineString", "Polygon"]
+      ],
+      "layout": {},
+      "paint": {
+        "line-color": "#ccc",
+        "line-blur": 0
+      }
+    },
+    {
+      "id": "landuse_barrier_rock",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "landuse",
+      "filter": [
+        "all",
+        ["==", "class", "rock"],
+        ["in", "$type", "LineString", "Polygon"]
+      ],
+      "layout": {},
+      "paint": {
+        "fill-color": "rgba(227,227,227,1)",
+        "fill-outline-color": "rgba(214,214,214,1)",
+        "fill-antialias": true
+      }
+    },
+    {
+      "id": "road_street_limited",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "street_limited"]
+      ],
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.25],
+            [20, 2]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 30]
+          ]
+        },
+        "line-dasharray": [1, 2]
+      }
+    },
+    {
+      "id": "landuse_barrier_line_fence",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "barrier_line",
+      "filter": ["==", "class", "fence"],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 6]
+          ]
+        },
+        "line-color": "#ccc"
+      }
+    },
+    {
+      "id": "road_service_polygon",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": ["all", ["==", "$type", "Polygon"], ["==", "type", "service"]],
+      "layout": {},
+      "paint": {
+        "fill-color": "#f7f7f7",
+        "fill-outline-color": "#ccc",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "road_pedestrian",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "Polygon"],
+        ["in", "type", "pedestrian", "platform"]
+      ],
+      "layout": {},
+      "paint": {
+        "fill-color": "#f7f7f7",
+        "fill-outline-color": "#ccc",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "building_shadow",
+      "type": "fill",
+      "source": "vector",
+      "source-layer": "building",
+      "minzoom": 10,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "#c2c3cc",
+        "fill-outline-color": {
+          "base": 1,
+          "stops": [
+            [13, "#dde1e9"],
+            [17, "rgba(194,195,204,1)"]
+          ]
+        },
+        "fill-opacity": 1,
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [13, [0, 0]],
+            [22, [0, 8]]
+          ]
+        }
+      }
+    },
+    {
+      "id": "building",
+      "ref": "building_shadow",
+      "paint": {
+        "fill-color": "#e2e4e9",
+        "fill-outline-color": {
+          "base": 1,
+          "stops": [
+            [13, "#dde1e9"],
+            [17, "rgba(194,195,204,1)"]
+          ]
+        },
+        "fill-opacity": 1,
+        "fill-translate": [0, 0]
+      }
+    },
+    {
+      "id": "tunnel_walk",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!=", "type", "cycleway"],
+          ["==", "class", "path"],
+          ["==", "structure", "tunnel"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#bfc2c9",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [0, 1.25],
+            [22, 20]
+          ]
+        },
+        "line-dasharray": [0, 1.5]
+      }
+    },
+    {
+      "id": "tunnel_major_rail",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!=", "type", "subway"],
+          ["==", "class", "major_rail"],
+          ["==", "structure", "tunnel"]
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.25],
+            [20, 4]
+          ]
+        },
+        "line-opacity": 1,
+        "line-gap-width": {
+          "base": 1,
+          "stops": [
+            [11.9, 0],
+            [12, 1],
+            [22, 6]
+          ]
+        },
+        "line-dasharray": [10, 3]
+      }
+    },
+    {
+      "id": "tunnel_primary",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "tunnel"],
+          ["in", "type", "primary", "secondary"]
+        ]
+      ],
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.25],
+            [20, 2]
+          ]
+        },
+        "line-dasharray": [10, 3],
+        "line-gap-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.25],
+            [20, 40]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel_motorway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "tunnel"],
+          ["in", "type", "motorway", "trunk"]
+        ]
+      ],
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.25],
+            [20, 2]
+          ]
+        },
+        "line-dasharray": [10, 3],
+        "line-gap-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.25],
+            [20, 40]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel_street",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "tunnel"],
+          ["in", "class", "", "street", "street_limited", "tertiary"]
+        ]
+      ],
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 2]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 1],
+            [20, 30]
+          ]
+        },
+        "line-dasharray": [10, 3]
+      }
+    },
+    {
+      "id": "tunnel_service",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "service"], ["==", "structure", "tunnel"]]
+      ],
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 2]
+          ]
+        },
+        "line-dasharray": [6, 5],
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [22, 34]
+          ]
+        }
+      }
+    },
+    {
+      "id": "tunnel_subway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!=", "osm_id", 120809795],
+          ["!=", "osm_id", 30133633],
+          ["==", "class", "major_rail"],
+          ["==", "structure", "tunnel"],
+          ["==", "type", "subway"]
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.25],
+            [20, 4]
+          ]
+        },
+        "line-opacity": 1,
+        "line-gap-width": {
+          "base": 1,
+          "stops": [
+            [11.9, 0],
+            [12, 1],
+            [22, 6]
+          ]
+        },
+        "line-dasharray": [10, 3]
+      }
+    },
+    {
+      "id": "tunnel_road_path_cycleway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "tunnel"],
+          ["in", "type", "cycleway", "pedestrian", "track"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [0, 1.5],
+            [22, 26]
+          ]
+        },
+        "line-dasharray": [1, 0]
+      }
+    },
+    {
+      "id": "road_subway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["!=", "structure", "tunnel"],
+        ["==", "class", "major_rail"],
+        ["==", "type", "subway"]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.5],
+            [20, 20]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_subway_service",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["!=", "structure", "tunnel"],
+        ["==", "class", "minor_rail"],
+        ["==", "type", "subway"]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#aaa",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [15, 0.5],
+            [22, 4]
+          ]
+        },
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [15, 1],
+            [22, 1]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 12]
+          ]
+        }
+      }
+    },
+    {
+      "id": "waterway",
+      "ref": "waterway_case",
+      "paint": {
+        "line-color": "#bee4f8",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [8, 0.5],
+            [20, 15]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_ferry",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "ferry"]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#72d3f0",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 6]
+          ]
+        },
+        "line-opacity": 1,
+        "line-dasharray": {
+          "base": 1,
+          "stops": [
+            [11, [2, 2]],
+            [22, [4, 4]]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_major_rail_solid",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["!=", "type", "subway"],
+        ["!in", "structure", "bridge", "tunnel"],
+        ["==", "class", "major_rail"]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [14, 1],
+            [22, 8]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_path_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["==", "class", "path"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#d5dae3",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [0, 2],
+            [22, 30]
+          ]
+        },
+        "line-dasharray": [0, 0]
+      }
+    },
+    {
+      "id": "road_path",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["!in", "type", "cycleway", "steps"],
+          ["==", "class", "path"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [0, 1.5],
+            [22, 26]
+          ]
+        },
+        "line-dasharray": [0, 1.5],
+        "line-blur": 0
+      }
+    },
+    {
+      "id": "road_path_MTB",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["!in", "type", "cycleway", "steps"],
+          ["==", "name", "MTB Reitti"],
+          ["==", "class", "path"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [0, 1.5],
+            [22, 26]
+          ]
+        },
+        "line-dasharray": [0, 1.5],
+        "line-blur": 0
+      }
+    },
+    {
+      "id": "road_path_steps_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["==", "class", "path"],
+          ["==", "type", "steps"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [14, 0.5],
+            [20, 4]
+          ]
+        },
+        "line-blur": 0,
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [14, 2],
+            [20, 32]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_path_steps",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["==", "class", "path"],
+          ["==", "type", "steps"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [14, 1.5],
+            [20, 40]
+          ]
+        },
+        "line-dasharray": {
+          "base": 1,
+          "stops": [
+            [14, [0.125, 0.125]],
+            [20, [0.125, 0.25]]
+          ]
+        },
+        "line-blur": 0
+      }
+    },
+    {
+      "id": "road_path_cycleway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["in", "type", "cycleway", "pedestrian", "track"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [0, 1.5],
+            [22, 26]
+          ]
+        },
+        "line-dasharray": [1, 0]
+      }
+    },
+    {
+      "id": "road_service",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["==", "class", "service"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [0, 1.5],
+            [22, 26]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_motorway_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["in", "class", "motorway", "trunk"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#f4d880",
+        "line-width": {
+          "base": 1.75,
+          "stops": [
+            [6, 1],
+            [20, 114]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_primary_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["in", "class", "primary", "secondary"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 1],
+            [20, 84]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_street_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["in", "class", "street", "tertiary"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 1],
+            [20, 54]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_construction",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "in",
+          "type",
+          "construction",
+          "construction:living_street",
+          "construction:motorway",
+          "construction:motorway_link",
+          "construction:pedestrian",
+          "construction:primary",
+          "construction:primary_link",
+          "construction:residential",
+          "construction:road",
+          "construction:secondary",
+          "construction:secondary_link",
+          "construction:tertiary",
+          "construction:tertiary_link",
+          "construction:trunk",
+          "construction:trunk_link",
+          "construction:unclassified"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.25],
+            [20, 4]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [10, 2],
+            [20, 40]
+          ]
+        },
+        "line-dasharray": [1, 1]
+      }
+    },
+    {
+      "id": "road_motorway_link_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["in", "class", "link", "motorway_link"],
+          ["in", "type", "motorway_link", "trunk_link"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#f4d880",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 1],
+            [20, 44]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_link_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["!=", "type", "trunk_link"], ["==", "class", "link"]]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 1],
+            [20, 44]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_motorway_link",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "structure", "bridge", "tunnel"],
+          ["in", "class", "link", "motorway_link"],
+          ["in", "type", "motorway_link", "trunk_link"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [10, "#fff"],
+            [10.2, "#fef2c6"]
+          ]
+        },
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [20, 40]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_link",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["!=", "type", "trunk_link"], ["==", "class", "link"]]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [20, 40]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_street",
+      "ref": "road_street_case",
+      "paint": {
+        "line-color": "rgba(255,255,255,1)",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 50]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_primary",
+      "ref": "road_primary_case",
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [9.9, "#eeeeee"],
+            [10.2, "#ffffff"]
+          ]
+        },
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [20, 80]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_motorway",
+      "ref": "road_motorway_case",
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [9.5, "#f4d880"],
+            [10.2, "#fef2c6"]
+          ]
+        },
+        "line-width": {
+          "base": 1.75,
+          "stops": [
+            [6, 0.5],
+            [20, 110]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_minor_rail",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["!in", "structure", "bridge", "tunnel"],
+        ["==", "class", "minor_rail"],
+        ["==", "type", "tram"]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [15, 0.5],
+            [22, 4]
+          ]
+        },
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [15, 1],
+            [22, 1]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 12]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_major_rail_case_bg",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!=", "type", "subway"],
+          ["==", "class", "major_rail"],
+          ["==", "structure", "bridge"]
+        ]
+      ],
+      "paint": {
+        "line-color": "#f0f1f2",
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [4, 0.25],
+            [20, 40]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_major_rail_case",
+      "ref": "bridge_major_rail_case_bg",
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [12, 0.25],
+            [20, 6]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 38]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_major_rail",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["!=", "type", "subway"],
+        ["==", "class", "major_rail"],
+        ["==", "structure", "bridge"]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [14, 1],
+            [22, 8]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_subway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["!=", "osm_id", 120809795],
+        ["==", "class", "major_rail"],
+        ["==", "structure", "bridge"],
+        ["==", "type", "subway"]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [6, 0.5],
+            [20, 20]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_path_bg",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "path"], ["==", "structure", "bridge"]]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#f0f1f2",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.5],
+            [20, 29.5]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_path_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "path"], ["==", "structure", "bridge"]]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [12, 0.25],
+            [20, 6]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 30]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_path",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["==", "class", "path"], ["==", "structure", "bridge"]]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 16.5]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_pedestrian_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round",
+        "line-cap": "butt",
+        "line-miter-limit": 2
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [12, 0.25],
+            [20, 6]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 30]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        ["==", "class", "pedestrian"],
+        ["==", "structure", "bridge"]
+      ]
+    },
+    {
+      "id": "bridge_pedestrian",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "paint": {
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 16.5]
+          ]
+        },
+        "line-color": "rgba(255, 255, 255, 1)"
+      },
+      "layout": {
+        "visibility": "visible"
+      },
+      "filter": [
+        "all",
+        ["==", "class", "pedestrian"],
+        ["==", "structure", "bridge"]
+      ]
+    },
+    {
+      "id": "bridge_street_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          [
+            "in",
+            "class",
+            "driveway",
+            "service",
+            "street",
+            "street_limited",
+            "tertiary"
+          ]
+        ]
+      ],
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.6,
+          "stops": [
+            [12, 0.5],
+            [20, 16]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 30]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_primary_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          ["in", "class", "primary", "secondary"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt"
+      },
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 2],
+            [20, 88]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_motorway_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          ["in", "class", "motorway", "trunk"]
+        ]
+      ],
+      "paint": {
+        "line-color": "#ccc",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 1],
+            [15, 2],
+            [20, 8]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [15, 8],
+            [20, 100]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_street",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          [
+            "in",
+            "class",
+            "driveway",
+            "service",
+            "street",
+            "street_limited",
+            "tertiary"
+          ]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgba(255,255,255,1)",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 50]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_primary",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          ["in", "class", "primary", "secondary"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [20, 80]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_motorway",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          ["in", "class", "motorway", "trunk"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [9.5, "#f4d880"],
+            [10.2, "#fef2c6"]
+          ]
+        },
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [15, 8],
+            [20, 100]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_motorway_link_case",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          ["in", "class", "link", "motorway_link"],
+          ["in", "type", "motorway_link", "trunk_link"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#f4d880",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 1],
+            [20, 44]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_motorway_link",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "structure", "bridge"],
+          ["in", "class", "link", "motorway_link"],
+          ["in", "type", "motorway_link", "trunk_link"]
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [
+            [10, "#fff"],
+            [10.2, "#fef2c6"]
+          ]
+        },
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [6, 0.5],
+            [20, 40]
+          ]
+        }
+      }
+    },
+    {
+      "id": "bridge_minor_rail",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "class", "minor_rail"],
+        ["==", "structure", "bridge"],
+        ["==", "type", "tram"]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [15, 0.5],
+            [22, 4]
+          ]
+        },
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [15, 1],
+            [22, 1]
+          ]
+        },
+        "line-gap-width": {
+          "base": 1.55,
+          "stops": [
+            [4, 0.25],
+            [20, 12]
+          ]
+        }
+      }
+    },
+    {
+      "id": "admin_country",
+      "type": "line",
+      "source": "vector",
+      "source-layer": "admin",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["all", ["<=", "admin_level", 2], ["==", "maritime", 0]]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#8b8a8a",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [3, 0.5],
+            [22, 15]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road_minor_one-way",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "road",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["==", "oneway", 1],
+          [
+            "in",
+            "class",
+            "driveway",
+            "main",
+            "motorway_link",
+            "service",
+            "street",
+            "street_limited"
+          ]
+        ]
+      ],
+      "layout": {
+        "icon-image": "icon-one-way",
+        "symbol-placement": "line",
+        "symbol-spacing": 100,
+        "icon-rotation-alignment": "map",
+        "icon-keep-upright": false,
+        "icon-size": {
+          "base": 1,
+          "stops": [
+            [15.4, 0],
+            [15.5, 0.25],
+            [22, 1.5]
+          ]
+        }
+      },
+      "paint": {}
+    },
+    {
+      "id": "road_waterway",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "road_label",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "ferry"]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name}",
+        "text-font": ["Gotham Rounded Book"],
+        "text-transform": "none",
+        "text-letter-spacing": 0,
+        "text-size": {
+          "base": 1.4,
+          "stops": [
+            [10, 7],
+            [20, 20]
+          ]
+        },
+        "text-padding": 2
+      },
+      "paint": {
+        "text-color": "#39c6ea",
+        "text-halo-color": "#bee4f8",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "housenum_label",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "housenum_label",
+      "filter": ["==", "$type", "Point"],
+      "layout": {
+        "text-field": "{house_num}",
+        "text-size": {
+          "stops": [
+            [15, 8],
+            [22, 17]
+          ]
+        },
+        "text-font": ["Gotham Rounded Book"]
+      },
+      "paint": {
+        "text-color": "#999",
+        "text-opacity": 0.7
+      }
+    },
+    {
+      "id": "poi_label_retail",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1457010362398.355"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [
+          "all",
+          ["in", "localrank", 1, 11, 2, 3, 4],
+          [
+            "in",
+            "name",
+            "Forum",
+            "Iso Omena",
+            "Jumbo",
+            "Kampinkeskus",
+            "Kauppakeskus Itis",
+            "Kauppakeskus Kaari",
+            "Kauppakeskus Kluuvi",
+            "Makkaratalo",
+            "Sello",
+            "Sokos",
+            "Stockmann",
+            "Stockmann Helsinki",
+            "World Trade Center Helsinki"
+          ],
+          ["in", "scalerank", 1, 2, 3, 4]
+        ]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_cinema",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1457010362398.355"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "type", "Cinema"]],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_hotel",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1457010362398.355"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["in", "type", "Bed And Breakfast", "Hostel", "Hotel"]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_theatre",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [
+          "all",
+          ["==", "type", "Theatre"],
+          ["in", "localrank", 1, 2, 3, 4],
+          ["in", "scalerank", 1, 2, 3, 4]
+        ]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_concert-hall",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "type", "Concert Hall"]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_attraction_scalerank_low",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["all", ["!in", "scalerank", 1, 2], ["==", "type", "Attraction"]]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Book"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_transportation",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "type", "Transportation"]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Book"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_attraction",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["all", ["!in", "scalerank", 3, 4, 5], ["==", "type", "Attraction"]]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_sibelius",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["==", "name", "Sibelius-monumentti"]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_park",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [
+          "all",
+          ["==", "type", "Park"],
+          ["in", "localrank", 1, 2, 3, 4],
+          ["in", "scalerank", 1, 2, 3, 4]
+        ]
+      ],
+      "layout": {
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 11]
+          ]
+        },
+        "text-max-width": 8,
+        "text-font": ["Gotham Rounded Medium Italic"],
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "rgba(142,166,109,1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_sq",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "road_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["!in", "name", "Aleksanterinkatu", "Keskuskatu"],
+        ["==", "$type", "Point"]
+      ],
+      "layout": {
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 11]
+          ]
+        },
+        "text-max-width": 8,
+        "text-font": ["Gotham Rounded Medium Italic"],
+        "text-anchor": "bottom",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#999",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_sport",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [
+          "all",
+          ["in", "localrank", 1, 2, 3, 4],
+          ["in", "scalerank", 1, 2, 3, 4],
+          ["in", "type", "", "Sports Centre", "Stadium"]
+        ]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_cemetary",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "type", "Cemetery"]],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_theme-park",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "type", "Theme Park"]],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_museum",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "type", "Museum"]],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_school",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["in", "type", "School", "University"]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_place-of-worship",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["all", ["<", "scalerank", 4], ["==", "type", "Place Of Worship"]]
+      ],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_parliament",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "type", "Parliament"]],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_hospital",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "type", "Hospital"]],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "visibility": "visible",
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-max-width": 8
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_harbour",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1452776685487.2012"
+      },
+      "source": "vector",
+      "source-layer": "poi_label",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["in", "type", "Ferry Terminal", "Harbour", "Marina"]
+      ],
+      "layout": {
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 11]
+          ]
+        },
+        "text-max-width": 8,
+        "text-font": ["Gotham Rounded Book"],
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#888",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "poi_label_subway-station_entrance",
+      "type": "symbol",
+      "metadata": {
+        "mapbox:group": "1457010208438.9548"
+      },
+      "source": "vector",
+      "source-layer": "rail_station_label",
+      "minzoom": 16,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "maki", "entrance"]],
+      "layout": {
+        "text-optional": true,
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 10]
+          ]
+        },
+        "text-allow-overlap": false,
+        "icon-image": "icon-subway-entrance",
+        "text-ignore-placement": false,
+        "text-font": ["Gotham Rounded Medium"],
+        "icon-allow-overlap": true,
+        "visibility": "visible",
+        "text-offset": {
+          "base": 1,
+          "stops": [
+            [15, [0, 0.5]],
+            [22, [0, 3]]
+          ]
+        },
+        "icon-optional": false,
+        "icon-size": {
+          "base": 1.15,
+          "stops": [
+            [15, 0.3],
+            [22, 1]
+          ]
+        },
+        "text-anchor": "top",
+        "text-field": "",
+        "text-max-width": 8,
+        "icon-ignore-placement": false
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0,
+        "icon-translate": [0, -5.25],
+        "icon-opacity": 1
+      }
+    },
+    {
+      "id": "water_label",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "water_label",
+      "minzoom": 5,
+      "filter": ["==", "$type", "Point"],
+      "layout": {
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 11]
+          ]
+        },
+        "text-max-width": 8,
+        "text-font": ["Gotham Rounded Medium Italic"],
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#39c6ea",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,0.5)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "place_label_island",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "place_label",
+      "minzoom": 10,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["in", "type", "island", "islet"],
+        ["==", "localrank", 1]
+      ],
+      "layout": {
+        "text-size": {
+          "stops": [
+            [0, 8],
+            [15, 11]
+          ]
+        },
+        "text-max-width": 8,
+        "text-font": ["Gotham Rounded Book"],
+        "text-offset": [0, 0.5],
+        "text-anchor": "top",
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#777",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "road_street_label",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "road_label",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "name", "Harakan talvipolku", "Suomenlinnan Huoltotunneli"],
+          [
+            "in",
+            "class",
+            "path",
+            "service",
+            "street",
+            "street_limited",
+            "tertiary"
+          ]
+        ]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name}",
+        "text-font": ["Gotham Rounded Medium"],
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "base": 1.4,
+          "stops": [
+            [10, 8],
+            [20, 14]
+          ]
+        },
+        "text-keep-upright": true,
+        "text-rotation-alignment": "map"
+      },
+      "paint": {
+        "text-color": {
+          "base": 1.4,
+          "stops": [
+            [13, "#999"],
+            [15, "#666"]
+          ]
+        },
+        "text-halo-color": "rgba(255,255,255,0.85)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "road_primary_label",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "road_label",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "motorway", "primary", "secondary", "trunk"]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name}",
+        "text-font": ["Gotham Rounded Medium"],
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "base": 1.4,
+          "stops": [
+            [10, 8],
+            [20, 14]
+          ]
+        },
+        "text-rotation-alignment": "map"
+      },
+      "paint": {
+        "text-color": {
+          "base": 1.4,
+          "stops": [
+            [13, "#999"],
+            [15, "#666"]
+          ]
+        },
+        "text-halo-color": "rgba(255,255,255,0.85)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "place_label_other",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "place_label",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        ["in", "type", "hamlet", "neighbourhood", "suburb", "town", "village"]
+      ],
+      "layout": {
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-font": ["Gotham Rounded Book"],
+        "text-max-width": 6,
+        "text-size": {
+          "stops": [
+            [10, 10],
+            [16, 18]
+          ],
+          "base": 1.2
+        }
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-color": "rgba(255,255,255,1.00)",
+        "text-halo-width": 1,
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "place_label_city",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "place_label",
+      "maxzoom": 13,
+      "filter": ["all", ["==", "$type", "Point"], ["==", "type", "city"]],
+      "layout": {
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-font": ["Gotham Rounded Medium"],
+        "text-max-width": 10,
+        "text-size": {
+          "stops": [
+            [6, 10],
+            [10, 16]
+          ],
+          "base": 1.4
+        },
+        "text-transform": "uppercase",
+        "text-letter-spacing": 0.125
+      },
+      "paint": {
+        "text-color": "#777",
+        "text-halo-color": "rgba(255,255,255,1.0)",
+        "text-halo-width": 1.5,
+        "text-halo-blur": 0,
+        "text-opacity": {
+          "base": 1,
+          "stops": [
+            [12, 1],
+            [13, 0]
+          ]
+        }
+      }
+    },
+    {
+      "id": "country_label",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "country_label",
+      "maxzoom": 12,
+      "filter": ["==", "$type", "Point"],
+      "layout": {
+        "text-field": "{name}\n{name_sv_nodefault}",
+        "text-font": ["Gotham Rounded Medium"],
+        "text-max-width": 10,
+        "text-size": {
+          "stops": [
+            [3, 10],
+            [8, 30]
+          ]
+        },
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1.5,
+        "text-halo-blur": 0
+      }
+    },
+    {
+      "id": "road_street_label_fisv",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "road_label",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        [
+          "all",
+          ["!in", "name", "Harakan talvipolku", "Suomenlinnan Huoltotunneli"],
+          [
+            "in",
+            "class",
+            "path",
+            "service",
+            "street",
+            "street_limited",
+            "tertiary"
+          ]
+        ]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name}   {name_sv_nodefault}",
+        "text-font": ["Gotham Rounded Medium"],
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "base": 1.4,
+          "stops": [
+            [10, 8],
+            [20, 14]
+          ]
+        },
+        "text-keep-upright": true,
+        "text-rotation-alignment": "map"
+      },
+      "paint": {
+        "text-color": {
+          "base": 1.4,
+          "stops": [
+            [13, "#999"],
+            [15, "#666"]
+          ]
+        },
+        "text-halo-color": "rgba(255,255,255,0.85)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "road_primary_label_fisv",
+      "type": "symbol",
+      "source": "vector",
+      "source-layer": "road_label",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["in", "class", "motorway", "primary", "secondary", "trunk"]
+      ],
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": "{name}   {name_sv_nodefault}",
+        "text-font": ["Gotham Rounded Medium"],
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "base": 1.4,
+          "stops": [
+            [10, 8],
+            [20, 14]
+          ]
+        },
+        "text-rotation-alignment": "map"
+      },
+      "paint": {
+        "text-color": {
+          "base": 1.4,
+          "stops": [
+            [13, "#999"],
+            [15, "#666"]
+          ]
+        },
+        "text-halo-color": "rgba(255,255,255,0.85)",
+        "text-halo-width": 2
+      }
+    }
+  ],
+  "created": "2016-05-12T07:20:14.210Z",
+  "id": "cio3ytjzp005dbzm1uaowh9s3",
+  "modified": "2016-05-18T13:09:30.929Z",
+  "owner": "vhamalai",
+  "draft": false
+}


### PR DESCRIPTION
The simple-style.json has been removed from HSL's repository. Persisting the required map style json in this repository to get map rendering working again

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/75)
<!-- Reviewable:end -->
