### PR TITLE
Add search functionality

### DIFF
--- a/src/components/RoutesAndLinesPage.tsx
+++ b/src/components/RoutesAndLinesPage.tsx
@@ -6,6 +6,7 @@ import { Container, Row } from '../layoutComponents';
 import { Path, routes } from '../routes'; // eslint-disable-line import/no-cycle
 import { SimpleButton } from '../uiComponents';
 import { RoutesAndLinesLists } from './routes-and-lines/RoutesAndLinesLists'; // eslint-disable-line import/no-cycle
+import { SearchContainer } from './routes-and-lines/search/conditions/SearchContainer';
 
 export const RoutesAndLinesPage = (): JSX.Element => {
   const { t } = useTranslation();
@@ -32,6 +33,7 @@ export const RoutesAndLinesPage = (): JSX.Element => {
           {t('lines.createNew')}
         </SimpleButton>
       </Row>
+      <SearchContainer />
       <RoutesAndLinesLists />
     </Container>
   );

--- a/src/components/RoutesAndLinesPage.tsx
+++ b/src/components/RoutesAndLinesPage.tsx
@@ -1,31 +1,17 @@
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MapEditorContext } from '../context/MapEditor';
 import { ModalMapContext } from '../context/ModalMapContext';
-import {
-  RouteLine,
-  RouteRoute,
-  useListChangingRoutesQuery,
-  useListOwnLinesQuery,
-} from '../generated/graphql';
-import { mapListChangingRoutesResult, mapListOwnLinesResult } from '../graphql';
 import { Container, Row } from '../layoutComponents';
 import { Path, routes } from '../routes'; // eslint-disable-line import/no-cycle
 import { SimpleButton } from '../uiComponents';
-import { LineTableRow } from './LineTableRow'; // eslint-disable-line import/no-cycle
-import { RoutesTable } from './RoutesTable';
-import { RoutesTableRow } from './RoutesTableRow'; // eslint-disable-line import/no-cycle
+import { RoutesAndLinesLists } from './routes-and-lines/RoutesAndLinesLists'; // eslint-disable-line import/no-cycle
 
 export const RoutesAndLinesPage = (): JSX.Element => {
   const { t } = useTranslation();
   const { dispatch: modalMapDispatch } = useContext(ModalMapContext);
   const { dispatch: mapEditorDispatch } = useContext(MapEditorContext);
   const createLineReactRoute = routes[Path.createLine];
-  const changingRoutesResult = useListChangingRoutesQuery();
-  const changingRoutes = mapListChangingRoutesResult(changingRoutesResult);
-  const ownLinesResult = useListOwnLinesQuery();
-  const ownLines = mapListOwnLinesResult(ownLinesResult);
-
   const onOpenModalMap = () => {
     mapEditorDispatch({ type: 'reset' });
     modalMapDispatch({ type: 'open' });
@@ -46,24 +32,7 @@ export const RoutesAndLinesPage = (): JSX.Element => {
           {t('lines.createNew')}
         </SimpleButton>
       </Row>
-      <h2 className="mb-14 mt-12 text-4xl font-bold">
-        {t('routes.changingRoutes')}
-      </h2>
-      {changingRoutes && changingRoutes.length > 0 && (
-        <RoutesTable>
-          {changingRoutes.map((item: RouteRoute) => (
-            <RoutesTableRow key={item.route_id} route={item} />
-          ))}
-        </RoutesTable>
-      )}
-      <h2 className="mb-14 mt-12 text-4xl font-bold">{t('routes.ownLines')}</h2>
-      {ownLines && ownLines.length > 0 && (
-        <RoutesTable>
-          {ownLines.map((item: RouteLine) => (
-            <LineTableRow key={item.line_id} line={item} />
-          ))}
-        </RoutesTable>
-      )}
+      <RoutesAndLinesLists />
     </Container>
   );
 };

--- a/src/components/routes-and-lines/LinesList.tsx
+++ b/src/components/routes-and-lines/LinesList.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { RouteLine } from '../../generated/graphql';
+import { LineTableRow } from '../LineTableRow'; // eslint-disable-line import/no-cycle
+import { RoutesTable } from '../RoutesTable';
+
+type Props = {
+  lines?: RouteLine[];
+};
+
+export const LinesList = ({ lines }: Props): JSX.Element => (
+  <RoutesTable>
+    {lines?.map((item: RouteLine) => (
+      <LineTableRow key={item.line_id} line={item} />
+    ))}
+  </RoutesTable>
+);

--- a/src/components/routes-and-lines/RoutesAndLinesLists.tsx
+++ b/src/components/routes-and-lines/RoutesAndLinesLists.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useListChangingRoutesQuery,
+  useListOwnLinesQuery,
+} from '../../generated/graphql';
+import {
+  mapListChangingRoutesResult,
+  mapListOwnLinesResult,
+} from '../../graphql';
+import { LinesList } from './LinesList'; // eslint-disable-line import/no-cycle
+import { RoutesList } from './RoutesList'; // eslint-disable-line import/no-cycle
+
+export const RoutesAndLinesLists = (): JSX.Element => {
+  const { t } = useTranslation();
+  const changingRoutesResult = useListChangingRoutesQuery();
+  const changingRoutes = mapListChangingRoutesResult(changingRoutesResult);
+
+  const ownLinesResult = useListOwnLinesQuery();
+  const ownLines = mapListOwnLinesResult(ownLinesResult);
+
+  return (
+    <div>
+      <h2 className="text-bold mb-14 mt-12 text-4xl">
+        {t('routes.changingRoutes')}
+      </h2>
+      <RoutesList routes={changingRoutes} />
+      <h2 className="text-bold mb-14 mt-12 text-4xl">{t('routes.ownLines')}</h2>
+      <LinesList lines={ownLines} />
+    </div>
+  );
+};

--- a/src/components/routes-and-lines/RoutesList.tsx
+++ b/src/components/routes-and-lines/RoutesList.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { RouteRoute } from '../../generated/graphql';
+import { RoutesTable } from '../RoutesTable';
+import { RoutesTableRow } from '../RoutesTableRow'; // eslint-disable-line import/no-cycle
+
+type Props = {
+  routes?: RouteRoute[];
+};
+
+export const RoutesList = ({ routes }: Props): JSX.Element => (
+  <RoutesTable>
+    {routes?.map((item: RouteRoute) => (
+      <RoutesTableRow key={item.route_id} route={item} />
+    ))}
+  </RoutesTable>
+);

--- a/src/components/routes-and-lines/search/SearchResultPage.tsx
+++ b/src/components/routes-and-lines/search/SearchResultPage.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearch, useSearchResults } from '../../../hooks';
+import { Container, Row } from '../../../layoutComponents';
+import { CloseIconButton } from '../../../uiComponents';
+import { LinesList } from '../LinesList'; // eslint-disable-line import/no-cycle
+import { RoutesList } from '../RoutesList'; // eslint-disable-line import/no-cycle
+import { SearchContainer } from './conditions/SearchContainer';
+import { FiltersContainer } from './filters/FiltersContainer';
+
+export const SearchResultPage = (): JSX.Element => {
+  const { queryParameters, handleClose } = useSearch();
+  const { lines, routes, resultCount } = useSearchResults();
+  const { t } = useTranslation();
+
+  return (
+    <Container>
+      <Row>
+        <h1 className="text-2xl font-bold">
+          {`${t('search.searchResultsTitle')} | ${t('routes.routes')}`}
+        </h1>
+        <CloseIconButton
+          label={t('close')}
+          className="ml-auto text-base font-bold text-brand"
+          onClick={handleClose}
+        />
+      </Row>
+      <SearchContainer />
+      <FiltersContainer />
+      <h1 className="my-4 text-2xl font-bold">
+        {t('search.resultCount', {
+          resultCount,
+        })}
+      </h1>
+      {queryParameters.filter.displayRoutes ? (
+        <RoutesList routes={routes} />
+      ) : (
+        <LinesList lines={lines} />
+      )}
+    </Container>
+  );
+};

--- a/src/components/routes-and-lines/search/conditions/PriorityCondition.tsx
+++ b/src/components/routes-and-lines/search/conditions/PriorityCondition.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Column, Row } from '../../../../layoutComponents';
+import { Priority } from '../../../../types/Priority';
+import { SimpleButton } from '../../../../uiComponents';
+
+type Props = {
+  priorities: Priority[];
+  onClick: (attributeName: string, value: Priority[]) => void;
+};
+
+export const PriorityCondition = ({
+  priorities,
+  onClick,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+
+  const onClickPriority = (priority: Priority) => {
+    const newPriorities = priorities.includes(priority)
+      ? priorities.filter((p) => p !== priority)
+      : priorities.concat(priority);
+
+    onClick('priorities', newPriorities);
+  };
+
+  const priorityButtonData: { priority: Priority; label: string }[] = [
+    {
+      priority: Priority.Standard,
+      label: t('priority.standard'),
+    },
+    {
+      priority: Priority.Draft,
+      label: t('priority.draft'),
+    },
+    {
+      priority: Priority.Temporary,
+      label: t('priority.temporary'),
+    },
+  ];
+
+  return (
+    <Column>
+      <h4 className="font-bold">{t('priority.label')}</h4>
+      <Row className="space-x-2">
+        {priorityButtonData.map((item) => (
+          <SimpleButton
+            onClick={() => onClickPriority(item.priority)}
+            inverted={!priorities.includes(item.priority)}
+            key={item.priority}
+          >
+            {item.label}
+          </SimpleButton>
+        ))}
+      </Row>
+    </Column>
+  );
+};

--- a/src/components/routes-and-lines/search/conditions/SearchConditionsToggle.tsx
+++ b/src/components/routes-and-lines/search/conditions/SearchConditionsToggle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
+import { IconButton } from '../../../../uiComponents';
+
+type Props = {
+  isToggled: boolean;
+  onClick: () => void;
+};
+
+export const SearchConditionToggle = ({
+  isToggled,
+  onClick,
+}: Props): JSX.Element => {
+  const iconClassName = 'text-3xl text-tweaked-brand';
+  return (
+    <IconButton
+      onClick={onClick}
+      icon={
+        isToggled ? (
+          <FaChevronUp className={iconClassName} />
+        ) : (
+          <FaChevronDown className={iconClassName} />
+        )
+      }
+      testId="SearchConditionToggle::toggle"
+    />
+  );
+};

--- a/src/components/routes-and-lines/search/conditions/SearchContainer.tsx
+++ b/src/components/routes-and-lines/search/conditions/SearchContainer.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearch } from '../../../../hooks';
+import { useToggle } from '../../../../hooks/useToggle';
+import { Column, Container, Row, Visible } from '../../../../layoutComponents';
+import { SimpleButton } from '../../../../uiComponents';
+import { PriorityCondition } from './PriorityCondition';
+import { SearchConditionToggle } from './SearchConditionsToggle';
+import { SearchInput } from './SearchInput';
+
+export const SearchContainer = (): JSX.Element => {
+  const { searchConditions, setSearchCondition, handleSearch } = useSearch();
+  const { t } = useTranslation();
+
+  const [isExpanded, toggleIsExpanded] = useToggle();
+
+  return (
+    <Container className="py-10">
+      <Row className="justify-center bg-background py-4">
+        <Column className="w-2/4">
+          <Row>
+            <label htmlFor="label">{t('search.searchLabel')}</label>
+          </Row>
+          <Row className="space-x-4">
+            <SearchInput
+              value={searchConditions.label}
+              onSearch={handleSearch}
+              onChange={(value) => setSearchCondition('label', value)}
+            />
+            <SearchConditionToggle
+              isToggled={isExpanded}
+              onClick={toggleIsExpanded}
+            />
+          </Row>
+        </Column>
+      </Row>
+      <Visible visible={isExpanded}>
+        <div className="border-2 border-background p-10">
+          <h4 className="text-bold text-2xl">
+            {t('search.advancedSearchTitle')}
+          </h4>
+          <PriorityCondition
+            onClick={setSearchCondition}
+            priorities={searchConditions.priorities}
+          />
+        </div>
+        <Row className="flex justify-end bg-background py-4">
+          <SimpleButton className="mr-6" inverted onClick={toggleIsExpanded}>
+            {t('hide')}
+          </SimpleButton>
+          <SimpleButton className="mr-6" onClick={handleSearch}>
+            {t('search.search')}
+          </SimpleButton>
+        </Row>
+      </Visible>
+    </Container>
+  );
+};

--- a/src/components/routes-and-lines/search/conditions/SearchInput.tsx
+++ b/src/components/routes-and-lines/search/conditions/SearchInput.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+type Props = {
+  value?: string;
+  onChange: (value: string) => void;
+  onSearch: () => void;
+};
+
+export const SearchInput = ({
+  value,
+  onChange,
+  onSearch,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const onKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      onSearch();
+    }
+  };
+  return (
+    <input
+      className="flex-1"
+      type="text"
+      value={value}
+      placeholder={t('search.searchPlaceholder')}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyPress={onKeyPress}
+    />
+  );
+};

--- a/src/components/routes-and-lines/search/filters/FiltersContainer.tsx
+++ b/src/components/routes-and-lines/search/filters/FiltersContainer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Row } from '../../../../layoutComponents';
+import { ResultSelector } from './ResultSelector';
+
+export const FiltersContainer = (): JSX.Element => (
+  <Row className="my-4">
+    <ResultSelector />
+  </Row>
+);

--- a/src/components/routes-and-lines/search/filters/ResultSelector.tsx
+++ b/src/components/routes-and-lines/search/filters/ResultSelector.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearch } from '../../../../hooks';
+import { SimpleSmallButton } from '../../../../uiComponents';
+
+export const ResultSelector = (): JSX.Element => {
+  const { t } = useTranslation();
+  const { queryParameters, setFilter } = useSearch();
+  const { displayRoutes } = queryParameters.filter;
+
+  const toggleDisplayRoutes = () => setFilter('displayRoutes', !displayRoutes);
+
+  return (
+    <div>
+      <SimpleSmallButton
+        inverted={displayRoutes}
+        onClick={toggleDisplayRoutes}
+        label={t('lines.lines')}
+      />
+      <SimpleSmallButton
+        onClick={toggleDisplayRoutes}
+        inverted={!displayRoutes}
+        label={t('lines.routes')}
+      />
+    </div>
+  );
+};

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -5909,6 +5909,13 @@ export type ListAllLinesQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type ListAllLinesQuery = { __typename?: 'query_root', route_line: Array<{ __typename?: 'route_line', line_id: UUID, label: string, name_i18n: string, short_name_i18n?: string | null | undefined, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined }> };
 
+export type SearchAllLinesQueryVariables = Exact<{
+  filter?: Maybe<RouteLineBoolExp>;
+}>;
+
+
+export type SearchAllLinesQuery = { __typename?: 'query_root', route_line: Array<{ __typename?: 'route_line', line_id: UUID, label: string, name_i18n: string, short_name_i18n?: string | null | undefined, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, line_routes: Array<{ __typename?: 'route_route', route_id: UUID, description_i18n?: string | null | undefined, starts_from_scheduled_stop_point_id: UUID, ends_at_scheduled_stop_point_id: UUID, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: string }> }> };
+
 export type ListOwnLinesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -6421,6 +6428,45 @@ export function useListAllLinesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type ListAllLinesQueryHookResult = ReturnType<typeof useListAllLinesQuery>;
 export type ListAllLinesLazyQueryHookResult = ReturnType<typeof useListAllLinesLazyQuery>;
 export type ListAllLinesQueryResult = Apollo.QueryResult<ListAllLinesQuery, ListAllLinesQueryVariables>;
+export const SearchAllLinesDocument = gql`
+    query SearchAllLines($filter: route_line_bool_exp) {
+  route_line(where: $filter) {
+    ...line_default_fields
+    line_routes {
+      ...route_all_fields
+    }
+  }
+}
+    ${LineDefaultFieldsFragmentDoc}
+${RouteAllFieldsFragmentDoc}`;
+
+/**
+ * __useSearchAllLinesQuery__
+ *
+ * To run a query within a React component, call `useSearchAllLinesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSearchAllLinesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSearchAllLinesQuery({
+ *   variables: {
+ *      filter: // value for 'filter'
+ *   },
+ * });
+ */
+export function useSearchAllLinesQuery(baseOptions?: Apollo.QueryHookOptions<SearchAllLinesQuery, SearchAllLinesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SearchAllLinesQuery, SearchAllLinesQueryVariables>(SearchAllLinesDocument, options);
+      }
+export function useSearchAllLinesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SearchAllLinesQuery, SearchAllLinesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SearchAllLinesQuery, SearchAllLinesQueryVariables>(SearchAllLinesDocument, options);
+        }
+export type SearchAllLinesQueryHookResult = ReturnType<typeof useSearchAllLinesQuery>;
+export type SearchAllLinesLazyQueryHookResult = ReturnType<typeof useSearchAllLinesLazyQuery>;
+export type SearchAllLinesQueryResult = Apollo.QueryResult<SearchAllLinesQuery, SearchAllLinesQueryVariables>;
 export const ListOwnLinesDocument = gql`
     query ListOwnLines {
   route_line {

--- a/src/graphql/route.ts
+++ b/src/graphql/route.ts
@@ -11,6 +11,7 @@ import {
   useGetRoutesWithInfrastructureLinksQuery,
   useListChangingRoutesQuery,
   useListOwnLinesQuery,
+  useSearchAllLinesQuery,
 } from '../generated/graphql';
 import { GqlQueryResult } from './types';
 
@@ -109,6 +110,20 @@ const LIST_ALL_LINES = gql`
     }
   }
 `;
+
+const SEARCH_ALL_LINES = gql`
+  query SearchAllLines($filter: route_line_bool_exp) {
+    route_line(where: $filter) {
+      ...line_default_fields
+      line_routes {
+        ...route_all_fields
+      }
+    }
+  }
+`;
+export const mapSearchAllLinesResult = (
+  result: ReturnType<typeof useSearchAllLinesQuery>,
+) => result.data?.route_line as RouteLine[];
 
 // TODO this is just listing all lines for now
 const LIST_OWN_LINES = gql`

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,6 @@
+export * from './search/useSearch';
+export * from './search/useSearchQueryParser';
+export * from './search/useSearchResults';
 export * from './useAsyncQuery';
 export * from './useCheckValidityAndPriorityConflicts';
 export * from './useContextStateSelector';

--- a/src/hooks/search/useSearch.ts
+++ b/src/hooks/search/useSearch.ts
@@ -1,0 +1,73 @@
+import { produce } from 'immer';
+import { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { Priority } from '../../types/Priority';
+import { createQueryParamString } from '../../utils';
+import { FilterConditions, useSearchQueryParser } from './useSearchQueryParser';
+
+export const useSearch = () => {
+  const history = useHistory();
+  const queryParameters = useSearchQueryParser();
+
+  const [searchConditions, setSearchConditions] = useState(
+    queryParameters.search,
+  );
+
+  const setSearchCondition = (
+    condition: string,
+    value: string | Priority[],
+  ) => {
+    setSearchConditions({
+      ...searchConditions,
+      [condition]: value,
+    });
+  };
+
+  /**
+   * Filters modify result table instantly by immediately
+   * pushing the change to query string
+   */
+  const setFilter = (filterName: keyof FilterConditions, value: boolean) => {
+    const combinedParameters = produce(queryParameters, (draft) => {
+      draft.filter[filterName] = value;
+    });
+
+    history.push({
+      pathname: '/routes/search',
+      search: `${createQueryParamString(combinedParameters)}`,
+      state: { update: true },
+    });
+  };
+
+  /**
+   * Pushes selected search conditions and live filters to query string
+   */
+  const handleSearch = () => {
+    const combinedParameters = {
+      search: { ...searchConditions },
+      filter: { ...queryParameters.filter },
+    };
+    history.push({
+      pathname: '/routes/search',
+      search: `${createQueryParamString(combinedParameters)}`,
+      state: { update: true },
+    });
+  };
+
+  const handleClose = () => {
+    history.push({
+      pathname: '/routes',
+      search: `${createQueryParamString(queryParameters)}`,
+      state: { update: true },
+    });
+  };
+
+  return {
+    queryParameters,
+    searchConditions,
+    setSearchCondition,
+    setFilter,
+    handleSearch,
+    handleClose,
+  };
+};

--- a/src/hooks/search/useSearchQueryParser.ts
+++ b/src/hooks/search/useSearchQueryParser.ts
@@ -1,0 +1,88 @@
+import { Priority } from '../../types/Priority';
+import { useUrlQuery } from '../useUrlQuery';
+
+export type SearchConditions = {
+  priorities: Priority[];
+  label: string;
+};
+
+export type FilterConditions = {
+  displayRoutes: boolean;
+};
+
+/**
+ * Search parameter object with search conditions and filter
+ * conditions separately
+ */
+export type SearchParameters = {
+  search: SearchConditions;
+  filter: FilterConditions;
+};
+
+/**
+ * Query string object where parameters are in string format
+ */
+export type QueryStringParameters = {
+  priorities: string;
+  label: string;
+  displayRoutes: string;
+};
+
+/**
+ * Query string object where parameters are deserialized and validated
+ * in their correct format
+ */
+export type DeserializedQueryStringParameters = {
+  priorities: Priority[];
+  label: string;
+  displayRoutes: boolean;
+};
+
+/**
+ * Parses the values in to integer and only accept values that are
+ * exsiting type of {Priority}
+ * @param priorities Priorities array in string format (csv).
+ */
+const parseAndValidatePriorities = (priorities: string) =>
+  priorities
+    .split(',')
+    .map((p) => parseInt(p, 10))
+    .filter((p) => Object.values(Priority).includes(p));
+
+/**
+ * Returns parsed and validated priorities if priority query string
+ * is existing. If the query string is not given, return default
+ * priorities
+ * @param priorities Priorities array in string format (csv).
+ */
+const getPriorities = (priorities: string) => {
+  const defaultPriorities = [Priority.Standard, Priority.Temporary];
+
+  return priorities === undefined
+    ? defaultPriorities
+    : parseAndValidatePriorities(priorities);
+};
+
+/**
+ * Deserializes and validates the query parameters in to correct types
+ * @param queryParams Object with parameters in string format
+ */
+const deserializeParameters = (
+  queryParams: QueryStringParameters,
+): SearchParameters => {
+  return {
+    search: {
+      label: queryParams.label || '',
+      priorities: getPriorities(queryParams.priorities),
+    },
+    filter: {
+      displayRoutes: queryParams.displayRoutes === 'true',
+    },
+  };
+};
+
+export const useSearchQueryParser = () => {
+  const queryStringObject = useUrlQuery();
+
+  return deserializeParameters(queryStringObject as QueryStringParameters);
+};

--- a/src/hooks/search/useSearchResults.ts
+++ b/src/hooks/search/useSearchResults.ts
@@ -1,0 +1,39 @@
+import {
+  RouteLine,
+  RouteRoute,
+  useSearchAllLinesQuery,
+} from '../../generated/graphql';
+import { mapSearchAllLinesResult } from '../../graphql';
+import { constructGqlFilterObject, mapToVariables } from '../../utils';
+import { useSearchQueryParser } from './useSearchQueryParser';
+
+export const useSearchResults = (): {
+  lines: RouteLine[];
+  routes: RouteRoute[];
+  resultCount: number;
+} => {
+  const parsedQueryParameters = useSearchQueryParser();
+
+  const searchConditions = constructGqlFilterObject(
+    parsedQueryParameters.search,
+  );
+
+  const linesResult = useSearchAllLinesQuery(mapToVariables(searchConditions));
+
+  const lines = mapSearchAllLinesResult(linesResult);
+
+  const routes = lines
+    ?.map((line) => line.line_routes)
+    ?.reduce((next, curr) => [...curr, ...next], []);
+
+  const resultCount =
+    (parsedQueryParameters.filter.displayRoutes
+      ? routes?.length
+      : lines?.length) || 0;
+
+  return {
+    lines,
+    routes,
+    resultCount,
+  };
+};

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+
+export const useToggle = (initialState = false): [boolean, () => void] => {
+  const [state, setState] = useState<boolean>(initialState);
+
+  const toggle = () => setState((value) => !value);
+  return [state, toggle];
+};

--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -36,6 +36,7 @@
     "areaOfOperation": "Area of operation",
     "additionalInformation": "Additional information",
     "routes": "Routes",
+    "lines": "Lines",
     "createNewRoute": "Create new route",
     "createNewRouteInstructions": "Route drawing opens in a new window."
   },
@@ -124,9 +125,18 @@
     "observationDate": "Observation date",
     "observationDateAdjusted": "Observation date adjusted"
   },
+  "search": {
+    "advancedSearchTitle": "Advanced search",
+    "searchResultsTitle": "Search results",
+    "resultCount": "{{ resultCount }} results",
+    "searchPlaceholder": "Enter label",
+    "searchLabel": "Search",
+    "search": "Search"
+  },
   "save": "Save",
   "edit": "Edit",
   "cancel": "Cancel",
   "close": "Close",
-  "version": "Version: {{ version }}"
+  "version": "Version: {{ version }}",
+  "hide": "Hide"
 }

--- a/src/locales/fi-FI/common.json
+++ b/src/locales/fi-FI/common.json
@@ -36,6 +36,7 @@
     "areaOfOperation": "Joukkoliikennekohde",
     "additionalInformation": "Oheistiedot",
     "routes": "Reitit",
+    "lines": "Linjat",
     "createNewRoute": "Luo reitti",
     "createNewRouteInstructions": "Täysin uuden reitin luominen avautuu karttanäkymään."
   },
@@ -124,9 +125,18 @@
     "observationDate": "Tarkasteluhetki",
     "observationDateAdjusted": "Tarkasteluhetkeä muutettu"
   },
+  "search": {
+    "advancedSearchTitle": "Tarkenna",
+    "searchResultsTitle": "Hakutulokset",
+    "resultCount": "{{ resultCount }} hakutulosta",
+    "searchPlaceholder": "Anna tunnus",
+    "searchLabel": "Haku",
+    "search": "Hae"
+  },
   "save": "Tallenna",
   "edit": "Muokkaa",
   "cancel": "Peruuta",
   "close": "Sulje",
-  "version": "Versio: {{ version }}"
+  "version": "Versio: {{ version }}",
+  "hide": "Piilota"
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,11 +6,13 @@ import { Map } from './components/map';
 import { EditLinePage } from './components/routes-and-lines/EditLinePage'; // eslint-disable-line import/no-cycle
 import { EditRoutePage } from './components/routes-and-lines/EditRoutePage'; // eslint-disable-line import/no-cycle
 import { LineDetailsPage } from './components/routes-and-lines/LineDetailsPage'; // eslint-disable-line import/no-cycle
+import { SearchResultPage } from './components/routes-and-lines/search/SearchResultPage'; // eslint-disable-line import/no-cycle
 import { RoutesAndLinesPage } from './components/RoutesAndLinesPage'; // eslint-disable-line import/no-cycle
 
 export enum Path {
   root = '/',
   routes = '/routes',
+  routesSearch = '/routes/search',
   editRoute = '/routes/:id/edit',
   createLine = '/lines/create',
   lineDetails = '/lines/:id',
@@ -58,6 +60,14 @@ export const routes: Record<Path, Route> = {
     getLink: () => Path.routes,
     component: RoutesAndLinesPage,
     includeInNav: true,
+  },
+  [Path.routesSearch]: {
+    _routerRoute: Path.routesSearch,
+    _exact: true,
+    translationKey: 'routes.routesSearchResult',
+    getLink: () => Path.routesSearch,
+    component: SearchResultPage,
+    includeInNav: false,
   },
   [Path.editRoute]: {
     _routerRoute: Path.editRoute,

--- a/src/uiComponents/CloseIconButton.tsx
+++ b/src/uiComponents/CloseIconButton.tsx
@@ -3,11 +3,17 @@ import React from 'react';
 interface Props {
   onClick: () => void;
   className?: string;
+  label?: string;
 }
 
-export const CloseIconButton = ({ onClick, className }: Props): JSX.Element => {
+export const CloseIconButton = ({
+  onClick,
+  className,
+  label,
+}: Props): JSX.Element => {
   return (
     <button className={className || ''} type="button" onClick={onClick}>
+      {label}
       <i className="icon-close-large ml-4 text-lg" />
     </button>
   );

--- a/src/uiComponents/SimpleSmallButton.tsx
+++ b/src/uiComponents/SimpleSmallButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+type Props = {
+  label: string;
+  inverted?: boolean;
+  onClick: () => void;
+};
+
+const commonClassNames =
+  'mr-2 font-bold border w-20 rounded text-sm font-light';
+
+export const SimpleSmallButton = ({
+  label,
+  inverted,
+  onClick,
+}: Props): JSX.Element => (
+  <button
+    onClick={onClick}
+    type="button"
+    className={`${commonClassNames} ${
+      inverted
+        ? 'border-grey bg-white text-gray-900 hover:border-brand active:border-brand'
+        : 'border-brand bg-brand text-white hover:bg-opacity-50 active:bg-opacity-50'
+    }`}
+  >
+    {label}
+  </button>
+);

--- a/src/uiComponents/index.ts
+++ b/src/uiComponents/index.ts
@@ -10,6 +10,7 @@ export * from './Listbox';
 export * from './Modal';
 export * from './SimpleButton';
 export * from './SimpleDropdownMenu';
+export * from './SimpleSmallButton';
 export * from './Spinner';
 export * from './Switch';
 export * from './Toast';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,5 +3,6 @@ export * from './errors';
 export * from './forms';
 export * from './gis';
 export * from './graphql';
+export * from './search';
 export * from './toastService';
 export * from './url';

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,99 @@
+import { produce } from 'immer';
+import {
+  DeserializedQueryStringParameters,
+  SearchConditions,
+  SearchParameters,
+} from '../hooks/search/useSearchQueryParser';
+import { Priority } from '../types/Priority';
+
+type SearchParametersGqlConfigurations = {
+  priority: {
+    value: Priority[];
+    replaceStar: boolean;
+    operator: string;
+  };
+  label: {
+    value: string;
+    replaceStar: boolean;
+    operator: string;
+  };
+};
+
+const defaultSearchParametersGqlConfig: SearchParametersGqlConfigurations = {
+  priority: {
+    value: [Priority.Standard, Priority.Temporary],
+    replaceStar: false,
+    operator: '_in',
+  },
+  label: {
+    value: '',
+    replaceStar: true,
+    operator: '_like',
+  },
+};
+
+const setConfigurations = (queryParams: SearchConditions) => {
+  const params: SearchParametersGqlConfigurations = produce(
+    defaultSearchParametersGqlConfig,
+    (draft) => {
+      draft.priority.value = queryParams.priorities;
+      draft.label.value = queryParams.label;
+    },
+  );
+
+  return params;
+};
+
+const replaceStarCharacter = (str: string) => {
+  return str ? str.replaceAll('*', '%') : '%';
+};
+
+const transformToFilterAttribute = (
+  key: string,
+  values: {
+    value: string | number[];
+    operator: string;
+    replaceStar: boolean;
+  },
+) => {
+  return {
+    [key]: {
+      [values.operator]: values.replaceStar
+        ? replaceStarCharacter(values.value as string)
+        : values.value,
+    },
+  };
+};
+
+export const constructGqlFilterObject = (params: SearchConditions) => {
+  const configuredParams = setConfigurations(params);
+
+  const result = Object.entries(configuredParams).map((entry) => {
+    const [key, value] = entry;
+    return transformToFilterAttribute(key, value);
+  });
+
+  return {
+    filter: {
+      ...result.reduce((next, curr) => ({ ...curr, ...next })),
+    },
+  };
+};
+
+export const createQueryParamString = (paramObject: SearchParameters) => {
+  const combinedObject: DeserializedQueryStringParameters = {
+    ...paramObject.filter,
+    ...paramObject.search,
+  };
+
+  let paramString = '?';
+  Object.keys(combinedObject).forEach((key) => {
+    if (paramString.length > 1) {
+      paramString += '&';
+    }
+    paramString += `${key}=${
+      combinedObject[key as keyof DeserializedQueryStringParameters]
+    }`;
+  });
+  return paramString;
+};


### PR DESCRIPTION
Adds the search functionality with the results page.

New hooks:
- useToggle
- useSearchQueryParser: parses deserializes and validates the query string in to search parameter object
- useSearch: stores the search conditions and handles the tranformation calls from search conditions and filters object in to query parameter string.
- useSearchResults: handles the GraphQL call and filtering for result lines / routes / resultCount

Utils:
- search.ts: has implementation for the query parameter string creator and the GqlFilterObject constructor

Components:
Folderstructure here is:
- routes-and-lines
  - search
    - conditions: Components that are related to search conditions (applies to GQL)
    - filters: Components that are related to live filtering, currently only one live filter (ResultsSelector).
    - results: Components that are related to displaying results

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/122)
<!-- Reviewable:end -->
