### PR TITLE
Refactor useGetLineDetails hook

### DIFF
--- a/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
@@ -1,7 +1,6 @@
 import produce from 'immer';
 import { DateTime } from 'luxon';
 import qs from 'qs';
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import { RouteLine } from '../../../generated/graphql';
@@ -31,7 +30,7 @@ export const ActionsRow = ({
   const onDateChange = (date: DateTime) => {
     const updatedUrlQuery = produce(queryParams, (draft) => {
       if (date.isValid) {
-        draft.selectedDate = date.toISODate();
+        draft.observationDate = date.toISODate();
       }
     });
 
@@ -51,7 +50,7 @@ export const ActionsRow = ({
           <input
             type="date"
             required
-            value={observationDate?.toISODate()}
+            value={observationDate?.toISODate() || ''}
             onChange={(e) => onDateChange(DateTime.fromISO(e.target.value))}
             className="flex-1"
           />

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -6999,6 +6999,13 @@ export type GetLineDetailsByIdQueryVariables = Exact<{
 
 export type GetLineDetailsByIdQuery = { __typename?: 'query_root', route_line_by_pk?: { __typename?: 'route_line', line_id: UUID, name_i18n: LocalizedString, short_name_i18n: LocalizedString, primary_vehicle_mode: ReusableComponentsVehicleModeEnum, type_of_line: RouteTypeOfLineEnum, transport_target: HslRouteTransportTargetEnum, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string } | null | undefined };
 
+export type GetLineValidityPeriodByIdQueryVariables = Exact<{
+  line_id: Scalars['uuid'];
+}>;
+
+
+export type GetLineValidityPeriodByIdQuery = { __typename?: 'query_root', route_line_by_pk?: { __typename?: 'route_line', line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined } | null | undefined };
+
 export type GetLinesByValidityQueryVariables = Exact<{
   filter?: Maybe<RouteLineBoolExp>;
 }>;
@@ -7828,6 +7835,43 @@ export function useGetLineDetailsByIdLazyQuery(baseOptions?: Apollo.LazyQueryHoo
 export type GetLineDetailsByIdQueryHookResult = ReturnType<typeof useGetLineDetailsByIdQuery>;
 export type GetLineDetailsByIdLazyQueryHookResult = ReturnType<typeof useGetLineDetailsByIdLazyQuery>;
 export type GetLineDetailsByIdQueryResult = Apollo.QueryResult<GetLineDetailsByIdQuery, GetLineDetailsByIdQueryVariables>;
+export const GetLineValidityPeriodByIdDocument = gql`
+    query GetLineValidityPeriodById($line_id: uuid!) {
+  route_line_by_pk(line_id: $line_id) {
+    line_id
+    validity_start
+    validity_end
+  }
+}
+    `;
+
+/**
+ * __useGetLineValidityPeriodByIdQuery__
+ *
+ * To run a query within a React component, call `useGetLineValidityPeriodByIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLineValidityPeriodByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetLineValidityPeriodByIdQuery({
+ *   variables: {
+ *      line_id: // value for 'line_id'
+ *   },
+ * });
+ */
+export function useGetLineValidityPeriodByIdQuery(baseOptions: Apollo.QueryHookOptions<GetLineValidityPeriodByIdQuery, GetLineValidityPeriodByIdQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetLineValidityPeriodByIdQuery, GetLineValidityPeriodByIdQueryVariables>(GetLineValidityPeriodByIdDocument, options);
+      }
+export function useGetLineValidityPeriodByIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetLineValidityPeriodByIdQuery, GetLineValidityPeriodByIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetLineValidityPeriodByIdQuery, GetLineValidityPeriodByIdQueryVariables>(GetLineValidityPeriodByIdDocument, options);
+        }
+export type GetLineValidityPeriodByIdQueryHookResult = ReturnType<typeof useGetLineValidityPeriodByIdQuery>;
+export type GetLineValidityPeriodByIdLazyQueryHookResult = ReturnType<typeof useGetLineValidityPeriodByIdLazyQuery>;
+export type GetLineValidityPeriodByIdQueryResult = Apollo.QueryResult<GetLineValidityPeriodByIdQuery, GetLineValidityPeriodByIdQueryVariables>;
 export const GetLinesByValidityDocument = gql`
     query GetLinesByValidity($filter: route_line_bool_exp) {
   route_line(where: $filter) {
@@ -8941,6 +8985,10 @@ export function useGetLineDetailsByIdAsyncQuery() {
           return useAsyncQuery<GetLineDetailsByIdQuery, GetLineDetailsByIdQueryVariables>(GetLineDetailsByIdDocument);
         }
 export type GetLineDetailsByIdAsyncQueryHookResult = ReturnType<typeof useGetLineDetailsByIdAsyncQuery>;
+export function useGetLineValidityPeriodByIdAsyncQuery() {
+          return useAsyncQuery<GetLineValidityPeriodByIdQuery, GetLineValidityPeriodByIdQueryVariables>(GetLineValidityPeriodByIdDocument);
+        }
+export type GetLineValidityPeriodByIdAsyncQueryHookResult = ReturnType<typeof useGetLineValidityPeriodByIdAsyncQuery>;
 export function useGetLinesByValidityAsyncQuery() {
           return useAsyncQuery<GetLinesByValidityQuery, GetLinesByValidityQueryVariables>(GetLinesByValidityDocument);
         }

--- a/ui/src/graphql/route.ts
+++ b/ui/src/graphql/route.ts
@@ -6,6 +6,7 @@ import {
   GetLineDetailsByIdQuery,
   GetLineDetailsWithRoutesByIdQuery,
   GetLinesByLabelAndPriorityQuery,
+  GetLineValidityPeriodByIdQuery,
   GetRouteDetailsByIdsQuery,
   InsertLineOneMutation,
   JourneyPatternScheduledStopPointInJourneyPattern,
@@ -178,6 +179,20 @@ const GET_LINE_DETAILS_BY_ID = gql`
 `;
 export const mapLineDetailsResult = (
   result: GqlQueryResult<GetLineDetailsByIdQuery>,
+) => result.data?.route_line_by_pk as RouteLine | undefined;
+
+const GET_LINE_VALIDITY_PERIOD_BY_ID = gql`
+  query GetLineValidityPeriodById($line_id: uuid!) {
+    route_line_by_pk(line_id: $line_id) {
+      line_id
+      validity_start
+      validity_end
+    }
+  }
+`;
+
+export const mapLineValidityPeriod = (
+  result: GqlQueryResult<GetLineValidityPeriodByIdQuery>,
 ) => result.data?.route_line_by_pk as RouteLine | undefined;
 
 const GET_LINES_BY_VALIDITY = gql`


### PR DESCRIPTION
Refactor hook to always update `observationDate` to queryString before fetching by the observationDate:
* If observationDate is not present in queryString, we check if the line is active today:
  * If line **is active today**, we set *today's date* to queryString
  * If line **is not active today**, we set line's *validity_start* to queryString

Note: If line priority is removed (https://github.com/HSLdevcom/jore4/issues/870), then this hook can be simplified a lot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/244)
<!-- Reviewable:end -->
