### PR TITLE
Add `redux-toolkit` for state management

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,8 @@ module.exports = {
     'no-param-reassign': [
       'error',
       // ignore 'draft' as its convention to use that name with immer: https://immerjs.github.io/immer/
-      { props: true, ignorePropertyModificationsFor: ['draft'] },
+      // ignore 'state' as `redux-toolkit` handles state modifications with `immer`
+      { props: true, ignorePropertyModificationsFor: ['draft', 'state'] },
     ],
     'no-shadow': 'off', // this might report false positives with TS: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md#how-to-use
     'no-unused-expressions': ['error', { allowTernary: true }], // allow expressions like `booleanValue ? doSomething() : doSomethingElse()`

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "@headlessui/react": "^1.0.0",
     "@hookform/resolvers": "^2.8.3",
     "@nebula.gl/edit-modes": "0.23.8",
+    "@reduxjs/toolkit": "^1.8.0",
     "@seznam/compose-react-refs": "^1.0.6",
     "@turf/area": "^6.5.0",
     "@types/react-router": "^5.1.17",
+    "@types/redux-logger": "^3.0.9",
     "apollo-link-scalars": "^4.0.1",
     "axios": "0.21.1",
     "graphql": "^15.5.3",
@@ -46,8 +48,10 @@
     "react-icons": "^4.3.1",
     "react-map-gl": "^6.1.16",
     "react-map-gl-draw": "0.21.1",
+    "react-redux": "^7.2.6",
     "react-router-dom": "^5.2.0",
     "react-spinners": "^0.11.0",
+    "redux-logger": "^3.0.6",
     "zod": "^3.11.6"
   },
   "devDependencies": {

--- a/src/components/map/stops/Stops.tsx
+++ b/src/components/map/stops/Stops.tsx
@@ -16,12 +16,15 @@ import {
 } from '../../../graphql';
 import {
   DeleteChanges,
+  useAppDispatch,
+  useAppSelector,
   useDeleteStop,
   useEditStop,
   useExtractRouteFromFeature,
   useGetDisplayedRoutes,
 } from '../../../hooks';
 import { useFilterStops } from '../../../hooks/useFilterStops';
+import { selectSelectedStopId, setSelectedStopIdAction } from '../../../redux';
 import { RequiredKeys } from '../../../types';
 import { ConfirmationDialog } from '../../../uiComponents';
 import {
@@ -51,11 +54,13 @@ export const Stops = React.forwardRef((props, ref) => {
   const [showEditForm, setShowEditForm] = useState(false);
 
   const { t } = useTranslation();
+  const dispatch = useAppDispatch();
   const { filter } = useFilterStops();
 
+  const selectedStopId = useAppSelector(selectSelectedStopId);
+
   const {
-    dispatch: mapEditorDispatch,
-    state: { selectedStopId, editedRouteData, creatingNewRoute },
+    state: { editedRouteData, creatingNewRoute },
   } = useContext(MapEditorContext);
   const { displayedRouteIds } = useGetDisplayedRoutes();
 
@@ -91,14 +96,8 @@ export const Stops = React.forwardRef((props, ref) => {
       ? mapRouteStopsToStopIds(editedRouteData.stops)
       : routes?.flatMap((route) => getRouteStopIds(route));
 
-  const setSelectedStopId = (id?: UUID) => {
-    mapEditorDispatch({
-      type: 'setState',
-      payload: {
-        selectedStopId: id,
-      },
-    });
-  };
+  const setSelectedStopId = (id?: UUID) =>
+    dispatch(setSelectedStopIdAction(id));
 
   const onOpenPopup = (point: DraftStop) => {
     setPopupInfo(point);

--- a/src/context/MapEditor/reducer.ts
+++ b/src/context/MapEditor/reducer.ts
@@ -17,7 +17,6 @@ export interface IMapEditorContext {
   initiallyDisplayedRouteIds?: UUID[];
   displayedRouteIds?: UUID[];
   creatingNewRoute: boolean;
-  selectedStopId?: UUID;
   canAddStops: boolean;
   drawingMode: Mode | undefined;
   editedRouteData: {
@@ -33,7 +32,6 @@ export const initialState: IMapEditorContext = {
   initiallyDisplayedRouteIds: undefined,
   displayedRouteIds: undefined,
   creatingNewRoute: false,
-  selectedStopId: undefined,
   canAddStops: false,
   drawingMode: undefined,
   editedRouteData: {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './redux';
 export * from './search/useSearch';
 export * from './search/useSearchQueryParser';
 export * from './search/useSearchResults';

--- a/src/hooks/redux.ts
+++ b/src/hooks/redux.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from '../redux';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,14 @@
 import { ApolloProvider } from '@apollo/client';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { AppProps } from 'next/app';
+import { Provider as ReduxProvider } from 'react-redux';
 import { Router } from '../components/Router';
 import { Toaster } from '../components/Toaster';
 import { ContextProviders } from '../context/ContextProviders';
 import '../generated/fontello/css/hsl-icons.css';
 import { createGraphqlClient } from '../graphql';
 import '../i18n';
+import { store } from '../redux';
 import '../styles/globals.css';
 
 function SafeHydrate({ children }: { children: JSX.Element }) {
@@ -22,12 +24,14 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <SafeHydrate>
       <ApolloProvider client={graphqlClient}>
-        <ContextProviders>
-          <Router />
-          <Toaster />
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <Component {...pageProps} />
-        </ContextProviders>
+        <ReduxProvider store={store}>
+          <ContextProviders>
+            <Router />
+            <Toaster />
+            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+            <Component {...pageProps} />
+          </ContextProviders>
+        </ReduxProvider>
       </ApolloProvider>
     </SafeHydrate>
   );

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -1,0 +1,3 @@
+export * from './selectors';
+export * from './slices/map';
+export * from './store';

--- a/src/redux/middleware/logger.ts
+++ b/src/redux/middleware/logger.ts
@@ -1,0 +1,10 @@
+import { createLogger } from 'redux-logger';
+
+export const logger = createLogger({
+  level: {
+    prevState: false, // don't log previous state as it can se seen from previous log entry
+    nextState: 'log',
+    action: 'log',
+    error: 'error',
+  },
+});

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,0 +1,3 @@
+import { mapReducer } from './slices/map';
+
+export const rootReducer = { map: mapReducer };

--- a/src/redux/selectors/index.ts
+++ b/src/redux/selectors/index.ts
@@ -1,0 +1,8 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { RootState } from '../store';
+
+export const selectMap = (state: RootState) => state.map;
+export const selectSelectedStopId = createSelector(
+  selectMap,
+  (map) => map.selectedStopId,
+);

--- a/src/redux/slices/map.ts
+++ b/src/redux/slices/map.ts
@@ -1,0 +1,23 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface IState {
+  selectedStopId?: UUID;
+}
+
+const initialState: IState = {
+  selectedStopId: undefined,
+};
+
+const slice = createSlice({
+  name: 'map',
+  initialState,
+  reducers: {
+    setSelectedStopId: (state, action: PayloadAction<UUID | undefined>) => {
+      state.selectedStopId = action.payload;
+    },
+  },
+});
+
+export const { setSelectedStopId: setSelectedStopIdAction } = slice.actions;
+
+export const mapReducer = slice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { logger } from './middleware/logger';
+import { rootReducer } from './rootReducer';
+
+export const store = configureStore({
+  reducer: rootReducer,
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+
+export type AppDispatch = typeof store.dispatch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,6 +842,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
+  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1939,6 +1946,16 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@reduxjs/toolkit@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.0.tgz#8ae875e481ed97e4a691aafa034f876bfd0413c4"
+  integrity sha512-cdfHWfcvLyhBUDicoFwG1u32JqvwKDxLxDd7zSmSoFw/RhYLOygIRtmaMjPRUUHmVmmAGAvquLLsKKU/677kSQ==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -2392,6 +2409,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
   integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/http-proxy@^1.17.5":
   version "1.17.7"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.7.tgz#30ea85cc2c868368352a37f0d0d3581e24834c6f"
@@ -2522,6 +2547,16 @@
     "@types/react" "*"
     "@types/viewport-mercator-project" "*"
 
+"@types/react-redux@^7.1.20":
+  version "7.1.23"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.23.tgz#3c2bb1bcc698ae69d70735f33c5a8e95f41ac528"
+  integrity sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
 "@types/react-router-dom@^5.1.7":
   version "5.1.7"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.7.tgz#a126d9ea76079ffbbdb0d9225073eb5797ab7271"
@@ -2564,6 +2599,13 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/redux-logger@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@types/redux-logger/-/redux-logger-3.0.9.tgz#9193b3d51bb6ab98d25514ba7764e4f98a64d3ec"
+  integrity sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==
+  dependencies:
+    redux "^4.0.0"
 
 "@types/scheduler@*":
   version "0.16.1"
@@ -4283,6 +4325,11 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+  integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -5810,7 +5857,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5971,6 +6018,11 @@ immer@^9.0.5:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.5.tgz#a7154f34fe7064f15f00554cc94c66cc0bf453ec"
   integrity sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ==
+
+immer@^9.0.7:
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
+  integrity sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==
 
 immutable@~3.7.6:
   version "3.7.6"
@@ -8914,7 +8966,7 @@ react-icons@^4.3.1:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
   integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
 
-react-is@17.0.2, react-is@^17.0.1:
+react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -8950,6 +9002,18 @@ react-map-gl@^6.1.16:
     prop-types "^15.7.2"
     resize-observer-polyfill "^1.5.1"
     viewport-mercator-project "^7.0.3"
+
+react-redux@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -9079,6 +9143,25 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
+  dependencies:
+    deep-diff "^0.3.5"
+
+redux-thunk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
+redux@^4.0.0, redux@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 regenerator-runtime@^0.13.4:
   version "0.13.7"
@@ -9243,6 +9326,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Minimal implementation in order to be able to continue work
based on this. Refactoring current state management from
React Context Api to redux can be done in later commits.

Related to HSLdevcom/jore4#707

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/132)
<!-- Reviewable:end -->
