### PR TITLE
Remove redundant comments

### DIFF
--- a/src/components/map/ModalMap.tsx
+++ b/src/components/map/ModalMap.tsx
@@ -79,8 +79,6 @@ export const ModalMap: React.FC<Props> = ({ className }) => {
     const stopIdsWithinRoute = mapRouteStopsToStopIds(routeStops);
 
     if (infraLinks && stopIdsWithinRoute && stopIdsWithinRoute.length >= 2) {
-      // TODO: user should be able to select starting stop and final stop from some kind of UI.
-      // TODO: for now, just use the first and last stops found.
       const startingStopId = stopIdsWithinRoute[0];
       const finalStopId = stopIdsWithinRoute[stopIdsWithinRoute.length - 1];
 


### PR DESCRIPTION
- It was decided that route's starting and ending stop should be journey pattern's first and last stop. It had already been implemented this way, so remove comments about this being a temporary solution.

Resolves HSLdevcom/jore4#677

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/128)
<!-- Reviewable:end -->
