### PR TITLE
Refactor route editing hooks

### DIFF
--- a/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -6,7 +6,7 @@ import {
   useGetRouteDetailsByIdsQuery,
 } from '../../../generated/graphql';
 import { mapRouteDetailsResult } from '../../../graphql';
-import { useDeleteRoute, useEditRoute } from '../../../hooks';
+import { useDeleteRoute, useEditRouteMetadata } from '../../../hooks';
 import { Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { mapToISODate } from '../../../time';
@@ -49,7 +49,7 @@ export const EditRoutePage = (): JSX.Element => {
     mapEditChangesToVariables,
     editRouteMutation,
     defaultErrorHandler,
-  } = useEditRoute();
+  } = useEditRouteMetadata();
   const { deleteRoute, defaultErrorHandler: defaultDeleteErrorHandler } =
     useDeleteRoute();
   const [conflicts, setConflicts] = useState<RouteRoute[]>([]);

--- a/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
+++ b/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { MdOutlineHistory } from 'react-icons/md';
 import { ServicePatternScheduledStopPoint } from '../../../generated/graphql';
 import { stopBelongsToJourneyPattern } from '../../../graphql';
-import { useEditRouteGeometry } from '../../../hooks';
+import { useEditRouteJourneyPattern } from '../../../hooks';
 import { Row } from '../../../layoutComponents';
 import {
   mapToShortDate,
@@ -31,7 +31,7 @@ export const RouteStopsRow = ({
 
   const belongsToJourneyPattern = stopBelongsToJourneyPattern(stop, routeId);
 
-  const { deleteStopFromJourneyPattern } = useEditRouteGeometry();
+  const { deleteStopFromJourneyPattern } = useEditRouteJourneyPattern();
 
   const deleteFromJourneyPattern = async () => {
     try {

--- a/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
+++ b/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
@@ -5,7 +5,7 @@ import {
   getStopsAlongRouteGeometry,
   stopBelongsToJourneyPattern,
 } from '../../../graphql';
-import { useEditRouteGeometry } from '../../../hooks';
+import { useEditRouteJourneyPattern } from '../../../hooks';
 import { showDangerToast, showSuccessToast } from '../../../utils';
 import { RouteStopsHeaderRow } from './RouteStopsHeaderRow';
 import { RouteStopsRow } from './RouteStopsRow';
@@ -24,7 +24,7 @@ export const RouteStopsSection = ({
   const [isOpen, setOpen] = useState(false);
   const { t } = useTranslation();
 
-  const { addStopToRouteJourneyPattern } = useEditRouteGeometry();
+  const { addStopToRouteJourneyPattern } = useEditRouteJourneyPattern();
 
   const onToggle = () => {
     setOpen(!isOpen);

--- a/src/hooks/routes/index.ts
+++ b/src/hooks/routes/index.ts
@@ -1,4 +1,5 @@
 export * from './useDeleteRoute';
-export * from './useEditRoute';
 export * from './useEditRouteGeometry';
+export * from './useEditRouteJourneyPattern';
+export * from './useEditRouteMetadata';
 export * from './useGetDisplayedRoutes';

--- a/src/hooks/routes/useEditRouteJourneyPattern.ts
+++ b/src/hooks/routes/useEditRouteJourneyPattern.ts
@@ -1,0 +1,105 @@
+import {
+  RouteRoute,
+  UpdateRouteJourneyPatternMutationVariables,
+  useDeleteStopFromJourneyPatternMutation,
+  useUpdateRouteJourneyPatternMutation,
+} from '../../generated/graphql';
+import {
+  getStopsAlongRouteGeometry,
+  stopBelongsToJourneyPattern,
+} from '../../graphql';
+import { RouteStop } from '../../redux';
+import { mapToVariables, removeFromApolloCache } from '../../utils';
+import { useExtractRouteFromFeature } from '../useExtractRouteFromFeature';
+import { mapStopsToScheduledStopPoints } from './useCreateRoute';
+
+interface DeleteStopFromJourneyPatternParams {
+  routeId: UUID;
+  stopPointId: UUID;
+}
+
+/**
+ * Hook for adding and removing single stops to route's journey pattern.
+ */
+export const useEditRouteJourneyPattern = () => {
+  const [updateRouteJourneyPatternMutation] =
+    useUpdateRouteJourneyPatternMutation();
+  const [deleteStopFromJourneyPatternMutation] =
+    useDeleteStopFromJourneyPatternMutation();
+
+  const { mapRouteStopsToStopIds } = useExtractRouteFromFeature();
+
+  const mapStopIdsToUpdateMutationVariables = (
+    stopsIds: UUID[],
+    routeId: UUID,
+  ) => {
+    const variables: UpdateRouteJourneyPatternMutationVariables = {
+      route_id: routeId,
+      new_journey_pattern: {
+        on_route_id: routeId,
+        scheduled_stop_point_in_journey_patterns:
+          mapStopsToScheduledStopPoints(stopsIds),
+      },
+    };
+
+    return mapToVariables(variables);
+  };
+
+  const addStopToRouteJourneyPattern = async (
+    stopPointId: UUID,
+    route: RouteRoute,
+  ) => {
+    const stopsAlongRoute = getStopsAlongRouteGeometry(route);
+
+    const routeStops: RouteStop[] = stopsAlongRoute.map((stop) => ({
+      id: stop.scheduled_stop_point_id,
+      belongsToRoute: stopBelongsToJourneyPattern(stop, route.route_id),
+    }));
+
+    const newRouteStops = routeStops.map((item) =>
+      item.id === stopPointId ? { ...item, belongsToRoute: true } : item,
+    );
+
+    const stopIdsWithinRoute = mapRouteStopsToStopIds(newRouteStops);
+
+    const variables = mapStopIdsToUpdateMutationVariables(
+      stopIdsWithinRoute,
+      route.route_id,
+    );
+
+    await updateRouteJourneyPatternMutation({
+      ...variables,
+      // remove scheduled stop point from cache after mutation
+      update(cache) {
+        removeFromApolloCache(cache, {
+          scheduled_stop_point_id: stopPointId,
+          __typename: 'service_pattern_scheduled_stop_point',
+        });
+      },
+    });
+  };
+
+  const deleteStopFromJourneyPattern = async ({
+    routeId,
+    stopPointId,
+  }: DeleteStopFromJourneyPatternParams) => {
+    await deleteStopFromJourneyPatternMutation({
+      ...mapToVariables({
+        route_id: routeId,
+        scheduled_stop_point_id: stopPointId,
+      }),
+      // remove scheduled stop point from cache after mutation
+      update(cache) {
+        removeFromApolloCache(cache, {
+          scheduled_stop_point_id: stopPointId,
+          __typename: 'service_pattern_scheduled_stop_point',
+        });
+      },
+    });
+  };
+
+  return {
+    deleteStopFromJourneyPattern,
+    addStopToRouteJourneyPattern,
+  };
+};

--- a/src/hooks/routes/useEditRouteMetadata.ts
+++ b/src/hooks/routes/useEditRouteMetadata.ts
@@ -39,7 +39,12 @@ const mapFormToInput = (state: RouteFormState): RouteRouteSetInput => {
   return mutation;
 };
 
-export const useEditRoute = () => {
+/**
+ * Hook for editing route's metadata.
+ * For editing route geometry (journey pattern and infrastructure links),
+ * use editRouteGeometry
+ */
+export const useEditRouteMetadata = () => {
   const { t } = useTranslation();
   const [mutateFunction] = usePatchRouteMutation();
   const { getConflictingRoutes } = useCheckValidityAndPriorityConflicts();


### PR DESCRIPTION
- Route metadata and geometry editing are now in separate hooks
- Route editing hooks can now be used similarly to other resource creation / editing hooks
- Separate hooks created also for adding and removing single stops from journey pattern