### PR TITLE
Fix multiple stop versions on map

### DIFF
--- a/ui/src/components/map/RouteStopsOverlay.tsx
+++ b/ui/src/components/map/RouteStopsOverlay.tsx
@@ -129,9 +129,12 @@ export const RouteStopsOverlay = ({ className = '' }: Props) => {
           </div>
         </div>
       </div>
-      {routeStops?.map((routeStop) => (
+      {routeStops?.map((routeStop, index) => (
         <StopRow
-          key={routeStop.label}
+          // This list is recreated every time when changes happen, so we can
+          // use index as key here
+          // eslint-disable-next-line react/no-array-index-key
+          key={`${routeStop.label}_${index}`}
           label={routeStop.label}
           onRoute={routeStop.belongsToJourneyPattern}
           isReadOnly={!routeEditingInProgress}

--- a/ui/src/components/map/routes/DrawRouteLayer.tsx
+++ b/ui/src/components/map/routes/DrawRouteLayer.tsx
@@ -43,7 +43,7 @@ import {
   setDraftRouteGeometryAction,
   stopRouteEditingAction,
 } from '../../../redux';
-import { showToast } from '../../../utils';
+import { filterDistinctConsecutiveRouteStops, showToast } from '../../../utils';
 import { addRoute, removeRoute } from '../mapUtils';
 import { featureStyle, handleStyle } from './editorStyles';
 
@@ -166,7 +166,12 @@ const DrawRouteLayerComponent = (
         editedRouteData?.id,
       );
 
-      dispatch(setDraftRouteGeometryAction({ stops: routeStops, infraLinks }));
+      dispatch(
+        setDraftRouteGeometryAction({
+          stops: filterDistinctConsecutiveRouteStops(routeStops),
+          infraLinks,
+        }),
+      );
 
       if (geometry) {
         addRoute(map, SNAPPING_LINE_LAYER_ID, geometry);
@@ -179,7 +184,7 @@ const DrawRouteLayerComponent = (
     },
     [
       baseRoute,
-      editedRouteData.id,
+      editedRouteData?.id,
       editedRouteData.stops,
       editedRouteData.infraLinks,
       creatingNewRoute,

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
@@ -111,9 +111,12 @@ export const RouteStopsSection = ({
         onToggle={onToggle}
       />
       {isOpen &&
-        displayedStops.map((item) => (
+        displayedStops.map((item, index) => (
           <RouteStopsRow
-            key={item.scheduled_stop_point_id}
+            // This list is recreated every time when changes happen, so we can
+            // use index as key here
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${item.label}_${index}`}
             stop={item}
             routeId={route.route_id}
             onAddToRoute={onAddToRoute}

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -1088,7 +1088,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
                 aria-haspopup="true"
                 class="mx-auto flex items-center px-3 focus:outline-none"
                 data-testid="stop-row-action-menu"
-                id="headlessui-menu-button-4"
+                id="headlessui-menu-button-6"
                 type="button"
               >
                 <svg

--- a/ui/src/graphql/route.ts
+++ b/ui/src/graphql/route.ts
@@ -538,6 +538,7 @@ export interface RouteStop {
    * Metadata (e.g. via point informaiton) of the stop in journey pattern
    */
   stop?: JourneyPatternScheduledStopPointInJourneyPattern;
+  scheduledStopPointId?: UUID;
 }
 
 /**
@@ -595,5 +596,6 @@ export const mapStopToRouteStop = (
     label: stop.label,
     belongsToJourneyPattern,
     stop: stopInJourneyPattern,
+    scheduledStopPointId: stop.scheduled_stop_point_id,
   };
 };

--- a/ui/src/hooks/routes/useEditRouteJourneyPattern.ts
+++ b/ui/src/hooks/routes/useEditRouteJourneyPattern.ts
@@ -10,7 +10,10 @@ import {
   RouteStop,
   stopBelongsToJourneyPattern,
 } from '../../graphql';
-import { removeFromApolloCache } from '../../utils';
+import {
+  filterDistinctConsecutiveRouteStops,
+  removeFromApolloCache,
+} from '../../utils';
 import { useValidateRoute } from './useValidateRoute';
 
 interface DeleteStopParams {
@@ -52,11 +55,16 @@ export const useEditRouteJourneyPattern = () => {
       return mapStopToRouteStop(stop, belongsToRoute, route.route_id);
     });
 
-    validateStopCount(routeStops);
+    // If multiple versions of one stop is active, they are in the list, but
+    // only one version should be added to the journey pattern
+    const distinctConsecutiveRouteStops =
+      filterDistinctConsecutiveRouteStops(routeStops);
+
+    validateStopCount(distinctConsecutiveRouteStops);
 
     const changes: UpdateJourneyPatternChanges = {
       routeId: route.route_id,
-      routeStops,
+      routeStops: distinctConsecutiveRouteStops,
     };
 
     return changes;

--- a/ui/src/hooks/stops/useMapStops.ts
+++ b/ui/src/hooks/stops/useMapStops.ts
@@ -1,77 +1,87 @@
+import { DateTime } from 'luxon';
 import { useCallback } from 'react';
 import {
   ReusableComponentsVehicleModeEnum,
+  RouteRoute,
   ServicePatternScheduledStopPoint,
   useGetRoutesWithInfrastructureLinksQuery,
-  useGetStopsByLabelsQuery,
 } from '../../generated/graphql';
-import {
-  getRouteStopLabels,
-  mapRouteResultToRoutes,
-  mapStopResultToStops,
-} from '../../graphql';
+import { getRouteStopLabels, mapRouteResultToRoutes } from '../../graphql';
 import {
   selectHasChangesInProgress,
   selectMapEditor,
+  selectMapObservationDate,
   selectSelectedStopId,
 } from '../../redux';
 import { RequiredKeys } from '../../types';
+import { Priority } from '../../types/Priority';
 import { mapToVariables } from '../../utils';
 import { useAppSelector } from '../redux';
 import { useGetDisplayedRoutes } from '../routes/useGetDisplayedRoutes';
 import { useExtractRouteFromFeature } from '../useExtractRouteFromFeature';
+import { filterHighestPriorityCurrentStops } from '../useFilterStops';
 
 export type StopWithVehicleMode = RequiredKeys<
   Partial<ServicePatternScheduledStopPoint>,
   'vehicle_mode_on_scheduled_stop_point'
 >;
 
+const extractHighestPriorityStopsFromRoute = (
+  route: RouteRoute,
+  observationDate: DateTime,
+) => {
+  const routeStopPoints =
+    route.route_journey_patterns[0].scheduled_stop_point_in_journey_patterns.flatMap(
+      (journeyPatternStop) => journeyPatternStop.scheduled_stop_points,
+    ) ?? [];
+
+  return filterHighestPriorityCurrentStops(
+    routeStopPoints,
+    observationDate,
+    // If the route is a draft, we want to select draft versions of stops if there are any
+    route.priority === Priority.Draft,
+  );
+};
+
 export const useMapStops = () => {
   const { editedRouteData, selectedRouteId } = useAppSelector(selectMapEditor);
   const routeEditingInProgress = useAppSelector(selectHasChangesInProgress);
+  const observationDate = useAppSelector(selectMapObservationDate);
   const { displayedRouteIds } = useGetDisplayedRoutes();
   const selectedStopId = useAppSelector(selectSelectedStopId);
   const { mapRouteStopsToStopLabels } = useExtractRouteFromFeature();
 
-  const selectedRoutesResult = useGetRoutesWithInfrastructureLinksQuery(
-    mapToVariables({ route_ids: selectedRouteId ? [selectedRouteId] : [] }),
-  );
-  const selectedRoutes = mapRouteResultToRoutes(selectedRoutesResult);
-  const selectedRouteStopsResult = useGetStopsByLabelsQuery(
-    mapToVariables({
-      stopLabels:
-        selectedRoutes?.flatMap((route) => getRouteStopLabels(route)) || [],
-    }),
-  );
-  const stopsIdsOnSelectedRoute = mapStopResultToStops(
-    selectedRouteStopsResult,
-  ).map((stop) => stop.scheduled_stop_point_id);
-
   const displayedRoutesResult = useGetRoutesWithInfrastructureLinksQuery(
     mapToVariables({ route_ids: displayedRouteIds }),
   );
-  const displayedRoutes = mapRouteResultToRoutes(displayedRoutesResult);
 
-  const stopLabelsOnEditedRoute = mapRouteStopsToStopLabels(
+  const displayedRoutes = mapRouteResultToRoutes(displayedRoutesResult);
+  const selectedRoute = displayedRoutes.find(
+    (route) => route.route_id === selectedRouteId,
+  );
+
+  const selectedRouteActiveStops = selectedRoute
+    ? extractHighestPriorityStopsFromRoute(selectedRoute, observationDate)
+    : [];
+
+  const selectedRouteActiveStopIds = selectedRouteActiveStops.map(
+    (stop) => stop.scheduled_stop_point_id,
+  );
+
+  const editedRouteStopIds = editedRouteData.stops
+    .filter((stop) => stop.belongsToJourneyPattern)
+    .flatMap((stop) => stop.scheduledStopPointId);
+
+  const editedRouteStopLabels = mapRouteStopsToStopLabels(
     editedRouteData.stops,
   );
-
-  const editedRouteStopsResult = useGetStopsByLabelsQuery(
-    mapToVariables({
-      stopLabels: stopLabelsOnEditedRoute,
-    }),
-  );
-
-  const stopsIdsOnEditedRoute = mapStopResultToStops(
-    editedRouteStopsResult,
-  ).map((stop) => stop.scheduled_stop_point_id);
 
   const getStopVehicleMode = useCallback(
     (
       stop: StopWithVehicleMode,
     ): ReusableComponentsVehicleModeEnum | undefined => {
       const stopsLabelsOnRoutes = [
-        ...stopLabelsOnEditedRoute,
+        ...editedRouteStopLabels,
         ...(displayedRoutes?.flatMap((route) => getRouteStopLabels(route)) ||
           []),
       ];
@@ -80,23 +90,26 @@ export const useMapStops = () => {
         ? stop.vehicle_mode_on_scheduled_stop_point[0].vehicle_mode
         : undefined;
     },
-    [displayedRoutes, stopLabelsOnEditedRoute],
+    [displayedRoutes, editedRouteStopLabels],
   );
 
   const getStopHighlighted = useCallback(
     (id: UUID): boolean => {
       // If editing a route, highlight stops on edited route
       // Otherwise highlight stops belonging to selected route
-      const highlightedStopIds = routeEditingInProgress
-        ? stopsIdsOnEditedRoute
-        : stopsIdsOnSelectedRoute;
+      // Also hilight selectedRoute stops until editedRouteData is loaded
+      const highlightedStopIds =
+        routeEditingInProgress && editedRouteData.stops.length > 0
+          ? editedRouteStopIds
+          : selectedRouteActiveStopIds;
 
       return highlightedStopIds?.includes(id) || selectedStopId === id;
     },
     [
       routeEditingInProgress,
-      stopsIdsOnEditedRoute,
-      stopsIdsOnSelectedRoute,
+      editedRouteData.stops.length,
+      editedRouteStopIds,
+      selectedRouteActiveStopIds,
       selectedStopId,
     ],
   );

--- a/ui/src/utils/stops.ts
+++ b/ui/src/utils/stops.ts
@@ -1,4 +1,5 @@
 import { ServicePatternScheduledStopPoint } from '../generated/graphql';
+import { RouteStop } from '../graphql/route';
 
 const sortStopsByTraversalForwards = (
   stop1: ServicePatternScheduledStopPoint,
@@ -24,3 +25,10 @@ export const sortStopsOnInfraLink = (
       ? sortStopsByTraversalForwards
       : sortStopsByTraversalBackwards,
   );
+
+/** Removes all duplicate labeled consecutive stops from the list
+ * This is used for example removing different versions of stops from the
+ * journey pattern list where only the labels are shown
+ */
+export const filterDistinctConsecutiveRouteStops = (stops: RouteStop[]) =>
+  stops.filter((route, index) => stops[index - 1]?.label !== route.label);


### PR DESCRIPTION
Resolves HSLdevcom/jore4#860
This also refactors useMapStops logic to make less graphQL fetches and getting the same information over and over again.

Additional note: Not sure if these two functionalities (getStopHighlighted, getStopVehicleMode) benefit from being in the same hook, or should they be split in to their own hooks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/262)
<!-- Reviewable:end -->
