### PR TITLE
Fix conflict resolver modal stylings

### DIFF
--- a/src/components/ConflictResolverModal.tsx
+++ b/src/components/ConflictResolverModal.tsx
@@ -84,7 +84,7 @@ export const ConflictResolverModal: React.FC<Props> = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      className={`fixed inset-16 z-10 overflow-y-auto p-10 drop-shadow-md ${
+      className={`fixed top-1/2 left-1/2 z-10 -translate-y-1/2 -translate-x-1/2 overflow-y-auto p-10 drop-shadow-md ${
         className || ''
       }`}
     >


### PR DESCRIPTION
Modal used to stretch to fill almost whole screen which looked
silly on large screens.

Now modal stretches only if its content causes it to stretch.

Related to HSLdevcom/jore4#636

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/130)
<!-- Reviewable:end -->
