### PR TITLE
Fix map loader showing when map is not open

### DIFF
--- a/ui/src/components/map/MapLoader.tsx
+++ b/ui/src/components/map/MapLoader.tsx
@@ -1,9 +1,10 @@
-import { useAppSelector } from '../../hooks';
+import { useAppSelector, useMapQueryParams } from '../../hooks';
 import { selectIsMapOperationLoading } from '../../redux';
 import { LoadingOverlay } from '../../uiComponents';
 
 export const MapLoader = () => {
+  const { isMapOpen } = useMapQueryParams();
   const isLoading = useAppSelector(selectIsMapOperationLoading);
 
-  return <LoadingOverlay visible={isLoading} />;
+  return <LoadingOverlay visible={isMapOpen && isLoading} />;
 };


### PR DESCRIPTION
- In some rare cases map loader was displayed when map modal was not visible

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/309)
<!-- Reviewable:end -->
