### PR TITLE
Pin hasura to :seed-data tag in docker-compose setup

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -3,7 +3,8 @@ services:
     # locking hasura image so that we can develop the UI against a static graphql API
     # Link to available jore4-hasura images in Docker Hub:
     # https://hub.docker.com/r/hsldevcom/jore4-hasura/tags?page=1&ordering=last_updated
-    image: 'hsldevcom/jore4-hasura:seed-main--20220808-d84f2548d6cad7225f6a8b18b6daab832a95d524'
+    # The :seed-data tag contains the latest main-build image with seed data.
+    image: 'hsldevcom/jore4-hasura:seed-data'
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:


### PR DESCRIPTION
The :seed-data tag contains Hasura's lastest main build with seed data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/338)
<!-- Reviewable:end -->
