### PR TITLE
Add line ID as a field to LineForm

### DIFF
--- a/src/components/forms/line/LineForm.tsx
+++ b/src/components/forms/line/LineForm.tsx
@@ -3,7 +3,9 @@ import React, { useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
+import { RouteLine } from '../../../generated/graphql';
 import { Row } from '../../../layoutComponents';
+import { mapToISODate } from '../../../time';
 import { FormContainer, SimpleButton } from '../../../uiComponents';
 import { submitFormByRef } from '../../../utils';
 import {
@@ -23,6 +25,22 @@ interface Props {
   defaultValues: Partial<FormState>;
   onSubmit: (state: FormState) => void;
 }
+
+export const mapLineToFormState = (line?: RouteLine) => {
+  const formState: Partial<FormState> = {
+    lineId: line?.line_id,
+    label: line?.label,
+    finnishName: line?.name_i18n,
+    primaryVehicleMode: line?.primary_vehicle_mode,
+    priority: line?.priority,
+    transportTarget: line?.transport_target,
+    typeOfLine: line?.type_of_line,
+    validityStart: mapToISODate(line?.validity_start),
+    validityEnd: mapToISODate(line?.validity_end),
+    indefinite: !line?.validity_end,
+  };
+  return formState;
+};
 
 export const LineForm = ({ defaultValues, onSubmit }: Props): JSX.Element => {
   const history = useHistory();

--- a/src/components/forms/line/LinePropertiesForm.tsx
+++ b/src/components/forms/line/LinePropertiesForm.tsx
@@ -12,6 +12,7 @@ import { TransportTargetDropdown } from './TransportTargetDropdown';
 import { VehicleModeDropdown } from './VehicleModeDropdown';
 
 export const schema = z.object({
+  lineId: z.string().uuid().optional(), // for lines that are edited
   label: z.string().min(1),
   finnishName: z.string().min(1),
   transportTarget: z.nativeEnum(HslRouteTransportTargetEnum),

--- a/src/components/routes-and-lines/edit-line/EditLinePage.tsx
+++ b/src/components/routes-and-lines/edit-line/EditLinePage.tsx
@@ -9,9 +9,12 @@ import { mapLineDetailsResult } from '../../../graphql';
 import { useEditLine } from '../../../hooks';
 import { Container } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
-import { mapToISODate } from '../../../time';
 import { mapToVariables, showSuccessToast } from '../../../utils';
-import { FormState, LineForm } from '../../forms/line/LineForm';
+import {
+  FormState,
+  LineForm,
+  mapLineToFormState,
+} from '../../forms/line/LineForm';
 import {
   ConflictResolverModal,
   mapLineToCommonConflictItem,
@@ -35,17 +38,7 @@ export const EditLinePage = (): JSX.Element => {
   const line = mapLineDetailsResult(lineDetailsResult);
   const { t } = useTranslation();
 
-  const defaultValues = {
-    label: line?.label,
-    finnishName: line?.name_i18n,
-    primaryVehicleMode: line?.primary_vehicle_mode,
-    priority: line?.priority,
-    transportTarget: line?.transport_target,
-    typeOfLine: line?.type_of_line,
-    validityStart: mapToISODate(line?.validity_start),
-    validityEnd: mapToISODate(line?.validity_end),
-    indefinite: !line?.validity_end,
-  };
+  const defaultValues = mapLineToFormState(line);
 
   const onSubmit = async (form: FormState) => {
     try {


### PR DESCRIPTION
The line ID is not displayed in any way, it’s just stored together with the rest of the form data. This allows to carry the edited line's data as a single object between functions instead of handling the ID and the rest of the data as separate objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/169)
<!-- Reviewable:end -->
