### PR TITLE
Fix closing route metadata view

### DIFF
--- a/ui/src/redux/slices/mapEditor.ts
+++ b/ui/src/redux/slices/mapEditor.ts
@@ -179,9 +179,13 @@ const slice = createSlice({
         metaData: action.payload,
       };
 
-      state.drawingMode = state.editedRouteData.templateRouteId
-        ? Mode.Edit
-        : Mode.Draw;
+      // Start drawing mode only if a route has not been drawn already
+      if (state.editedRouteData.infraLinks?.length === 0) {
+        state.drawingMode = state.editedRouteData.templateRouteId
+          ? Mode.Edit
+          : Mode.Draw;
+      }
+
       state.isRouteMetadataFormOpen = false;
     },
     /**


### PR DESCRIPTION
Disables starting to draw a new route on map when closing metadata view
on a new route. Only start draw mode if the route is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/263)
<!-- Reviewable:end -->
