### PR TITLE
Fix line edit page information missing bux

### DIFF
--- a/src/components/routes-and-lines/edit-line/EditLinePage.tsx
+++ b/src/components/routes-and-lines/edit-line/EditLinePage.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../generated/graphql';
 import { mapLineDetailsResult } from '../../../graphql';
 import { useEditLine } from '../../../hooks';
-import { Container } from '../../../layoutComponents';
+import { Container, Visible } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { mapToISODate } from '../../../time';
 import { mapToVariables, showSuccessToast } from '../../../utils';
@@ -83,7 +83,9 @@ export const EditLinePage = (): JSX.Element => {
         </h1>
       </PageHeader>
       <Container>
-        <LineForm onSubmit={onSubmit} defaultValues={defaultValues} />
+        <Visible visible={!!line}>
+          <LineForm onSubmit={onSubmit} defaultValues={defaultValues} />
+        </Visible>
       </Container>
     </div>
   );


### PR DESCRIPTION
- If editing a line, do not render line form before line object has been fetched

Resolves HSLdevcom/jore4#686

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/183)
<!-- Reviewable:end -->
