### PR TITLE
Add generic graphql result mappers

### DIFF
--- a/ui/src/components/map/RouteStopsOverlay.tsx
+++ b/ui/src/components/map/RouteStopsOverlay.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useGetRoutesWithInfrastructureLinksQuery } from '../../generated/graphql';
-import { getStopsFromRoute, mapRoutesDetailsResult } from '../../graphql';
+import { getStopsFromRoute, mapRouteResultToRoutes } from '../../graphql';
 import { getRouteStops, useAppDispatch, useAppSelector } from '../../hooks';
 import { mapDirectionToShortUiName } from '../../i18n/uiNameMappings';
 import { Visible } from '../../layoutComponents';
@@ -74,7 +74,7 @@ export const RouteStopsOverlay = ({ className = '' }: Props) => {
     mapToVariables({ route_ids: [selectedRouteId] }),
   );
 
-  const routes = mapRoutesDetailsResult(routesResult);
+  const routes = mapRouteResultToRoutes(routesResult);
   const selectedRoute = routes?.[0];
 
   // FIXME: the typings are off, shouldn't compare editedRouteData.metaData with selectedRoute

--- a/ui/src/components/map/routes/DrawRouteLayer.tsx
+++ b/ui/src/components/map/routes/DrawRouteLayer.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../../generated/graphql';
 import {
   mapGraphQLRouteToInfraLinks,
-  mapRoutesDetailsResult,
+  mapRouteResultToRoutes,
 } from '../../../graphql';
 import {
   getRouteStops,
@@ -123,7 +123,7 @@ const DrawRouteLayerComponent = (
     variables: { route_ids: baseGeometryRouteId ? [baseGeometryRouteId] : [] },
   });
 
-  const routes = mapRoutesDetailsResult(routesResult);
+  const routes = mapRouteResultToRoutes(routesResult);
 
   const onUpdateRouteGeometry = useCallback(
     async (newFeatures: LineStringFeature[]) => {

--- a/ui/src/components/map/routes/RouteLayer.tsx
+++ b/ui/src/components/map/routes/RouteLayer.tsx
@@ -2,7 +2,7 @@ import { LineLayout } from 'maplibre-gl';
 import { Layer, Source } from 'react-map-gl';
 import { useGetRouteDetailsByIdsQuery } from '../../../generated/graphql';
 import { theme } from '../../../generated/theme';
-import { mapRouteDetailsResult } from '../../../graphql';
+import { mapRouteResultToRoute } from '../../../graphql';
 import { mapGeoJSONtoFeature, mapToVariables } from '../../../utils';
 
 const { colors } = theme;
@@ -23,7 +23,7 @@ export const RouteLayer = ({ routeId, isSelected }: Props) => {
   const routeDetailsResult = useGetRouteDetailsByIdsQuery(
     mapToVariables({ route_ids: [routeId] }),
   );
-  const routeDetails = mapRouteDetailsResult(routeDetailsResult);
+  const routeDetails = mapRouteResultToRoute(routeDetailsResult);
 
   // do not render anything before data is received
   if (!routeDetails?.route_shape || !routeDetails.route_line) {

--- a/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -5,7 +5,7 @@ import {
   RouteRoute,
   useGetRouteDetailsByIdsQuery,
 } from '../../../generated/graphql';
-import { mapRouteDetailsResult } from '../../../graphql';
+import { mapRouteResultToRoute } from '../../../graphql';
 import { useDeleteRoute, useEditRouteMetadata } from '../../../hooks';
 import { Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
@@ -68,7 +68,7 @@ export const EditRoutePage = (): JSX.Element => {
   const routeDetailsResult = useGetRouteDetailsByIdsQuery({
     ...mapToVariables({ route_ids: [id] }),
   });
-  const route = mapRouteDetailsResult(routeDetailsResult);
+  const route = mapRouteResultToRoute(routeDetailsResult);
   const { t } = useTranslation();
 
   const onSave = () => {

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
@@ -5,8 +5,8 @@ import {
   useListOwnLinesQuery,
 } from '../../../generated/graphql';
 import {
-  mapListChangingRoutesResult,
   mapListOwnLinesResult,
+  mapRouteResultToRoutes,
 } from '../../../graphql';
 import { LinesList } from './LinesList';
 import { ListFooter } from './ListFooter';
@@ -25,7 +25,7 @@ export const RoutesAndLinesLists = (): JSX.Element => {
   const changingRoutesResult = useListChangingRoutesQuery({
     variables: { limit: changingRoutesLimit },
   });
-  const changingRoutes = mapListChangingRoutesResult(changingRoutesResult);
+  const changingRoutes = mapRouteResultToRoutes(changingRoutesResult);
 
   // own lines
   const ownLinesResult = useListOwnLinesQuery();

--- a/ui/src/components/routes-and-lines/main/RoutesTable.spec.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesTable.spec.tsx
@@ -8,8 +8,8 @@ import {
 } from '../../../generated/graphql';
 import {
   GqlQueryResult,
-  mapListChangingRoutesResult,
   mapListOwnLinesResult,
+  mapRouteResultToRoutes,
 } from '../../../graphql';
 import {
   buildLocalizedString,
@@ -54,7 +54,7 @@ describe(`<${RoutesTable.name} />`, () => {
 
   test('Renders the table with route data', async () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const routes = mapListChangingRoutesResult(routesResponseMock)!;
+    const routes = mapRouteResultToRoutes(routesResponseMock)!;
     const { asFragment } = render(
       <RoutesTable testId={testId}>
         {routes.map((item: RouteRoute) => (

--- a/ui/src/graphql/index.ts
+++ b/ui/src/graphql/index.ts
@@ -2,6 +2,7 @@ export * from './auth';
 export * from './client';
 export * from './infrastructureNetwork';
 export * from './journeyPattern';
+export * from './resultMappers';
 export * from './route';
 export * from './servicePattern';
 export * from './types';

--- a/ui/src/graphql/resultMappers.ts
+++ b/ui/src/graphql/resultMappers.ts
@@ -1,0 +1,28 @@
+import { QueryRoot, RouteRoute } from '../generated/graphql';
+import { GqlQueryResult, GqlQueryResultData } from './types';
+
+type RouteLike = Pick<RouteRoute, '__typename'>;
+type QueryRootLike<T> = Pick<QueryRoot, '__typename'> & T;
+
+// TODO: extend and generalize this for other query results too
+
+// eslint-disable-next-line camelcase
+type RoutePkQueryResult = QueryRootLike<{ route_route_by_pk?: RouteLike }>;
+// eslint-disable-next-line camelcase
+type RouteQueryResult = QueryRootLike<{ route_route?: RouteLike[] }>;
+
+const isRouteQueryResult = (
+  result: GqlQueryResult<GqlQueryResultData>,
+): result is GqlQueryResult<RouteQueryResult> => {
+  return !!result.data && 'route_route' in result.data;
+};
+export const mapRouteResultToRoute = (
+  result: GqlQueryResult<RoutePkQueryResult> | GqlQueryResult<RouteQueryResult>,
+) =>
+  (isRouteQueryResult(result)
+    ? result.data?.route_route?.[0]
+    : result.data?.route_route_by_pk) as RouteRoute | undefined;
+
+export const mapRouteResultToRoutes = (
+  result: GqlQueryResult<RouteQueryResult>,
+) => (result.data?.route_route || []) as RouteRoute[];

--- a/ui/src/graphql/route.ts
+++ b/ui/src/graphql/route.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ApolloQueryResult, FetchResult, gql } from '@apollo/client';
+import { FetchResult, gql } from '@apollo/client';
 import {
   GetCurrentOrFutureLinesByLabelQuery,
   GetHighestPriorityLineDetailsWithRoutesQuery,
@@ -7,16 +7,11 @@ import {
   GetLineDetailsWithRoutesByIdQuery,
   GetLinesByLabelAndPriorityQuery,
   GetLineValidityPeriodByIdQuery,
-  GetRouteDetailsByIdsQuery,
   InsertLineOneMutation,
   JourneyPatternScheduledStopPointInJourneyPattern,
-  ListChangingRoutesQuery,
   RouteLine,
   RouteRoute,
   ServicePatternScheduledStopPoint,
-  useGetRouteDetailsByIdsQuery,
-  useGetRouteDetailsByLabelWildcardQuery,
-  useGetRoutesWithInfrastructureLinksQuery,
   useListOwnLinesQuery,
   useSearchLinesAndRoutesQuery,
 } from '../generated/graphql';
@@ -166,9 +161,6 @@ const LIST_CHANGING_ROUTES = gql`
     }
   }
 `;
-export const mapListChangingRoutesResult = (
-  result: GqlQueryResult<ListChangingRoutesQuery>,
-) => result.data?.route_route as RouteRoute[] | undefined;
 
 const GET_LINE_DETAILS_BY_ID = gql`
   query GetLineDetailsById($line_id: uuid!) {
@@ -375,18 +367,6 @@ const GET_CURRENT_OR_FUTURE_LINES_BY_LABEL = gql`
 export const mapCurrentOrFutureLinesResult = (
   result: GqlQueryResult<GetCurrentOrFutureLinesByLabelQuery>,
 ) => result.data?.route_line as RouteLine[] | undefined;
-
-export const mapRouteDetailsResult = (
-  result: ReturnType<typeof useGetRouteDetailsByIdsQuery>,
-) => result.data?.route_route[0] as RouteRoute | undefined;
-
-export const mapRoutesDetailsResult = (
-  result:
-    | ApolloQueryResult<GetRouteDetailsByIdsQuery>
-    | ReturnType<typeof useGetRoutesWithInfrastructureLinksQuery>
-    | ReturnType<typeof useGetRouteDetailsByLabelWildcardQuery>
-    | ReturnType<typeof useGetRouteDetailsByIdsQuery>,
-) => result.data?.route_route as RouteRoute[] | [];
 
 const GET_ROUTES_WITH_INFRASTRUCTURE_LINKS = gql`
   query GetRoutesWithInfrastructureLinks($route_ids: [uuid!]) {

--- a/ui/src/hooks/routes/useGetDisplayedRoutes.ts
+++ b/ui/src/hooks/routes/useGetDisplayedRoutes.ts
@@ -7,7 +7,7 @@ import {
   GetRouteDetailsByLabelsQuery,
   GetRouteDetailsByLabelsQueryVariables,
 } from '../../generated/graphql';
-import { mapRoutesDetailsResult } from '../../graphql';
+import { mapRouteResultToRoutes } from '../../graphql';
 import {
   selectMapEditor,
   selectMapObservationDate,
@@ -41,7 +41,7 @@ export const useGetDisplayedRoutes = () => {
       const routeDetailsResult = await getRouteDetailsByIds({
         route_ids: initiallyDisplayedRouteIds,
       });
-      const routeDetails = mapRoutesDetailsResult(routeDetailsResult);
+      const routeDetails = mapRouteResultToRoutes(routeDetailsResult);
 
       if (!routeDetails.length) {
         return [];
@@ -54,7 +54,7 @@ export const useGetDisplayedRoutes = () => {
         date: observationDate,
       });
 
-      const displayedRouteDetails = mapRoutesDetailsResult(
+      const displayedRouteDetails = mapRouteResultToRoutes(
         displayedRouteDetailsResult,
       );
 

--- a/ui/src/hooks/stops/useMapStops.ts
+++ b/ui/src/hooks/stops/useMapStops.ts
@@ -8,7 +8,7 @@ import {
 import {
   getRouteStopLabels,
   mapGetStopsResult,
-  mapRoutesDetailsResult,
+  mapRouteResultToRoutes,
 } from '../../graphql';
 import {
   selectHasChangesInProgress,
@@ -36,7 +36,7 @@ export const useMapStops = () => {
   const selectedRoutesResult = useGetRoutesWithInfrastructureLinksQuery(
     mapToVariables({ route_ids: selectedRouteId ? [selectedRouteId] : [] }),
   );
-  const selectedRoutes = mapRoutesDetailsResult(selectedRoutesResult);
+  const selectedRoutes = mapRouteResultToRoutes(selectedRoutesResult);
   const selectedRouteStopsResult = useGetStopsByLabelsQuery(
     mapToVariables({
       stopLabels:
@@ -50,7 +50,7 @@ export const useMapStops = () => {
   const displayedRoutesResult = useGetRoutesWithInfrastructureLinksQuery(
     mapToVariables({ route_ids: displayedRouteIds }),
   );
-  const displayedRoutes = mapRoutesDetailsResult(displayedRoutesResult);
+  const displayedRoutes = mapRouteResultToRoutes(displayedRoutesResult);
 
   const stopLabelsOnEditedRoute = mapRouteStopsToStopLabels(
     editedRouteData.stops,

--- a/ui/src/hooks/useChooseRouteDropdown.ts
+++ b/ui/src/hooks/useChooseRouteDropdown.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { useGetRouteDetailsByLabelWildcardQuery } from '../generated/graphql';
-import { mapRoutesDetailsResult } from '../graphql';
+import { mapRouteResultToRoutes } from '../graphql';
 import { Priority } from '../types/Priority';
 import { mapToSqlLikeValue, mapToVariables } from '../utils';
 
@@ -16,7 +16,7 @@ export const useChooseRouteDropdown = (
       priorities,
     }),
   );
-  const routes = mapRoutesDetailsResult(routesResult);
+  const routes = mapRouteResultToRoutes(routesResult);
 
   return routes;
 };


### PR DESCRIPTION
Only for route.route entities for now; to be extended and generalized with other types in the future

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/249)
<!-- Reviewable:end -->
