### PR TITLE
Load initial stops properly and show loading spinner in map

### DIFF
--- a/ui/src/components/forms/stop/StopForm.tsx
+++ b/ui/src/components/forms/stop/StopForm.tsx
@@ -10,12 +10,12 @@ import {
 import {
   CreateChanges,
   EditChanges,
-  useAppAction,
   useCreateStop,
   useEditStop,
+  useLoader,
 } from '../../../hooks';
 import { Column, Row } from '../../../layoutComponents';
-import { setMapEditorLoadingAction } from '../../../redux';
+import { Operation } from '../../../redux';
 import { mapToISODate } from '../../../time';
 import { RequiredKeys } from '../../../types';
 import {
@@ -97,7 +97,7 @@ const StopFormComponent = (
 
   const { prepareEdit, defaultErrorHandler } = useEditStop();
   const { prepareCreate } = useCreateStop();
-  const setIsLoading = useAppAction(setMapEditorLoadingAction);
+  const { setIsLoading } = useLoader(Operation.SaveStop);
 
   const mapFormStateToInput = (state: FormState) => {
     const input = {

--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -9,9 +9,9 @@ import { Column } from '../../layoutComponents';
 import {
   selectHasDraftRouteGeometry,
   selectIsCreateStopModeEnabled,
+  selectIsMapOperationLoading,
   selectMapEditor,
   selectMapFilter,
-  selectModalMap,
   selectSelectedRouteId,
   setSelectedRouteIdAction,
 } from '../../redux';
@@ -49,12 +49,9 @@ export const MapComponent = (
 ): JSX.Element => {
   const routeEditorRef = useRef<ExplicitAny>(null);
 
-  const {
-    drawingMode,
-    initiallyDisplayedRouteIds,
-    isLoading: isMapEditorLoading,
-  } = useAppSelector(selectMapEditor);
-  const { isLoading: isModalMapLoading } = useAppSelector(selectModalMap);
+  const { drawingMode, initiallyDisplayedRouteIds } =
+    useAppSelector(selectMapEditor);
+  const isLoading = useAppSelector(selectIsMapOperationLoading);
 
   const hasDraftRouteGeometry = useAppSelector(selectHasDraftRouteGeometry);
   const { showStopFilterOverlay } = useAppSelector(selectMapFilter);
@@ -234,7 +231,7 @@ export const MapComponent = (
         onDeleteDrawnRoute={() => editorLayerRef.current?.onDeleteRoute()}
         ref={routeEditorRef}
       />
-      <LoadingOverlay visible={isMapEditorLoading || isModalMapLoading} />
+      <LoadingOverlay visible={isLoading} />
     </Maplibre>
   );
 };

--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -11,6 +11,7 @@ import {
   selectIsCreateStopModeEnabled,
   selectMapEditor,
   selectMapFilter,
+  selectModalMap,
   selectSelectedRouteId,
   setSelectedRouteIdAction,
 } from '../../redux';
@@ -48,8 +49,12 @@ export const MapComponent = (
 ): JSX.Element => {
   const routeEditorRef = useRef<ExplicitAny>(null);
 
-  const { drawingMode, initiallyDisplayedRouteIds, isLoading } =
-    useAppSelector(selectMapEditor);
+  const {
+    drawingMode,
+    initiallyDisplayedRouteIds,
+    isLoading: isMapEditorLoading,
+  } = useAppSelector(selectMapEditor);
+  const { isLoading: isModalMapLoading } = useAppSelector(selectModalMap);
 
   const hasDraftRouteGeometry = useAppSelector(selectHasDraftRouteGeometry);
   const { showStopFilterOverlay } = useAppSelector(selectMapFilter);
@@ -229,7 +234,7 @@ export const MapComponent = (
         onDeleteDrawnRoute={() => editorLayerRef.current?.onDeleteRoute()}
         ref={routeEditorRef}
       />
-      <LoadingOverlay visible={isLoading} />
+      <LoadingOverlay visible={isMapEditorLoading || isModalMapLoading} />
     </Maplibre>
   );
 };

--- a/ui/src/components/map/MapFooter.tsx
+++ b/ui/src/components/map/MapFooter.tsx
@@ -38,7 +38,7 @@ export const MapFooter: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
 
-  const { drawingMode, creatingNewRoute, selectedRouteId, isLoading } =
+  const { drawingMode, creatingNewRoute, selectedRouteId } =
     useAppSelector(selectMapEditor);
   const hasDraftRouteGeometry = useAppSelector(selectHasDraftRouteGeometry);
 
@@ -98,9 +98,7 @@ export const MapFooter: React.FC<Props> = ({
         </SimpleButton>
         <SimpleButton
           onClick={onSave}
-          disabled={
-            !(hasChangesInProgress && hasDraftRouteGeometry) || isLoading
-          }
+          disabled={!(hasChangesInProgress && hasDraftRouteGeometry)}
           testId={testIds.saveButton}
         >
           {t('routes.save')}

--- a/ui/src/components/map/MapOverlay.tsx
+++ b/ui/src/components/map/MapOverlay.tsx
@@ -10,7 +10,7 @@ export const MapOverlay: React.FC<MapOverlayProps> = ({
   children,
 }) => {
   return (
-    <Column className={`w-72 bg-white shadow-md ${className}`}>
+    <Column className={`w-72 rounded bg-white shadow-md ${className}`}>
       {children}
     </Column>
   );

--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -68,6 +68,10 @@ export const Maplibre: FunctionComponent<Props> = ({
     if (mapRef.current) {
       const mapGL = mapRef.current.getMap();
 
+      // Viewport change event can be fired before map is completely loaded
+      // resulting in stops to be loaded for incorrect view
+      if (!mapGL.loaded()) return;
+
       const bounds = mapGL.getBounds();
 
       const from = point([newViewport.longitude, newViewport.latitude]);
@@ -139,6 +143,9 @@ export const Maplibre: FunctionComponent<Props> = ({
       transformRequest={transformRequest}
       doubleClickZoom={false}
       ref={mapRef}
+      onLoad={() => {
+        onViewportChange(viewport);
+      }}
     >
       {children}
       <NavigationControl style={navStyle} showCompass={false} />

--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -1,10 +1,10 @@
 import distance from '@turf/distance';
 import { point, Units } from '@turf/helpers';
 import debounce from 'lodash/debounce';
-import { FunctionComponent, useMemo, useRef, useState } from 'react';
+import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
 import MapGL, { MapEvent, MapRef, NavigationControl } from 'react-map-gl';
-import { useAppDispatch, useMapQueryParams } from '../../hooks';
-import { setViewPortAction } from '../../redux';
+import { useAppAction, useAppDispatch, useMapQueryParams } from '../../hooks';
+import { setModalMapLoadingAction, setViewPortAction } from '../../redux';
 import hslSimpleStyle from './hslSimpleStyle.json';
 import rasterMapStyle from './rasterMapStyle.json';
 
@@ -46,6 +46,12 @@ export const Maplibre: FunctionComponent<Props> = ({
   });
 
   const dispatch = useAppDispatch();
+  const setIsLoading = useAppAction(setModalMapLoadingAction);
+
+  useEffect(() => {
+    setIsLoading(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const updateMapDetailsDebounced = useMemo(
     () =>
@@ -129,6 +135,11 @@ export const Maplibre: FunctionComponent<Props> = ({
 
   const mapStyle = useVectorTilesAsBaseMap ? hslSimpleStyle : rasterMapStyle;
 
+  const onLoad = () => {
+    setIsLoading(false);
+    onViewportChange(viewport);
+  };
+
   return (
     <MapGL
       // eslint-disable-next-line react/jsx-props-no-spreading
@@ -143,9 +154,7 @@ export const Maplibre: FunctionComponent<Props> = ({
       transformRequest={transformRequest}
       doubleClickZoom={false}
       ref={mapRef}
-      onLoad={() => {
-        onViewportChange(viewport);
-      }}
+      onLoad={onLoad}
     >
       {children}
       <NavigationControl style={navStyle} showCompass={false} />

--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -64,7 +64,7 @@ export const Maplibre: FunctionComponent<Props> = ({
           }),
         );
         setMapPosition(latitude, longitude, zoom);
-      }, 500),
+      }, 800),
     [dispatch, setMapPosition],
   );
 

--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -1,10 +1,10 @@
 import distance from '@turf/distance';
 import { point, Units } from '@turf/helpers';
 import debounce from 'lodash/debounce';
-import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
+import { FunctionComponent, useMemo, useRef, useState } from 'react';
 import MapGL, { MapEvent, MapRef, NavigationControl } from 'react-map-gl';
-import { useAppAction, useAppDispatch, useMapQueryParams } from '../../hooks';
-import { setModalMapLoadingAction, setViewPortAction } from '../../redux';
+import { useAppDispatch, useLoader, useMapQueryParams } from '../../hooks';
+import { Operation, setViewPortAction } from '../../redux';
 import hslSimpleStyle from './hslSimpleStyle.json';
 import rasterMapStyle from './rasterMapStyle.json';
 
@@ -46,12 +46,9 @@ export const Maplibre: FunctionComponent<Props> = ({
   });
 
   const dispatch = useAppDispatch();
-  const setIsLoading = useAppAction(setModalMapLoadingAction);
-
-  useEffect(() => {
-    setIsLoading(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { setIsLoading } = useLoader(Operation.LoadMap, {
+    immediatelyOn: true,
+  });
 
   const updateMapDetailsDebounced = useMemo(
     () =>

--- a/ui/src/components/map/routes/DrawRouteLayer.tsx
+++ b/ui/src/components/map/routes/DrawRouteLayer.tsx
@@ -31,14 +31,15 @@ import {
   useAppDispatch,
   useAppSelector,
   useExtractRouteFromFeature,
+  useLoader,
 } from '../../../hooks';
 import {
   Mode,
+  Operation,
   resetDraftRouteGeometryAction,
   selectHasDraftRouteGeometry,
   selectMapEditor,
   setDraftRouteGeometryAction,
-  setMapEditorLoadingAction,
   stopRouteEditingAction,
 } from '../../../redux';
 import { filterDistinctConsecutiveRouteStops, showToast } from '../../../utils';
@@ -89,6 +90,8 @@ const DrawRouteLayerComponent = (
     getRemovedStopLabels,
     getOldRouteGeometryVariables,
   } = useExtractRouteFromFeature();
+
+  const { setIsLoading } = useLoader(Operation.MatchRoute);
 
   const { t } = useTranslation();
 
@@ -148,12 +151,12 @@ const DrawRouteLayerComponent = (
       // retrieve infra links with stops for snapping line from mapmatching service
       const { geometry } = snappingLineFeature;
 
-      dispatch(setMapEditorLoadingAction(true));
+      setIsLoading(true);
 
       const { infraLinksWithStops, matchedGeometry } =
         await getInfraLinksWithStopsForGeometry(geometry);
 
-      dispatch(setMapEditorLoadingAction(false));
+      setIsLoading(false);
 
       // retrieve stop and infra link data from base route if we don't yet have edited data
       // TODO: this should happen only once, not every time the snapping line is updated
@@ -210,6 +213,7 @@ const DrawRouteLayerComponent = (
       dispatch,
       map,
       onDelete,
+      setIsLoading,
     ],
   );
 

--- a/ui/src/components/map/routes/RouteEditor.tsx
+++ b/ui/src/components/map/routes/RouteEditor.tsx
@@ -11,18 +11,19 @@ import {
   useCreateRoute,
   useDeleteRoute,
   useEditRouteGeometry,
+  useLoader,
   useMapQueryParams,
 } from '../../../hooks';
 import {
   initializeMapEditorWithRoutesAction,
   Mode,
+  Operation,
   resetRouteCreatingAction,
   selectDrawingMode,
   selectMapEditor,
   selectMapObservationDate,
   selectSelectedRouteId,
   setLineInfoAction,
-  setMapEditorLoadingAction,
   setMapObservationDateAction,
   setRouteMetadataAction,
   setSelectedRouteIdAction,
@@ -100,8 +101,7 @@ const RouteEditorComponent = (
     await editRouteGeometryMutation(variables);
   };
 
-  const setIsLoading = (loading: boolean) =>
-    dispatch(setMapEditorLoadingAction(loading));
+  const { setIsLoading } = useLoader(Operation.SaveRoute);
 
   const createRoute = async () => {
     const changes = await prepareCreate({

--- a/ui/src/components/map/stops/EditStopLayer.tsx
+++ b/ui/src/components/map/stops/EditStopLayer.tsx
@@ -12,11 +12,12 @@ import {
   useCreateStop,
   useDeleteStop,
   useEditStop,
+  useLoader,
   useMapStops,
 } from '../../../hooks';
 import {
+  Operation,
   setEditedStopDataAction,
-  setMapEditorLoadingAction,
   setSelectedStopIdAction,
 } from '../../../redux';
 import {
@@ -63,7 +64,10 @@ export const EditStopLayer: React.FC<Props> = ({
 
   const setSelectedStopId = useAppAction(setSelectedStopIdAction);
   const setEditedStopData = useAppAction(setEditedStopDataAction);
-  const setIsLoading = useAppAction(setMapEditorLoadingAction);
+  const { setIsLoading: setIsLoadingBrokenRoutes } = useLoader(
+    Operation.CheckBrokenRoutes,
+  );
+  const { setIsLoading: setIsLoadingSaveStop } = useLoader(Operation.SaveStop);
 
   const { mapCreateChangesToVariables, insertStopMutation } = useCreateStop();
   const {
@@ -139,10 +143,10 @@ export const EditStopLayer: React.FC<Props> = ({
 
   const onRemoveStop = async (stopId?: UUID) => {
     if (stopId) {
-      setIsLoading(true);
+      setIsLoadingBrokenRoutes(true);
       // we are removing stop that is already stored to backend
       await onPrepareDelete(stopId);
-      setIsLoading(false);
+      setIsLoadingBrokenRoutes(false);
     } else {
       // we are removing a draft stop
       await onRemoveDraftStop();
@@ -156,7 +160,7 @@ export const EditStopLayer: React.FC<Props> = ({
       const patch: ScheduledStopPointSetInput = {
         measured_location: mapLngLatToGeoJSON(event.lngLat),
       };
-      setIsLoading(true);
+      setIsLoadingBrokenRoutes(true);
       try {
         const changes = await prepareEdit({
           stopId,
@@ -166,7 +170,7 @@ export const EditStopLayer: React.FC<Props> = ({
       } catch (err) {
         defaultErrorHandler(err as Error);
       }
-      setIsLoading(false);
+      setIsLoadingBrokenRoutes(false);
     } else {
       // for draft stops, just update the edited stop data
       setEditedStopData({
@@ -180,7 +184,7 @@ export const EditStopLayer: React.FC<Props> = ({
   };
 
   const doCreateStop = async (changes: CreateChanges) => {
-    setIsLoading(true);
+    setIsLoadingSaveStop(true);
     try {
       const variables = mapCreateChangesToVariables(changes);
       await insertStopMutation(variables);
@@ -190,11 +194,11 @@ export const EditStopLayer: React.FC<Props> = ({
     } catch (err) {
       defaultErrorHandler(err as Error);
     }
-    setIsLoading(false);
+    setIsLoadingSaveStop(false);
   };
 
   const doEditStop = async (changes: EditChanges) => {
-    setIsLoading(true);
+    setIsLoadingSaveStop(true);
     try {
       const variables = mapEditChangesToVariables(changes);
 
@@ -214,7 +218,7 @@ export const EditStopLayer: React.FC<Props> = ({
     } catch (err) {
       defaultErrorHandler(err as Error);
     }
-    setIsLoading(false);
+    setIsLoadingSaveStop(false);
   };
 
   // we are removing stop that is already stored to backend

--- a/ui/src/components/map/stops/Stops.tsx
+++ b/ui/src/components/map/stops/Stops.tsx
@@ -11,16 +11,17 @@ import {
   useCreateStop,
   useEditStop,
   useFilterStops,
+  useLoader,
   useMapStops,
 } from '../../../hooks';
 import {
+  Operation,
   selectEditedStopData,
   selectIsCreateStopModeEnabled,
   selectMapViewport,
   selectSelectedStopId,
   setEditedStopDataAction,
   setIsCreateStopModeEnabledAction,
-  setModalMapLoadingAction,
   setSelectedStopIdAction,
 } from '../../../redux';
 import { Priority } from '../../../types/Priority';
@@ -45,7 +46,7 @@ export const Stops = React.forwardRef((props, ref) => {
   const setIsCreateStopModeEnabled = useAppAction(
     setIsCreateStopModeEnabledAction,
   );
-  const setIsLoading = useAppAction(setModalMapLoadingAction);
+  const { setIsLoading } = useLoader(Operation.FetchStops);
 
   const { getStopVehicleMode, getStopHighlighted } = useMapStops();
 
@@ -58,6 +59,12 @@ export const Stops = React.forwardRef((props, ref) => {
   );
 
   useEffect(() => {
+    /**
+     * Here we sync getStopsByLocation query loading state with useLoader hook state.
+     *
+     * We could also use useLoader's immediatelyOn option instead of useEffect,
+     * but using options to dynamically control loading state feels semantically wrong.
+     */
     setIsLoading(stopsResult.loading);
   }, [setIsLoading, stopsResult.loading]);
 

--- a/ui/src/components/map/stops/Stops.tsx
+++ b/ui/src/components/map/stops/Stops.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle } from 'react';
+import React, { useEffect, useImperativeHandle } from 'react';
 import { MapEvent } from 'react-map-gl';
 import {
   ServicePatternScheduledStopPoint,
@@ -20,7 +20,7 @@ import {
   selectSelectedStopId,
   setEditedStopDataAction,
   setIsCreateStopModeEnabledAction,
-  setMapEditorLoadingAction,
+  setModalMapLoadingAction,
   setSelectedStopIdAction,
 } from '../../../redux';
 import { Priority } from '../../../types/Priority';
@@ -45,7 +45,7 @@ export const Stops = React.forwardRef((props, ref) => {
   const setIsCreateStopModeEnabled = useAppAction(
     setIsCreateStopModeEnabledAction,
   );
-  const setIsLoading = useAppAction(setMapEditorLoadingAction);
+  const setIsLoading = useAppAction(setModalMapLoadingAction);
 
   const { getStopVehicleMode, getStopHighlighted } = useMapStops();
 
@@ -56,6 +56,10 @@ export const Stops = React.forwardRef((props, ref) => {
       measured_location_filter: constructWithinViewportGqlFilter(viewport),
     }),
   );
+
+  useEffect(() => {
+    setIsLoading(stopsResult.loading);
+  }, [setIsLoading, stopsResult.loading]);
 
   // When stops are loading, show previously loaded stops to avoid stops
   // disappearing and flickering on every map move / zoom

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesPage.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesPage.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useMapQueryParams } from '../../../hooks';
 import { Container, Row } from '../../../layoutComponents';
-import { resetMapEditorStateAction } from '../../../redux';
+import { resetMapEditorStateAction, resetModalMapAction } from '../../../redux';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { SimpleButton } from '../../../uiComponents';
 import { SearchContainer } from '../search/conditions/SearchContainer';
@@ -13,6 +13,7 @@ export const RoutesAndLinesPage = (): JSX.Element => {
   const { addMapOpenQueryParameter } = useMapQueryParams();
   const createLineReactRoute = routeDetails[Path.createLine];
   const onOpenModalMap = () => {
+    dispatch(resetModalMapAction());
     dispatch(resetMapEditorStateAction());
     addMapOpenQueryParameter();
   };

--- a/ui/src/hooks/ui/index.ts
+++ b/ui/src/hooks/ui/index.ts
@@ -1,3 +1,4 @@
 export * from './useAlertsAndHighLights';
 export * from './useChooseLineDropdown';
 export * from './useChooseRouteDropdown';
+export * from './useLoader';

--- a/ui/src/hooks/ui/useLoader.ts
+++ b/ui/src/hooks/ui/useLoader.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { Operation, setLoadingAction } from '../../redux';
+
+interface LoaderOptions {
+  immediatelyOn?: boolean;
+}
+
+export const useLoader = (operation: Operation, options?: LoaderOptions) => {
+  const dispatch = useDispatch();
+
+  const setIsLoading = useCallback(
+    (isLoading: boolean) =>
+      dispatch(setLoadingAction({ operation, isLoading })),
+    [dispatch, operation],
+  );
+
+  useEffect(() => {
+    setIsLoading(options?.immediatelyOn || false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { setIsLoading };
+};

--- a/ui/src/redux/index.ts
+++ b/ui/src/redux/index.ts
@@ -1,5 +1,6 @@
 export * from './ReduxProvider';
 export * from './selectors';
+export * from './slices/loader';
 export * from './slices/map';
 export * from './slices/mapEditor';
 export * from './slices/mapFilter';

--- a/ui/src/redux/rootReducer.ts
+++ b/ui/src/redux/rootReducer.ts
@@ -1,4 +1,5 @@
 import { AnyAction, combineReducers } from '@reduxjs/toolkit';
+import { loaderReducer } from './slices/loader';
 import { mapReducer } from './slices/map';
 import { mapEditorReducer } from './slices/mapEditor';
 import { mapFilterReducer } from './slices/mapFilter';
@@ -7,6 +8,7 @@ import { modalsReducer } from './slices/modals';
 import { loginFailedAction, userReducer } from './slices/user';
 
 const appReducer = combineReducers({
+  loader: loaderReducer,
   map: mapReducer,
   mapEditor: mapEditorReducer,
   mapFilter: mapFilterReducer,

--- a/ui/src/redux/selectors/index.ts
+++ b/ui/src/redux/selectors/index.ts
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { DateTime } from 'luxon';
+import { mapOperations, Operation } from '../slices/loader';
 import { RootState } from '../store';
 import { mapFromStoreType } from '../utils/mappers';
 
@@ -9,6 +10,7 @@ export const selectMapFilter = (state: RootState) => state.mapFilter;
 export const selectModalMap = (state: RootState) => state.modalMap;
 export const selectUser = (state: RootState) => state.user;
 export const selectModals = (state: RootState) => state.modals;
+export const selectLoader = (state: RootState) => state.loader;
 
 export const selectSelectedStopId = createSelector(
   selectMap,
@@ -68,4 +70,12 @@ export const selectViaModal = createSelector(
 export const selectIsViaModalOpen = createSelector(
   selectModals,
   (modals) => modals.viaModal.isOpen,
+);
+
+export const selectIsMapOperationLoading = createSelector(
+  selectLoader,
+  (loaders) =>
+    Object.entries(loaders)
+      .filter(([operation]) => mapOperations.includes(operation as Operation))
+      .some(([, isLoading]) => isLoading),
 );

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -1,0 +1,49 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export enum Operation {
+  LoadMap = 'loadMap',
+  FetchStops = 'fetchStops',
+  SaveStop = 'saveStop',
+  SaveRoute = 'saveRoute',
+  MatchRoute = 'matchRoute',
+  CheckBrokenRoutes = 'checkBrokenRoutes',
+}
+
+export const mapOperations = [
+  Operation.LoadMap,
+  Operation.FetchStops,
+  Operation.SaveStop,
+  Operation.SaveRoute,
+  Operation.MatchRoute,
+  Operation.CheckBrokenRoutes,
+];
+
+type IState = {
+  [key in Operation]: boolean;
+};
+
+const initialState: IState = {
+  [Operation.LoadMap]: false,
+  [Operation.FetchStops]: false,
+  [Operation.SaveStop]: false,
+  [Operation.SaveRoute]: false,
+  [Operation.MatchRoute]: false,
+  [Operation.CheckBrokenRoutes]: false,
+};
+
+const slice = createSlice({
+  name: 'loader',
+  initialState,
+  reducers: {
+    setLoading: (
+      state: IState,
+      action: PayloadAction<{ operation: Operation; isLoading: boolean }>,
+    ) => {
+      state[action.payload.operation] = action.payload.isLoading;
+    },
+  },
+});
+
+export const { setLoading: setLoadingAction } = slice.actions;
+
+export const loaderReducer = slice.reducer;

--- a/ui/src/redux/slices/mapEditor.ts
+++ b/ui/src/redux/slices/mapEditor.ts
@@ -66,10 +66,6 @@ interface IState {
    * Id of the route that has been selected in the map view
    */
   selectedRouteId?: UUID;
-  /**
-   * Is map editor loading
-   */
-  isLoading: boolean;
 }
 
 const initialState: IState = {
@@ -87,7 +83,6 @@ const initialState: IState = {
   },
   isRouteMetadataFormOpen: false,
   selectedRouteId: undefined,
-  isLoading: false,
 };
 
 export enum Mode {
@@ -295,12 +290,6 @@ const slice = createSlice({
     ) => {
       state.isRouteMetadataFormOpen = action.payload;
     },
-    /**
-     * Set map editor loading state
-     */
-    setLoading: (state: IState, action: PayloadAction<boolean>) => {
-      state.isLoading = action.payload;
-    },
   },
 });
 
@@ -321,7 +310,6 @@ export const {
   resetDraftRouteGeometry: resetDraftRouteGeometryAction,
   setSelectedRouteId: setSelectedRouteIdAction,
   setRouteMetadataFormOpen: setRouteMetadataFormOpenAction,
-  setLoading: setMapEditorLoadingAction,
 } = slice.actions;
 
 export const mapEditorReducer = slice.reducer;

--- a/ui/src/redux/slices/modalMap.ts
+++ b/ui/src/redux/slices/modalMap.ts
@@ -20,12 +20,16 @@ const slice = createSlice({
   name: 'modalMap',
   initialState,
   reducers: {
-    setViewPort: (state, action: PayloadAction<Viewport>) => {
+    setViewPort: (state: IState, action: PayloadAction<Viewport>) => {
       state.viewport = action.payload;
+    },
+    reset: () => {
+      return initialState;
     },
   },
 });
 
-export const { setViewPort: setViewPortAction } = slice.actions;
+export const { setViewPort: setViewPortAction, reset: resetModalMapAction } =
+  slice.actions;
 
 export const modalMapReducer = slice.reducer;

--- a/ui/src/redux/slices/modalMap.ts
+++ b/ui/src/redux/slices/modalMap.ts
@@ -9,13 +9,11 @@ export const HELSINKI_CITY_CENTER_COORDINATES = {
 interface IState {
   isOpen: boolean;
   viewport: Viewport;
-  isLoading: boolean;
 }
 
 const initialState: IState = {
   isOpen: false,
   viewport: { ...HELSINKI_CITY_CENTER_COORDINATES, radius: 0 },
-  isLoading: false,
 };
 
 const slice = createSlice({
@@ -28,16 +26,10 @@ const slice = createSlice({
     reset: () => {
       return initialState;
     },
-    setLoading: (state: IState, action: PayloadAction<boolean>) => {
-      state.isLoading = action.payload;
-    },
   },
 });
 
-export const {
-  setViewPort: setViewPortAction,
-  reset: resetModalMapAction,
-  setLoading: setModalMapLoadingAction,
-} = slice.actions;
+export const { setViewPort: setViewPortAction, reset: resetModalMapAction } =
+  slice.actions;
 
 export const modalMapReducer = slice.reducer;

--- a/ui/src/redux/slices/modalMap.ts
+++ b/ui/src/redux/slices/modalMap.ts
@@ -9,11 +9,13 @@ export const HELSINKI_CITY_CENTER_COORDINATES = {
 interface IState {
   isOpen: boolean;
   viewport: Viewport;
+  isLoading: boolean;
 }
 
 const initialState: IState = {
   isOpen: false,
   viewport: { ...HELSINKI_CITY_CENTER_COORDINATES, radius: 0 },
+  isLoading: false,
 };
 
 const slice = createSlice({
@@ -26,10 +28,16 @@ const slice = createSlice({
     reset: () => {
       return initialState;
     },
+    setLoading: (state: IState, action: PayloadAction<boolean>) => {
+      state.isLoading = action.payload;
+    },
   },
 });
 
-export const { setViewPort: setViewPortAction, reset: resetModalMapAction } =
-  slice.actions;
+export const {
+  setViewPort: setViewPortAction,
+  reset: resetModalMapAction,
+  setLoading: setModalMapLoadingAction,
+} = slice.actions;
 
 export const modalMapReducer = slice.reducer;

--- a/ui/src/uiComponents/LoadingOverlay.tsx
+++ b/ui/src/uiComponents/LoadingOverlay.tsx
@@ -14,7 +14,7 @@ export const LoadingOverlay: React.FC<Props> = ({ visible, testId = '' }) => {
 
   return (
     <div
-      className="fixed top-1/2 left-1/2 z-50 flex h-32 -translate-y-1/2 -translate-x-1/2 cursor-wait border border-light-grey bg-background px-20 shadow-lg"
+      className="fixed top-1/2 left-1/2 z-50 flex h-32 -translate-y-1/2 -translate-x-1/2 cursor-wait rounded border border-light-grey bg-background px-20 shadow-lg"
       data-testid={testId}
     >
       <PulseLoader


### PR DESCRIPTION
- Fix bug where wrong stops were loaded on initial map load
- Display loading overlay when loading the map
- Display loading overlay when fetching stops in map
- Fine tune loading overlay styles

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/295)
<!-- Reviewable:end -->
