### PR TITLE
Fix broken route draw debounce

### DIFF
--- a/ui/src/hooks/routes/useExtractRouteFromFeature.ts
+++ b/ui/src/hooks/routes/useExtractRouteFromFeature.ts
@@ -90,11 +90,12 @@ export const useExtractRouteFromFeature = () => {
    * This is used for example removing different versions of stops from the
    * journey pattern list where only the labels are shown
    */
-  const filterDistinctConsecutiveRouteStops = <
-    TStop extends Pick<ServicePatternScheduledStopPoint, 'label'>,
-  >(
-    stops: TStop[],
-  ) => stops.filter((stop, index) => stops[index - 1]?.label !== stop.label);
+  const filterDistinctConsecutiveRouteStops = useCallback(
+    <TStop extends Pick<ServicePatternScheduledStopPoint, 'label'>>(
+      stops: TStop[],
+    ) => stops.filter((stop, index) => stops[index - 1]?.label !== stop.label),
+    [],
+  );
 
   /**
    * Sort and filter the stop points


### PR DESCRIPTION
- Missing useCallback in a hook function caused route draw debounce to be broken resulting in tons of extra map matching calls

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/299)
<!-- Reviewable:end -->
