### PR TITLE
Refactor store type mappings

### DIFF
--- a/ui/src/components/map/RouteStopsOverlayRow.tsx
+++ b/ui/src/components/map/RouteStopsOverlayRow.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch } from '../../hooks';
-import { mapFromStoreType, setStopOnRouteAction } from '../../redux';
+import { setStopOnRouteAction } from '../../redux';
 import { RouteStop } from '../../redux/types';
 import { AlignDirection, SimpleDropdownMenu } from '../../uiComponents';
 import { PriorityBadge } from './PriorityBadge';
@@ -29,13 +29,12 @@ export const RouteStopsOverlayRow = ({
 }: Props) => {
   const { t } = useTranslation();
 
-  const stopMetadata = mapFromStoreType(stop);
   const dispatch = useAppDispatch();
 
   const setOnRoute = (onRoute: boolean) => {
     dispatch(
       setStopOnRouteAction({
-        stopLabel: stopMetadata.label,
+        stopLabel: stop.label,
         belongsToJourneyPattern: onRoute,
       }),
     );
@@ -44,14 +43,14 @@ export const RouteStopsOverlayRow = ({
   return (
     <div
       className="flex h-10 items-center justify-between border-b p-2"
-      data-testid={rowTestId.generate(stopMetadata.label)}
+      data-testid={rowTestId.generate(stop.label)}
     >
       <div className="flex items-center">
         <div className="w-10">
           <PriorityBadge
-            priority={stopMetadata.priority}
-            validityStart={stopMetadata.validity_start}
-            validityEnd={stopMetadata.validity_end}
+            priority={stop.priority}
+            validityStart={stop.validity_start}
+            validityEnd={stop.validity_end}
           />
         </div>
         <div
@@ -59,21 +58,19 @@ export const RouteStopsOverlayRow = ({
             belongsToJourneyPattern ? 'text-black' : 'text-gray-300'
           }`}
         >
-          {stopMetadata.label}
+          {stop.label}
         </div>
       </div>
       {!isReadOnly && (
         <div className="text-tweaked-brand">
           <SimpleDropdownMenu
             alignItems={AlignDirection.Left}
-            testId={menuButtonTestId.generate(stopMetadata.label)}
+            testId={menuButtonTestId.generate(stop.label)}
           >
             <button
               type="button"
               onClick={() => setOnRoute(!belongsToJourneyPattern)}
-              data-testid={addToJourneyPatternButtonTestId.generate(
-                stopMetadata.label,
-              )}
+              data-testid={addToJourneyPatternButtonTestId.generate(stop.label)}
             >
               {belongsToJourneyPattern
                 ? t('stops.removeFromRoute')

--- a/ui/src/components/map/RouteStopsOverlayRow.tsx
+++ b/ui/src/components/map/RouteStopsOverlayRow.tsx
@@ -10,16 +10,10 @@ interface Props {
   isReadOnly?: boolean;
 }
 
-const rowTestId = {
-  generate: (label: string) => `RouteStopsOverlayRow::${label}`,
-};
-
-const menuButtonTestId = {
-  generate: (label: string) => `RouteStopsOverlayRow::${label}::menu`,
-};
-
-const addToJourneyPatternButtonTestId = {
-  generate: (label: string) =>
+const testIds = {
+  row: (label: string) => `RouteStopsOverlayRow::${label}`,
+  menuButton: (label: string) => `RouteStopsOverlayRow::${label}::menu`,
+  addToJourneyPatternButton: (label: string) =>
     `RouteStopsOverlayRow::${label}::menu::addToJourneyPatternButton`,
 };
 
@@ -43,7 +37,7 @@ export const RouteStopsOverlayRow = ({
   return (
     <div
       className="flex h-10 items-center justify-between border-b p-2"
-      data-testid={rowTestId.generate(stop.label)}
+      data-testid={testIds.row(stop.label)}
     >
       <div className="flex items-center">
         <div className="w-10">
@@ -65,12 +59,12 @@ export const RouteStopsOverlayRow = ({
         <div className="text-tweaked-brand">
           <SimpleDropdownMenu
             alignItems={AlignDirection.Left}
-            testId={menuButtonTestId.generate(stop.label)}
+            testId={testIds.menuButton(stop.label)}
           >
             <button
               type="button"
               onClick={() => setOnRoute(!belongsToJourneyPattern)}
-              data-testid={addToJourneyPatternButtonTestId.generate(stop.label)}
+              data-testid={testIds.addToJourneyPatternButton(stop.label)}
             >
               {belongsToJourneyPattern
                 ? t('stops.removeFromRoute')

--- a/ui/src/redux/mappers/mapEditor.ts
+++ b/ui/src/redux/mappers/mapEditor.ts
@@ -1,6 +1,5 @@
 import { StopWithJourneyPatternFieldsFragment } from '../../generated/graphql';
 import { RouteStop } from '../types';
-import { mapToStoreType } from './storeType';
 
 /**
  * Maps a RouteStop object to a stop in journey pattern that can be used when
@@ -58,6 +57,6 @@ export const buildRouteStop = <
   return {
     belongsToJourneyPattern,
     stopInJourneyPattern,
-    stop: mapToStoreType(stop),
+    stop,
   };
 };

--- a/ui/src/redux/selectors/index.ts
+++ b/ui/src/redux/selectors/index.ts
@@ -1,10 +1,14 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { mapFromStoreType } from '../mappers/storeType';
 import { mapOperations, Operation } from '../slices/loader';
+import { MapState } from '../slices/map';
+import { MapEditorState } from '../slices/mapEditor';
 import { RootState } from '../store';
 
-export const selectMap = (state: RootState) => state.map;
-export const selectMapEditor = (state: RootState) => state.mapEditor;
+export const selectMap = (state: RootState) =>
+  mapFromStoreType<MapState>(state.map);
+export const selectMapEditor = (state: RootState) =>
+  mapFromStoreType<MapEditorState>(state.mapEditor);
 export const selectMapFilter = (state: RootState) => state.mapFilter;
 export const selectModalMap = (state: RootState) => state.modalMap;
 export const selectUser = (state: RootState) => state.user;
@@ -16,8 +20,9 @@ export const selectSelectedStopId = createSelector(
   (map) => map.selectedStopId,
 );
 
-export const selectEditedStopData = createSelector(selectMap, (map) =>
-  map.editedStopData ? mapFromStoreType(map.editedStopData) : undefined,
+export const selectEditedStopData = createSelector(
+  selectMap,
+  (map) => map.editedStopData,
 );
 
 export const selectIsCreateStopModeEnabled = createSelector(

--- a/ui/src/redux/slices/map.ts
+++ b/ui/src/redux/slices/map.ts
@@ -2,12 +2,14 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { StopWithLocation } from '../../graphql';
 import { mapToStoreType, StoreType } from '../mappers/storeType';
 
-interface IState {
+export interface MapState {
   selectedStopId?: UUID;
-  editedStopData?: StoreType<StopWithLocation>;
+  editedStopData?: StopWithLocation;
   isCreateStopModeEnabled: boolean;
   isMoveStopModeEnabled: boolean;
 }
+
+type IState = StoreType<MapState>;
 
 const initialState: IState = {
   selectedStopId: undefined,

--- a/ui/src/redux/slices/mapEditor.ts
+++ b/ui/src/redux/slices/mapEditor.ts
@@ -8,7 +8,7 @@ import { RouteInfraLink } from '../../graphql';
 import { mapToStoreType, StoreType } from '../mappers/storeType';
 import { RouteStop } from '../types';
 
-interface IState {
+export interface MapEditorState {
   /**
    * Is new route creation in progress
    */
@@ -33,7 +33,7 @@ interface IState {
      * Metadata of the line to which the route belongs
      * Used e.g. for determining the vehicle mode
      */
-    lineInfo?: StoreType<LineAllFieldsFragment>;
+    lineInfo?: LineAllFieldsFragment;
     /**
      * Array of stops along the route geometry with
      * information whether or not the stops belongs to the route (journey pattern)
@@ -45,11 +45,11 @@ interface IState {
      * TODO: should start using this instead of the "stops" variable above
      * For now, everything is way too tightly coupled, so cannot get rid of the other one
      */
-    stopsEligibleForJourneyPattern: StoreType<RouteStopFieldsFragment>[];
+    stopsEligibleForJourneyPattern: RouteStopFieldsFragment[];
     /**
      * Array of infrastructure links along the created / edited route
      */
-    infraLinks?: StoreType<RouteInfraLink>[];
+    infraLinks?: RouteInfraLink[];
     /**
      * Id of the route used as a template route, when creating a new route
      */
@@ -64,6 +64,8 @@ interface IState {
    */
   selectedRouteId?: UUID;
 }
+
+type IState = StoreType<MapEditorState>;
 
 const initialState: IState = {
   creatingNewRoute: false,
@@ -212,20 +214,17 @@ const slice = createSlice({
     setDraftRouteGeometry: {
       reducer: (
         state: IState,
-        action: PayloadAction<{
-          stops: RouteStop[];
-          stopsEligibleForJourneyPattern: RouteStopFieldsFragment[];
-          infraLinks: RouteInfraLink[];
-        }>,
+        action: PayloadAction<
+          StoreType<{
+            stops: RouteStop[];
+            stopsEligibleForJourneyPattern: RouteStopFieldsFragment[];
+            infraLinks: RouteInfraLink[];
+          }>
+        >,
       ) => {
-        const { stops, stopsEligibleForJourneyPattern, infraLinks } =
-          action.payload;
-
         state.editedRouteData = {
           ...state.editedRouteData,
-          stops,
-          stopsEligibleForJourneyPattern,
-          infraLinks,
+          ...action.payload,
         };
       },
       prepare: ({

--- a/ui/src/redux/types/mapEditor.ts
+++ b/ui/src/redux/types/mapEditor.ts
@@ -3,7 +3,6 @@ import {
   ScheduledStopPointInJourneyPatternAllFieldsFragment,
 } from '../../generated/graphql';
 import { RouteInfraLink } from '../../graphql';
-import { StoreType } from '../mappers/storeType';
 
 export interface RouteGeometry {
   routeStops: RouteStop[];
@@ -28,5 +27,5 @@ export interface RouteStop {
   /**
    * Current stop instance attached to the route (journey pattern)
    */
-  stop: StoreType<ScheduledStopPointAllFieldsFragment>;
+  stop: ScheduledStopPointAllFieldsFragment;
 }

--- a/ui/src/utils/object.ts
+++ b/ui/src/utils/object.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon';
 
-export type PlainObject = Record<string, unknown>;
+// using ExplicitAny instead of unknown so that also interface types would be compatible
+export type PlainObject = Record<string, ExplicitAny>;
 
 export const isPlainObject = (input: unknown): input is PlainObject => {
   return (


### PR DESCRIPTION
- Move all mapToStoreType calls to reducers
- Move all mapFromStoreType calls to selectors
- Fix StoreType type to be truly recursive
- Move all StoreType<X> definitions to slice root states

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/347)
<!-- Reviewable:end -->
