### PR TITLE
Refactor query parameter in search results

### DIFF
--- a/src/components/routes-and-lines/search/ResultList.tsx
+++ b/src/components/routes-and-lines/search/ResultList.tsx
@@ -1,0 +1,30 @@
+import { RouteLine, RouteRoute } from '../../../generated/graphql';
+import { DisplayedSearchResultType } from '../../../hooks';
+import { LinesList } from '../main/LinesList';
+import { RoutesList } from '../main/RoutesList';
+
+interface Props {
+  lines?: RouteLine[];
+  routes?: RouteRoute[];
+  displayedData: DisplayedSearchResultType;
+}
+
+/** Depending on displayeData this component will return the
+ * corresponding list element
+ */
+export const ResultList = ({
+  lines,
+  routes,
+  displayedData,
+}: Props): JSX.Element => {
+  switch (displayedData) {
+    case DisplayedSearchResultType.Lines:
+      return <LinesList lines={lines} />;
+    case DisplayedSearchResultType.Routes:
+      return <RoutesList routes={routes} />;
+    default:
+      // eslint-disable-next-line no-console
+      console.error(`Error: ${displayedData} does not exist.`);
+      return <></>;
+  }
+};

--- a/src/components/routes-and-lines/search/SearchResultPage.tsx
+++ b/src/components/routes-and-lines/search/SearchResultPage.tsx
@@ -2,26 +2,23 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearch, useSearchResults } from '../../../hooks';
 import { usePagination } from '../../../hooks/usePagination';
-import { Container, Row } from '../../../layoutComponents';
+import { Container, Row, Visible } from '../../../layoutComponents';
 import { CloseIconButton, Pagination } from '../../../uiComponents';
-import { LinesList } from '../main/LinesList';
-import { RoutesList } from '../main/RoutesList';
 import { SearchContainer } from './conditions/SearchContainer';
 import { FiltersContainer } from './filters/FiltersContainer';
+import { ResultList } from './ResultList';
 
 export const SearchResultPage = (): JSX.Element => {
-  const { queryParameters, handleClose } = useSearch();
-  const { lines, routes, resultCount } = useSearchResults();
+  const { handleClose } = useSearch();
+  const { resultCount } = useSearchResults();
   const { t } = useTranslation();
   const { getPaginatedData } = usePagination();
+  const { lines, routes } = useSearchResults();
   const itemsPerPage = 10;
 
   const displayedLines = getPaginatedData(lines, itemsPerPage);
   const displayedRoutes = getPaginatedData(routes, itemsPerPage);
-
-  const totalCountOfDisplayedData = queryParameters.filter.displayRoutes
-    ? routes?.length
-    : lines?.length;
+  const { queryParameters } = useSearch();
 
   return (
     <Container>
@@ -42,20 +39,20 @@ export const SearchResultPage = (): JSX.Element => {
           resultCount,
         })}
       </h1>
-      {queryParameters.filter.displayRoutes ? (
-        <RoutesList routes={displayedRoutes} />
-      ) : (
-        <LinesList lines={displayedLines} />
-      )}
-      {lines?.length > 0 && (
+      <ResultList
+        lines={displayedLines}
+        routes={displayedRoutes}
+        displayedData={queryParameters.filter.displayedData}
+      />
+      <Visible visible={!!resultCount}>
         <div className="grid grid-cols-4">
           <Pagination
             className="col-span-2 col-start-2 pt-4"
             itemsPerPage={itemsPerPage}
-            totalItemsCount={totalCountOfDisplayedData}
+            totalItemsCount={resultCount}
           />
         </div>
-      )}
+      </Visible>
     </Container>
   );
 };

--- a/src/components/routes-and-lines/search/filters/ResultSelector.tsx
+++ b/src/components/routes-and-lines/search/filters/ResultSelector.tsx
@@ -1,25 +1,28 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearch } from '../../../../hooks';
+import { DisplayedSearchResultType, useSearch } from '../../../../hooks';
 import { SimpleSmallButton } from '../../../../uiComponents';
 
 export const ResultSelector = (): JSX.Element => {
   const { t } = useTranslation();
   const { queryParameters, setFilter } = useSearch();
-  const { displayRoutes } = queryParameters.filter;
+  const { displayedData } = queryParameters.filter;
 
-  const toggleDisplayRoutes = () => setFilter('displayRoutes', !displayRoutes);
+  const displayRoutes = () =>
+    setFilter('displayedData', DisplayedSearchResultType.Routes);
+  const displayLines = () =>
+    setFilter('displayedData', DisplayedSearchResultType.Lines);
 
   return (
     <div>
       <SimpleSmallButton
-        inverted={displayRoutes}
-        onClick={toggleDisplayRoutes}
+        inverted={displayedData !== DisplayedSearchResultType.Lines}
+        onClick={displayLines}
         label={t('lines.lines')}
       />
       <SimpleSmallButton
-        onClick={toggleDisplayRoutes}
-        inverted={!displayRoutes}
+        onClick={displayRoutes}
+        inverted={displayedData !== DisplayedSearchResultType.Routes}
         label={t('lines.routes')}
       />
     </div>

--- a/src/hooks/search/useSearch.ts
+++ b/src/hooks/search/useSearch.ts
@@ -3,7 +3,11 @@ import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Priority } from '../../types/Priority';
 import { createQueryParamString } from '../../utils';
-import { FilterConditions, useSearchQueryParser } from './useSearchQueryParser';
+import {
+  DisplayedSearchResultType,
+  FilterConditions,
+  useSearchQueryParser,
+} from './useSearchQueryParser';
 
 export const useSearch = () => {
   const history = useHistory();
@@ -27,7 +31,10 @@ export const useSearch = () => {
    * Filters modify result table instantly by immediately
    * pushing the change to query string
    */
-  const setFilter = (filterName: keyof FilterConditions, value: boolean) => {
+  const setFilter = (
+    filterName: keyof FilterConditions,
+    value: DisplayedSearchResultType,
+  ) => {
     const combinedParameters = produce(queryParameters, (draft) => {
       draft.filter[filterName] = value;
     });

--- a/src/hooks/search/useSearchQueryParser.ts
+++ b/src/hooks/search/useSearchQueryParser.ts
@@ -6,8 +6,14 @@ export type SearchConditions = {
   label: string;
 };
 
+/** Enum for different search result options */
+export enum DisplayedSearchResultType {
+  Routes = 'routes',
+  Lines = 'lines',
+}
+
 export type FilterConditions = {
-  displayRoutes: boolean;
+  displayedData: DisplayedSearchResultType;
 };
 
 /**
@@ -25,7 +31,7 @@ export type SearchParameters = {
 export type QueryStringParameters = {
   priorities: string;
   label: string;
-  displayRoutes: string;
+  displayedData: string;
 };
 
 /**
@@ -35,7 +41,7 @@ export type QueryStringParameters = {
 export type DeserializedQueryStringParameters = {
   priorities: Priority[];
   label: string;
-  displayRoutes: boolean;
+  displayedData: DisplayedSearchResultType;
 };
 
 /**
@@ -48,6 +54,22 @@ const parseAndValidatePriorities = (priorities: string) =>
     .split(',')
     .map((p) => parseInt(p, 10))
     .filter((p) => Object.values(Priority).includes(p));
+
+/**
+ * If displayedData query string is not given or is invalid,
+ * default to Lines
+ */
+const mapDisplayedData = (displayedData: string) => {
+  if (
+    Object.values(DisplayedSearchResultType).includes(
+      displayedData as DisplayedSearchResultType,
+    )
+  ) {
+    return displayedData as DisplayedSearchResultType;
+  }
+
+  return DisplayedSearchResultType.Lines;
+};
 
 /**
  * Returns parsed and validated priorities if priority query string
@@ -76,7 +98,7 @@ const deserializeParameters = (
       priorities: getPriorities(queryParams.priorities),
     },
     filter: {
-      displayRoutes: queryParams.displayRoutes === 'true',
+      displayedData: mapDisplayedData(queryParams.displayedData),
     },
   };
 };

--- a/src/hooks/search/useSearchResults.ts
+++ b/src/hooks/search/useSearchResults.ts
@@ -5,7 +5,10 @@ import {
 } from '../../generated/graphql';
 import { mapSearchAllLinesResult } from '../../graphql';
 import { constructGqlFilterObject, mapToVariables } from '../../utils';
-import { useSearchQueryParser } from './useSearchQueryParser';
+import {
+  DisplayedSearchResultType,
+  useSearchQueryParser,
+} from './useSearchQueryParser';
 
 export const useSearchResults = (): {
   lines: RouteLine[];
@@ -26,14 +29,24 @@ export const useSearchResults = (): {
     ?.map((line) => line.line_routes)
     ?.reduce((next, curr) => [...curr, ...next], []);
 
-  const resultCount =
-    (parsedQueryParameters.filter.displayRoutes
-      ? routes?.length
-      : lines?.length) || 0;
+  const getResultCount = () => {
+    switch (parsedQueryParameters.filter.displayedData) {
+      case DisplayedSearchResultType.Lines:
+        return lines?.length;
+      case DisplayedSearchResultType.Routes:
+        return routes?.length;
+      default:
+        // eslint-disable-next-line no-console
+        console.error(
+          `Error: ${parsedQueryParameters.filter.displayedData} does not exist.`,
+        );
+        return 0;
+    }
+  };
 
   return {
     lines,
     routes,
-    resultCount,
+    resultCount: getResultCount(),
   };
 };

--- a/src/uiComponents/Pagination.tsx
+++ b/src/uiComponents/Pagination.tsx
@@ -19,7 +19,7 @@ const DEFAULT_ITEMS_PER_PAGE = 10;
  * And current page is 7 then we render ... 5 6 7 8 9 ... If amountOfNeighbours = 1
  * we render ... 6 7 8 ... (default = 2)
  * @param totalItemsCount the total count of the data which is being paginated
- * @param itemsPerPage how much items there is per page (default=10)
+ * @param itemsPerPage how many items there are per page (default=10)
  */
 export const Pagination = ({
   amountOfNeighbours = DEFAULT_AMOUNT_OF_NEIGHBOURS,


### PR DESCRIPTION
Refactor `displayRoutes` query parameter to `displayedData` for extensibility and to make the behaviour more descriptive. *displayRoutes* as variable name suggests that it either displays routes or does not display routes. But here it was used so that if displayRoutes was false, it displays lines instead, and for that it was not that good of a variable name.

There are also couple of other minor fixes, like grammatic error fix and use of `<Visible>` component

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/174)
<!-- Reviewable:end -->
