### PR TITLE
Remove observation nullability

### DIFF
--- a/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
@@ -32,10 +32,6 @@ export const ActionsRow = ({
     const updatedUrlQuery = produce(queryParams, (draft) => {
       if (date.isValid) {
         draft.selectedDate = date.toISODate();
-        delete draft.showAll;
-      } else {
-        draft.showAll = true.toString();
-        delete draft.selectedDate;
       }
     });
 
@@ -54,7 +50,8 @@ export const ActionsRow = ({
         <Column className="w-1/4">
           <input
             type="date"
-            value={observationDate?.toISODate() || ''}
+            required
+            value={observationDate?.toISODate()}
             onChange={(e) => onDateChange(DateTime.fromISO(e.target.value))}
             className="flex-1"
           />

--- a/ui/src/hooks/line-details/useGetLineDetails.ts
+++ b/ui/src/hooks/line-details/useGetLineDetails.ts
@@ -75,8 +75,7 @@ const getInitialDate = (
   }
 
   const isActiveToday =
-    validityStart &&
-    validityStart <= DateTime.now() &&
+    (!validityStart || validityStart <= DateTime.now()) &&
     (!validityEnd || validityEnd >= DateTime.now());
 
   if (isActiveToday) {

--- a/ui/src/hooks/line-details/useGetLineDetails.ts
+++ b/ui/src/hooks/line-details/useGetLineDetails.ts
@@ -125,7 +125,7 @@ export const useGetLineDetails = () => {
   const selectedDate = queryParams.selectedDate as string | undefined;
 
   const fetchLineDetails = async () => {
-    if (lineDetailsResult) {
+    if (lineDetailsResult?.data) {
       const lineDetails = mapLineDetailsWithRoutesResult(lineDetailsResult);
       const initialDate = getInitialDate(
         selectedDate,


### PR DESCRIPTION
This PR
* **Removes** the possibility to set observationDate to null.
* **Fixes a bug** where line details page fetched information with null parameters, which caused the result to be one random line information from the database. Now we check that the parameter exists before fetching the information.
* **Fixes a bug** where we did not support the possibility that `validity_start` could be null. Now the support is there and if the `validity_start` is null for a line, it will be considered as active (and if the validity_end is in the future or null)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/237)
<!-- Reviewable:end -->
