### PR TITLE
Refactor dropdown to have more flexibility

### DIFF
--- a/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
+++ b/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
@@ -11,7 +11,7 @@ import {
   MAX_DATE,
   MIN_DATE,
 } from '../../../time';
-import { SimpleDropdownMenu } from '../../../uiComponents';
+import { AlignDirection, SimpleDropdownMenu } from '../../../uiComponents';
 import { showDangerToast, showSuccessToast } from '../../../utils';
 
 interface Props {
@@ -80,7 +80,10 @@ export const RouteStopsRow = ({
       </td>
       <td>&nbsp;</td>
       <td>
-        <SimpleDropdownMenu testId="stop-row-action-menu">
+        <SimpleDropdownMenu
+          alignItems={AlignDirection.Left}
+          testId="stop-row-action-menu"
+        >
           {belongsToJourneyPattern ? (
             <button type="button" onClick={deleteFromJourneyPattern}>
               {t('stops.removeFromRoute')}

--- a/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -422,12 +422,12 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           </td>
           <td>
             <div
-              class="static h-full"
+              class="relative"
             >
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                class="mx-auto flex h-full items-center px-3 focus:outline-none"
+                class="mx-auto flex items-center px-3 focus:outline-none"
                 data-testid="stop-row-action-menu"
                 id="headlessui-menu-button-3"
                 type="button"
@@ -508,12 +508,12 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           </td>
           <td>
             <div
-              class="static h-full"
+              class="relative"
             >
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                class="mx-auto flex h-full items-center px-3 focus:outline-none"
+                class="mx-auto flex items-center px-3 focus:outline-none"
                 data-testid="stop-row-action-menu"
                 id="headlessui-menu-button-4"
                 type="button"
@@ -594,12 +594,12 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           </td>
           <td>
             <div
-              class="static h-full"
+              class="relative"
             >
               <button
                 aria-expanded="false"
                 aria-haspopup="true"
-                class="mx-auto flex h-full items-center px-3 focus:outline-none"
+                class="mx-auto flex items-center px-3 focus:outline-none"
                 data-testid="stop-row-action-menu"
                 id="headlessui-menu-button-5"
                 type="button"

--- a/src/components/routes-and-lines/line-drafts/LineDraftTableRow.tsx
+++ b/src/components/routes-and-lines/line-drafts/LineDraftTableRow.tsx
@@ -6,7 +6,11 @@ import { useShowRoutesOnModal } from '../../../hooks';
 import { mapPriorityToUiName } from '../../../i18n/uiNameMappings';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { mapToShortDate } from '../../../time';
-import { IconButton, SimpleDropdownMenu } from '../../../uiComponents';
+import {
+  AlignDirection,
+  IconButton,
+  SimpleDropdownMenu,
+} from '../../../uiComponents';
 
 interface Props {
   className?: string;
@@ -55,7 +59,7 @@ export const LineDraftTableRow = ({
           />
         </td>
         <td className={commonClassName}>
-          <SimpleDropdownMenu>
+          <SimpleDropdownMenu alignItems={AlignDirection.Left}>
             <Link
               type="button"
               to={routeDetails[Path.lineDetails].getLink(line.line_id)}

--- a/src/uiComponents/SimpleDropdownMenu.tsx
+++ b/src/uiComponents/SimpleDropdownMenu.tsx
@@ -7,36 +7,54 @@ import { dropdownTransition } from './Listbox';
 interface Props {
   children: ReactNode;
   testId?: string;
+  /** Set value to align menu items to right or left. Default: no alignment */
+  alignItems?: AlignDirection;
 }
+
+export enum AlignDirection {
+  Right,
+  Left,
+  NoAlign,
+}
+
+const getAlignClassName = (alignItems: AlignDirection) => {
+  switch (alignItems) {
+    case AlignDirection.Right:
+      return 'left-0';
+    case AlignDirection.Left:
+      return 'right-0';
+    default:
+      return '';
+  }
+};
 
 export const SimpleDropdownMenu = ({
   children,
   testId,
+  alignItems = AlignDirection.NoAlign,
 }: Props): JSX.Element => {
+  const alignClassName = getAlignClassName(alignItems);
+  const commonClassName = `${alignClassName} absolute z-10 origin-top-right overflow-visible bg-white text-black shadow-md focus:outline-none`;
+  const menuItemClassName = `border-x border-b first-of-type:border-t whitespace-nowrap border-black w-full py-1 px-2 focus:outline-none text-left`;
+
   return (
-    <Menu as="div" className="static h-full">
+    <Menu as="div" className="relative">
       {({ open }) => (
         <>
           <Menu.Button
-            className="mx-auto flex h-full items-center px-3 focus:outline-none"
+            className="mx-auto flex items-center px-3 focus:outline-none"
             data-testid={testId}
           >
             <MdMoreVert className="text-3xl" />
           </Menu.Button>
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <Transition show={open} as={Fragment} {...dropdownTransition}>
-            <Menu.Items
-              static
-              className="absolute z-10 w-max origin-top-right overflow-visible bg-white text-black shadow-md focus:outline-none"
-            >
+            <Menu.Items static className={commonClassName}>
               {React.Children.map(children, (child) => (
                 <Menu.Item>
                   {() =>
                     React.isValidElement(child)
-                      ? addClassName(
-                          child,
-                          `border-x border-b first-of-type:border-t border-black w-full py-1 px-2 focus:outline-none text-left`,
-                        )
+                      ? addClassName(child, menuItemClassName)
                       : child
                   }
                 </Menu.Item>


### PR DESCRIPTION
* Add the possibility to open the menu items right or left from the parent.
  * Use this in RouteStopsRow.tsx and LineDraftTableRow.tsx

Changes to SimpleDropdownMenu:
* Possibility to open menu items right / left
* Change Menu className `static` -> `relative`
* Remove Menu.Items className `w-max`
* Add Menu.Item className `whitespace-nowrap`
* Remove className `h-full` from Menu and Menu.Button

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/194)
<!-- Reviewable:end -->
