### PR TITLE
Add line details observation by date

### DIFF
--- a/src/components/routes-and-lines/line-details/ActionsRow.tsx
+++ b/src/components/routes-and-lines/line-details/ActionsRow.tsx
@@ -1,0 +1,61 @@
+import produce from 'immer';
+import { DateTime } from 'luxon';
+import qs from 'qs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router';
+import { useUrlQuery } from '../../../hooks';
+import { useGetLineDetails } from '../../../hooks/line-details/useGetLineDetails';
+import { Column, Container, Row } from '../../../layoutComponents';
+import { SimpleButton } from '../../../uiComponents';
+
+export const ActionsRow = ({ className = '' }: { className?: string }) => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const queryParams = useUrlQuery();
+
+  const { observationDate } = useGetLineDetails();
+
+  const onDateChange = (date: DateTime) => {
+    const updatedUrlQuery = produce(queryParams, (draft) => {
+      if (date.isValid) {
+        draft.selectedDate = date.toISODate();
+        delete draft.showAll;
+      } else {
+        draft.showAll = true.toString();
+        delete draft.selectedDate;
+      }
+    });
+
+    const queryString = qs.stringify(updatedUrlQuery);
+    history.push({
+      search: `?${queryString}`,
+    });
+  };
+
+  return (
+    <Container className={className}>
+      <Row>
+        <h2 className="text-sm font-bold">{t('filters.observationDate')}</h2>
+      </Row>
+      <Row>
+        <Column className="w-1/4">
+          <input
+            type="date"
+            value={observationDate?.toISODate() || ''}
+            onChange={(e) => onDateChange(DateTime.fromISO(e.target.value))}
+            className="flex-1"
+          />
+        </Column>
+        <SimpleButton
+          className="ml-auto"
+          inverted
+          disabled
+          onClick={() => console.log('TODO')} // eslint-disable-line no-console
+        >
+          {t('lines.showDrafts')}
+        </SimpleButton>
+      </Row>
+    </Container>
+  );
+};

--- a/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
+++ b/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { AiFillPlusCircle } from 'react-icons/ai';
 import { useParams } from 'react-router-dom';
+import { RouteLine } from '../../../generated/graphql';
 import {
-  RouteLine,
-  useGetLineDetailsWithRoutesByIdQuery,
-} from '../../../generated/graphql';
-import { mapLineDetailsWithRoutesResult } from '../../../graphql';
-import { useAppDispatch, useMapUrlQuery } from '../../../hooks';
+  useAppDispatch,
+  useGetLineDetails,
+  useMapUrlQuery,
+} from '../../../hooks';
 import { Column, Container, Row } from '../../../layoutComponents';
 import {
   resetMapEditorStateAction,
@@ -16,8 +16,8 @@ import {
 } from '../../../redux';
 import { DateLike, mapToShortDate } from '../../../time';
 import { SimpleButton } from '../../../uiComponents';
-import { mapToVariables } from '../../../utils';
 import { PageHeader } from '../common/PageHeader';
+import { ActionsRow } from './ActionsRow';
 import { AdditionalInformation } from './AdditionalInformation';
 import { MapPreview } from './MapPreview';
 import { RouteStopsTable } from './RouteStopsTable';
@@ -91,13 +91,11 @@ const LineTitle: React.FC<LineTitleProps> = ({
 export const LineDetailsPage = (): JSX.Element => {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
+
   const dispatch = useAppDispatch();
   const { addMapOpenQueryParameter } = useMapUrlQuery();
 
-  const lineDetailsResult = useGetLineDetailsWithRoutesByIdQuery(
-    mapToVariables({ line_id: id }),
-  );
-  const line = mapLineDetailsWithRoutesResult(lineDetailsResult);
+  const { line } = useGetLineDetails();
 
   const buildValidityPeriod = (
     validityStart?: DateLike | null,
@@ -131,8 +129,9 @@ export const LineDetailsPage = (): JSX.Element => {
           </Column>
         </Row>
       </PageHeader>
+      <ActionsRow className="!pt-4 !pb-0" />
       {line && (
-        <Container>
+        <Container className="pt-10">
           <Column>
             <Row>
               <AdditionalInformation className="w-2/3" line={line} />

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -6701,6 +6701,15 @@ export type GetLineDetailsWithRoutesByIdQueryVariables = Exact<{
 
 export type GetLineDetailsWithRoutesByIdQuery = { __typename?: 'query_root', route_line_by_pk?: { __typename?: 'route_line', line_id: UUID, name_i18n: string, short_name_i18n?: string | null | undefined, primary_vehicle_mode: ReusableComponentsVehicleModeEnum, type_of_line: RouteTypeOfLineEnum, transport_target: HslRouteTransportTargetEnum, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, line_routes: Array<{ __typename?: 'route_route', route_id: UUID, description_i18n?: string | null | undefined, starts_from_scheduled_stop_point_id: UUID, ends_at_scheduled_stop_point_id: UUID, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: string, infrastructure_links_along_route: Array<{ __typename?: 'route_infrastructure_link_along_route', infrastructure_link: { __typename?: 'infrastructure_network_infrastructure_link', scheduled_stop_point_located_on_infrastructure_link: Array<{ __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, scheduled_stop_point_in_journey_patterns: Array<{ __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern', journey_pattern_id: UUID, scheduled_stop_point_id: UUID, scheduled_stop_point_sequence: number, is_timing_point: boolean, is_via_point: boolean, journey_pattern: { __typename?: 'journey_pattern_journey_pattern', on_route_id: UUID } }> }> } }>, starts_from_scheduled_stop_point?: { __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined } | null | undefined, ends_at_scheduled_stop_point?: { __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined } | null | undefined }> } | null | undefined };
 
+export type GetHighestPriorityLineDetailsWithRoutesQueryVariables = Exact<{
+  lineFilters?: Maybe<RouteLineBoolExp>;
+  lineRouteFilters?: Maybe<RouteRouteBoolExp>;
+  routeStopFilters?: Maybe<ServicePatternScheduledStopPointBoolExp>;
+}>;
+
+
+export type GetHighestPriorityLineDetailsWithRoutesQuery = { __typename?: 'query_root', route_line: Array<{ __typename?: 'route_line', line_id: UUID, name_i18n: string, short_name_i18n?: string | null | undefined, primary_vehicle_mode: ReusableComponentsVehicleModeEnum, type_of_line: RouteTypeOfLineEnum, transport_target: HslRouteTransportTargetEnum, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, line_routes: Array<{ __typename?: 'route_route', route_id: UUID, description_i18n?: string | null | undefined, starts_from_scheduled_stop_point_id: UUID, ends_at_scheduled_stop_point_id: UUID, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: string, infrastructure_links_along_route: Array<{ __typename?: 'route_infrastructure_link_along_route', infrastructure_link: { __typename?: 'infrastructure_network_infrastructure_link', scheduled_stop_point_located_on_infrastructure_link: Array<{ __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, scheduled_stop_point_in_journey_patterns: Array<{ __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern', journey_pattern_id: UUID, scheduled_stop_point_id: UUID, scheduled_stop_point_sequence: number, is_timing_point: boolean, is_via_point: boolean, journey_pattern: { __typename?: 'journey_pattern_journey_pattern', on_route_id: UUID } }> }> } }>, starts_from_scheduled_stop_point?: { __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined } | null | undefined, ends_at_scheduled_stop_point?: { __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined } | null | undefined }> }> };
+
 export type GetRouteDetailsByIdsQueryVariables = Exact<{
   route_ids?: Maybe<Array<Scalars['uuid']> | Scalars['uuid']>;
 }>;
@@ -7456,6 +7465,62 @@ export function useGetLineDetailsWithRoutesByIdLazyQuery(baseOptions?: Apollo.La
 export type GetLineDetailsWithRoutesByIdQueryHookResult = ReturnType<typeof useGetLineDetailsWithRoutesByIdQuery>;
 export type GetLineDetailsWithRoutesByIdLazyQueryHookResult = ReturnType<typeof useGetLineDetailsWithRoutesByIdLazyQuery>;
 export type GetLineDetailsWithRoutesByIdQueryResult = Apollo.QueryResult<GetLineDetailsWithRoutesByIdQuery, GetLineDetailsWithRoutesByIdQueryVariables>;
+export const GetHighestPriorityLineDetailsWithRoutesDocument = gql`
+    query GetHighestPriorityLineDetailsWithRoutes($lineFilters: route_line_bool_exp, $lineRouteFilters: route_route_bool_exp, $routeStopFilters: service_pattern_scheduled_stop_point_bool_exp) {
+  route_line(where: $lineFilters, order_by: {priority: desc}, limit: 1) {
+    ...line_all_fields
+    line_routes(where: $lineRouteFilters) {
+      ...route_with_stops
+      infrastructure_links_along_route {
+        infrastructure_link {
+          scheduled_stop_point_located_on_infrastructure_link(where: $routeStopFilters) {
+            ...scheduled_stop_point_default_fields
+            scheduled_stop_point_in_journey_patterns {
+              ...scheduled_stop_point_in_journey_pattern_default_fields
+              journey_pattern {
+                on_route_id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    ${LineAllFieldsFragmentDoc}
+${RouteWithStopsFragmentDoc}
+${ScheduledStopPointDefaultFieldsFragmentDoc}
+${ScheduledStopPointInJourneyPatternDefaultFieldsFragmentDoc}`;
+
+/**
+ * __useGetHighestPriorityLineDetailsWithRoutesQuery__
+ *
+ * To run a query within a React component, call `useGetHighestPriorityLineDetailsWithRoutesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetHighestPriorityLineDetailsWithRoutesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetHighestPriorityLineDetailsWithRoutesQuery({
+ *   variables: {
+ *      lineFilters: // value for 'lineFilters'
+ *      lineRouteFilters: // value for 'lineRouteFilters'
+ *      routeStopFilters: // value for 'routeStopFilters'
+ *   },
+ * });
+ */
+export function useGetHighestPriorityLineDetailsWithRoutesQuery(baseOptions?: Apollo.QueryHookOptions<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>(GetHighestPriorityLineDetailsWithRoutesDocument, options);
+      }
+export function useGetHighestPriorityLineDetailsWithRoutesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>(GetHighestPriorityLineDetailsWithRoutesDocument, options);
+        }
+export type GetHighestPriorityLineDetailsWithRoutesQueryHookResult = ReturnType<typeof useGetHighestPriorityLineDetailsWithRoutesQuery>;
+export type GetHighestPriorityLineDetailsWithRoutesLazyQueryHookResult = ReturnType<typeof useGetHighestPriorityLineDetailsWithRoutesLazyQuery>;
+export type GetHighestPriorityLineDetailsWithRoutesQueryResult = Apollo.QueryResult<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>;
 export const GetRouteDetailsByIdsDocument = gql`
     query GetRouteDetailsByIds($route_ids: [uuid!]) {
   route_route(where: {route_id: {_in: $route_ids}}) {
@@ -8263,6 +8328,10 @@ export function useGetLineDetailsWithRoutesByIdAsyncQuery() {
           return useAsyncQuery<GetLineDetailsWithRoutesByIdQuery, GetLineDetailsWithRoutesByIdQueryVariables>(GetLineDetailsWithRoutesByIdDocument);
         }
 export type GetLineDetailsWithRoutesByIdAsyncQueryHookResult = ReturnType<typeof useGetLineDetailsWithRoutesByIdAsyncQuery>;
+export function useGetHighestPriorityLineDetailsWithRoutesAsyncQuery() {
+          return useAsyncQuery<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>(GetHighestPriorityLineDetailsWithRoutesDocument);
+        }
+export type GetHighestPriorityLineDetailsWithRoutesAsyncQueryHookResult = ReturnType<typeof useGetHighestPriorityLineDetailsWithRoutesAsyncQuery>;
 export function useGetRouteDetailsByIdsAsyncQuery() {
           return useAsyncQuery<GetRouteDetailsByIdsQuery, GetRouteDetailsByIdsQueryVariables>(GetRouteDetailsByIdsDocument);
         }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './line-details/useGetLineDetails';
 export * from './redux';
 export * from './routes';
 export * from './search/useSearch';

--- a/src/hooks/line-details/useGetLineDetails.ts
+++ b/src/hooks/line-details/useGetLineDetails.ts
@@ -1,0 +1,149 @@
+import produce from 'immer';
+import { groupBy } from 'lodash';
+import { DateTime } from 'luxon';
+import { useParams } from 'react-router-dom';
+import {
+  RouteDirectionEnum,
+  RouteLine,
+  RouteRoute,
+  useGetHighestPriorityLineDetailsWithRoutesQuery,
+  useGetLineDetailsWithRoutesByIdQuery,
+} from '../../generated/graphql';
+import {
+  mapHighestPriorityLineDetailsWithRoutesResult,
+  mapLineDetailsWithRoutesResult,
+} from '../../graphql';
+import { parseDate } from '../../time';
+import {
+  constructActiveDateGqlFilter,
+  constructDraftPriorityGqlFilter,
+  constructLabelGqlFilter,
+  mapToVariables,
+} from '../../utils';
+import { useUrlQuery } from '../useUrlQuery';
+
+const findHighestPriorityRoute = (routes: RouteRoute[]) =>
+  routes.reduce((prev, curr) => (prev.priority > curr.priority ? prev : curr));
+
+/** Returns highest priority routes filtered by given direction */
+const filterRoutesByHighestPriorityAndDirection = (
+  direction: RouteDirectionEnum,
+  routes: RouteRoute[],
+) => {
+  const routesFilteredByDirection = routes.filter(
+    (route) => route.direction === direction,
+  );
+  const routesGroupedByLabel = groupBy(routesFilteredByDirection, 'label');
+
+  const highestPriorityRoutes = Object.keys(routesGroupedByLabel).map((key) =>
+    findHighestPriorityRoute(routesGroupedByLabel[key]),
+  );
+
+  return highestPriorityRoutes;
+};
+
+const filterRoutesByHighestPriority = (lineRoutes: RouteRoute[]) => {
+  const filteredOutboundRoutes = filterRoutesByHighestPriorityAndDirection(
+    RouteDirectionEnum.Outbound,
+    lineRoutes,
+  );
+  const filteredInboundRoutes = filterRoutesByHighestPriorityAndDirection(
+    RouteDirectionEnum.Inbound,
+    lineRoutes,
+  );
+  return [...filteredOutboundRoutes, ...filteredInboundRoutes];
+};
+
+const filterLineDetailsByDate = (line: RouteLine) => {
+  const filteredRoutes = filterRoutesByHighestPriority(line?.line_routes);
+
+  const filteredLine = produce(line, (draft) => {
+    draft.line_routes = filteredRoutes;
+  });
+
+  return filteredLine;
+};
+
+/** Returns the initial observation date depending on the parameters. */
+const getInitialDate = (
+  selectedISODate: string,
+  validityStart?: DateTime | null,
+  validityEnd?: DateTime | null,
+) => {
+  if (selectedISODate) {
+    return parseDate(selectedISODate);
+  }
+
+  const isActiveToday =
+    validityStart &&
+    validityStart <= DateTime.now() &&
+    (!validityEnd || validityEnd >= DateTime.now());
+
+  if (isActiveToday) {
+    // DateTime.now() triggers infinite re-renders, so need to doublecast it
+    return DateTime.fromISO(DateTime.now().toISODate());
+  }
+
+  return validityStart;
+};
+
+const constructLineDetailsGqlFilters = (
+  line?: RouteLine,
+  observationDate?: DateTime | null,
+) => {
+  const lineFilters = {
+    ...constructLabelGqlFilter(line?.label),
+    ...constructActiveDateGqlFilter(observationDate),
+    ...constructDraftPriorityGqlFilter(line?.priority),
+  };
+
+  const lineRouteFilters = {
+    ...constructActiveDateGqlFilter(observationDate),
+    ...constructDraftPriorityGqlFilter(line?.priority),
+  };
+
+  const routeStopFilters = constructActiveDateGqlFilter(observationDate);
+
+  return {
+    variables: {
+      lineFilters,
+      lineRouteFilters,
+      routeStopFilters,
+    },
+  };
+};
+
+/** Gets the line details depending on query parameters. */
+export const useGetLineDetails = () => {
+  const { id } = useParams<{ id: string }>();
+  const queryParams = useUrlQuery();
+
+  const [selectedDate, showAll] = [
+    queryParams.selectedDate as string,
+    queryParams.showAll === 'true',
+  ];
+
+  const lineDetailsResult = useGetLineDetailsWithRoutesByIdQuery(
+    mapToVariables({ line_id: id }),
+  );
+
+  const line = mapLineDetailsWithRoutesResult(lineDetailsResult);
+  const observationDate = showAll
+    ? undefined
+    : getInitialDate(selectedDate, line?.validity_start, line?.validity_end);
+
+  const lineByDateResult = useGetHighestPriorityLineDetailsWithRoutesQuery(
+    constructLineDetailsGqlFilters(line, observationDate),
+  );
+
+  const lineByDate =
+    mapHighestPriorityLineDetailsWithRoutesResult(lineByDateResult);
+
+  const filteredLine =
+    !showAll && lineByDate ? filterLineDetailsByDate(lineByDate) : undefined;
+
+  return {
+    line: showAll ? line : filteredLine,
+    observationDate,
+  };
+};

--- a/src/locales/en-US/common.json
+++ b/src/locales/en-US/common.json
@@ -44,7 +44,8 @@
     "routes": "Routes",
     "lines": "Lines",
     "createNewRoute": "Create new route",
-    "createNewRouteInstructions": "Route drawing opens in a new window."
+    "createNewRouteInstructions": "Route drawing opens in a new window.",
+    "showDrafts": "Show drafts"
   },
   "stops": {
     "stop": "Stop",

--- a/src/locales/fi-FI/common.json
+++ b/src/locales/fi-FI/common.json
@@ -44,7 +44,8 @@
     "routes": "Reitit",
     "lines": "Linjat",
     "createNewRoute": "Luo reitti",
-    "createNewRouteInstructions": "Uuden reitin luominen avautuu karttanäkymään."
+    "createNewRouteInstructions": "Uuden reitin luominen avautuu karttanäkymään.",
+    "showDrafts": "Näytä luonnokset"
   },
   "stops": {
     "stop": "Pysäkki",

--- a/src/utils/gql.ts
+++ b/src/utils/gql.ts
@@ -1,0 +1,36 @@
+import { DateTime } from 'luxon';
+import { Priority } from '../types/Priority';
+
+/** Constructs an object for gql to filter out all
+ * results which are not active on the given date
+ */
+export const constructActiveDateGqlFilter = (date?: DateTime | null) => ({
+  _and: [
+    {
+      _or: [
+        { validity_start: { _lte: date } },
+        { validity_start: { _is_null: true } },
+      ],
+    },
+    {
+      _or: [
+        { validity_end: { _gte: date } },
+        { validity_end: { _is_null: true } },
+      ],
+    },
+  ],
+});
+
+/** Constructs an object for gql to filter out all drafts if
+ * the given priority is not draft itself
+ */
+export const constructDraftPriorityGqlFilter = (priority?: Priority) => ({
+  priority: {
+    _nin: priority !== Priority.Draft ? [Priority.Draft] : [],
+  },
+});
+
+/** Constructs an object for gql to filter by label */
+export const constructLabelGqlFilter = (label?: string) => ({
+  label: { _eq: label },
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './graphql';
 export * from './search';
 export * from './toastService';
 export * from './url';
+export * from './gql';


### PR DESCRIPTION
HSLdevcom/jore4#493

Add observation date functionality to line details page.

When navigating to the line details page for the first time, it will use **todays date** as observation date, if the line is active **today**. If the line **is not active** today, it will use the lines **first active date** as observation date.

With the date picker, the user can clear the date to see the raw details of the line.

Technical note:
The query will filter out the draft-versions and also choose only the line, routes, stops which are active on the given date. But because graphQL seems not to have groupBy, the correct line_routes are filtered in the code (to show only the highest priority route per label).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/147)
<!-- Reviewable:end -->
