### PR TITLE
Show routes in map for selected observation date

### DIFF
--- a/src/components/LineTableRow.tsx
+++ b/src/components/LineTableRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdPinDrop } from 'react-icons/md';
 import { Link } from 'react-router-dom';
@@ -20,7 +19,13 @@ export const LineTableRow = ({ className, line }: Props): JSX.Element => {
 
   const showLineRoutes = () => {
     const lineRouteIds = line.line_routes?.map((item) => item.route_id);
-    showRoutesOnModal(lineRouteIds);
+
+    showRoutesOnModal(
+      lineRouteIds,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      line.validity_start!,
+      line.validity_end,
+    );
   };
 
   return (

--- a/src/components/RoutesAndLinesPage.tsx
+++ b/src/components/RoutesAndLinesPage.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MapEditorContext } from '../context/MapEditorContext';
+import { MapEditorContext } from '../context/MapEditor';
 import { ModalMapContext } from '../context/ModalMapContext';
 import {
   RouteLine,

--- a/src/components/RoutesTableRow.tsx
+++ b/src/components/RoutesTableRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdPinDrop } from 'react-icons/md';
 import { Link } from 'react-router-dom';
@@ -45,7 +44,14 @@ export const RoutesTableRow = ({ className, route }: Props): JSX.Element => {
         <td className="w-20 border">
           <IconButton
             className="h-full w-full"
-            onClick={() => showRoutesOnModal([route.route_id])}
+            onClick={() =>
+              showRoutesOnModal(
+                [route.route_id],
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                route.validity_start!,
+                route.validity_end,
+              )
+            }
             icon={<MdPinDrop className="text-5xl text-tweaked-brand" />}
             testId="RoutesTableRow::showRoute"
           />

--- a/src/components/map/DrawRouteLayer.tsx
+++ b/src/components/map/DrawRouteLayer.tsx
@@ -19,7 +19,7 @@ import {
   Editor,
   RENDER_STATE,
 } from 'react-map-gl-draw';
-import { MapEditorContext, Mode } from '../../context/MapEditorContext';
+import { MapEditorContext, Mode } from '../../context/MapEditor';
 import {
   ReusableComponentsVehicleModeEnum,
   useGetRoutesWithInfrastructureLinksQuery,

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { HTMLOverlay, MapEvent } from 'react-map-gl';
-import { MapEditorContext } from '../../context/MapEditorContext';
+import { MapEditorContext } from '../../context/MapEditor';
 import { MapFilterContext } from '../../context/MapFilter';
 import { useGetDisplayedRoutes } from '../../hooks';
 import { Column } from '../../layoutComponents';

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -8,6 +8,7 @@ import React, {
 import { HTMLOverlay, MapEvent } from 'react-map-gl';
 import { MapEditorContext } from '../../context/MapEditorContext';
 import { MapFilterContext } from '../../context/MapFilter';
+import { useGetDisplayedRoutes } from '../../hooks';
 import { Column } from '../../layoutComponents';
 import { FilterPanel } from '../../uiComponents/FilterPanel';
 import { DrawRouteLayer } from './DrawRouteLayer';
@@ -40,13 +41,15 @@ export const MapComponent = (
   externalRef: Ref<ExplicitAny>,
 ): JSX.Element => {
   const {
-    state: { displayedRouteIds, drawingMode, hasRoute },
+    state: { drawingMode, hasRoute, initiallyDisplayedRouteIds },
   } = useContext(MapEditorContext);
   const {
     state: { showStopFilterOverlay },
   } = useContext(MapFilterContext);
 
-  const routeSelected = !!(displayedRouteIds && displayedRouteIds.length > 0);
+  const { displayedRouteIds } = useGetDisplayedRoutes();
+
+  const routeSelected = !!initiallyDisplayedRouteIds?.length;
 
   const [showInfraLinks, setShowInfraLinks] = useState(!routeSelected);
   const [showDynamicInfraLinks, setShowDynamicInfraLinks] = useState(false);
@@ -165,7 +168,7 @@ export const MapComponent = (
       {showDynamicInfraLinks && <DynamicInfraLinksVectorLayer />}
       {showRoute &&
         routeSelected &&
-        displayedRouteIds.map((item) => (
+        displayedRouteIds?.map((item) => (
           <RouteLayer key={item} routeId={item} />
         ))}
     </Maplibre>

--- a/src/components/map/MapFooter.tsx
+++ b/src/components/map/MapFooter.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdDelete } from 'react-icons/md';
 import { MapEditorContext, Mode } from '../../context/MapEditorContext';
+import { useEditRouteGeometry } from '../../hooks';
 import { Row, Visible } from '../../layoutComponents';
 import { SimpleButton } from '../../uiComponents';
 
@@ -29,14 +30,13 @@ export const MapFooter: React.FC<Props> = ({
     state: { drawingMode, displayedRouteIds, creatingNewRoute, hasRoute },
   } = useContext(MapEditorContext);
 
-  const viewMode = drawingMode === undefined;
-  const changesInProgress = creatingNewRoute || !viewMode;
+  const { hasChangesInProgress, isInViewMode } = useEditRouteGeometry();
 
   return (
     <Row className="space-x-4 bg-white px-10 py-5">
       <SimpleButton
         onClick={onDrawRoute}
-        disabled={!viewMode || creatingNewRoute}
+        disabled={!isInViewMode || creatingNewRoute}
         inverted={drawingMode !== Mode.Draw}
       >
         {t('map.drawRoute')}
@@ -62,22 +62,22 @@ export const MapFooter: React.FC<Props> = ({
       <SimpleButton
         className="!px-3"
         onClick={onDeleteRoute}
-        disabled={!changesInProgress}
+        disabled={!hasChangesInProgress}
       >
         <MdDelete aria-label={t('map.deleteRoute')} />
       </SimpleButton>
-      <Visible visible={changesInProgress}>
+      <Visible visible={hasChangesInProgress}>
         <SimpleButton
           className="!ml-auto"
           onClick={onCancel}
-          disabled={!changesInProgress}
+          disabled={!hasChangesInProgress}
           inverted
         >
           {t('cancel')}
         </SimpleButton>
         <SimpleButton
           onClick={onSave}
-          disabled={!(changesInProgress && hasRoute)}
+          disabled={!(hasChangesInProgress && hasRoute)}
         >
           {t('routes.save')}
         </SimpleButton>

--- a/src/components/map/MapFooter.tsx
+++ b/src/components/map/MapFooter.tsx
@@ -1,8 +1,13 @@
 import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdDelete } from 'react-icons/md';
-import { MapEditorContext, Mode } from '../../context/MapEditorContext';
-import { useEditRouteGeometry } from '../../hooks';
+import {
+  hasChangesInProgressSelector,
+  isInViewModeSelector,
+  MapEditorContext,
+  Mode,
+} from '../../context/MapEditor';
+import { useContextStateSelector } from '../../hooks';
 import { Row, Visible } from '../../layoutComponents';
 import { SimpleButton } from '../../uiComponents';
 
@@ -30,7 +35,14 @@ export const MapFooter: React.FC<Props> = ({
     state: { drawingMode, displayedRouteIds, creatingNewRoute, hasRoute },
   } = useContext(MapEditorContext);
 
-  const { hasChangesInProgress, isInViewMode } = useEditRouteGeometry();
+  const hasChangesInProgress = useContextStateSelector(
+    MapEditorContext,
+    hasChangesInProgressSelector,
+  );
+  const isInViewMode = useContextStateSelector(
+    MapEditorContext,
+    isInViewModeSelector,
+  );
 
   return (
     <Row className="space-x-4 bg-white px-10 py-5">

--- a/src/components/map/ModalMap.tsx
+++ b/src/components/map/ModalMap.tsx
@@ -116,7 +116,7 @@ export const ModalMap: React.FC<Props> = ({ className }) => {
           mapEditorDispatch({
             type: 'setState',
             payload: {
-              displayedRouteIds: [
+              initiallyDisplayedRouteIds: [
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 newRouteId!,
               ],

--- a/src/components/map/ModalMap.tsx
+++ b/src/components/map/ModalMap.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MapEditorContext, Mode } from '../../context/MapEditorContext';
+import { MapEditorContext, Mode } from '../../context/MapEditor';
 import { MapFilterContext, setObservationDate } from '../../context/MapFilter';
 import { ModalMapContext } from '../../context/ModalMapContext';
 import { useExtractRouteFromFeature } from '../../hooks';

--- a/src/components/map/ObservationDateOverlay.tsx
+++ b/src/components/map/ObservationDateOverlay.tsx
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdLayers } from 'react-icons/md';
 import { MapFilterContext, setObservationDate } from '../../context/MapFilter';
-import { useFilterStops } from '../../hooks';
+import { useEditRouteGeometry, useFilterStops } from '../../hooks';
 import { Column, Row } from '../../layoutComponents';
 import { IconButton } from '../../uiComponents';
 import { MapOverlay } from './MapOverlay';
@@ -19,7 +19,9 @@ export const ObservationDateOverlay = ({ className }: Props) => {
     state: { observationDate },
     dispatch,
   } = useContext(MapFilterContext);
+
   const { toggleShowFilters } = useFilterStops();
+  const { hasChangesInProgress } = useEditRouteGeometry();
 
   return (
     <MapOverlay className={`${className} rounded`}>
@@ -33,6 +35,7 @@ export const ObservationDateOverlay = ({ className }: Props) => {
               dispatch(setObservationDate(DateTime.fromISO(e.target.value)))
             }
             className="flex-1"
+            disabled={hasChangesInProgress}
           />
           <IconButton
             className="block h-11 w-11 self-stretch rounded-md border border-black"

--- a/src/components/map/ObservationDateOverlay.tsx
+++ b/src/components/map/ObservationDateOverlay.tsx
@@ -2,8 +2,12 @@ import { DateTime } from 'luxon';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdLayers } from 'react-icons/md';
+import {
+  hasChangesInProgressSelector,
+  MapEditorContext,
+} from '../../context/MapEditor';
 import { MapFilterContext, setObservationDate } from '../../context/MapFilter';
-import { useEditRouteGeometry, useFilterStops } from '../../hooks';
+import { useContextStateSelector, useFilterStops } from '../../hooks';
 import { Column, Row } from '../../layoutComponents';
 import { IconButton } from '../../uiComponents';
 import { MapOverlay } from './MapOverlay';
@@ -21,7 +25,10 @@ export const ObservationDateOverlay = ({ className }: Props) => {
   } = useContext(MapFilterContext);
 
   const { toggleShowFilters } = useFilterStops();
-  const { hasChangesInProgress } = useEditRouteGeometry();
+  const hasChangesInProgress = useContextStateSelector(
+    MapEditorContext,
+    hasChangesInProgressSelector,
+  );
 
   return (
     <MapOverlay className={`${className} rounded`}>

--- a/src/components/map/RouteStopsOverlay.tsx
+++ b/src/components/map/RouteStopsOverlay.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MapEditorContext } from '../../context/MapEditorContext';
+import { MapEditorContext } from '../../context/MapEditor';
 import {
   ServicePatternScheduledStopPoint,
   useGetRoutesWithInfrastructureLinksQuery,

--- a/src/components/map/Routes.tsx
+++ b/src/components/map/Routes.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { MapEditorContext, Mode } from '../../context/MapEditorContext';
+import { MapEditorContext, Mode } from '../../context/MapEditor';
 import { FormState, schema } from '../forms/RoutePropertiesForm';
 import { CreateRouteModal } from './CreateRouteModal';
 

--- a/src/components/map/Stops.tsx
+++ b/src/components/map/Stops.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MapEvent } from 'react-map-gl';
 import { CallbackEvent } from 'react-map-gl/src/components/draggable-control';
-import { MapEditorContext } from '../../context/MapEditorContext';
+import { MapEditorContext } from '../../context/MapEditor';
 import {
   ReusableComponentsVehicleModeEnum,
   ServicePatternScheduledStopPoint,

--- a/src/components/map/Stops.tsx
+++ b/src/components/map/Stops.tsx
@@ -15,7 +15,11 @@ import {
   mapGetStopsResult,
   mapRoutesDetailsResult,
 } from '../../graphql';
-import { useEditStop, useExtractRouteFromFeature } from '../../hooks';
+import {
+  useEditStop,
+  useExtractRouteFromFeature,
+  useGetDisplayedRoutes,
+} from '../../hooks';
 import { useFilterStops } from '../../hooks/useFilterStops';
 import { RequiredKeys } from '../../types';
 import { ConfirmationDialog } from '../../uiComponents';
@@ -51,13 +55,10 @@ export const Stops = React.forwardRef((props, ref) => {
 
   const {
     dispatch: mapEditorDispatch,
-    state: {
-      selectedStopId,
-      displayedRouteIds,
-      editedRouteData,
-      creatingNewRoute,
-    },
+    state: { selectedStopId, editedRouteData, creatingNewRoute },
   } = useContext(MapEditorContext);
+  const { displayedRouteIds } = useGetDisplayedRoutes();
+
   // TODO: Fetch only the stops visible on the map?
   const stopsResult = useGetStopsQuery({});
   const unfilteredStops = mapGetStopsResult(stopsResult);

--- a/src/components/routes-and-lines/LineDetailsPage.tsx
+++ b/src/components/routes-and-lines/LineDetailsPage.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AiFillPlusCircle } from 'react-icons/ai';
 import { useParams } from 'react-router-dom';
-import { MapEditorContext } from '../../context/MapEditorContext';
+import { MapEditorContext } from '../../context/MapEditor';
 import { ModalMapContext } from '../../context/ModalMapContext';
 import {
   RouteLine,

--- a/src/components/routes-and-lines/RouteStopsHeaderRow.tsx
+++ b/src/components/routes-and-lines/RouteStopsHeaderRow.tsx
@@ -1,5 +1,4 @@
 import { DateTime } from 'luxon';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
 import { MdOutlineHistory, MdPinDrop } from 'react-icons/md';
@@ -55,7 +54,14 @@ export const RouteStopsHeaderRow = ({
       <td className="w-20 border-l-4 border-r-4 border-white">
         <IconButton
           className="h-full w-full"
-          onClick={() => showRoutesOnModal([route.route_id])}
+          onClick={() =>
+            showRoutesOnModal(
+              [route.route_id],
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              route.validity_start!,
+              route.validity_end,
+            )
+          }
           icon={<MdPinDrop className="text-5xl text-tweaked-brand" />}
           testId="RouteStopsHeaderRow::showRoute"
         />

--- a/src/context/ContextProviders.tsx
+++ b/src/context/ContextProviders.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MapEditorContextProvider } from './MapEditorContextProvider';
+import { MapEditorContextProvider } from './MapEditor';
 import { MapFilterContextProvider } from './MapFilter';
 import { ModalMapContextProvider } from './ModalMapContextProvider';
 import { UserContextProvider } from './UserContextProvider';

--- a/src/context/MapEditor/context.ts
+++ b/src/context/MapEditor/context.ts
@@ -1,12 +1,5 @@
 import React, { Dispatch } from 'react';
-import {
-  IMapEditorContext,
-  initialState,
-  MapEditorActions,
-  Mode,
-} from './MapEditorReducer';
-
-export { Mode };
+import { IMapEditorContext, initialState, MapEditorActions } from './reducer';
 
 export const MapEditorContext = React.createContext<{
   state: IMapEditorContext;

--- a/src/context/MapEditor/contextProvider.tsx
+++ b/src/context/MapEditor/contextProvider.tsx
@@ -1,6 +1,6 @@
 import { FC, useReducer } from 'react';
-import { MapEditorContext } from './MapEditorContext';
-import { initialState, mapEditorReducer } from './MapEditorReducer';
+import { MapEditorContext } from './context';
+import { initialState, mapEditorReducer } from './reducer';
 
 export const MapEditorContextProvider: FC = ({ children }) => {
   const [state, dispatch] = useReducer(mapEditorReducer, initialState);

--- a/src/context/MapEditor/index.ts
+++ b/src/context/MapEditor/index.ts
@@ -1,0 +1,4 @@
+export * from './context';
+export * from './contextProvider';
+export * from './reducer';
+export * from './selectors';

--- a/src/context/MapEditor/reducer.ts
+++ b/src/context/MapEditor/reducer.ts
@@ -1,6 +1,6 @@
 import produce from 'immer';
-import { FormState as RouteFormState } from '../components/forms/RoutePropertiesForm';
-import { InfrastructureLinkAlongRoute } from '../graphql';
+import { FormState as RouteFormState } from '../../components/forms/RoutePropertiesForm';
+import { InfrastructureLinkAlongRoute } from '../../graphql';
 
 export enum Mode {
   Draw,

--- a/src/context/MapEditor/selectors.ts
+++ b/src/context/MapEditor/selectors.ts
@@ -1,0 +1,9 @@
+import { IMapEditorContext } from './reducer';
+
+export const isInViewModeSelector = (state: IMapEditorContext) =>
+  state.drawingMode === undefined;
+
+export const hasChangesInProgressSelector = (state: IMapEditorContext) => {
+  const isInViewMode = isInViewModeSelector(state);
+  return state.creatingNewRoute || !isInViewMode;
+};

--- a/src/context/MapEditorReducer.ts
+++ b/src/context/MapEditorReducer.ts
@@ -14,6 +14,7 @@ export interface RouteStop {
 
 export interface IMapEditorContext {
   hasRoute: boolean;
+  initiallyDisplayedRouteIds?: UUID[];
   displayedRouteIds?: UUID[];
   creatingNewRoute: boolean;
   selectedStopId?: UUID;
@@ -29,6 +30,7 @@ export interface IMapEditorContext {
 
 export const initialState: IMapEditorContext = {
   hasRoute: false,
+  initiallyDisplayedRouteIds: undefined,
   displayedRouteIds: undefined,
   creatingNewRoute: false,
   selectedStopId: undefined,

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5947,6 +5947,14 @@ export type GetRouteDetailsByIdsQueryVariables = Exact<{
 
 export type GetRouteDetailsByIdsQuery = { __typename?: 'query_root', route_route: Array<{ __typename?: 'route_route', route_id: UUID, description_i18n?: string | null | undefined, starts_from_scheduled_stop_point_id: UUID, ends_at_scheduled_stop_point_id: UUID, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: string, route_line?: { __typename?: 'route_line', label: string } | null | undefined, route_journey_patterns: Array<{ __typename?: 'journey_pattern_journey_pattern', journey_pattern_id: UUID, on_route_id: UUID, scheduled_stop_point_in_journey_patterns: Array<{ __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern', journey_pattern_id: UUID, scheduled_stop_point_id: UUID, scheduled_stop_point_sequence: number, is_timing_point: boolean, is_via_point: boolean, scheduled_stop_point?: { __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined } | null | undefined }> }> }> };
 
+export type GetRouteDetailsByLabelsQueryVariables = Exact<{
+  labels?: Maybe<Array<Scalars['String']> | Scalars['String']>;
+  date?: Maybe<Scalars['timestamptz']>;
+}>;
+
+
+export type GetRouteDetailsByLabelsQuery = { __typename?: 'query_root', route_route: Array<{ __typename?: 'route_route', route_id: UUID, description_i18n?: string | null | undefined, starts_from_scheduled_stop_point_id: UUID, ends_at_scheduled_stop_point_id: UUID, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: string, route_line?: { __typename?: 'route_line', label: string } | null | undefined, route_journey_patterns: Array<{ __typename?: 'journey_pattern_journey_pattern', journey_pattern_id: UUID, on_route_id: UUID, scheduled_stop_point_in_journey_patterns: Array<{ __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern', journey_pattern_id: UUID, scheduled_stop_point_id: UUID, scheduled_stop_point_sequence: number, is_timing_point: boolean, is_via_point: boolean, scheduled_stop_point?: { __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined } | null | undefined }> }> }> };
+
 export type GetRoutesWithInfrastructureLinksQueryVariables = Exact<{
   route_ids?: Maybe<Array<Scalars['uuid']> | Scalars['uuid']>;
 }>;
@@ -6650,6 +6658,47 @@ export function useGetRouteDetailsByIdsLazyQuery(baseOptions?: Apollo.LazyQueryH
 export type GetRouteDetailsByIdsQueryHookResult = ReturnType<typeof useGetRouteDetailsByIdsQuery>;
 export type GetRouteDetailsByIdsLazyQueryHookResult = ReturnType<typeof useGetRouteDetailsByIdsLazyQuery>;
 export type GetRouteDetailsByIdsQueryResult = Apollo.QueryResult<GetRouteDetailsByIdsQuery, GetRouteDetailsByIdsQueryVariables>;
+export const GetRouteDetailsByLabelsDocument = gql`
+    query GetRouteDetailsByLabels($labels: [String!], $date: timestamptz) {
+  route_route(
+    where: {label: {_in: $labels}, validity_start: {_lte: $date}, _or: [{validity_end: {_gte: $date}}, {validity_end: {_is_null: true}}]}
+  ) {
+    ...route_with_journey_pattern_stops
+    route_line {
+      label
+    }
+  }
+}
+    ${RouteWithJourneyPatternStopsFragmentDoc}`;
+
+/**
+ * __useGetRouteDetailsByLabelsQuery__
+ *
+ * To run a query within a React component, call `useGetRouteDetailsByLabelsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRouteDetailsByLabelsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRouteDetailsByLabelsQuery({
+ *   variables: {
+ *      labels: // value for 'labels'
+ *      date: // value for 'date'
+ *   },
+ * });
+ */
+export function useGetRouteDetailsByLabelsQuery(baseOptions?: Apollo.QueryHookOptions<GetRouteDetailsByLabelsQuery, GetRouteDetailsByLabelsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetRouteDetailsByLabelsQuery, GetRouteDetailsByLabelsQueryVariables>(GetRouteDetailsByLabelsDocument, options);
+      }
+export function useGetRouteDetailsByLabelsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRouteDetailsByLabelsQuery, GetRouteDetailsByLabelsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetRouteDetailsByLabelsQuery, GetRouteDetailsByLabelsQueryVariables>(GetRouteDetailsByLabelsDocument, options);
+        }
+export type GetRouteDetailsByLabelsQueryHookResult = ReturnType<typeof useGetRouteDetailsByLabelsQuery>;
+export type GetRouteDetailsByLabelsLazyQueryHookResult = ReturnType<typeof useGetRouteDetailsByLabelsLazyQuery>;
+export type GetRouteDetailsByLabelsQueryResult = Apollo.QueryResult<GetRouteDetailsByLabelsQuery, GetRouteDetailsByLabelsQueryVariables>;
 export const GetRoutesWithInfrastructureLinksDocument = gql`
     query GetRoutesWithInfrastructureLinks($route_ids: [uuid!]) {
   route_route(where: {route_id: {_in: $route_ids}}) {

--- a/src/graphql/route.ts
+++ b/src/graphql/route.ts
@@ -196,6 +196,27 @@ const GET_ROUTE_DETAILS_BY_IDS = gql`
     }
   }
 `;
+
+const GET_ROUTE_DETAILS_BY_LABELS = gql`
+  query GetRouteDetailsByLabels($labels: [String!], $date: timestamptz) {
+    route_route(
+      where: {
+        label: { _in: $labels }
+        validity_start: { _lte: $date }
+        _or: [
+          { validity_end: { _gte: $date } }
+          { validity_end: { _is_null: true } }
+        ]
+      }
+    ) {
+      ...route_with_journey_pattern_stops
+      route_line {
+        label
+      }
+    }
+  }
+`;
+
 export const mapRouteDetailsResult = (
   result: ReturnType<typeof useGetRouteDetailsByIdsQuery>,
 ) => result.data?.route_route[0] as RouteRoute | undefined;
@@ -203,7 +224,8 @@ export const mapRouteDetailsResult = (
 export const mapRoutesDetailsResult = (
   result:
     | ApolloQueryResult<GetRouteDetailsByIdsQuery>
-    | ReturnType<typeof useGetRoutesWithInfrastructureLinksQuery>,
+    | ReturnType<typeof useGetRoutesWithInfrastructureLinksQuery>
+    | ReturnType<typeof useGetRouteDetailsByIdsQuery>,
 ) => result.data?.route_route as RouteRoute[] | [];
 
 const GET_ROUTES_WITH_INFRASTRUCTURE_LINKS = gql`

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useAsyncQuery';
 export * from './useCheckValidityAndPriorityConflicts';
+export * from './useContextStateSelector';
 export * from './useCreateLine';
 export * from './useCreateStop';
 export * from './useDeleteRoute';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,6 +9,7 @@ export * from './useEditRouteGeometry';
 export * from './useEditStop';
 export * from './useExtractRouteFromFeature';
 export * from './useFilterStops';
+export * from './useGetDisplayedRoutes';
 export * from './useGetStopLinkAndDirection';
 export * from './useShowRoutesOnModal';
 export * from './useUrlQuery';

--- a/src/hooks/useContextStateSelector.ts
+++ b/src/hooks/useContextStateSelector.ts
@@ -1,0 +1,14 @@
+// This is lazily typed (not really typed at all)
+// as this will be replaced with proper selectors in the close future
+// TODO: Use state management library's selectors
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Context, useContext } from 'react';
+
+export function useContextStateSelector<T>(
+  context: Context<any>,
+  selectorFunction: (state: any) => T,
+) {
+  const { state } = useContext(context);
+
+  return selectorFunction(state);
+}

--- a/src/hooks/useEditRouteGeometry.ts
+++ b/src/hooks/useEditRouteGeometry.ts
@@ -1,4 +1,6 @@
+import { useContext } from 'react';
 import { FormState as RouteFormState } from '../components/forms/RoutePropertiesForm';
+import { MapEditorContext } from '../context/MapEditorContext';
 import { RouteStop } from '../context/MapEditorReducer';
 import {
   InsertRouteOneMutationVariables,
@@ -42,6 +44,10 @@ export const useEditRouteGeometry = () => {
     useDeleteStopFromJourneyPatternMutation();
 
   const { mapRouteStopsToStopIds } = useExtractRouteFromFeature();
+
+  const {
+    state: { drawingMode, creatingNewRoute },
+  } = useContext(MapEditorContext);
 
   const mapStopsToScheduledStopPoints = (stops: UUID[]) => {
     return {
@@ -190,12 +196,18 @@ export const useEditRouteGeometry = () => {
     });
   };
 
+  // TODO: Implement with selectors
+  const isInViewMode = drawingMode === undefined;
+  const hasChangesInProgress = creatingNewRoute || !isInViewMode;
+
   return {
     // edit
     updateRouteGeometryMutation,
     mapRouteDetailsToUpdateMutationVariables,
     deleteStopFromJourneyPattern,
     addStopToRouteJourneyPattern,
+    isInViewMode,
+    hasChangesInProgress,
     // create
     insertRouteMutation,
     mapRouteDetailsToInsertMutationVariables,

--- a/src/hooks/useEditRouteGeometry.ts
+++ b/src/hooks/useEditRouteGeometry.ts
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
 import { FormState as RouteFormState } from '../components/forms/RoutePropertiesForm';
-import { MapEditorContext } from '../context/MapEditorContext';
-import { RouteStop } from '../context/MapEditorReducer';
+import { RouteStop } from '../context/MapEditor';
 import {
   InsertRouteOneMutationVariables,
   RouteDirectionEnum,
@@ -44,10 +42,6 @@ export const useEditRouteGeometry = () => {
     useDeleteStopFromJourneyPatternMutation();
 
   const { mapRouteStopsToStopIds } = useExtractRouteFromFeature();
-
-  const {
-    state: { drawingMode, creatingNewRoute },
-  } = useContext(MapEditorContext);
 
   const mapStopsToScheduledStopPoints = (stops: UUID[]) => {
     return {
@@ -196,18 +190,12 @@ export const useEditRouteGeometry = () => {
     });
   };
 
-  // TODO: Implement with selectors
-  const isInViewMode = drawingMode === undefined;
-  const hasChangesInProgress = creatingNewRoute || !isInViewMode;
-
   return {
     // edit
     updateRouteGeometryMutation,
     mapRouteDetailsToUpdateMutationVariables,
     deleteStopFromJourneyPattern,
     addStopToRouteJourneyPattern,
-    isInViewMode,
-    hasChangesInProgress,
     // create
     insertRouteMutation,
     mapRouteDetailsToInsertMutationVariables,

--- a/src/hooks/useExtractRouteFromFeature.ts
+++ b/src/hooks/useExtractRouteFromFeature.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { getBusRoute } from '../api/routing';
-import { RouteStop } from '../context/MapEditorReducer';
+import { RouteStop } from '../context/MapEditor';
 import {
   GetStopsAlongInfrastructureLinksDocument,
   GetStopsAlongInfrastructureLinksQuery,

--- a/src/hooks/useGetDisplayedRoutes.ts
+++ b/src/hooks/useGetDisplayedRoutes.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react';
-import { MapEditorContext } from '../context/MapEditorContext';
+import { MapEditorContext } from '../context/MapEditor';
 import { MapFilterContext } from '../context/MapFilter';
 import {
   GetRouteDetailsByIdsDocument,

--- a/src/hooks/useGetDisplayedRoutes.ts
+++ b/src/hooks/useGetDisplayedRoutes.ts
@@ -1,0 +1,82 @@
+import { useContext, useEffect } from 'react';
+import { MapEditorContext } from '../context/MapEditorContext';
+import { MapFilterContext } from '../context/MapFilter';
+import {
+  GetRouteDetailsByIdsDocument,
+  GetRouteDetailsByIdsQuery,
+  GetRouteDetailsByIdsQueryVariables,
+  GetRouteDetailsByLabelsDocument,
+  GetRouteDetailsByLabelsQuery,
+  GetRouteDetailsByLabelsQueryVariables,
+} from '../generated/graphql';
+import { mapRoutesDetailsResult } from '../graphql';
+import { useAsyncQuery } from './useAsyncQuery';
+
+export const useGetDisplayedRoutes = () => {
+  const [getRouteDetailsByLabels] = useAsyncQuery<
+    GetRouteDetailsByLabelsQuery,
+    GetRouteDetailsByLabelsQueryVariables
+  >(GetRouteDetailsByLabelsDocument);
+
+  const [getRouteDetailsByIds] = useAsyncQuery<
+    GetRouteDetailsByIdsQuery,
+    GetRouteDetailsByIdsQueryVariables
+  >(GetRouteDetailsByIdsDocument);
+
+  const {
+    state: { observationDate },
+  } = useContext(MapFilterContext);
+
+  const {
+    state: { displayedRouteIds, initiallyDisplayedRouteIds },
+    dispatch,
+  } = useContext(MapEditorContext);
+
+  useEffect(() => {
+    const updateDisplayedRoutes = async () => {
+      if (!initiallyDisplayedRouteIds) {
+        return [];
+      }
+      const routeDetailsResult = await getRouteDetailsByIds({
+        route_ids: initiallyDisplayedRouteIds,
+      });
+      const routeDetails = mapRoutesDetailsResult(routeDetailsResult);
+
+      if (!routeDetails.length) {
+        return [];
+      }
+
+      const labels = routeDetails?.map((route) => route.label);
+
+      const displayedRouteDetailsResult = await getRouteDetailsByLabels({
+        labels,
+        date: observationDate,
+      });
+
+      const displayedRouteDetails = mapRoutesDetailsResult(
+        displayedRouteDetailsResult,
+      );
+
+      dispatch({
+        type: 'setState',
+        payload: {
+          displayedRouteIds: displayedRouteDetails.map(
+            (route) => route.route_id,
+          ),
+        },
+      });
+
+      return displayedRouteDetails;
+    };
+
+    updateDisplayedRoutes();
+  }, [
+    getRouteDetailsByLabels,
+    observationDate,
+    dispatch,
+    getRouteDetailsByIds,
+    initiallyDisplayedRouteIds,
+  ]);
+
+  return { displayedRouteIds };
+};

--- a/src/hooks/useShowRoutesOnModal.ts
+++ b/src/hooks/useShowRoutesOnModal.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { useContext } from 'react';
-import { MapEditorContext } from '../context/MapEditorContext';
+import { MapEditorContext } from '../context/MapEditor';
 import { MapFilterContext, setObservationDate } from '../context/MapFilter';
 import { ModalMapContext } from '../context/ModalMapContext';
 import { Maybe } from '../generated/graphql';

--- a/src/hooks/useShowRoutesOnModal.ts
+++ b/src/hooks/useShowRoutesOnModal.ts
@@ -11,7 +11,7 @@ export const useShowRoutesOnModal = () => {
     mapEditorDispatch({
       type: 'setState',
       payload: {
-        displayedRouteIds: routeIds,
+        initiallyDisplayedRouteIds: routeIds,
       },
     });
 

--- a/src/hooks/useShowRoutesOnModal.ts
+++ b/src/hooks/useShowRoutesOnModal.ts
@@ -1,12 +1,17 @@
+import { DateTime } from 'luxon';
 import { useContext } from 'react';
 import { MapEditorContext } from '../context/MapEditorContext';
+import { MapFilterContext, setObservationDate } from '../context/MapFilter';
 import { ModalMapContext } from '../context/ModalMapContext';
+import { Maybe } from '../generated/graphql';
+import { isDateInRange } from '../time';
 
 export const useShowRoutesOnModal = () => {
   const { dispatch: modalMapDispatch } = useContext(ModalMapContext);
   const { dispatch: mapEditorDispatch } = useContext(MapEditorContext);
+  const { dispatch: mapFilterDispatch } = useContext(MapFilterContext);
 
-  const showRoutesOnModal = async (routeIds: UUID[]) => {
+  const showRoutesOnModalById = (routeIds: UUID[]) => {
     mapEditorDispatch({ type: 'reset' });
     mapEditorDispatch({
       type: 'setState',
@@ -16,6 +21,23 @@ export const useShowRoutesOnModal = () => {
     });
 
     modalMapDispatch({ type: 'open' });
+  };
+
+  const showRoutesOnModal = (
+    routeIds: UUID[],
+    validityStart: DateTime,
+    validityEnd?: Maybe<DateTime>,
+  ) => {
+    const newObservationDate = isDateInRange(
+      DateTime.now(),
+      validityStart,
+      validityEnd,
+    )
+      ? DateTime.now()
+      : validityStart;
+
+    mapFilterDispatch(setObservationDate(newObservationDate));
+    showRoutesOnModalById(routeIds);
   };
 
   return { showRoutesOnModal };

--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -119,7 +119,8 @@
     "future": "Future",
     "current": "Current",
     "past": "Past",
-    "observationDate": "Observation date"
+    "observationDate": "Observation date",
+    "observationDateAdjusted": "Observation date adjusted"
   },
   "save": "Save",
   "edit": "Edit",

--- a/src/locales/fi-FI/common.json
+++ b/src/locales/fi-FI/common.json
@@ -119,7 +119,8 @@
     "future": "Tulevat",
     "current": "Nykyiset",
     "past": "Menneet",
-    "observationDate": "Tarkasteluhetki"
+    "observationDate": "Tarkasteluhetki",
+    "observationDateAdjusted": "Tarkasteluhetkeä muutettu"
   },
   "save": "Tallenna",
   "edit": "Muokkaa",

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,5 +1,6 @@
 import isString from 'lodash/isString';
 import { DateTime, Settings } from 'luxon';
+import { Maybe } from './generated/graphql';
 import { i18n } from './i18n';
 
 Settings.defaultZone = 'Europe/Helsinki';
@@ -59,3 +60,11 @@ export const mapToISODate = (date?: DateLike | null) =>
 
 export const MIN_DATE = DateTime.fromISO('1970-01-01').startOf('day');
 export const MAX_DATE = DateTime.fromISO('2050-12-31').endOf('day');
+
+export const isDateInRange = (
+  date: DateTime,
+  startDate: DateTime,
+  endDate?: Maybe<DateTime>,
+) => {
+  return date >= startDate && (!endDate?.isValid || date <= endDate);
+};


### PR DESCRIPTION
- User selects observation date in the map view -> display correct validity version of the route
- If user selects a future / past route from the list view to be displayed in the map, adjust observation date so the route is shown
- Observation date input is disabled while creating / editing route geometry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/121)
<!-- Reviewable:end -->
