### PR TITLE
Hide navbar links from non-logged in users

### DIFF
--- a/cypress/integration/changeLanguage.spec.ts
+++ b/cypress/integration/changeLanguage.spec.ts
@@ -4,6 +4,7 @@ describe('Verify that language chancing works', () => {
   let navbar: Navbar;
   beforeEach(() => {
     navbar = new Navbar();
+    cy.mockLogin();
     cy.visit('/');
   });
   it('Changes language from FI to EN', () => {

--- a/src/components/navbar/NavLinks.tsx
+++ b/src/components/navbar/NavLinks.tsx
@@ -1,12 +1,13 @@
 import React, { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
+import { LoggedIn } from '../../layoutComponents/LoggedIn';
 import { routeDetails } from '../../router/routeDetails';
 
 export const NavLinks: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
-    <>
+    <LoggedIn>
       {Object.values(routeDetails)
         .filter((item) => item.includeInNav)
         .map(({ translationKey, getLink }) => (
@@ -23,6 +24,6 @@ export const NavLinks: FunctionComponent = () => {
             </NavLink>
           </div>
         ))}
-    </>
+    </LoggedIn>
   );
 };

--- a/src/layoutComponents/LoggedIn.tsx
+++ b/src/layoutComponents/LoggedIn.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useAppSelector } from '../hooks';
+import { selectUser } from '../redux';
+
+/*
+ * Convenience component for conditionally hiding components from
+ * non-logged in users. Should be removed when proper user
+ * permissions are implemented.
+ */
+export const LoggedIn: React.FC = ({ children }) => {
+  const { userInfo } = useAppSelector(selectUser);
+  const loggedIn = !!userInfo?.permissions;
+  return loggedIn ? <>{children}</> : null;
+};


### PR DESCRIPTION
This change was desired for MVP launch as this makes is
less likely for first time users to navigate to view
that would require logging in in order to be usable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/212)
<!-- Reviewable:end -->
