### PR TITLE
Revert "Add regex validation to validity end"

### DIFF
--- a/src/components/forms/ConfirmSaveForm.tsx
+++ b/src/components/forms/ConfirmSaveForm.tsx
@@ -12,6 +12,12 @@ export const schema = z.object({
     .string()
     .min(1)
     .regex(/[0-9]{4}-[0-9]{2}-[0-9]{2}/),
+  // TODO: also validityEnd could/should be validated against regex
+  // but only when "indefinite" is set to false. Anyway, seems like zod
+  // schemas start to cause TS errors if merged with each other after
+  // .partial() and .refine() methods have been called, so validation
+  // is left out for now. See message of commit
+  // c7f8d6f6f95712a6d7a6d5003c4b170390e731f9 for details
   validityEnd: z.string(),
   indefinite: z.boolean(),
 });

--- a/src/components/forms/ConfirmSaveForm.tsx
+++ b/src/components/forms/ConfirmSaveForm.tsx
@@ -12,7 +12,7 @@ export const schema = z.object({
     .string()
     .min(1)
     .regex(/[0-9]{4}-[0-9]{2}-[0-9]{2}/),
-  validityEnd: z.string().regex(/[0-9]{4}-[0-9]{2}-[0-9]{2}/),
+  validityEnd: z.string(),
   indefinite: z.boolean(),
 });
 


### PR DESCRIPTION
This reverts commit 52bffa18a630419815023499fcb1b96e51f5bb5f.

Reverted change actually introduced a bug where form validation
started to fail if form was set to "indefinte" and "validityEnd"
date was missing.

Proper way to tackle the issue would be introducing
some kind of conditional validation e.g. by using
`partial()` and `refine()` methods from `zod`
as instucted here: https://github.com/colinhacks/zod/issues/61

Example implementation would look something like this:

```
export const schema = z
  .object({
    priority: z.nativeEnum(Priority),
    validityStart: z
      .string()
      .min(1)
      .regex(/[0-9]{4}-[0-9]{2}-[0-9]{2}/),
  })
  .merge(
    z
      .object({
        validityEnd: z.string().regex(/[0-9]{4}-[0-9]{2}-[0-9]{2}/),
        indefinite: z.boolean(),
      })
      .partial()
      .refine((data) => !!data.indefinite || !!data.validityEnd),
  );

```

The problem is that zod won't let us to `merge()` schemas after
`refine()` has been called (https://giters.com/colinhacks/zod/issues/597),
and causes problems in all places where ConfirmationForm has been used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/93)
<!-- Reviewable:end -->
