### PR TITLE
Fix missing css class definitions for form layout

### DIFF
--- a/ui/src/components/forms/common/FormRow.tsx
+++ b/ui/src/components/forms/common/FormRow.tsx
@@ -10,7 +10,6 @@ export const FormRow: React.FC<Props> = ({
   columns = 1,
   children,
 }) => {
-  // flex flex-col items-start space-y-5 md:flex-row md:items-center md:space-x-8 md:space-y-0
   const narrowClassName = 'grid grid-cols-1 gap-y-5';
   const wideClassName = `md:grid-cols-${columns} md:gap-x-8`;
   return (

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -47,4 +47,11 @@ module.exports = {
       });
     }),
   ],
+  safelist: [
+    {
+      // these classes are referenced dynamically by a template string, so have to remove them from tree-shaking
+      pattern: /^grid/,
+      variants: ['md'],
+    },
+  ],
 };


### PR DESCRIPTION
Had to exclude some classes from tree-shaking as they are referenced dynamically

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/288)
<!-- Reviewable:end -->
