### PR TITLE
Allow users to edit lines with indefinite validity

### DIFF
--- a/src/components/forms/ConfirmSaveForm.tsx
+++ b/src/components/forms/ConfirmSaveForm.tsx
@@ -18,7 +18,7 @@ export const schema = z.object({
   // .partial() and .refine() methods have been called, so validation
   // is left out for now. See message of commit
   // c7f8d6f6f95712a6d7a6d5003c4b170390e731f9 for details
-  validityEnd: z.string(),
+  validityEnd: z.string().optional(),
   indefinite: z.boolean(),
 });
 


### PR DESCRIPTION
There was an error where editions to lines with indefinite validity couldn't be saved as form validation gave error for missing validityEnd field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/109)
<!-- Reviewable:end -->
