### PR TITLE
Fix modal covering loading overlay bug

### DIFF
--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -9,13 +9,12 @@ import { Column } from '../../layoutComponents';
 import {
   selectHasDraftRouteGeometry,
   selectIsCreateStopModeEnabled,
-  selectIsMapOperationLoading,
   selectMapEditor,
   selectMapFilter,
   selectSelectedRouteId,
   setSelectedRouteIdAction,
 } from '../../redux';
-import { FilterPanel, LoadingOverlay } from '../../uiComponents';
+import { FilterPanel } from '../../uiComponents';
 import { Maplibre } from './Maplibre';
 import { InfraLinksVectorLayer } from './network';
 import { ObservationDateOverlay } from './ObservationDateOverlay';
@@ -51,7 +50,6 @@ export const MapComponent = (
 
   const { drawingMode, initiallyDisplayedRouteIds } =
     useAppSelector(selectMapEditor);
-  const isLoading = useAppSelector(selectIsMapOperationLoading);
 
   const hasDraftRouteGeometry = useAppSelector(selectHasDraftRouteGeometry);
   const { showStopFilterOverlay } = useAppSelector(selectMapFilter);
@@ -231,7 +229,6 @@ export const MapComponent = (
         onDeleteDrawnRoute={() => editorLayerRef.current?.onDeleteRoute()}
         ref={routeEditorRef}
       />
-      <LoadingOverlay visible={isLoading} />
     </Maplibre>
   );
 };

--- a/ui/src/components/map/MapLoader.tsx
+++ b/ui/src/components/map/MapLoader.tsx
@@ -1,0 +1,9 @@
+import { useAppSelector } from '../../hooks';
+import { selectIsMapOperationLoading } from '../../redux';
+import { LoadingOverlay } from '../../uiComponents';
+
+export const MapLoader = () => {
+  const isLoading = useAppSelector(selectIsMapOperationLoading);
+
+  return <LoadingOverlay visible={isLoading} />;
+};

--- a/ui/src/components/map/index.ts
+++ b/ui/src/components/map/index.ts
@@ -1,1 +1,3 @@
 export * from './Map';
+export * from './MapLoader';
+export * from './ModalMap';

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import React, { FunctionComponent } from 'react';
 import { BrowserRouter, Route, Switch, useParams } from 'react-router-dom';
-import { ModalMap } from '../components/map/ModalMap';
+import { MapLoader, ModalMap } from '../components/map';
 import { Navbar } from '../components/navbar';
 import { CreateNewLinePage } from '../components/routes-and-lines/create-line/CreateNewLinePage';
 import { EditLinePage } from '../components/routes-and-lines/edit-line/EditLinePage';
@@ -98,6 +98,7 @@ export const Router: FunctionComponent = () => {
         ))}
       </Switch>
       <ModalMap />
+      <MapLoader />
     </BrowserRouter>
   );
 };


### PR DESCRIPTION
Edit confirmation dialogs would be rendered on top of loading overlay. Changing the order with z-index does not work if the components are in different level in the DOM hierarchy. Therefore loading overlay was moved to upper level in the component hierarchy.

Separate MapLoader component was created, because Router component should have nothing to do with deciding whether or not a loading overlay should be displayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/306)
<!-- Reviewable:end -->
