### PR TITLE
Fix stop list menu creating horizontal scrollbars to the list

### DIFF
--- a/ui/src/components/map/RouteStopsOverlay.tsx
+++ b/ui/src/components/map/RouteStopsOverlay.tsx
@@ -10,7 +10,11 @@ import {
   setRouteMetadataFormOpenAction,
   setStopOnRouteAction,
 } from '../../redux';
-import { EditButton, SimpleDropdownMenu } from '../../uiComponents';
+import {
+  AlignDirection,
+  EditButton,
+  SimpleDropdownMenu,
+} from '../../uiComponents';
 import { mapToVariables } from '../../utils';
 import { MapOverlay, MapOverlayHeader } from './MapOverlay';
 
@@ -57,7 +61,7 @@ const StopRow = ({
       </div>
       {!isReadOnly && (
         <div className="text-tweaked-brand">
-          <SimpleDropdownMenu>
+          <SimpleDropdownMenu alignItems={AlignDirection.Left}>
             <button type="button" onClick={() => setOnRoute(!onRoute)}>
               {onRoute ? t('stops.removeFromRoute') : t('stops.addToRoute')}
             </button>


### PR DESCRIPTION
Ideally this would not be fixed by changing the alignment, but playing with overlays proved to be quite difficult; Setting overflow-y to auto would not allow setting overflow-x to visible (https://stackoverflow.com/questions/6421966/css-overflow-x-visible-and-overflow-y-hidden-causing-scrollbar-issue)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/292)
<!-- Reviewable:end -->
