### PR TITLE
Fix bug causing map to reopen after after close

### DIFF
--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -1,7 +1,7 @@
 import distance from '@turf/distance';
 import { point, Units } from '@turf/helpers';
 import debounce from 'lodash/debounce';
-import { FunctionComponent, useMemo, useRef, useState } from 'react';
+import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
 import MapGL, { MapEvent, MapRef, NavigationControl } from 'react-map-gl';
 import { useAppDispatch, useLoader, useMapQueryParams } from '../../hooks';
 import { Operation, setViewPortAction } from '../../redux';
@@ -136,6 +136,13 @@ export const Maplibre: FunctionComponent<Props> = ({
     setIsLoading(false);
     onViewportChange(viewport);
   };
+
+  useEffect(() => {
+    // Cancel the debounced update if the map is going to be closed.
+    return () => {
+      updateMapDetailsDebounced.cancel();
+    };
+  }, [updateMapDetailsDebounced]);
 
   return (
     <MapGL


### PR DESCRIPTION
If the map was closed during the debounced 800ms after map move action, the debounced function still executed and caused the map to re-open. This commit will cancel the debounced function if the map is closed.
Resolves HSLdevcom/jore4#913

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/304)
<!-- Reviewable:end -->
