### PR TITLE
Allow enabling/disabling docker volume for jore4-testdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ yarn-error.log*
 .vscode
 docker/*
 !docker/docker-compose.custom.yml
-!docker/2524600800000_seed-data
+!docker/docker-compose.testdb-volume.yml
 
 pg_data
 mbtiles

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Non-VSCode users can sort imports e.g. by running `yarn lint --fix` on command l
 
 ## Setting up dependencies for local development
 
-Run `./start-dependencies.sh` to set up microservices required for local deveopment in docker-compose.
+Run `./start-dependencies.sh` to set up microservices required for local development in docker-compose.
 Script uses Jore4 project's shared docker-compose file defined in [`jore4-flux`](https://github.com/HSLdevcom/jore4-flux#docker-compose) repository.
 Edit `start-dependencies.sh` script if you want to start only certain subset of our microservices.
 For overriding settings defined in base docker-compose file just edit
 `docker/docker-compose.custom.yml` and run `./start-dependencies.sh` again.
+If you wish to persist the data in the database, start dependencies with `./start-dependencies.sh --volume`
 Docker containers can be stopped gracefully by running `./stop-dependencies.sh`
 If docker setup seems to be in somehow non-working state, you can remove all containers by running `docker rm --force $(docker ps -aq)` and then start dependencies again.
 

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -40,8 +40,3 @@ services:
       - 25432:5432
     networks:
       - jore4
-
-  jore4-testdb:
-    # preserve db's state to local disk to avoid data loss if db container is removed
-    volumes:
-      - './testdb:/var/lib/postgresql/data'

--- a/docker/docker-compose.testdb-volume.yml
+++ b/docker/docker-compose.testdb-volume.yml
@@ -1,0 +1,5 @@
+services:
+  jore4-testdb:
+    # preserve db's state to local disk to avoid data loss if db container is removed
+    volumes:
+      - './testdb:/var/lib/postgresql/data'

--- a/start-dependencies.sh
+++ b/start-dependencies.sh
@@ -19,5 +19,15 @@ else
   echo "E2E docker-compose package is up to date, no need to download new version."
 fi
 
+if [[ "${1:-x}" == "--volume" ]]
+then
+  # start the testdb with mounted volume
+  DOCKER_COMPOSE_CMD="docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.testdb-volume.yml -f ./docker/docker-compose.custom.yml"
+  echo $DOCKER_COMPOSE_CMD
+else
+  DOCKER_COMPOSE_CMD="docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.custom.yml"
+  echo $DOCKER_COMPOSE_CMD
+fi
+
 # start up only services that are needed in local ui development
-docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.custom.yml up -d jore4-auth jore4-testdb jore4-hasura jore4-mbtiles jore4-mapmatchingdb jore4-mapmatching
+$DOCKER_COMPOSE_CMD up -d jore4-auth jore4-testdb jore4-hasura jore4-mbtiles jore4-mapmatchingdb jore4-mapmatching


### PR DESCRIPTION
Having the volume enabled by default ended up causing lots of issues when switching between hasura versions resulting in incompatible migration states.
This compose yaml section has only been commented out however because in some cases it is actually desired to save the state between development sessions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/85)
<!-- Reviewable:end -->
