### PR TITLE
Fix route hilight bug after edit

### DIFF
--- a/ui/src/components/map/routes/DrawRouteLayer.tsx
+++ b/ui/src/components/map/routes/DrawRouteLayer.tsx
@@ -108,7 +108,7 @@ const DrawRouteLayerComponent = (
   useImperativeHandle(externalRef, () => ({
     onDeleteRoute: () => {
       // currently user can draw only one route, so id of it will always be '0'
-      const routeId = '0';
+      const routeId = SNAPPING_LINE_LAYER_ID;
       onDelete(routeId);
     },
   }));


### PR DESCRIPTION
Fix bug which caused hilight colors to go off after route edit and deselect

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/259)
<!-- Reviewable:end -->
