### PR TITLE
Rework line drafts page

### DIFF
--- a/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
@@ -1,10 +1,10 @@
-import produce from 'immer';
-import { DateTime } from 'luxon';
 import qs from 'qs';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router';
 import { RouteLine } from '../../../generated/graphql';
-import { useGetLineDetails, useUrlQuery } from '../../../hooks';
+import {
+  useGetLineDetails,
+  useObservationDateQueryParam,
+} from '../../../hooks';
 import { Column, Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { SimpleButton } from '../../../uiComponents';
@@ -22,22 +22,14 @@ export const ActionsRow = ({
   className?: string;
 }): JSX.Element => {
   const { t } = useTranslation();
-  const history = useHistory();
-  const queryParams = useUrlQuery();
 
-  const { line, observationDate } = useGetLineDetails();
+  const { line } = useGetLineDetails();
 
-  const onDateChange = (date: DateTime) => {
-    const updatedUrlQuery = produce(queryParams, (draft) => {
-      if (date.isValid) {
-        draft.observationDate = date.toISODate();
-      }
-    });
+  const { observationDate, setObservationDateToUrl } =
+    useObservationDateQueryParam();
 
-    const queryString = qs.stringify(updatedUrlQuery);
-    history.push({
-      search: `?${queryString}`,
-    });
+  const onDateChange = (value: string) => {
+    setObservationDateToUrl(value);
   };
 
   return (
@@ -51,7 +43,7 @@ export const ActionsRow = ({
             type="date"
             required
             value={observationDate?.toISODate() || ''}
-            onChange={(e) => onDateChange(DateTime.fromISO(e.target.value))}
+            onChange={(e) => onDateChange(e.target.value)}
             className="flex-1"
           />
         </Column>

--- a/ui/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
@@ -31,7 +31,7 @@ export const LineDetailsPage = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const { addMapOpenQueryParameter } = useMapUrlQuery();
 
-  const { line } = useGetLineDetails();
+  const { line, observationDate } = useGetLineDetails();
 
   const onCreateRoute = () => {
     dispatch(resetMapEditorStateAction());
@@ -74,7 +74,10 @@ export const LineDetailsPage = (): JSX.Element => {
                   {t('lines.routes')}
                 </h1>
                 {line.line_routes?.length > 0 ? (
-                  <RouteStopsTable routes={line.line_routes} />
+                  <RouteStopsTable
+                    routes={line.line_routes}
+                    observationDate={observationDate ?? DateTime.now()}
+                  />
                 ) : (
                   <CreateRouteBox onCreateRoute={onCreateRoute} />
                 )}

--- a/ui/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
@@ -6,6 +5,7 @@ import {
   useAppSelector,
   useGetLineDetails,
   useMapUrlQuery,
+  useObservationDateQueryParam,
 } from '../../../hooks';
 import { Column, Container, Row, Visible } from '../../../layoutComponents';
 import {
@@ -31,7 +31,8 @@ export const LineDetailsPage = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const { addMapOpenQueryParameter } = useMapUrlQuery();
 
-  const { line, observationDate } = useGetLineDetails();
+  const { line } = useGetLineDetails();
+  const { observationDate } = useObservationDateQueryParam();
 
   const onCreateRoute = () => {
     dispatch(resetMapEditorStateAction());
@@ -73,10 +74,10 @@ export const LineDetailsPage = (): JSX.Element => {
                 <h1 className="mt-8 text-3xl font-semibold">
                   {t('lines.routes')}
                 </h1>
-                {line.line_routes?.length > 0 ? (
+                {line.line_routes?.length > 0 && observationDate ? (
                   <RouteStopsTable
                     routes={line.line_routes}
-                    observationDate={observationDate ?? DateTime.now()}
+                    observationDate={observationDate}
                   />
                 ) : (
                   <CreateRouteBox onCreateRoute={onCreateRoute} />

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
@@ -9,7 +9,6 @@ import {
 import {
   filterHighestPriorityCurrentStops,
   useEditRouteJourneyPattern,
-  useGetLineDetails,
 } from '../../../hooks';
 import { Priority } from '../../../types/Priority';
 import { showDangerToast, showSuccessToast } from '../../../utils';
@@ -19,12 +18,14 @@ import { RouteStopsRow } from './RouteStopsRow';
 interface Props {
   className?: string;
   route: RouteRoute;
+  observationDate: DateTime;
   showUnusedStops: boolean;
 }
 
 export const RouteStopsSection = ({
   className = '',
   route,
+  observationDate,
   showUnusedStops,
 }: Props) => {
   const [isOpen, setOpen] = useState(false);
@@ -40,8 +41,6 @@ export const RouteStopsSection = ({
   const onToggle = () => {
     setOpen(!isOpen);
   };
-
-  const { observationDate } = useGetLineDetails();
 
   const stopsAlongRoute = getEligibleStopsAlongRouteGeometry(route);
 

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsTable.spec.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsTable.spec.tsx
@@ -198,7 +198,11 @@ describe(`<${RouteStopsTable.name} />`, () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const line = mapLineDetailsWithRoutesResult(mockResponse)!;
     const { container, asFragment } = render(
-      <RouteStopsTable testId={testId} routes={line.line_routes} />,
+      <RouteStopsTable
+        observationDate={DateTime.fromISO('2022-01-01')}
+        testId={testId}
+        routes={line.line_routes}
+      />,
     );
 
     // the stops don't show as the accordion is not open

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsTable.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsTable.tsx
@@ -1,5 +1,6 @@
 import { Switch as HuiSwitch } from '@headlessui/react';
 import orderBy from 'lodash/orderBy';
+import { DateTime } from 'luxon/src/datetime';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RouteRoute } from '../../../generated/graphql';
@@ -9,10 +10,16 @@ import { RouteStopsSection } from './RouteStopsSection';
 interface Props {
   className?: string;
   routes: RouteRoute[];
+  observationDate: DateTime;
   testId?: string;
 }
 
-export const RouteStopsTable = ({ className = '', routes, testId }: Props) => {
+export const RouteStopsTable = ({
+  className = '',
+  routes,
+  observationDate,
+  testId,
+}: Props) => {
   const { t } = useTranslation();
   const [showUnusedStops, setShowUnusedStops] = useState(false);
   const sortedRoutes = orderBy(routes, ['label', 'direction'], ['asc', 'desc']);
@@ -38,6 +45,7 @@ export const RouteStopsTable = ({ className = '', routes, testId }: Props) => {
             <RouteStopsSection
               key={item.route_id}
               route={item}
+              observationDate={observationDate}
               showUnusedStops={showUnusedStops}
             />
           );

--- a/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
@@ -1,21 +1,20 @@
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router';
-import { RouteLine } from '../../../generated/graphql';
-import { useUrlQuery } from '../../../hooks';
+import { useObservationDateQueryParam, useUrlQuery } from '../../../hooks';
 import { useGetLineDraftDetails } from '../../../hooks/line-drafts/useGetLineDraftDetails';
-import { Container, Row } from '../../../layoutComponents';
+import { Column, Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { CloseIconButton } from '../../../uiComponents';
-import { RoutesTable } from '../main/RoutesTable';
-import { LineDraftTableHeader } from './LineDraftsTableHeader';
-import { LineDraftTableRow } from './LineDraftTableRow';
+import { RouteStopsTable } from '../line-details/RouteStopsTable';
 
 export const LineDraftsPage = (): JSX.Element => {
   const { t } = useTranslation();
   const history = useHistory();
   const { label } = useParams<{ label: string }>();
-  const queryParams = useUrlQuery();
-  const { lines } = useGetLineDraftDetails();
+  const { queryParams } = useUrlQuery();
+  const { observationDate, setObservationDateToUrl } =
+    useObservationDateQueryParam();
+  const { routes } = useGetLineDraftDetails();
 
   const onClose = () => {
     // If there is no returnTo set, we return to 'routes and lines' page
@@ -26,6 +25,10 @@ export const LineDraftsPage = (): JSX.Element => {
     history.push({
       pathname,
     });
+  };
+
+  const onDateChange = (value: string) => {
+    setObservationDateToUrl(value);
   };
 
   return (
@@ -40,13 +43,23 @@ export const LineDraftsPage = (): JSX.Element => {
           onClick={onClose}
         />
       </Row>
-      {lines?.length ? (
-        <RoutesTable>
-          <LineDraftTableHeader />
-          {lines?.map((item: RouteLine) => (
-            <LineDraftTableRow key={item.line_id} line={item} />
-          ))}
-        </RoutesTable>
+      <Row>
+        <h2 className="text-sm font-bold">{t('filters.observationDate')}</h2>
+      </Row>
+      <Row>
+        <Column className="w-1/4">
+          <input
+            type="date"
+            required
+            value={observationDate?.toISODate() || ''}
+            onChange={(e) => onDateChange(e.target.value)}
+            className="flex-1"
+          />
+        </Column>
+      </Row>
+
+      {routes?.length && observationDate ? (
+        <RouteStopsTable routes={routes} observationDate={observationDate} />
       ) : (
         <Row className="py-20">
           <p className="mx-auto flex text-2xl font-bold">

--- a/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router';
 import { RouteLine } from '../../../generated/graphql';
@@ -15,13 +14,13 @@ export const LineDraftsPage = (): JSX.Element => {
   const { t } = useTranslation();
   const history = useHistory();
   const { label } = useParams<{ label: string }>();
-  const { returnTo } = useUrlQuery();
+  const queryParams = useUrlQuery();
   const { lines } = useGetLineDraftDetails();
 
   const onClose = () => {
     // If there is no returnTo set, we return to 'routes and lines' page
-    const pathname = returnTo
-      ? routeDetails[Path.lineDetails].getLink(returnTo as string)
+    const pathname = queryParams.returnTo
+      ? routeDetails[Path.lineDetails].getLink(queryParams.returnTo as string)
       : routeDetails[Path.routes].getLink();
 
     history.push({

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -7068,13 +7068,12 @@ export type GetHighestPriorityLineDetailsWithRoutesQueryVariables = Exact<{
 
 export type GetHighestPriorityLineDetailsWithRoutesQuery = { __typename?: 'query_root', route_line: Array<{ __typename?: 'route_line', line_id: UUID, name_i18n: LocalizedString, short_name_i18n: LocalizedString, primary_vehicle_mode: ReusableComponentsVehicleModeEnum, type_of_line: RouteTypeOfLineEnum, transport_target: HslRouteTransportTargetEnum, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, line_routes: Array<{ __typename?: 'route_route', route_id: UUID, name_i18n: LocalizedString, description_i18n?: LocalizedString | null | undefined, origin_name_i18n: LocalizedString, origin_short_name_i18n: LocalizedString, destination_name_i18n: LocalizedString, destination_short_name_i18n: LocalizedString, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: RouteDirectionEnum, infrastructure_links_along_route: Array<{ __typename?: 'route_infrastructure_link_along_route', route_id: UUID, infrastructure_link_id: UUID, infrastructure_link_sequence: number, is_traversal_forwards: boolean, infrastructure_link: { __typename?: 'infrastructure_network_infrastructure_link', infrastructure_link_id: UUID, scheduled_stop_points_located_on_infrastructure_link: Array<{ __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, measured_location: GeoJSON.Point, located_on_infrastructure_link_id: UUID, direction: InfrastructureNetworkDirectionEnum, relative_distance_from_infrastructure_link_start: number, closest_point_on_infrastructure_link?: GeoJSON.Geometry | null | undefined, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, scheduled_stop_point_in_journey_patterns: Array<{ __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern', journey_pattern_id: UUID, scheduled_stop_point_label: string, scheduled_stop_point_sequence: number, is_timing_point: boolean, is_via_point: boolean, via_point_name_i18n?: LocalizedString | null | undefined, via_point_short_name_i18n?: LocalizedString | null | undefined, journey_pattern: { __typename?: 'journey_pattern_journey_pattern', journey_pattern_id: UUID, on_route_id: UUID } }>, vehicle_mode_on_scheduled_stop_point: Array<{ __typename?: 'service_pattern_vehicle_mode_on_scheduled_stop_point', vehicle_mode: ReusableComponentsVehicleModeEnum }> }> } }> }> }> };
 
-export type GetLinesByLabelAndPriorityQueryVariables = Exact<{
-  label: Scalars['String'];
-  priority: Scalars['Int'];
+export type GetRoutesWithStopsQueryVariables = Exact<{
+  routeFilters?: Maybe<RouteRouteBoolExp>;
 }>;
 
 
-export type GetLinesByLabelAndPriorityQuery = { __typename?: 'query_root', route_line: Array<{ __typename?: 'route_line', line_id: UUID, name_i18n: LocalizedString, short_name_i18n: LocalizedString, primary_vehicle_mode: ReusableComponentsVehicleModeEnum, type_of_line: RouteTypeOfLineEnum, transport_target: HslRouteTransportTargetEnum, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, line_routes: Array<{ __typename?: 'route_route', route_id: UUID, name_i18n: LocalizedString, description_i18n?: LocalizedString | null | undefined, origin_name_i18n: LocalizedString, origin_short_name_i18n: LocalizedString, destination_name_i18n: LocalizedString, destination_short_name_i18n: LocalizedString, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: RouteDirectionEnum }> }> };
+export type GetRoutesWithStopsQuery = { __typename?: 'query_root', route_route: Array<{ __typename?: 'route_route', route_id: UUID, name_i18n: LocalizedString, description_i18n?: LocalizedString | null | undefined, origin_name_i18n: LocalizedString, origin_short_name_i18n: LocalizedString, destination_name_i18n: LocalizedString, destination_short_name_i18n: LocalizedString, route_shape?: GeoJSON.LineString | null | undefined, on_line_id: UUID, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, label: string, direction: RouteDirectionEnum, route_line?: { __typename?: 'route_line', line_id: UUID } | null | undefined, infrastructure_links_along_route: Array<{ __typename?: 'route_infrastructure_link_along_route', route_id: UUID, infrastructure_link_id: UUID, infrastructure_link_sequence: number, is_traversal_forwards: boolean, infrastructure_link: { __typename?: 'infrastructure_network_infrastructure_link', infrastructure_link_id: UUID, scheduled_stop_points_located_on_infrastructure_link: Array<{ __typename?: 'service_pattern_scheduled_stop_point', scheduled_stop_point_id: UUID, label: string, measured_location: GeoJSON.Point, located_on_infrastructure_link_id: UUID, direction: InfrastructureNetworkDirectionEnum, relative_distance_from_infrastructure_link_start: number, closest_point_on_infrastructure_link?: GeoJSON.Geometry | null | undefined, validity_start?: luxon.DateTime | null | undefined, validity_end?: luxon.DateTime | null | undefined, priority: number, scheduled_stop_point_in_journey_patterns: Array<{ __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern', journey_pattern_id: UUID, scheduled_stop_point_label: string, scheduled_stop_point_sequence: number, is_timing_point: boolean, is_via_point: boolean, via_point_name_i18n?: LocalizedString | null | undefined, via_point_short_name_i18n?: LocalizedString | null | undefined, journey_pattern: { __typename?: 'journey_pattern_journey_pattern', journey_pattern_id: UUID, on_route_id: UUID } }>, vehicle_mode_on_scheduled_stop_point: Array<{ __typename?: 'service_pattern_vehicle_mode_on_scheduled_stop_point', vehicle_mode: ReusableComponentsVehicleModeEnum }> }> } }> }> };
 
 export type GetRouteDetailsByIdsQueryVariables = Exact<{
   route_ids?: Maybe<Array<Scalars['uuid']> | Scalars['uuid']>;
@@ -8068,46 +8067,65 @@ export function useGetHighestPriorityLineDetailsWithRoutesLazyQuery(baseOptions?
 export type GetHighestPriorityLineDetailsWithRoutesQueryHookResult = ReturnType<typeof useGetHighestPriorityLineDetailsWithRoutesQuery>;
 export type GetHighestPriorityLineDetailsWithRoutesLazyQueryHookResult = ReturnType<typeof useGetHighestPriorityLineDetailsWithRoutesLazyQuery>;
 export type GetHighestPriorityLineDetailsWithRoutesQueryResult = Apollo.QueryResult<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>;
-export const GetLinesByLabelAndPriorityDocument = gql`
-    query GetLinesByLabelAndPriority($label: String!, $priority: Int!) {
-  route_line(where: {label: {_eq: $label}, priority: {_eq: $priority}}) {
-    ...line_all_fields
-    line_routes {
-      ...route_all_fields
+export const GetRoutesWithStopsDocument = gql`
+    query GetRoutesWithStops($routeFilters: route_route_bool_exp) {
+  route_route(where: $routeFilters) {
+    ...route_all_fields
+    route_line {
+      line_id
+    }
+    infrastructure_links_along_route {
+      route_id
+      infrastructure_link_id
+      infrastructure_link_sequence
+      is_traversal_forwards
+      infrastructure_link {
+        infrastructure_link_id
+        scheduled_stop_points_located_on_infrastructure_link {
+          ...scheduled_stop_point_all_fields
+          scheduled_stop_point_in_journey_patterns {
+            ...scheduled_stop_point_in_journey_pattern_all_fields
+            journey_pattern {
+              journey_pattern_id
+              on_route_id
+            }
+          }
+        }
+      }
     }
   }
 }
-    ${LineAllFieldsFragmentDoc}
-${RouteAllFieldsFragmentDoc}`;
+    ${RouteAllFieldsFragmentDoc}
+${ScheduledStopPointAllFieldsFragmentDoc}
+${ScheduledStopPointInJourneyPatternAllFieldsFragmentDoc}`;
 
 /**
- * __useGetLinesByLabelAndPriorityQuery__
+ * __useGetRoutesWithStopsQuery__
  *
- * To run a query within a React component, call `useGetLinesByLabelAndPriorityQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetLinesByLabelAndPriorityQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetRoutesWithStopsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRoutesWithStopsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetLinesByLabelAndPriorityQuery({
+ * const { data, loading, error } = useGetRoutesWithStopsQuery({
  *   variables: {
- *      label: // value for 'label'
- *      priority: // value for 'priority'
+ *      routeFilters: // value for 'routeFilters'
  *   },
  * });
  */
-export function useGetLinesByLabelAndPriorityQuery(baseOptions: Apollo.QueryHookOptions<GetLinesByLabelAndPriorityQuery, GetLinesByLabelAndPriorityQueryVariables>) {
+export function useGetRoutesWithStopsQuery(baseOptions?: Apollo.QueryHookOptions<GetRoutesWithStopsQuery, GetRoutesWithStopsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetLinesByLabelAndPriorityQuery, GetLinesByLabelAndPriorityQueryVariables>(GetLinesByLabelAndPriorityDocument, options);
+        return Apollo.useQuery<GetRoutesWithStopsQuery, GetRoutesWithStopsQueryVariables>(GetRoutesWithStopsDocument, options);
       }
-export function useGetLinesByLabelAndPriorityLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetLinesByLabelAndPriorityQuery, GetLinesByLabelAndPriorityQueryVariables>) {
+export function useGetRoutesWithStopsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRoutesWithStopsQuery, GetRoutesWithStopsQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetLinesByLabelAndPriorityQuery, GetLinesByLabelAndPriorityQueryVariables>(GetLinesByLabelAndPriorityDocument, options);
+          return Apollo.useLazyQuery<GetRoutesWithStopsQuery, GetRoutesWithStopsQueryVariables>(GetRoutesWithStopsDocument, options);
         }
-export type GetLinesByLabelAndPriorityQueryHookResult = ReturnType<typeof useGetLinesByLabelAndPriorityQuery>;
-export type GetLinesByLabelAndPriorityLazyQueryHookResult = ReturnType<typeof useGetLinesByLabelAndPriorityLazyQuery>;
-export type GetLinesByLabelAndPriorityQueryResult = Apollo.QueryResult<GetLinesByLabelAndPriorityQuery, GetLinesByLabelAndPriorityQueryVariables>;
+export type GetRoutesWithStopsQueryHookResult = ReturnType<typeof useGetRoutesWithStopsQuery>;
+export type GetRoutesWithStopsLazyQueryHookResult = ReturnType<typeof useGetRoutesWithStopsLazyQuery>;
+export type GetRoutesWithStopsQueryResult = Apollo.QueryResult<GetRoutesWithStopsQuery, GetRoutesWithStopsQueryVariables>;
 export const GetRouteDetailsByIdsDocument = gql`
     query GetRouteDetailsByIds($route_ids: [uuid!]) {
   route_route(where: {route_id: {_in: $route_ids}}) {
@@ -9045,10 +9063,10 @@ export function useGetHighestPriorityLineDetailsWithRoutesAsyncQuery() {
           return useAsyncQuery<GetHighestPriorityLineDetailsWithRoutesQuery, GetHighestPriorityLineDetailsWithRoutesQueryVariables>(GetHighestPriorityLineDetailsWithRoutesDocument);
         }
 export type GetHighestPriorityLineDetailsWithRoutesAsyncQueryHookResult = ReturnType<typeof useGetHighestPriorityLineDetailsWithRoutesAsyncQuery>;
-export function useGetLinesByLabelAndPriorityAsyncQuery() {
-          return useAsyncQuery<GetLinesByLabelAndPriorityQuery, GetLinesByLabelAndPriorityQueryVariables>(GetLinesByLabelAndPriorityDocument);
+export function useGetRoutesWithStopsAsyncQuery() {
+          return useAsyncQuery<GetRoutesWithStopsQuery, GetRoutesWithStopsQueryVariables>(GetRoutesWithStopsDocument);
         }
-export type GetLinesByLabelAndPriorityAsyncQueryHookResult = ReturnType<typeof useGetLinesByLabelAndPriorityAsyncQuery>;
+export type GetRoutesWithStopsAsyncQueryHookResult = ReturnType<typeof useGetRoutesWithStopsAsyncQuery>;
 export function useGetRouteDetailsByIdsAsyncQuery() {
           return useAsyncQuery<GetRouteDetailsByIdsQuery, GetRouteDetailsByIdsQueryVariables>(GetRouteDetailsByIdsDocument);
         }

--- a/ui/src/graphql/route.ts
+++ b/ui/src/graphql/route.ts
@@ -5,7 +5,6 @@ import {
   GetHighestPriorityLineDetailsWithRoutesQuery,
   GetLineDetailsByIdQuery,
   GetLineDetailsWithRoutesByIdQuery,
-  GetLinesByLabelAndPriorityQuery,
   GetLineValidityPeriodByIdQuery,
   InsertLineOneMutation,
   JourneyPatternScheduledStopPointInJourneyPattern,
@@ -273,22 +272,35 @@ export const mapHighestPriorityLineDetailsWithRoutesResult = (
     ? (result.data?.route_line[0] as RouteLine)
     : undefined;
 
-const GET_LINES_BY_LABEL = gql`
-  query GetLinesByLabelAndPriority($label: String!, $priority: Int!) {
-    route_line(
-      where: { label: { _eq: $label }, priority: { _eq: $priority } }
-    ) {
-      ...line_all_fields
-      line_routes {
-        ...route_all_fields
+const GET_ROUTES_WITH_STOPS = gql`
+  query GetRoutesWithStops($routeFilters: route_route_bool_exp) {
+    route_route(where: $routeFilters) {
+      ...route_all_fields
+      route_line {
+        line_id
+      }
+      infrastructure_links_along_route {
+        route_id
+        infrastructure_link_id
+        infrastructure_link_sequence
+        is_traversal_forwards
+        infrastructure_link {
+          infrastructure_link_id
+          scheduled_stop_points_located_on_infrastructure_link {
+            ...scheduled_stop_point_all_fields
+            scheduled_stop_point_in_journey_patterns {
+              ...scheduled_stop_point_in_journey_pattern_all_fields
+              journey_pattern {
+                journey_pattern_id
+                on_route_id
+              }
+            }
+          }
+        }
       }
     }
   }
 `;
-
-export const mapLinesByLabelAndPriorityResult = (
-  result: GqlQueryResult<GetLinesByLabelAndPriorityQuery>,
-) => result.data?.route_line as RouteLine[];
 
 const GET_ROUTE_DETAILS_BY_IDS = gql`
   query GetRouteDetailsByIds($route_ids: [uuid!]) {

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -16,6 +16,7 @@ export * from './useChooseRouteDropdown';
 export * from './useExtractRouteFromFeature';
 export * from './useFilterStops';
 export * from './useMapUrlQuery';
+export * from './useObservationDateQueryParam';
 export * from './useShowRoutesOnModal';
 export * from './useUrlQuery';
 export * from './via';

--- a/ui/src/hooks/line-drafts/useGetLineDraftDetails.ts
+++ b/ui/src/hooks/line-drafts/useGetLineDraftDetails.ts
@@ -1,17 +1,60 @@
+import { DateTime } from 'luxon';
+import { useCallback, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { useGetLinesByLabelAndPriorityQuery } from '../../generated/graphql';
-import { mapLinesByLabelAndPriorityResult } from '../../graphql';
+import { useObservationDateQueryParam, useUrlQuery } from '..';
+import {
+  RouteRoute,
+  useGetRoutesWithStopsQuery,
+} from '../../generated/graphql';
+import { mapRouteResultToRoutes } from '../../graphql';
+import { isDateInRange } from '../../time';
 import { Priority } from '../../types/Priority';
-import { mapToVariables } from '../../utils';
+import {
+  constructPriorityEqualGqlFilter,
+  constructRouteLineLabelGqlFilter,
+  mapToVariables,
+} from '../../utils';
+
+const isRouteActiveOnObservationDate = (
+  route: RouteRoute,
+  observationDate: DateTime,
+) => isDateInRange(observationDate, route.validity_start, route.validity_end);
 
 export const useGetLineDraftDetails = () => {
   const { label } = useParams<{ label: string }>();
 
-  const lineDetailsResult = useGetLinesByLabelAndPriorityQuery(
-    mapToVariables({ label, priority: Priority.Draft }),
-  );
+  const { queryParams } = useUrlQuery();
+  const { observationDate, setObservationDateToUrl } =
+    useObservationDateQueryParam();
 
-  const lines = mapLinesByLabelAndPriorityResult(lineDetailsResult);
+  // Get all draft routes by line label
+  const routeFilters = {
+    ...constructRouteLineLabelGqlFilter(label),
+    ...constructPriorityEqualGqlFilter(Priority.Draft),
+  };
 
-  return { lines };
+  const result = useGetRoutesWithStopsQuery(mapToVariables({ routeFilters }));
+
+  const routes = mapRouteResultToRoutes(result);
+
+  // Filter routes by observationDate in UI (and not in gql query) to avoid
+  // unnecessary graphql queries which would cause the list to reload on every date change
+  const filteredRoutes = observationDate
+    ? routes.filter((route) =>
+        isRouteActiveOnObservationDate(route, observationDate),
+      )
+    : [];
+
+  /** Determines and sets date to query parameters if it's not there */
+  const initializeObservationDate = useCallback(async () => {
+    if (!queryParams.observationDate) {
+      setObservationDateToUrl(DateTime.now().toISODate(), true);
+    }
+  }, [queryParams.observationDate, setObservationDateToUrl]);
+
+  useEffect(() => {
+    initializeObservationDate();
+  }, [initializeObservationDate]);
+
+  return { routes: filteredRoutes };
 };

--- a/ui/src/hooks/search/useSearchQueryParser.ts
+++ b/ui/src/hooks/search/useSearchQueryParser.ts
@@ -104,7 +104,7 @@ const deserializeParameters = (
 };
 
 export const useSearchQueryParser = () => {
-  const queryStringObject = useUrlQuery();
+  const { queryParams } = useUrlQuery();
 
-  return deserializeParameters(queryStringObject as QueryStringParameters);
+  return deserializeParameters(queryParams as QueryStringParameters);
 };

--- a/ui/src/hooks/useObservationDateQueryParam.ts
+++ b/ui/src/hooks/useObservationDateQueryParam.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { parseDate } from '../time';
+import { useUrlQuery } from './useUrlQuery';
+
+export const useObservationDateQueryParam = () => {
+  const { queryParams, setToUrlQuery } = useUrlQuery();
+
+  // Memoize the actual value to prevent unnecessary updates
+  const observationDate = useMemo(
+    () => parseDate(queryParams.observationDate as string),
+    [queryParams.observationDate],
+  );
+
+  /** Sets observationDate to URL query
+   * replace flag can be given to replace the earlier url query instead
+   * of pushing it. This affects how the back button or history.back() works.
+   * If the history is replaced, it means that back button will not go to the
+   * url which was replaced, but rather the one before it.
+   */
+  const setObservationDateToUrl = (date: string, replace = false) => {
+    setToUrlQuery({ paramName: 'observationDate', value: date, replace });
+  };
+
+  return { observationDate, setObservationDateToUrl };
+};

--- a/ui/src/hooks/usePagination.spec.tsx
+++ b/ui/src/hooks/usePagination.spec.tsx
@@ -39,7 +39,7 @@ describe(`${hookForNames.result.current.getPaginatedData}`, () => {
   test('should show paginated data for page 1', () => {
     const data = [1, 2, 3, 4, 5];
     const itemsPerPage = 2;
-    urlQueryMock.mockReturnValueOnce({ page: 1 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 1 } });
 
     const { result } = renderHook(usePagination);
 
@@ -49,7 +49,7 @@ describe(`${hookForNames.result.current.getPaginatedData}`, () => {
   });
 
   test('should show paginated data for page 2', () => {
-    urlQueryMock.mockReturnValueOnce({ page: 2 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 2 } });
     const { result } = renderHook(usePagination);
     const data = [1, 2, 3, 4, 5];
     const itemsPerPage = 2;
@@ -60,7 +60,7 @@ describe(`${hookForNames.result.current.getPaginatedData}`, () => {
   });
 
   test('should show paginated data for page 3', () => {
-    urlQueryMock.mockReturnValueOnce({ page: 3 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 3 } });
     const { result } = renderHook(usePagination);
     const data = [1, 2, 3, 4, 5];
     const itemsPerPage = 2;
@@ -71,7 +71,7 @@ describe(`${hookForNames.result.current.getPaginatedData}`, () => {
   });
 
   test('should not crash with empty data', () => {
-    urlQueryMock.mockReturnValueOnce({ page: 1 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 1 } });
     const { result } = renderHook(usePagination);
     const data: number[] = [];
     const itemsPerPage = 2;
@@ -82,7 +82,7 @@ describe(`${hookForNames.result.current.getPaginatedData}`, () => {
   });
 
   test('should paginate to page 1 if page query parameter is not given', () => {
-    urlQueryMock.mockReturnValueOnce({});
+    urlQueryMock.mockReturnValueOnce({ queryParams: {} });
     const { result } = renderHook(usePagination);
     const data: number[] = [1, 2, 3, 4, 5];
     const itemsPerPage = 2;
@@ -95,6 +95,7 @@ describe(`${hookForNames.result.current.getPaginatedData}`, () => {
 
 describe(`${hookForNames.result.current.setPage.name}`, () => {
   test('should call history with page=5', () => {
+    urlQueryMock.mockReturnValueOnce({ queryParams: {} });
     const { result } = renderHook(usePagination);
 
     result.current.setPage(5);
@@ -103,7 +104,7 @@ describe(`${hookForNames.result.current.setPage.name}`, () => {
   });
 
   test('should overwrite existing page query parameter', () => {
-    urlQueryMock.mockReturnValueOnce({ page: '5' });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: '5' } });
     const { result } = renderHook(usePagination);
     result.current.setPage(10);
 
@@ -113,7 +114,9 @@ describe(`${hookForNames.result.current.setPage.name}`, () => {
   });
 
   test('should not remove existing query parameters', () => {
-    urlQueryMock.mockReturnValueOnce({ name: 'TestName', line: 'TestLine' });
+    urlQueryMock.mockReturnValueOnce({
+      queryParams: { name: 'TestName', line: 'TestLine' },
+    });
     const { result } = renderHook(usePagination);
     result.current.setPage(10);
 
@@ -237,7 +240,7 @@ describe(`${hookForNames.result.current.currentPage}`, () => {
   });
 
   test('should return correct currentPage', () => {
-    urlQueryMock.mockReturnValueOnce({ page: 3 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 3 } });
     const { result } = renderHook(usePagination);
     expect(result.current.currentPage).toBe(3);
   });

--- a/ui/src/hooks/usePagination.ts
+++ b/ui/src/hooks/usePagination.ts
@@ -18,8 +18,8 @@ export const usePagination = (): {
   ) => number[];
 } => {
   const history = useHistory();
-  const queryParams = useUrlQuery();
-  const initialPage = parseInt(queryParams.page as string, 10) || 1;
+  const { queryParams } = useUrlQuery();
+  const initialPage = parseInt(queryParams?.page as string, 10) || 1;
 
   const getPaginatedData = <T>(data: Array<T>, itemsPerPage: number) => {
     const currentPage = initialPage;

--- a/ui/src/hooks/useUrlQuery.ts
+++ b/ui/src/hooks/useUrlQuery.ts
@@ -1,7 +1,42 @@
+import produce from 'immer';
 import qs from 'qs';
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 export const useUrlQuery = () => {
   const query = useLocation().search;
-  return qs.parse(query, { ignoreQueryPrefix: true });
+  const queryParams = qs.parse(query, { ignoreQueryPrefix: true });
+
+  const history = useHistory();
+
+  /** Sets parameter to URL query
+   * replace flag can be given to replace the earlier url query instead
+   * of pushing it. This affects how the back button or history.back() works.
+   * If the history is replaced, it means that back button will not go to the
+   * url which was replaced, but rather the one before it.
+   */
+  const setToUrlQuery = ({
+    paramName,
+    value,
+    replace = false,
+  }: {
+    paramName: string;
+    value: string;
+    replace?: boolean;
+  }) => {
+    const updatedUrlQuery = produce(queryParams, (draft) => {
+      draft[paramName] = value;
+    });
+
+    const queryString = qs.stringify(updatedUrlQuery);
+
+    replace
+      ? history.replace({
+          search: `?${queryString}`,
+        })
+      : history.push({
+          search: `?${queryString}`,
+        });
+  };
+
+  return { queryParams, setToUrlQuery };
 };

--- a/ui/src/time.ts
+++ b/ui/src/time.ts
@@ -64,8 +64,11 @@ export const MAX_DATE = DateTime.fromISO('2050-12-31').endOf('day');
 
 export const isDateInRange = (
   date: DateTime,
-  startDate: DateTime,
+  startDate?: Maybe<DateTime>,
   endDate?: Maybe<DateTime>,
 ) => {
-  return date >= startDate && (!endDate?.isValid || date <= endDate);
+  return (
+    (!startDate?.isValid || date >= startDate) &&
+    (!endDate?.isValid || date <= endDate)
+  );
 };

--- a/ui/src/uiComponents/Pagination.spec.tsx
+++ b/ui/src/uiComponents/Pagination.spec.tsx
@@ -10,6 +10,7 @@ const urlQueryMock = useUrlQuery as jest.Mock;
 
 describe(`<${Pagination.name}>`, () => {
   test('should render all 5 page numbers', async () => {
+    urlQueryMock.mockReturnValueOnce({ queryParams: {} });
     render(<Pagination itemsPerPage={2} totalItemsCount={10} />);
 
     expect(screen.queryByText('01')).toBeVisible();
@@ -21,7 +22,7 @@ describe(`<${Pagination.name}>`, () => {
   });
 
   test('prev button should be disabled on first page', async () => {
-    urlQueryMock.mockReturnValueOnce({ page: 1 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 1 } });
     render(<Pagination itemsPerPage={2} totalItemsCount={10} />);
 
     const prevButton = await screen.findByTestId('prevPageButtonIcon');
@@ -32,7 +33,7 @@ describe(`<${Pagination.name}>`, () => {
   });
 
   test('next button should be disabled on last page', async () => {
-    urlQueryMock.mockReturnValueOnce({ page: 5 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 5 } });
     render(<Pagination itemsPerPage={2} totalItemsCount={10} />);
 
     const prevButton = await screen.findByTestId('prevPageButtonIcon');
@@ -43,7 +44,7 @@ describe(`<${Pagination.name}>`, () => {
   });
 
   test('prev and next button should be disabled if only one page', async () => {
-    urlQueryMock.mockReturnValueOnce({ page: 1 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 1 } });
     render(<Pagination itemsPerPage={10} totalItemsCount={10} />);
 
     const prevButton = await screen.findByTestId('prevPageButtonIcon');
@@ -54,7 +55,7 @@ describe(`<${Pagination.name}>`, () => {
   });
 
   test('current page should be SPAN element', async () => {
-    urlQueryMock.mockReturnValueOnce({ page: 1 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 1 } });
     render(<Pagination itemsPerPage={2} totalItemsCount={10} />);
 
     const oneButton = await screen.findByText('01');
@@ -71,7 +72,7 @@ describe(`<${Pagination.name}>`, () => {
   });
 
   test('should render dots next to first page button', async () => {
-    urlQueryMock.mockReturnValueOnce({ page: 8 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 8 } });
     render(
       <Pagination
         amountOfNeighbours={1}
@@ -106,7 +107,7 @@ describe(`<${Pagination.name}>`, () => {
   });
 
   test('should render dots next to last page button', async () => {
-    urlQueryMock.mockReturnValueOnce({ page: 3 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 3 } });
     render(
       <Pagination
         amountOfNeighbours={1}
@@ -141,7 +142,7 @@ describe(`<${Pagination.name}>`, () => {
   });
 
   test('should render dots next to first page and last page buttons', async () => {
-    urlQueryMock.mockReturnValueOnce({ page: 5 });
+    urlQueryMock.mockReturnValueOnce({ queryParams: { page: 5 } });
     render(
       <Pagination
         amountOfNeighbours={1}

--- a/ui/src/utils/gql.ts
+++ b/ui/src/utils/gql.ts
@@ -32,9 +32,21 @@ export const constructDraftPriorityGqlFilter = (priority?: Priority) => ({
   },
 });
 
+/** Constructs an object for gql to filter out all but the given priority */
+export const constructPriorityEqualGqlFilter = (priority: Priority) => ({
+  priority: {
+    _eq: priority,
+  },
+});
+
 /** Constructs an object for gql to filter by label */
 export const constructLabelGqlFilter = (label?: string) => ({
   label: { _eq: label },
+});
+
+/** Constructs an object for gql to filter route by line label */
+export const constructRouteLineLabelGqlFilter = (label: string) => ({
+  route_line: constructLabelGqlFilter(label),
 });
 
 export const constructWithinViewportGqlFilter = (


### PR DESCRIPTION
LineDraftsPage will now show all the draft routes which are under the given line label. This is mostly for MVP and this page will be modified in the future to have much more details about route versions etc.

There is also two commits to:
* Decouple useGetLineDetails from RouteStopsSection, so that RouteStopsSection is reusable.
* Move setObservationDate (to query parameters) to useUrlQuery hook, so that it is also reusable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/267)
<!-- Reviewable:end -->
