### PR TITLE
Refactor how stops are handled in UI

### DIFF
--- a/src/components/map/Stops.tsx
+++ b/src/components/map/Stops.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../generated/graphql';
 import { mapGetStopsResult } from '../../graphql/queries';
 import { Point } from '../../types';
-import { mapToVariables, showToast } from '../../utils';
+import { mapToVariables, removeFromApolloCache, showToast } from '../../utils';
 import { EditStopModal } from './EditStopModal';
 import { Stop } from './Stop';
 import { StopPopup } from './StopPopup';
@@ -85,19 +85,12 @@ export const Stops = React.forwardRef((props, ref) => {
       // we are removing stop that is already stored to backend
       removeStopMutation({
         ...mapToVariables({ id }),
+        // remove stop from cache after mutation
         update(cache) {
-          // Remove stop from apollo's cache after deletion so that
-          // it also disappears from ui.
-          // TODO: probably we shouldn't have to do this manually or
-          // at least we should have helper function for this.
-          // Based on https://stackoverflow.com/a/66713628
-          const cached = cache.identify({
+          removeFromApolloCache(cache, {
             scheduled_stop_point_id: id,
             __typename: 'service_pattern_scheduled_stop_point',
           });
-          // @ts-expect-error something
-          cache.evict(cached);
-          cache.gc();
         },
       });
     } else {

--- a/src/context/MapEditorReducer.ts
+++ b/src/context/MapEditorReducer.ts
@@ -11,6 +11,7 @@ export enum Mode {
 export interface IMapEditorContext {
   hasRoute: boolean;
   displayedRouteIds?: UUID[];
+  selectedStopId?: UUID;
   canAddStops: boolean;
   routeDetails?: Partial<RouteFormState>;
   drawingMode: Mode | undefined;
@@ -22,6 +23,7 @@ export interface IMapEditorContext {
 export const initialState: IMapEditorContext = {
   hasRoute: false,
   displayedRouteIds: undefined,
+  selectedStopId: undefined,
   canAddStops: false,
   drawingMode: undefined,
   routeDetails: undefined,

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5931,6 +5931,13 @@ export type PatchLineMutation = { __typename?: 'mutation_root', update_route_lin
 
 export type ScheduledStopPointDefaultFieldsFragment = { __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: any | null | undefined, validity_end?: any | null | undefined };
 
+export type RemoveStopMutationVariables = Exact<{
+  id: Scalars['uuid'];
+}>;
+
+
+export type RemoveStopMutation = { __typename?: 'mutation_root', delete_service_pattern_scheduled_stop_point?: { __typename?: 'service_pattern_scheduled_stop_point_mutation_response', returning: Array<{ __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID }> } | null | undefined };
+
 export const ScheduledStopPointInJourneyPatternDefaultFieldsFragmentDoc = gql`
     fragment scheduled_stop_point_in_journey_pattern_default_fields on journey_pattern_scheduled_stop_point_in_journey_pattern {
   journey_pattern_id
@@ -6555,3 +6562,40 @@ export function usePatchLineMutation(baseOptions?: Apollo.MutationHookOptions<Pa
 export type PatchLineMutationHookResult = ReturnType<typeof usePatchLineMutation>;
 export type PatchLineMutationResult = Apollo.MutationResult<PatchLineMutation>;
 export type PatchLineMutationOptions = Apollo.BaseMutationOptions<PatchLineMutation, PatchLineMutationVariables>;
+export const RemoveStopDocument = gql`
+    mutation RemoveStop($id: uuid!) {
+  delete_service_pattern_scheduled_stop_point(
+    where: {scheduled_stop_point_id: {_eq: $id}}
+  ) {
+    returning {
+      scheduled_stop_point_id
+    }
+  }
+}
+    `;
+export type RemoveStopMutationFn = Apollo.MutationFunction<RemoveStopMutation, RemoveStopMutationVariables>;
+
+/**
+ * __useRemoveStopMutation__
+ *
+ * To run a mutation, you first call `useRemoveStopMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveStopMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeStopMutation, { data, loading, error }] = useRemoveStopMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useRemoveStopMutation(baseOptions?: Apollo.MutationHookOptions<RemoveStopMutation, RemoveStopMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RemoveStopMutation, RemoveStopMutationVariables>(RemoveStopDocument, options);
+      }
+export type RemoveStopMutationHookResult = ReturnType<typeof useRemoveStopMutation>;
+export type RemoveStopMutationResult = Apollo.MutationResult<RemoveStopMutation>;
+export type RemoveStopMutationOptions = Apollo.BaseMutationOptions<RemoveStopMutation, RemoveStopMutationVariables>;

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -48,7 +48,11 @@ const link = process.browser
   : apolloLink;
 
 const cache = new InMemoryCache({
-  typePolicies: {},
+  typePolicies: {
+    service_pattern_scheduled_stop_point: {
+      keyFields: ['scheduled_stop_point_id'],
+    },
+  },
 });
 
 const client = new ApolloClient({

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { gql } from '@apollo/client';
+import {
+  ServicePatternScheduledStopPoint,
+  useGetStopsQuery,
+} from '../generated/graphql';
 
 /*
  * Define graphql queries here and then `@graphql-codegen` can generate TypeScript code for those.
@@ -68,3 +72,9 @@ const QUERY_GET_ALL_STOPS = gql`
     }
   }
 `;
+export const mapGetStopsResult = (
+  result: ReturnType<typeof useGetStopsQuery>,
+) =>
+  result.data?.service_pattern_scheduled_stop_point as
+    | ServicePatternScheduledStopPoint[]
+    | undefined;

--- a/src/graphql/servicePattern.ts
+++ b/src/graphql/servicePattern.ts
@@ -9,3 +9,15 @@ const SCHEDULED_STOP_POINT_DEFAULT_FIELDS = gql`
     validity_end
   }
 `;
+
+const REMOVE_STOP = gql`
+  mutation RemoveStop($id: uuid!) {
+    delete_service_pattern_scheduled_stop_point(
+      where: { scheduled_stop_point_id: { _eq: $id } }
+    ) {
+      returning {
+        scheduled_stop_point_id
+      }
+    }
+  }
+`;

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,3 +1,4 @@
+import { ApolloCache, Reference, StoreObject } from '@apollo/client';
 import { Scalars } from '../generated/graphql';
 import { Point } from '../types';
 
@@ -16,4 +17,19 @@ export const mapPointToPointGeography = ({
   // TODO: where should we get z-coordinate? Api schema requires it.
   // Use 0 as z-coordinate for now.
   return { type: 'Point', coordinates: [longitude, latitude, 0] };
+};
+
+// Removes item from apollo's cache.
+// TODO: do we really have to do this manually?
+export const removeFromApolloCache = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cache: ApolloCache<any>,
+  identity: StoreObject | Reference,
+) => {
+  // Based on https://stackoverflow.com/a/66713628
+  const cached = cache.identify(identity);
+  // @ts-expect-error something seems to be wrong here. The solution mentioned
+  // above stackoverflow response won't give ts errors, but it doesn't work either...
+  cache.evict(cached);
+  cache.gc();
 };


### PR DESCRIPTION
Original implementation of stops handling was implemented back in
the days when we didn't yet have backend instance.
Because of that stops were handled 100% in UI.
At some point the implementation was changed so that we fetched stops
to the UI from the backend, but then kind of combined stops from
backend with stops in the UI and the result was really confusing.

After this refactoring things are still quite messy, but perhaps still
better than they were.

- Now it is possible to delete stops from the backend via the UI
- Now we inform users about the fact that dragging stops isn't actually
  supported right now

There are still major issues:
- When new stop is created, it is not fetched to the UI (and temporary,
  corresponding unsaved stop in the UI won't be removed)
- Editing existing stops won't work and actually just results duplicating
  of existing stop (!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/88)
<!-- Reviewable:end -->
