### PR TITLE
Define heading styles globally 

### DIFF
--- a/ui/src/components/forms/common/ConfirmSaveForm.tsx
+++ b/ui/src/components/forms/common/ConfirmSaveForm.tsx
@@ -52,11 +52,8 @@ export const ConfirmSaveForm = ({ className = '' }: Props): JSX.Element => {
 
   return (
     <div className={className}>
-      <h2 className="pb-6 text-xl font-bold">
-        {t('saveChangesModal.validityPeriod')}
-      </h2>
-
-      <Row className="mb-4">
+      <h3>{t('saveChangesModal.validityPeriod')}</h3>
+      <Row className="mb-4 pt-6">
         <Column>
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label>{t('priority.label')}</label>

--- a/ui/src/components/forms/common/InputLabel.tsx
+++ b/ui/src/components/forms/common/InputLabel.tsx
@@ -22,10 +22,7 @@ export const InputLabel = <FormState extends FieldValues>({
   const hasError = !!get(errors, fieldPath);
 
   return (
-    <label
-      className={`text-sm ${className}`}
-      htmlFor={`${translationPrefix}.${fieldPath}`}
-    >
+    <label className={className} htmlFor={`${translationPrefix}.${fieldPath}`}>
       {t(`${translationPrefix}.${fieldPath}`)}
       {hasError && <span className="ml-1 text-hsl-red">*</span>}
     </label>

--- a/ui/src/components/forms/line/LinePropertiesForm.tsx
+++ b/ui/src/components/forms/line/LinePropertiesForm.tsx
@@ -64,7 +64,7 @@ export const LinePropertiesForm = ({ className = '' }: Props): JSX.Element => {
   return (
     <div data-testid={testIds.form} className={className}>
       <Row>
-        <h2 className="mb-8 text-2xl font-bold">{t('lines.properties')}</h2>
+        <h2 className="mb-8">{t('lines.properties')}</h2>
       </Row>
       <FormColumn>
         <FormRow mdColumns={3}>

--- a/ui/src/components/forms/route/RoutePropertiesForm.tsx
+++ b/ui/src/components/forms/route/RoutePropertiesForm.tsx
@@ -67,7 +67,7 @@ const RoutePropertiesFormComponent = (
       >
         {routeLabel && (
           <Row>
-            <h2 className="mb-8 text-2xl font-bold">
+            <h2 className="mb-8">
               {t('routes.route')} {routeLabel}
             </h2>
           </Row>

--- a/ui/src/components/forms/route/TemplateRouteSelector.tsx
+++ b/ui/src/components/forms/route/TemplateRouteSelector.tsx
@@ -22,7 +22,7 @@ export const TemplateRouteSelector = ({
 
   return (
     <div className="prelative relative w-full rounded-md border border-light-grey bg-background px-3 py-4">
-      <h2 className="mb-4 text-xl font-bold">{t('routes.searchTemplate')}</h2>
+      <h3 className="mb-4">{t('routes.searchTemplate')}</h3>
       <Row className="mb-4">
         <Column>
           {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}

--- a/ui/src/components/forms/route/TerminusNameInputs.tsx
+++ b/ui/src/components/forms/route/TerminusNameInputs.tsx
@@ -27,9 +27,7 @@ export const TerminusNameInputs = ({ className = '' }: Props): JSX.Element => {
   const { t } = useTranslation();
   return (
     <div className={`${className} w-full`}>
-      <h2 className="my-4 w-full pt-1 text-xl font-bold">
-        {t('routes.origin.title')}
-      </h2>
+      <h3 className="my-4 w-full pt-1">{t('routes.origin.title')}</h3>
       <FormColumn>
         <FormRow mdColumns={2}>
           <InputField<RouteFormState>
@@ -58,9 +56,7 @@ export const TerminusNameInputs = ({ className = '' }: Props): JSX.Element => {
           />
         </FormRow>
       </FormColumn>
-      <h2 className="my-4 w-full pt-1 text-xl font-bold">
-        {t('routes.destination.title')}
-      </h2>
+      <h3 className="my-4 w-full pt-1">{t('routes.destination.title')}</h3>
       <FormColumn>
         <FormRow mdColumns={2}>
           <InputField<RouteFormState>

--- a/ui/src/components/forms/stop/StopForm.tsx
+++ b/ui/src/components/forms/stop/StopForm.tsx
@@ -167,13 +167,11 @@ const StopFormComponent = (
         ref={ref}
       >
         <div className="mx-12">
-          <h2 className="pb-6 text-xl font-bold">{t('stops.stop')}</h2>
+          <h3 className="pb-6">{t('stops.stop')}</h3>
           <FormColumn>
             <FormRow mdColumns={2}>
               <Column>
-                <h3 className="mb-2 text-lg font-bold">
-                  {t('stops.nameAddress')}
-                </h3>
+                <h5 className="mb-2">{t('stops.nameAddress')}</h5>
                 <InputField<FormState>
                   type="text"
                   translationPrefix="stops"
@@ -182,7 +180,7 @@ const StopFormComponent = (
                 />
               </Column>
               <Column>
-                <h3 className="mb-2 text-lg font-bold">{t('map.location')}</h3>
+                <h5 className="mb-2">{t('map.location')}</h5>
                 <FormRow mdColumns={2}>
                   <InputField<FormState>
                     type="number"

--- a/ui/src/components/map/MapHeader.tsx
+++ b/ui/src/components/map/MapHeader.tsx
@@ -11,7 +11,7 @@ export const MapHeader: React.FC<Props> = ({ onClose }) => {
   const { t } = useTranslation();
   return (
     <Row className="bg-white px-11 py-4">
-      <h2 className="text-2xl font-bold">{t('map.joreMap')}</h2>
+      <h2>{t('map.joreMap')}</h2>
       <CloseIconButton
         className="ml-auto font-bold text-brand"
         label={t('close')}

--- a/ui/src/components/map/ObservationDateOverlay.tsx
+++ b/ui/src/components/map/ObservationDateOverlay.tsx
@@ -41,9 +41,7 @@ export const ObservationDateOverlay = ({ className = '' }: Props) => {
   return (
     <MapOverlay className={`${className} rounded`}>
       <Column className="space-y-1 p-3">
-        <label className="text-sm" htmlFor={dateInputId}>
-          {t('filters.observationDate')}
-        </label>
+        <label htmlFor={dateInputId}>{t('filters.observationDate')}</label>
         <Row className="space-x-1">
           <input
             type="date"

--- a/ui/src/components/map/ObservationDateOverlay.tsx
+++ b/ui/src/components/map/ObservationDateOverlay.tsx
@@ -36,10 +36,14 @@ export const ObservationDateOverlay = ({ className = '' }: Props) => {
     setObservationDateToUrl(DateTime.fromISO(value));
   };
 
+  const dateInputId = 'observation-date-input';
+
   return (
     <MapOverlay className={`${className} rounded`}>
       <Column className="space-y-1 p-3">
-        <h2 className="text-sm font-bold">{t('filters.observationDate')}</h2>
+        <label className="text-sm" htmlFor={dateInputId}>
+          {t('filters.observationDate')}
+        </label>
         <Row className="space-x-1">
           <input
             type="date"
@@ -47,6 +51,7 @@ export const ObservationDateOverlay = ({ className = '' }: Props) => {
             onChange={onObservationDateChange}
             className="flex-1"
             disabled={hasChangesInProgress}
+            id={dateInputId}
           />
           <IconButton
             className="block h-11 w-11 self-stretch rounded-md border border-black"

--- a/ui/src/components/map/RouteStopsOverlay.tsx
+++ b/ui/src/components/map/RouteStopsOverlay.tsx
@@ -48,12 +48,10 @@ export const RouteStopsOverlay = ({ className = '' }: Props): JSX.Element => {
       <MapOverlayHeader testId={testIds.mapOverlayHeader}>
         <i className="icon-bus-alt text-2xl text-tweaked-brand" />
         <div>
-          <h2 className="text-2xl font-bold text-tweaked-brand">
-            {routeMetadata.label}
-          </h2>
-          <div className="text-light text-xs text-gray-500">
+          <h2 className="text-tweaked-brand">{routeMetadata.label}</h2>
+          <p className="text-light text-xs text-gray-500">
             {routeMetadata?.name_i18n.fi_FI}
-          </div>
+          </p>
         </div>
         <Visible visible={creatingNewRoute}>
           <EditButton
@@ -67,9 +65,9 @@ export const RouteStopsOverlay = ({ className = '' }: Props): JSX.Element => {
         </div>
         <div className="ml-2 flex flex-col">
           <Row className="items-center gap-2">
-            <h2 className="text-base font-bold text-black">
+            <p className="text-base font-bold text-black">
               {routeMetadata.label}
-            </h2>
+            </p>
             <PriorityBadge
               priority={routeMetadata.priority}
               validityStart={routeMetadata.validity_start}

--- a/ui/src/components/map/RouteStopsOverlayRow.tsx
+++ b/ui/src/components/map/RouteStopsOverlayRow.tsx
@@ -47,13 +47,13 @@ export const RouteStopsOverlayRow = ({
             validityEnd={stop.validity_end}
           />
         </div>
-        <div
+        <span
           className={`text-sm font-bold ${
             belongsToJourneyPattern ? 'text-black' : 'text-gray-300'
           }`}
         >
           {stop.label}
-        </div>
+        </span>
       </div>
       {!isReadOnly && (
         <div className="text-tweaked-brand">

--- a/ui/src/components/map/StopFilterOverlay.tsx
+++ b/ui/src/components/map/StopFilterOverlay.tsx
@@ -50,10 +50,10 @@ export const StopFilterOverlay = ({ className = '' }: Props): JSX.Element => {
   return (
     <MapOverlay className={`rounded-b ${className}`}>
       <MapOverlayHeader>
-        <h2 className="text-xl font-bold">{t('filters.title')}</h2>
+        <h4>{t('filters.title')}</h4>
       </MapOverlayHeader>
       <div className="px-4 pt-4 pb-2">
-        <h4 className="mb-3.5 font-bold">{t('stops.stops')}</h4>
+        <p className="mb-3.5 font-bold">{t('stops.stops')} </p>
         <FilterRow className="mb-4" filter={highestPriorityCurrentFilterItem} />
         <Section>
           {timeBasedFilterItems.map((filter) => (

--- a/ui/src/components/map/stops/StopPopup.tsx
+++ b/ui/src/components/map/stops/StopPopup.tsx
@@ -52,9 +52,7 @@ export const StopPopup = ({
         <Row>
           <Column className="w-full">
             <Row>
-              <h3 className="text-xl font-bold">
-                {t('stops.stopWithLabel', { stopLabel: label })}
-              </h3>
+              <h3>{t('stops.stopWithLabel', { stopLabel: label })}</h3>
               <CloseIconButton className="ml-auto" onClick={onClose} />
             </Row>
           </Column>

--- a/ui/src/components/modal/ModalHeader.tsx
+++ b/ui/src/components/modal/ModalHeader.tsx
@@ -9,7 +9,7 @@ interface Props {
 export const ModalHeader = ({ onClose, heading }: Props): JSX.Element => {
   return (
     <Row className="border border-light-grey bg-background px-14 py-7">
-      <p className="text-2xl font-bold">{heading}</p>
+      <h2>{heading}</h2>
       <CloseIconButton className="ml-auto" onClick={onClose} />
     </Row>
   );

--- a/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
+++ b/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
@@ -66,7 +66,7 @@ export const CreateNewLinePage = (): JSX.Element => {
       />
       <Row>
         <i className="icon-bus-alt text-6xl text-tweaked-brand" />
-        <h1 className="text-3xl font-bold">{t('lines.createNew')}</h1>
+        <h1>{t('lines.createNew')}</h1>
       </Row>
       <LineForm onSubmit={onSubmit} defaultValues={defaultValues} />
     </Container>

--- a/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
@@ -83,8 +83,8 @@ export const EditLinePage = (): JSX.Element => {
       />
       <PageHeader>
         <Row>
-          <i className="icon-bus-alt text-3xl text-tweaked-brand" />
-          <h1 className="text-3xl font-bold">
+          <h1>
+            <i className="icon-bus-alt text-tweaked-brand" />
             {t('lines.line', { label: line?.label })}
           </h1>
         </Row>

--- a/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -104,8 +104,8 @@ export const EditRoutePage = (): JSX.Element => {
     <div>
       <PageHeader>
         <Row>
-          <i className="icon-bus-alt text-3xl text-tweaked-brand" />
-          <h1 className="text-3xl font-bold">
+          <h1>
+            <i className="icon-bus-alt text-tweaked-brand" />
             {t('lines.line', { label: route?.route_line?.label || '' })}
           </h1>
         </Row>

--- a/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
@@ -33,19 +33,22 @@ export const ActionsRow = ({
     setObservationDateToUrl(DateTime.fromISO(value));
   };
 
+  const dateInputId = 'observation-date-input';
+
   return (
     <Container className={className}>
       <Row>
-        <h2 className="text-sm font-bold">{t('filters.observationDate')}</h2>
-      </Row>
-      <Row>
         <Column className="w-1/4">
+          <label className="text-sm" htmlFor={dateInputId}>
+            {t('filters.observationDate')}
+          </label>
           <input
             type="date"
             required
             value={observationDate.toISODate()}
             onChange={(e) => onDateChange(e.target.value)}
             className="flex-1"
+            id={dateInputId}
           />
         </Column>
 

--- a/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
@@ -39,9 +39,7 @@ export const ActionsRow = ({
     <Container className={className}>
       <Row>
         <Column className="w-1/4">
-          <label className="text-sm" htmlFor={dateInputId}>
-            {t('filters.observationDate')}
-          </label>
+          <label htmlFor={dateInputId}>{t('filters.observationDate')}</label>
           <input
             type="date"
             required

--- a/ui/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineDetailsPage.tsx
@@ -67,9 +67,7 @@ export const LineDetailsPage = (): JSX.Element => {
           </Row>
           <Row>
             <Column className="w-full">
-              <h1 className="mt-8 text-3xl font-semibold">
-                {t('lines.routes')}
-              </h1>
+              <h1 className="mt-8">{t('lines.routes')}</h1>
               {line.line_routes?.length > 0 ? (
                 <RouteStopsTable routes={line.line_routes} />
               ) : (

--- a/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
@@ -33,9 +33,9 @@ export const LineTitle: React.FC<Props> = ({
   return (
     <Column>
       <Row className={`items-center ${className}`}>
-        <span className="mr-4 text-4xl font-bold" data-testid={testIds.heading}>
+        <h1 className="mr-4" data-testid={testIds.heading}>
           {t('lines.line', { label: line.label })}
-        </span>
+        </h1>
         <span>
           {line.line_routes?.length > 0 &&
             line.line_routes.map((item) => (

--- a/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
@@ -46,9 +46,7 @@ export const LineDraftsPage = (): JSX.Element => {
       </Row>
       <Row>
         <Column className="w-1/4">
-          <label className="text-sm" htmlFor={dateInputId}>
-            {t('filters.observationDate')}
-          </label>
+          <label htmlFor={dateInputId}>{t('filters.observationDate')}</label>
           <input
             type="date"
             required

--- a/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
@@ -32,12 +32,12 @@ export const LineDraftsPage = (): JSX.Element => {
     setObservationDateToUrl(DateTime.fromISO(value));
   };
 
+  const dateInputId = 'observation-date-input';
+
   return (
     <Container>
       <Row>
-        <h1 className="text-2xl font-bold">
-          {`${t('lines.draftsTitle')} | ${t('lines.line', { label })}`}
-        </h1>
+        <h2>{`${t('lines.draftsTitle')} | ${t('lines.line', { label })}`}</h2>
         <CloseIconButton
           label={t('close')}
           className="ml-auto text-base font-bold text-brand"
@@ -45,16 +45,17 @@ export const LineDraftsPage = (): JSX.Element => {
         />
       </Row>
       <Row>
-        <h2 className="text-sm font-bold">{t('filters.observationDate')}</h2>
-      </Row>
-      <Row>
         <Column className="w-1/4">
+          <label className="text-sm" htmlFor={dateInputId}>
+            {t('filters.observationDate')}
+          </label>
           <input
             type="date"
             required
             value={observationDate.toISODate() || ''}
             onChange={(e) => onDateChange(e.target.value)}
             className="flex-1"
+            id={dateInputId}
           />
         </Column>
       </Row>
@@ -63,9 +64,7 @@ export const LineDraftsPage = (): JSX.Element => {
         <RouteStopsTable routes={routes} />
       ) : (
         <Row className="py-20">
-          <p className="mx-auto flex text-2xl font-bold">
-            {t('lines.noDrafts')}
-          </p>
+          <h2 className="mx-auto flex">{t('lines.noDrafts')}</h2>
         </Row>
       )}
     </Container>

--- a/ui/src/components/routes-and-lines/main/RouteLineTableRow.tsx
+++ b/ui/src/components/routes-and-lines/main/RouteLineTableRow.tsx
@@ -39,7 +39,7 @@ export const RouteLineTableRow = ({
         <Link to={routeDetails[Path.lineDetails].getLink(lineId)}>
           <Row className="items-center">
             <Column className="w-1/2 font-bold">
-              <p className="text-2xl">{rowItem.label}</p>
+              <h2>{rowItem.label}</h2>
               <p>{rowItem.name_i18n.fi_FI}</p>
             </Column>
             <Column className="w-1/2 text-right">

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
@@ -33,7 +33,7 @@ export const RoutesAndLinesLists = (): JSX.Element => {
 
   return (
     <div>
-      <h2 className="text-bold mb-14 mt-12 text-2xl">{t('lines.routes')}</h2>
+      <h2 className="mb-14 mt-12">{t('lines.routes')}</h2>
       <ListHeader
         showOwnLines={showOwnChangingRoutes}
         limit={changingRoutesLimit}
@@ -43,7 +43,7 @@ export const RoutesAndLinesLists = (): JSX.Element => {
       />
       <RoutesList routes={changingRoutes} />
       <ListFooter onLimitChange={setChangingRoutesLimit} className="mt-8" />
-      <h2 className="text-bold mb-14 mt-12 text-2xl">{t('lines.lines')}</h2>
+      <h2 className="mb-14 mt-12">{t('lines.lines')}</h2>
       <LinesList lines={ownLines} />
     </div>
   );

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesPage.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesPage.tsx
@@ -25,7 +25,7 @@ export const RoutesAndLinesPage = (): JSX.Element => {
   return (
     <Container>
       <Row>
-        <h1 className="text-3xl font-bold">{t('routes.routes')}</h1>
+        <h1>{t('routes.routes')}</h1>
         <SimpleButton containerClassName="ml-auto" onClick={onOpenModalMap}>
           {t('map.open')}
         </SimpleButton>

--- a/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
@@ -25,11 +25,9 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <p
-                  class="text-2xl"
-                >
+                <h2>
                   65
-                </p>
+                </h2>
                 <p>
                   Rautatientori - Veräjälaakso
                 </p>
@@ -96,11 +94,9 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <p
-                  class="text-2xl"
-                >
+                <h2>
                   71
-                </p>
+                </h2>
                 <p>
                   Rautatientori - Malmi as.
                 </p>
@@ -167,11 +163,9 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <p
-                  class="text-2xl"
-                >
+                <h2>
                   785K
-                </p>
+                </h2>
                 <p>
                   Rautatientori - Nikkilä
                 </p>
@@ -238,11 +232,9 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <p
-                  class="text-2xl"
-                >
+                <h2>
                   1234
-                </p>
+                </h2>
                 <p>
                   Erottaja - Arkkadiankatu
                 </p>
@@ -321,11 +313,9 @@ exports[`<RoutesTable /> Renders the table with route data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <p
-                  class="text-2xl"
-                >
+                <h2>
                   1
-                </p>
+                </h2>
                 <p>
                   route 1
                 </p>

--- a/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearch, useSearchResults } from '../../../hooks';
 import { usePagination } from '../../../hooks/usePagination';
@@ -27,9 +26,7 @@ export const SearchResultPage = (): JSX.Element => {
   return (
     <Container testId={testIds.container}>
       <Row>
-        <h1 className="text-2xl font-bold">
-          {`${t('search.searchResultsTitle')} | ${t('routes.routes')}`}
-        </h1>
+        <h2>{`${t('search.searchResultsTitle')} | ${t('routes.routes')}`}</h2>
         <CloseIconButton
           label={t('close')}
           className="ml-auto text-base font-bold text-brand"
@@ -38,11 +35,11 @@ export const SearchResultPage = (): JSX.Element => {
       </Row>
       <SearchContainer />
       <FiltersContainer />
-      <h1 className="my-4 text-2xl font-bold">
+      <h2 className="my-4">
         {t('search.resultCount', {
           resultCount,
         })}
-      </h1>
+      </h2>
       <ResultList
         lines={displayedLines}
         routes={displayedRoutes}

--- a/ui/src/components/routes-and-lines/search/conditions/PriorityCondition.tsx
+++ b/ui/src/components/routes-and-lines/search/conditions/PriorityCondition.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Column, Row } from '../../../../layoutComponents';
 import { Priority } from '../../../../types/Priority';
@@ -40,7 +39,7 @@ export const PriorityCondition = ({
 
   return (
     <Column>
-      <h4 className="font-bold">{t('priority.label')}</h4>
+      <p className="font-bold">{t('priority.label')}</p>
       <Row className="space-x-2">
         {priorityButtonData.map((item) => (
           <SimpleButton

--- a/ui/src/components/routes-and-lines/search/conditions/SearchContainer.tsx
+++ b/ui/src/components/routes-and-lines/search/conditions/SearchContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearch } from '../../../../hooks';
 import { useToggle } from '../../../../hooks/useToggle';
@@ -40,9 +39,7 @@ export const SearchContainer = (): JSX.Element => {
       </Row>
       <Visible visible={isExpanded}>
         <div className="border-2 border-background p-10">
-          <h4 className="text-bold text-2xl">
-            {t('search.advancedSearchTitle')}
-          </h4>
+          <h2>{t('search.advancedSearchTitle')}</h2>
           <PriorityCondition
             onClick={setSearchCondition}
             priorities={searchConditions.priorities}

--- a/ui/src/pages/Main.tsx
+++ b/ui/src/pages/Main.tsx
@@ -19,13 +19,13 @@ export const Main: React.FC = () => {
       className="min-h-screen bg-brand bg-opacity-50 p-20"
     >
       <div className="mx-auto w-4/5 rounded-lg bg-white p-10 leading-8 shadow-2xl">
-        <h1 className="mb-10 text-center text-4xl font-bold">
+        <h1 className="mb-10 text-center text-4xl ">
           {t('welcomePage.heading')}
         </h1>
         <div className="mb-6 space-y-6 text-xl">
-          <h2 className="font-bold">{t('welcomePage.subheading1')}</h2>
+          <h3>{t('welcomePage.subheading1')}</h3>
           <p>{t('welcomePage.paragraph1')}</p>
-          <h2 className="font-bold">{t('welcomePage.subheading2')}</h2>
+          <h3>{t('welcomePage.subheading2')}</h3>
           <p>{t('welcomePage.paragraph2')}</p>
         </div>
 

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -25,3 +25,27 @@ label {
   size: 14px;
   margin-bottom: 4px;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-weight: 700;
+}
+
+h1 {
+  font-size: 32px;
+}
+
+h2 {
+  font-size: 26px;
+}
+
+h3 {
+  font-size: 22px;
+}
+
+h4 {
+  font-size: 20px;
+}

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -22,7 +22,7 @@ input:disabled {
 
 label {
   font-weight: 700;
-  size: 14px;
+  font-size: 14px;
   margin-bottom: 4px;
 }
 

--- a/ui/src/uiComponents/FilterPanel.tsx
+++ b/ui/src/uiComponents/FilterPanel.tsx
@@ -90,11 +90,11 @@ export const FilterPanel = ({
   return (
     <div className={`inline-block ${className}`}>
       <Card className="flex-col rounded-b-none">
-        <h3 className={headingClassName}>{t('map.showRoutes')}</h3>
+        <h6 className={headingClassName}>{t('map.showRoutes')}</h6>
         <ToggleRow toggles={routes} />
       </Card>
       <Card className="flex-col rounded-none !border-t-0">
-        <h3 className={headingClassName}>{t('map.showStops')}</h3>
+        <h6 className={headingClassName}>{t('map.showStops')}</h6>
         <ToggleRow toggles={stops} />
       </Card>
       <Card className="flex-col rounded-t-none !py-2.5 !px-5">


### PR DESCRIPTION
- Use h1, h2, etc. html tags according to styles

For now on, it should be clear which heading tag
should be used instead of choosing something between
h1-h4 "randomly" and then styling those individually.

Also fixed html tags with text content to be more semantically
correct (e.g. use label tag for observation date inputs instead
of heading tag that was styled to look like label!).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/352)
<!-- Reviewable:end -->
