### PR TITLE
Improve move stop usability

### DIFF
--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -9,6 +9,7 @@ import { Column } from '../../layoutComponents';
 import {
   selectHasDraftRouteGeometry,
   selectIsCreateStopModeEnabled,
+  selectIsMoveStopModeEnabled,
   selectMapEditor,
   selectMapFilter,
   selectSelectedRouteId,
@@ -65,6 +66,7 @@ export const MapComponent = (
   const [showStops, setShowStops] = useState(true);
 
   const isCreateStopModeEnabled = useAppSelector(selectIsCreateStopModeEnabled);
+  const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
 
   // TODO: avoid any type
   const editorLayerRef = useRef<ExplicitAny>(null);
@@ -94,10 +96,19 @@ export const MapComponent = (
     }
   };
 
+  const onMoveStop = (e: MapEvent) => {
+    if (!drawingMode) {
+      stopsRef.current?.onMoveStop(e);
+    }
+  };
+
   const onClick = (e: MapEvent) => {
     if (isCreateStopModeEnabled) {
       onCreateStop(e);
       return;
+    }
+    if (isMoveStopModeEnabled) {
+      onMoveStop(e);
     }
 
     // Retrieve all rendered features on the map

--- a/ui/src/components/map/MapFooter.tsx
+++ b/ui/src/components/map/MapFooter.tsx
@@ -9,6 +9,7 @@ import {
   selectHasDraftRouteGeometry,
   selectIsCreateStopModeEnabled,
   selectIsInViewMode,
+  selectIsMoveStopModeEnabled,
   selectMapEditor,
   setIsCreateStopModeEnabledAction,
 } from '../../redux';
@@ -39,14 +40,19 @@ export const MapFooter: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
 
-  const { drawingMode, creatingNewRoute, selectedRouteId } =
-    useAppSelector(selectMapEditor);
+  const {
+    drawingMode,
+    creatingNewRoute,
+    isRouteMetadataFormOpen,
+    selectedRouteId,
+  } = useAppSelector(selectMapEditor);
   const hasDraftRouteGeometry = useAppSelector(selectHasDraftRouteGeometry);
 
   const hasChangesInProgress = useAppSelector(selectHasChangesInProgress);
   const isInViewMode = useAppSelector(selectIsInViewMode);
 
   const isCreateStopModeEnabled = useAppSelector(selectIsCreateStopModeEnabled);
+  const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
   const setIsCreateStopModeEnabled = useAppAction(
     setIsCreateStopModeEnabledAction,
   );
@@ -60,7 +66,12 @@ export const MapFooter: React.FC<Props> = ({
       <SimpleButton
         testId={testIds.drawRouteButton}
         onClick={onDrawRoute}
-        disabled={!isInViewMode || creatingNewRoute}
+        disabled={
+          !isInViewMode ||
+          creatingNewRoute ||
+          isCreateStopModeEnabled ||
+          isMoveStopModeEnabled
+        }
         inverted={drawingMode !== Mode.Draw}
       >
         {t('map.drawRoute')}
@@ -75,7 +86,7 @@ export const MapFooter: React.FC<Props> = ({
       </SimpleButton>
       <SimpleButton
         onClick={onAddStops}
-        disabled={drawingMode !== undefined}
+        disabled={drawingMode !== undefined || creatingNewRoute}
         inverted={!isCreateStopModeEnabled}
         testId={testIds.addStopButton}
       >
@@ -84,11 +95,11 @@ export const MapFooter: React.FC<Props> = ({
       <SimpleButton
         className="h-full !px-3 text-xl"
         onClick={onDeleteRoute}
-        disabled={!hasChangesInProgress}
+        disabled={!hasChangesInProgress || isRouteMetadataFormOpen}
       >
         <MdDelete aria-label={t('map.deleteRoute')} />
       </SimpleButton>
-      <Visible visible={hasChangesInProgress}>
+      <Visible visible={hasChangesInProgress && !isRouteMetadataFormOpen}>
         <SimpleButton
           containerClassName="!ml-auto"
           onClick={onCancel}

--- a/ui/src/components/map/markers/Circle.tsx
+++ b/ui/src/components/map/markers/Circle.tsx
@@ -6,6 +6,7 @@ interface Props {
   borderWidth?: number;
   fillColor?: string;
   borderColor?: string;
+  strokeDashArray?: number;
   centerDot?: boolean;
   centerDotSize?: number;
   onClick?: () => void;
@@ -17,6 +18,7 @@ const CircleComponent = ({
   borderWidth = 2,
   fillColor = 'white',
   borderColor = 'black',
+  strokeDashArray = 0,
   centerDot = false,
   centerDotSize = 2,
   onClick,
@@ -37,6 +39,7 @@ const CircleComponent = ({
         cy={size / 2}
         r={size / 2 - borderWidth}
         stroke={borderColor}
+        strokeDasharray={strokeDashArray}
         strokeWidth={borderWidth}
         fill={fillColor}
       />

--- a/ui/src/components/map/stops/CreateStopMarker.tsx
+++ b/ui/src/components/map/stops/CreateStopMarker.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { theme } from '../../../generated/theme';
+import { resetEnabledModesAction } from '../../../redux';
 import { Coords } from '../../../types';
 import { Circle } from '../markers';
 
@@ -10,6 +12,7 @@ interface Props {
 }
 export const CreateStopMarker = ({ onCursorMove }: Props): JSX.Element => {
   const [mouseCoords, setMouseCoords] = React.useState<Coords>();
+  const dispatch = useDispatch();
 
   const createStopMarkerSize = 20;
 
@@ -30,6 +33,17 @@ export const CreateStopMarker = ({ onCursorMove }: Props): JSX.Element => {
     // hide marker if the mouse leaves from the map area
     setMouseCoords(undefined);
   };
+
+  const detectKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      dispatch(resetEnabledModesAction());
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', detectKeyDown, true);
+    return () => document.removeEventListener('keydown', detectKeyDown, true);
+  });
 
   return (
     <div

--- a/ui/src/components/map/stops/EditStopLayer.tsx
+++ b/ui/src/components/map/stops/EditStopLayer.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { Ref, useEffect, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { MapEvent } from 'react-map-gl';
 import { CallbackEvent } from 'react-map-gl/src/components/draggable-control';
+import { useDispatch } from 'react-redux';
 import { StopPopupInfoFragment } from '../../../generated/graphql';
 import { ScheduledStopPointSetInput, StopWithLocation } from '../../../graphql';
 import {
@@ -8,22 +10,23 @@ import {
   DeleteChanges,
   EditChanges,
   isEditChanges,
-  StopWithVehicleMode,
   useAppAction,
+  useAppSelector,
   useCreateStop,
   useDeleteStop,
   useEditStop,
   useLoader,
-  useMapStops,
 } from '../../../hooks';
 import {
   Operation,
+  selectIsMoveStopModeEnabled,
   setEditedStopDataAction,
+  setIsMoveStopModeEnabledAction,
+  setSelectedRouteIdAction,
   setSelectedStopIdAction,
 } from '../../../redux';
 import {
   mapLngLatToGeoJSON,
-  mapLngLatToPoint,
   removeFromApolloCache,
   showSuccessToast,
 } from '../../../utils';
@@ -35,7 +38,6 @@ import {
 import { DeleteStopConfirmationDialog } from './DeleteStopConfirmationDialog';
 import { EditStopConfirmationDialog } from './EditStopConfirmationDialog';
 import { EditStopModal } from './EditStopModal';
-import { Stop } from './Stop';
 import { StopPopup } from './StopPopup';
 
 enum StopEditorViews {
@@ -48,296 +50,297 @@ interface Props {
   editedStopData: StopWithLocation;
   onEditingFinished?: () => void;
   onPopupClose?: () => void;
+  ref: Ref<ExplicitAny>;
 }
 
-export const EditStopLayer: React.FC<Props> = ({
-  editedStopData,
-  onEditingFinished,
-  onPopupClose,
-}) => {
-  const [isStopDraggable, setIsStopDraggable] = useState(false);
-  const [createChanges, setCreateChanges] = useState<CreateChanges>();
-  const [editChanges, setEditChanges] = useState<EditChanges>();
-  const [deleteChanges, setDeleteChanges] = useState<DeleteChanges>();
-  const [displayedEditor, setDisplayedEditor] = useState<StopEditorViews>(
-    StopEditorViews.None,
-  );
+export const EditStopLayer: React.FC<Props> = React.forwardRef(
+  ({ editedStopData, onEditingFinished, onPopupClose }, ref) => {
+    const [createChanges, setCreateChanges] = useState<CreateChanges>();
+    const [editChanges, setEditChanges] = useState<EditChanges>();
+    const [deleteChanges, setDeleteChanges] = useState<DeleteChanges>();
+    const [displayedEditor, setDisplayedEditor] = useState<StopEditorViews>(
+      StopEditorViews.None,
+    );
 
-  const { t } = useTranslation();
+    const dispatch = useDispatch();
+    const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
 
-  const setSelectedStopId = useAppAction(setSelectedStopIdAction);
-  const setEditedStopData = useAppAction(setEditedStopDataAction);
-  const { setIsLoading: setIsLoadingBrokenRoutes } = useLoader(
-    Operation.CheckBrokenRoutes,
-  );
-  const { setIsLoading: setIsLoadingSaveStop } = useLoader(Operation.SaveStop);
+    const { t } = useTranslation();
 
-  const { mapCreateChangesToVariables, insertStopMutation } = useCreateStop();
-  const {
-    prepareEdit,
-    mapEditChangesToVariables,
-    editStopMutation,
-    defaultErrorHandler,
-  } = useEditStop();
-  const {
-    prepareDelete,
-    mapDeleteChangesToVariables,
-    removeStop,
-    defaultErrorHandler: deleteErrorHandler,
-  } = useDeleteStop();
+    const setSelectedStopId = useAppAction(setSelectedStopIdAction);
+    const setEditedStopData = useAppAction(setEditedStopDataAction);
+    const { setIsLoading: setIsLoadingBrokenRoutes } = useLoader(
+      Operation.CheckBrokenRoutes,
+    );
+    const { setIsLoading: setIsLoadingSaveStop } = useLoader(
+      Operation.SaveStop,
+    );
 
-  const { getStopVehicleMode } = useMapStops();
+    const { mapCreateChangesToVariables, insertStopMutation } = useCreateStop();
+    const {
+      prepareEdit,
+      mapEditChangesToVariables,
+      editStopMutation,
+      defaultErrorHandler,
+    } = useEditStop();
+    const {
+      prepareDelete,
+      mapDeleteChangesToVariables,
+      removeStop,
+      defaultErrorHandler: deleteErrorHandler,
+    } = useDeleteStop();
 
-  // computed values for the edited stop
-  const isDraftStop = !editedStopData.scheduled_stop_point_id;
-  const defaultDisplayedEditor = isDraftStop
-    ? StopEditorViews.Modal
-    : StopEditorViews.Popup;
-  const editedStopLocation = mapLngLatToPoint(
-    editedStopData.measured_location.coordinates,
-  );
+    // computed values for the edited stop
+    const isDraftStop = !editedStopData.scheduled_stop_point_id;
+    const defaultDisplayedEditor = isDraftStop
+      ? StopEditorViews.Modal
+      : StopEditorViews.Popup;
 
-  // when a stop is first edited, immediately show the proper editor view
-  useEffect(() => {
-    setDisplayedEditor(defaultDisplayedEditor);
-  }, [defaultDisplayedEditor, editedStopData]);
+    // when a stop is first edited, immediately show the proper editor view
+    useEffect(() => {
+      if (!isMoveStopModeEnabled) {
+        setDisplayedEditor(defaultDisplayedEditor);
+      }
+    }, [
+      defaultDisplayedEditor,
+      dispatch,
+      editedStopData,
+      isMoveStopModeEnabled,
+    ]);
 
-  const onStopClicked = () => {
-    setSelectedStopId(editedStopData?.scheduled_stop_point_id);
+    const onCloseEditors = () => {
+      setCreateChanges(undefined);
+      setSelectedStopId(undefined);
+      setEditedStopData(undefined);
+      setDisplayedEditor(StopEditorViews.None);
+      onPopupClose?.();
+    };
 
-    // for draft stops, we show the modal immediately
-    setDisplayedEditor(defaultDisplayedEditor);
-  };
+    const onFinishEditing = () => {
+      setCreateChanges(undefined);
+      setEditChanges(undefined);
+      setDeleteChanges(undefined);
+      onCloseEditors();
 
-  const onCloseEditors = () => {
-    setCreateChanges(undefined);
-    setSelectedStopId(undefined);
-    setEditedStopData(undefined);
-    setDisplayedEditor(StopEditorViews.None);
-    onPopupClose?.();
-  };
+      if (onEditingFinished) {
+        onEditingFinished();
+      }
+    };
 
-  const onFinishEditing = () => {
-    setCreateChanges(undefined);
-    setEditChanges(undefined);
-    setDeleteChanges(undefined);
-    onCloseEditors();
-
-    if (onEditingFinished) {
-      onEditingFinished();
-    }
-  };
-
-  const onPrepareDelete = async (stopId: UUID) => {
-    // we are removing stop that is already stored to backend
-    try {
-      const changes = await prepareDelete({
-        stopId,
-      });
-
-      setDeleteChanges(changes);
-    } catch (err) {
-      deleteErrorHandler(err as Error);
-    }
-  };
-
-  const onRemoveDraftStop = async () => {
-    onFinishEditing();
-  };
-
-  const onRemoveStop = async (stopId?: UUID) => {
-    if (stopId) {
-      setIsLoadingBrokenRoutes(true);
+    const onPrepareDelete = async (stopId: UUID) => {
       // we are removing stop that is already stored to backend
-      await onPrepareDelete(stopId);
-      setIsLoadingBrokenRoutes(false);
-    } else {
-      // we are removing a draft stop
-      await onRemoveDraftStop();
-    }
-  };
-
-  const onStopDragEnd = async (event: CallbackEvent) => {
-    const stopId = editedStopData.scheduled_stop_point_id;
-    if (stopId) {
-      // if this is a stop existing on the backend, also prepare the changes to be confirmed
-      const patch: ScheduledStopPointSetInput = {
-        measured_location: mapLngLatToGeoJSON(event.lngLat),
-      };
-      setIsLoadingBrokenRoutes(true);
       try {
-        const changes = await prepareEdit({
+        const changes = await prepareDelete({
           stopId,
-          patch,
         });
-        setEditChanges(changes);
+
+        setDeleteChanges(changes);
+      } catch (err) {
+        deleteErrorHandler(err as Error);
+      }
+    };
+
+    const onRemoveDraftStop = async () => {
+      onFinishEditing();
+    };
+
+    const onRemoveStop = async (stopId?: UUID) => {
+      if (stopId) {
+        setIsLoadingBrokenRoutes(true);
+        // we are removing stop that is already stored to backend
+        await onPrepareDelete(stopId);
+        setIsLoadingBrokenRoutes(false);
+      } else {
+        // we are removing a draft stop
+        await onRemoveDraftStop();
+      }
+    };
+
+    const onMoveStop = async (event: CallbackEvent) => {
+      const stopId = editedStopData.scheduled_stop_point_id;
+      if (stopId) {
+        // if this is a stop existing on the backend, also prepare the changes to be confirmed
+        const patch: ScheduledStopPointSetInput = {
+          measured_location: mapLngLatToGeoJSON(event.lngLat),
+        };
+        setIsLoadingBrokenRoutes(true);
+        try {
+          const changes = await prepareEdit({
+            stopId,
+            patch,
+          });
+          setEditChanges(changes);
+        } catch (err) {
+          defaultErrorHandler(err as Error);
+        }
+        setIsLoadingBrokenRoutes(false);
+      } else {
+        // for draft stops, just update the edited stop data
+        setEditedStopData({
+          ...editedStopData,
+          measured_location: mapLngLatToGeoJSON(event.lngLat),
+        });
+      }
+    };
+
+    const onCancelEdit = () => {
+      dispatch(setIsMoveStopModeEnabledAction(false));
+      setDisplayedEditor(StopEditorViews.Popup);
+      setEditChanges(undefined);
+    };
+
+    const doCreateStop = async (changes: CreateChanges) => {
+      setIsLoadingSaveStop(true);
+      try {
+        const variables = mapCreateChangesToVariables(changes);
+        await insertStopMutation(variables);
+
+        showSuccessToast(t('stops.saveSuccess'));
+        onFinishEditing();
       } catch (err) {
         defaultErrorHandler(err as Error);
       }
-      setIsLoadingBrokenRoutes(false);
-    } else {
-      // for draft stops, just update the edited stop data
-      setEditedStopData({
-        ...editedStopData,
-        measured_location: mapLngLatToGeoJSON(event.lngLat),
-      });
-    }
+      setIsLoadingSaveStop(false);
+    };
 
-    // remove draggability of the stop that it could be edited
-    setIsStopDraggable(false);
-  };
+    const doEditStop = async (changes: EditChanges) => {
+      setIsLoadingSaveStop(true);
+      try {
+        const variables = mapEditChangesToVariables(changes);
 
-  const doCreateStop = async (changes: CreateChanges) => {
-    setIsLoadingSaveStop(true);
-    try {
-      const variables = mapCreateChangesToVariables(changes);
-      await insertStopMutation(variables);
+        await editStopMutation({
+          variables,
+          update(cache) {
+            removeFromApolloCache(cache, {
+              infrastructure_link_id:
+                variables.stop_patch.located_on_infrastructure_link_id,
+              __typename: 'infrastructure_network_infrastructure_link',
+            });
+          },
+        });
 
-      showSuccessToast(t('stops.saveSuccess'));
-      onFinishEditing();
-    } catch (err) {
-      defaultErrorHandler(err as Error);
-    }
-    setIsLoadingSaveStop(false);
-  };
+        showSuccessToast(t('stops.editSuccess'));
+        onFinishEditing();
+      } catch (err) {
+        defaultErrorHandler(err as Error);
+      }
+      dispatch(setIsMoveStopModeEnabledAction(false));
+      setIsLoadingSaveStop(false);
+    };
 
-  const doEditStop = async (changes: EditChanges) => {
-    setIsLoadingSaveStop(true);
-    try {
-      const variables = mapEditChangesToVariables(changes);
+    // we are removing stop that is already stored to backend
+    const doDeleteStop = async (changes: DeleteChanges) => {
+      try {
+        const variables = mapDeleteChangesToVariables(changes);
+        await removeStop(variables);
 
-      await editStopMutation({
-        variables,
-        update(cache) {
-          removeFromApolloCache(cache, {
-            infrastructure_link_id:
-              variables.stop_patch.located_on_infrastructure_link_id,
-            __typename: 'infrastructure_network_infrastructure_link',
-          });
-        },
-      });
+        showSuccessToast(t('stops.removeSuccess'));
+        onFinishEditing();
+      } catch (err) {
+        deleteErrorHandler(err as Error);
+      }
+    };
 
-      showSuccessToast(t('stops.editSuccess'));
-      onFinishEditing();
-    } catch (err) {
-      defaultErrorHandler(err as Error);
-    }
-    setIsLoadingSaveStop(false);
-  };
+    const createChangesValid = (changes: CreateChanges) => {
+      return !changes.conflicts?.length;
+    };
 
-  // we are removing stop that is already stored to backend
-  const doDeleteStop = async (changes: DeleteChanges) => {
-    try {
-      const variables = mapDeleteChangesToVariables(changes);
-      await removeStop(variables);
+    const onStopFormSubmit = async (changes: EditChanges | CreateChanges) => {
+      // for editing, it'll need to show a confirmation windows
+      if (isEditChanges(changes)) {
+        setEditChanges(changes);
+        return;
+      }
 
-      showSuccessToast(t('stops.removeSuccess'));
-      onFinishEditing();
-    } catch (err) {
-      deleteErrorHandler(err as Error);
-    }
-  };
+      setCreateChanges(changes);
 
-  const createChangesValid = (changes: CreateChanges) => {
-    return !changes.conflicts?.length;
-  };
+      if (createChangesValid(changes)) {
+        // for creating, it'll execute the creation if changes were valid
+        await doCreateStop(changes);
+      }
+    };
 
-  const onStopFormSubmit = async (changes: EditChanges | CreateChanges) => {
-    // for editing, it'll need to show a confirmation windows
-    if (isEditChanges(changes)) {
-      setEditChanges(changes);
-      return;
-    }
+    const getActiveChanges = () => {
+      if (createChanges && editChanges) {
+        throw new Error('Undefined state');
+      }
+      return createChanges || editChanges;
+    };
 
-    setCreateChanges(changes);
+    const getCurrentConflicts = () => {
+      const changes = getActiveChanges();
 
-    if (createChangesValid(changes)) {
-      // for creating, it'll execute the creation if changes were valid
-      await doCreateStop(changes);
-    }
-  };
+      return changes?.conflicts;
+    };
 
-  const getActiveChanges = () => {
-    if (createChanges && editChanges) {
-      throw new Error('Undefined state');
-    }
-    return createChanges || editChanges;
-  };
+    const hideEditors = () => {
+      setDisplayedEditor(StopEditorViews.None);
+      dispatch(setSelectedRouteIdAction(undefined));
+    };
 
-  const getCurrentConflicts = () => {
-    const changes = getActiveChanges();
+    const onStartMoveStop = () => {
+      hideEditors();
+      dispatch(setIsMoveStopModeEnabledAction(true));
+    };
 
-    return changes?.conflicts;
-  };
+    useImperativeHandle(ref, () => ({
+      onMoveStop: async (e: MapEvent) => onMoveStop(e),
+    }));
 
-  const getVehicleMode = () =>
-    editedStopData.scheduled_stop_point_id
-      ? getStopVehicleMode(editedStopData as StopWithVehicleMode)
-      : undefined;
+    const currentConflicts = getCurrentConflicts();
+    return (
+      <>
+        {displayedEditor === StopEditorViews.Popup && (
+          <StopPopup
+            // If displaying popup, editedStopData contains all StopPopupInfoFragment fields
+            // StopWithLocation type has many fields (e.g. label) optional, so need to cast here.
+            stop={editedStopData as StopPopupInfoFragment}
+            onEdit={() => {
+              setDisplayedEditor(StopEditorViews.Modal);
+            }}
+            onMove={onStartMoveStop}
+            onDelete={() =>
+              onRemoveStop(editedStopData.scheduled_stop_point_id)
+            }
+            onClose={onCloseEditors}
+          />
+        )}
+        {displayedEditor === StopEditorViews.Modal && (
+          <EditStopModal
+            defaultValues={mapStopDataToFormState(editedStopData)}
+            onCancel={onCloseEditors}
+            onClose={onCloseEditors}
+            onSubmit={onStopFormSubmit}
+          />
+        )}
+        {currentConflicts?.length && (
+          <ConflictResolverModal
+            onClose={() => {
+              setCreateChanges(undefined);
+              setEditChanges(undefined);
+            }}
+            conflicts={currentConflicts?.map(mapStopToCommonConflictItem)}
+          />
+        )}
+        {editChanges && !editChanges?.conflicts?.length && (
+          <EditStopConfirmationDialog
+            isOpen={!!editChanges}
+            onCancel={onCancelEdit}
+            onConfirm={() => doEditStop(editChanges)}
+            editChanges={editChanges}
+          />
+        )}
+        {deleteChanges && (
+          <DeleteStopConfirmationDialog
+            isOpen={!!deleteChanges}
+            onCancel={() => setDeleteChanges(undefined)}
+            onConfirm={() => doDeleteStop(deleteChanges)}
+            deleteChanges={deleteChanges}
+          />
+        )}
+      </>
+    );
+  },
+);
 
-  const currentConflicts = getCurrentConflicts();
-  return (
-    <>
-      {/* Creates new <Stop> instance for both existing and draft stops */}
-      <Stop
-        testId="map:stopMarker:editedStop"
-        selected
-        longitude={editedStopLocation.longitude}
-        latitude={editedStopLocation.latitude}
-        onClick={() => onStopClicked()}
-        draggable={isStopDraggable}
-        onDragEnd={(e) => onStopDragEnd(e)}
-        isHighlighted
-        onVehicleRoute={getVehicleMode()}
-      />
-      {displayedEditor === StopEditorViews.Popup && (
-        <StopPopup
-          // If displaying popup, editedStopData contains all StopPopupInfoFragment fields
-          // StopWithLocation type has many fields (e.g. label) optional, so need to cast here.
-          stop={editedStopData as StopPopupInfoFragment}
-          onEdit={() => {
-            setDisplayedEditor(StopEditorViews.Modal);
-          }}
-          onMove={() => {
-            setIsStopDraggable(true);
-          }}
-          onDelete={() => onRemoveStop(editedStopData.scheduled_stop_point_id)}
-          onClose={onCloseEditors}
-        />
-      )}
-      {displayedEditor === StopEditorViews.Modal && (
-        <EditStopModal
-          defaultValues={mapStopDataToFormState(editedStopData)}
-          onCancel={onCloseEditors}
-          onClose={onCloseEditors}
-          onSubmit={onStopFormSubmit}
-        />
-      )}
-      {currentConflicts?.length && (
-        <ConflictResolverModal
-          onClose={() => {
-            setCreateChanges(undefined);
-            setEditChanges(undefined);
-          }}
-          conflicts={currentConflicts?.map(mapStopToCommonConflictItem)}
-        />
-      )}
-      {editChanges && !editChanges?.conflicts?.length && (
-        <EditStopConfirmationDialog
-          isOpen={!!editChanges}
-          onCancel={() => setEditChanges(undefined)}
-          onConfirm={() => doEditStop(editChanges)}
-          editChanges={editChanges}
-        />
-      )}
-      {deleteChanges && (
-        <DeleteStopConfirmationDialog
-          isOpen={!!deleteChanges}
-          onCancel={() => setDeleteChanges(undefined)}
-          onConfirm={() => doDeleteStop(deleteChanges)}
-          deleteChanges={deleteChanges}
-        />
-      )}
-    </>
-  );
-};
+EditStopLayer.displayName = 'EditStopLayer';

--- a/ui/src/components/map/stops/Stop.tsx
+++ b/ui/src/components/map/stops/Stop.tsx
@@ -2,6 +2,8 @@ import { Marker } from 'react-map-gl';
 import { CallbackEvent } from 'react-map-gl/src/components/draggable-control';
 import { ReusableComponentsVehicleModeEnum } from '../../../generated/graphql';
 import { theme } from '../../../generated/theme';
+import { useAppSelector } from '../../../hooks';
+import { selectIsMoveStopModeEnabled } from '../../../redux';
 import { Point } from '../../../types';
 import { Circle } from '../markers';
 
@@ -9,13 +11,30 @@ const { colors } = theme;
 
 interface Props extends Point {
   testId?: string;
-  draggable?: boolean;
   selected?: boolean;
   onClick: () => void;
   onDragEnd?: (event: CallbackEvent) => void;
   onVehicleRoute?: ReusableComponentsVehicleModeEnum;
   isHighlighted?: boolean;
 }
+
+const getBorderColor = (
+  isHilighted: boolean,
+  isPlaceholder: boolean,
+  onVehicleRoute?: ReusableComponentsVehicleModeEnum,
+) => {
+  if (isPlaceholder) {
+    return colors.grey;
+  }
+  if (isHilighted) {
+    return colors.selectedMapItem;
+  }
+  const vehicleStopColor = onVehicleRoute
+    ? colors.stops[onVehicleRoute]
+    : 'black';
+
+  return vehicleStopColor;
+};
 
 export const Stop = ({
   testId,
@@ -24,20 +43,21 @@ export const Stop = ({
   onClick,
   onDragEnd,
   selected = false,
-  draggable = false,
   onVehicleRoute = undefined,
   isHighlighted = false,
 }: Props): JSX.Element => {
+  const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
   const iconSize = 30;
   const selectedIconSize = 32;
+  // If the stop is being moved, we use different styles for the stop
+  // to indicate the placeholder of the old location
+  const isPlaceholder = selected && isMoveStopModeEnabled;
+  const iconBorderColor = getBorderColor(
+    isHighlighted,
+    isPlaceholder,
+    onVehicleRoute,
+  );
 
-  const vehicleStopColor = onVehicleRoute
-    ? colors.stops[onVehicleRoute]
-    : 'black';
-
-  const iconBorderColor = isHighlighted
-    ? colors.selectedMapItem
-    : vehicleStopColor;
   const iconFillColor = onVehicleRoute || selected ? 'white' : colors.lightGrey;
 
   const iconBorderWidth = 3;
@@ -49,7 +69,6 @@ export const Stop = ({
       latitude={latitude}
       offsetTop={-1 * ((selected ? selectedIconSize : iconSize) / 2)}
       offsetLeft={-1 * ((selected ? selectedIconSize : iconSize) / 2)}
-      draggable={draggable}
       onDragEnd={onDragEnd}
       className="rounded-full"
     >
@@ -60,6 +79,7 @@ export const Stop = ({
         borderColor={iconBorderColor}
         fillColor={iconFillColor}
         borderWidth={iconBorderWidth}
+        strokeDashArray={isPlaceholder ? 2 : 0}
         centerDot={selected}
         centerDotSize={selected ? centerDotSize * 1.5 : centerDotSize}
       />

--- a/ui/src/redux/selectors/index.ts
+++ b/ui/src/redux/selectors/index.ts
@@ -25,6 +25,11 @@ export const selectIsCreateStopModeEnabled = createSelector(
   (map) => map.isCreateStopModeEnabled,
 );
 
+export const selectIsMoveStopModeEnabled = createSelector(
+  selectMap,
+  (map) => map.isMoveStopModeEnabled,
+);
+
 export const selectMapViewport = createSelector(
   selectModalMap,
   (modalMap) => modalMap.viewport,

--- a/ui/src/redux/slices/map.ts
+++ b/ui/src/redux/slices/map.ts
@@ -6,12 +6,14 @@ interface IState {
   selectedStopId?: UUID;
   editedStopData?: StoreType<StopWithLocation>;
   isCreateStopModeEnabled: boolean;
+  isMoveStopModeEnabled: boolean;
 }
 
 const initialState: IState = {
   selectedStopId: undefined,
   editedStopData: undefined,
   isCreateStopModeEnabled: false,
+  isMoveStopModeEnabled: false,
 };
 
 const slice = createSlice({
@@ -23,6 +25,13 @@ const slice = createSlice({
     },
     setIsCreateStopModeEnabled: (state, action: PayloadAction<boolean>) => {
       state.isCreateStopModeEnabled = action.payload;
+    },
+    setIsMoveStopModeEnabled: (state, action: PayloadAction<boolean>) => {
+      state.isMoveStopModeEnabled = action.payload;
+    },
+    resetEnabledModes: (state) => {
+      state.isMoveStopModeEnabled = false;
+      state.isCreateStopModeEnabled = false;
     },
     setEditedStopData: {
       reducer: (
@@ -41,6 +50,8 @@ const slice = createSlice({
 export const {
   setSelectedStopId: setSelectedStopIdAction,
   setIsCreateStopModeEnabled: setIsCreateStopModeEnabledAction,
+  setIsMoveStopModeEnabled: setIsMoveStopModeEnabledAction,
+  resetEnabledModes: resetEnabledModesAction,
   setEditedStopData: setEditedStopDataAction,
 } = slice.actions;
 


### PR DESCRIPTION
Resolves HSLdevcom/jore4#733

Move stop functionality and visualisation improved to be more intuitive.
* Stop draggability is now removed. Pressing "move stop" will go to "moveStopMode" and clicking a location will attempt to move the stop there. This now works the same way as when creating a new stop. (Stop marker following the cursor and only one click will decide where to move the stop).
* The stop that is being moved will have the old location visualised with dotted gray circle
* Pressing ESC button will cancel the move
  * This also works when creating stop
* When moving a stop, other modals will be closed / hidden
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/325)
<!-- Reviewable:end -->
