### PR TITLE
Add CI job for e2e testing using a specific branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,8 +50,9 @@ jobs:
           docker push $IMAGE_NAME:builder
           docker push $IMAGE_NAME:latest
 
-  run_e2e_tests:
+  run_e2e_tests_from_main:
     needs: push_to_registry
+    name: Run default jore4-robot e2e tests
     runs-on: ubuntu-20.04
     steps:
       - name: Extract metadata to env variables
@@ -72,4 +73,40 @@ jobs:
 
       - name: upload test results
         if: always()
+        uses: HSLdevcom/jore4-robot/github-actions/upload-results@actions-v1
+
+  run_e2e_tests_from_branch:
+    needs: push_to_registry
+    name: Run e2e tests from jore4-robot branch
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Extract metadata to env variables
+        uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
+
+      - name: start e2e env
+        uses: HSLdevcom/jore4-flux/github-actions/setup-e2e-environment@setup-e2e-environment-v1
+        with:
+          ui_version: $IMAGE_NAME:$COMMIT_ID
+
+      - name: check if branch exists in e2e test repo
+        run: |
+          export BRANCH_EXISTS=$(git ls-remote --exit-code --heads https://github.com/HSLdevcom/jore4-robot.git ${{ env.BRANCH_NAME }})
+          if [ -n "$BRANCH_EXISTS" ]; then
+            echo "Branch found in E2E test repository!"
+          else
+            echo "Branch not found in E2E test repository!"
+          fi
+          echo "BRANCH_EXISTS=${BRANCH_EXISTS}" >> "${GITHUB_ENV}"
+
+      - name: run e2e smoke tests from branch
+        if: ${{ env.BRANCH_EXISTS }}
+        uses: HSLdevcom/jore4-robot/github-actions/run-rf-tests@actions-v1
+        with:
+          included_tag: smoke
+          test_suite_version: ${{ env.BRANCH_NAME }}
+          e2e_username: ${{ secrets.ROBOT_HSLID_EMAIL }}
+          e2e_password: ${{ secrets.ROBOT_HSLID_PASSWORD }}
+
+      - name: upload test results
+        if: ${{ always() && env.BRANCH_EXISTS }}
         uses: HSLdevcom/jore4-robot/github-actions/upload-results@actions-v1


### PR DESCRIPTION
The script looks for a branch with the same name in the jore4-robot repository. If it exists, it runs the tests from that branch. If not, it'll return with success.

This is useful when developing the UI and it required changes also in the e2e tests. Just create a branch with the same name in the jore4-robot repository and fix the tests there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/170)
<!-- Reviewable:end -->
