### PR TITLE
Fix graphql result mappers

### DIFF
--- a/ui/src/graphql/resultMappers.ts
+++ b/ui/src/graphql/resultMappers.ts
@@ -4,6 +4,11 @@ import { GqlQueryResult, GqlQueryResultData } from './types';
 type RouteLike = Pick<RouteRoute, '__typename'>;
 type QueryRootLike<T> = Pick<QueryRoot, '__typename'> & T;
 
+// Using a static, constant array (instead of `result || []`) as a default value for array queries
+// to avoid infinite render loop caused by constantly changing object reference. This array is
+// constant as we don't want anyone to write to this globally shared variable.
+const emptyArray = [] as const;
+
 // TODO: extend and generalize this for other query results too
 
 // eslint-disable-next-line camelcase
@@ -25,4 +30,4 @@ export const mapRouteResultToRoute = (
 
 export const mapRouteResultToRoutes = (
   result: GqlQueryResult<RouteQueryResult>,
-) => (result.data?.route_route || []) as RouteRoute[];
+) => (result.data?.route_route as RouteRoute[]) || emptyArray;


### PR DESCRIPTION
There was a bug where the missing result was always defaulted to a new instance of an empty array, thus resulting in an infinite rendering loop

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/252)
<!-- Reviewable:end -->
