### PR TITLE
Extend search filters

### DIFF
--- a/ui/src/components/forms/common/EnumDropdown.tsx
+++ b/ui/src/components/forms/common/EnumDropdown.tsx
@@ -10,6 +10,7 @@ const testIds = {
 // this was implemented by processing the Enum values as strings.
 
 export interface EnumDropdownProps<TEnum> extends FormInputProps {
+  id?: string;
   testId?: string;
   // eslint-disable-next-line @typescript-eslint/ban-types
   enumType: Object;
@@ -24,6 +25,7 @@ export interface EnumDropdownProps<TEnum> extends FormInputProps {
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function EnumDropdown<TEnum extends Object>({
+  id,
   testId,
   enumType,
   uiNameMapper,
@@ -54,6 +56,7 @@ export function EnumDropdown<TEnum extends Object>({
 
   return (
     <Listbox
+      id={id}
       testId={testId || testIds.enumDropdown}
       buttonContent={
         value ? uiNameMapper(value as unknown as TEnum) : placeholder

--- a/ui/src/components/forms/common/EnumDropdown.tsx
+++ b/ui/src/components/forms/common/EnumDropdown.tsx
@@ -1,5 +1,5 @@
 import { FormInputProps, Listbox } from '../../../uiComponents';
-import { getEnumValues } from '../../../utils';
+import { AllOptionEnum, getEnumValues } from '../../../utils';
 
 const testIds = {
   enumDropdown: 'EnumDropdown::button',
@@ -15,8 +15,13 @@ export interface EnumDropdownProps<TEnum> extends FormInputProps {
   enumType: Object;
   uiNameMapper: (key: TEnum) => string;
   placeholder: string;
+  includeAllOption?: boolean;
 }
 
+/**
+ * Creates dropdown from enum values. This dropdown can be enrichted with 'All' option by giving
+ * it the includeAllOption flag as true.
+ */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function EnumDropdown<TEnum extends Object>({
   testId,
@@ -24,9 +29,12 @@ export function EnumDropdown<TEnum extends Object>({
   uiNameMapper,
   placeholder,
   value,
+  includeAllOption,
   ...formInputProps
 }: EnumDropdownProps<TEnum>) {
-  const values = getEnumValues(enumType);
+  const values = getEnumValues(
+    includeAllOption ? { ...AllOptionEnum, ...enumType } : enumType,
+  );
 
   const mapToOption = (item: string) => ({
     key: item,

--- a/ui/src/components/forms/line/VehicleModeDropdown.tsx
+++ b/ui/src/components/forms/line/VehicleModeDropdown.tsx
@@ -6,10 +6,15 @@ import { EnumDropdown } from '../common/EnumDropdown';
 
 interface Props extends FormInputProps {
   testId?: string;
+  includeAllOption?: boolean;
 }
 
+/** Creates VehicleModeDropdown from ReusableComponentsVehicleModeEnum. This Dropdown can be
+ * enrichted with 'All' option by giving it includeAllOption flag as true.
+ */
 export const VehicleModeDropdown = ({
   testId,
+  includeAllOption,
   ...formInputProps
 }: Props): JSX.Element => {
   const { t } = useTranslation();
@@ -20,6 +25,7 @@ export const VehicleModeDropdown = ({
       enumType={ReusableComponentsVehicleModeEnum}
       placeholder={t('lines.chooseVehicleMode')}
       uiNameMapper={mapVehicleModeToUiName}
+      includeAllOption={includeAllOption}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...formInputProps}
     />

--- a/ui/src/components/forms/line/VehicleModeDropdown.tsx
+++ b/ui/src/components/forms/line/VehicleModeDropdown.tsx
@@ -5,6 +5,7 @@ import { FormInputProps } from '../../../uiComponents';
 import { EnumDropdown } from '../common/EnumDropdown';
 
 interface Props extends FormInputProps {
+  id?: string;
   testId?: string;
   includeAllOption?: boolean;
 }
@@ -13,6 +14,7 @@ interface Props extends FormInputProps {
  * enrichted with 'All' option by giving it includeAllOption flag as true.
  */
 export const VehicleModeDropdown = ({
+  id,
   testId,
   includeAllOption,
   ...formInputProps
@@ -21,6 +23,7 @@ export const VehicleModeDropdown = ({
 
   return (
     <EnumDropdown<ReusableComponentsVehicleModeEnum>
+      id={id}
       testId={testId}
       enumType={ReusableComponentsVehicleModeEnum}
       placeholder={t('lines.chooseVehicleMode')}

--- a/ui/src/components/routes-and-lines/search/conditions/SearchContainer.tsx
+++ b/ui/src/components/routes-and-lines/search/conditions/SearchContainer.tsx
@@ -3,6 +3,9 @@ import { useSearch } from '../../../../hooks';
 import { useToggle } from '../../../../hooks/useToggle';
 import { Column, Container, Row, Visible } from '../../../../layoutComponents';
 import { SimpleButton } from '../../../../uiComponents';
+import { AllOptionEnum } from '../../../../utils';
+import { FormRow } from '../../../forms/common';
+import { VehicleModeDropdown } from '../../../forms/line/VehicleModeDropdown';
 import { PriorityCondition } from './PriorityCondition';
 import { SearchConditionToggle } from './SearchConditionsToggle';
 import { SearchInput } from './SearchInput';
@@ -15,6 +18,12 @@ export const SearchContainer = (): JSX.Element => {
   const testIds = {
     searchInput: 'SearchContainer::SearchInput',
   };
+
+  const onChangeVehiclemode = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchCondition('primaryVehicleMode', e.target.value);
+  };
+
+  const vehicleModeDropdownId = 'search.primaryVehicleMode';
 
   return (
     <Container className="py-10">
@@ -38,12 +47,27 @@ export const SearchContainer = (): JSX.Element => {
         </Column>
       </Row>
       <Visible visible={isExpanded}>
-        <div className="border-2 border-background p-10">
+        <div className="space-y-5 border-2 border-background p-10">
           <h2>{t('search.advancedSearchTitle')}</h2>
-          <PriorityCondition
-            onClick={setSearchCondition}
-            priorities={searchConditions.priorities}
-          />
+          <FormRow mdColumns={4}>
+            <Column>
+              <label htmlFor={vehicleModeDropdownId}>
+                {t(`lines.primaryVehicleMode`)}
+              </label>
+              <VehicleModeDropdown
+                id={vehicleModeDropdownId}
+                onChange={onChangeVehiclemode}
+                includeAllOption
+                value={searchConditions.primaryVehicleMode ?? AllOptionEnum.All}
+              />
+            </Column>
+          </FormRow>
+          <FormRow mdColumns={4}>
+            <PriorityCondition
+              onClick={setSearchCondition}
+              priorities={searchConditions.priorities}
+            />
+          </FormRow>
         </div>
         <Row className="flex justify-end bg-background py-4">
           <SimpleButton

--- a/ui/src/hooks/search/useSearchQueryParser.ts
+++ b/ui/src/hooks/search/useSearchQueryParser.ts
@@ -1,9 +1,12 @@
+import { ReusableComponentsVehicleModeEnum } from '../../generated/graphql';
 import { Priority } from '../../types/Priority';
+import { AllOptionEnum } from '../../utils/enum';
 import { useUrlQuery } from '../urlQuery/useUrlQuery';
 
 export type SearchConditions = {
   priorities: Priority[];
   label: string;
+  primaryVehicleMode?: ReusableComponentsVehicleModeEnum | AllOptionEnum;
 };
 
 /** Enum for different search result options */
@@ -31,6 +34,7 @@ export type SearchParameters = {
 export type QueryStringParameters = {
   priorities: string;
   label: string;
+  primaryVehicleMode?: string;
   displayedData: string;
 };
 
@@ -41,6 +45,7 @@ export type QueryStringParameters = {
 export type DeserializedQueryStringParameters = {
   priorities: Priority[];
   label: string;
+  primaryVehicleMode?: ReusableComponentsVehicleModeEnum | AllOptionEnum;
   displayedData: DisplayedSearchResultType;
 };
 
@@ -72,6 +77,22 @@ const mapDisplayedData = (displayedData: string) => {
 };
 
 /**
+ * If primaryVehicleMode query string is not given or is invalid,
+ * default to All option
+ */
+const mapPrimaryVehicleModeToEnum = (primaryVehicleMode?: string) => {
+  if (
+    Object.values(ReusableComponentsVehicleModeEnum).includes(
+      primaryVehicleMode as ReusableComponentsVehicleModeEnum,
+    )
+  ) {
+    return primaryVehicleMode as ReusableComponentsVehicleModeEnum;
+  }
+
+  return AllOptionEnum.All;
+};
+
+/**
  * Returns parsed and validated priorities if priority query string
  * is existing. If the query string is not given, return default
  * priorities
@@ -96,6 +117,9 @@ const deserializeParameters = (
     search: {
       label: queryParams.label || '',
       priorities: getPriorities(queryParams.priorities),
+      primaryVehicleMode: mapPrimaryVehicleModeToEnum(
+        queryParams.primaryVehicleMode,
+      ),
     },
     filter: {
       displayedData: mapDisplayedData(queryParams.displayedData),

--- a/ui/src/i18n/uiNameMappings.ts
+++ b/ui/src/i18n/uiNameMappings.ts
@@ -7,6 +7,7 @@ import {
 import { i18n } from '../i18n';
 import { Priority } from '../types/Priority';
 import { RouteDirection } from '../types/RouteDirection';
+import { AllOptionEnum } from '../utils';
 
 export const mapPriorityToUiName = (key: Priority) => {
   const uiStrings: Record<Priority, string> = {
@@ -18,8 +19,8 @@ export const mapPriorityToUiName = (key: Priority) => {
 };
 
 export const mapVehicleModeToUiName = (
-  key: ReusableComponentsVehicleModeEnum,
-) => i18n.t(`vehicleModeEnum.${key}`);
+  key: ReusableComponentsVehicleModeEnum | AllOptionEnum.All,
+) => i18n.t(key === AllOptionEnum.All ? key : `vehicleModeEnum.${key}`);
 
 export const mapLineTypeToUiName = (key: RouteTypeOfLineEnum) =>
   i18n.t(`lineTypeEnum.${key}`);

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -164,7 +164,8 @@
     "ferry": "Ferry",
     "metro": "Metro",
     "train": "Train",
-    "tram": "Tram"
+    "tram": "Tram",
+    "all": "All"
   },
   "lineTypeEnum": {
     "regional_rail_service": "Regional rail service",
@@ -259,6 +260,7 @@
   "close": "Close",
   "version": "Version: {{ version }}",
   "hide": "Hide",
+  "all": "All",
   "welcomePage": {
     "heading": "JORE4:n käyttöönotto alkaa!",
     "subheading1": "Mitä?",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -164,7 +164,8 @@
     "ferry": "Lautta",
     "metro": "Metro",
     "train": "Juna",
-    "tram": "Raitiovaunu"
+    "tram": "Raitiovaunu",
+    "all": "Kaikki"
   },
   "lineTypeEnum": {
     "regional_rail_service": "Seudullinen juna",
@@ -259,6 +260,7 @@
   "close": "Sulje",
   "version": "Versio: {{ version }}",
   "hide": "Piilota",
+  "all": "Kaikki",
   "welcomePage": {
     "heading": "JORE4:n käyttöönotto alkaa!",
     "subheading1": "Mitä?",

--- a/ui/src/uiComponents/Listbox.tsx
+++ b/ui/src/uiComponents/Listbox.tsx
@@ -35,7 +35,7 @@ export const dropdownTransition: TransitionClasses = {
 export interface FormInputProps {
   value?: string;
   onChange: ValueFn;
-  onBlur: Noop;
+  onBlur?: Noop;
   fieldState?: ControllerFieldState;
 }
 

--- a/ui/src/utils/enum.ts
+++ b/ui/src/utils/enum.ts
@@ -4,3 +4,10 @@ export function getEnumValues(inputEnum: Object): string[] {
     (value) => typeof value === 'string',
   ) as string[];
 }
+
+/** This enum is used to add the 'All' option to enumDropdowns and also having
+ * the correct types on searchConditions
+ */
+export enum AllOptionEnum {
+  All = 'all',
+}

--- a/ui/src/utils/search.ts
+++ b/ui/src/utils/search.ts
@@ -48,45 +48,72 @@ export const mapToSqlLikeValue = (str: string) => {
   return str.replaceAll('*', '%');
 };
 
-const transformToFilterAttribute = (
+const mapToFilterAttribute = (
   key: string,
   values: {
     value: string | number[];
     operator: string;
     replaceStar: boolean;
+    isLineProperty?: boolean;
   },
+  isRouteFilter: boolean,
 ) => {
-  return {
+  const filter = {
     [key]: {
       [values.operator]: values.replaceStar
         ? mapToSqlLikeValue(values.value as string) || '%'
         : values.value,
     },
   };
+
+  // If creating route filter but the property is for line, we then
+  // wrap the filter in route_line to get the filter from the route's line
+  return isRouteFilter && values.isLineProperty
+    ? { route_line: filter }
+    : filter;
+};
+
+/** Maps the given parameters to GQL filter attributes. Also takes in to
+ * consideration if we are generating route filter. In that case we wrap all
+ * line property filters in to route_line wrapper.
+ */
+const mapConfiguredParamsToFilterAttributes = (
+  configuredParams: SearchParametersGqlConfigurations,
+  isRouteFilter: boolean,
+) => {
+  const filterAttributes = Object.entries(configuredParams).map((entry) => {
+    const [key, value] = entry;
+    return mapToFilterAttribute(key, value, isRouteFilter);
+  });
+
+  // TODO: This Object.assign is fine for now, but this should be changed to
+  // reduce + merge combination when adding the next 'isLineProperty' filter,
+  // because it will result in duplicatekey's and Object.assign will overwrite
+  // duplicate keys instead of merging them.
+  // Converting array [{key: value}, ...] into a single object {key: value, ...}
+  return Object.assign({}, ...filterAttributes);
 };
 
 export const constructGqlFilterObject = (params: SearchConditions) => {
   const configuredParams = setConfigurations(params);
 
-  const result = Object.entries(configuredParams).map((entry) => {
-    const [key, value] = entry;
-    return transformToFilterAttribute(key, value);
-  });
+  const lineFilter = mapConfiguredParamsToFilterAttributes(
+    configuredParams,
+    false,
+  );
 
-  // Converting array [{key: value}, ...] into a single object {key: value, ...}
-  const filter = Object.assign({}, ...result);
+  const routeFilter = mapConfiguredParamsToFilterAttributes(
+    configuredParams,
+    true,
+  );
 
   // TODO: This will be changed to dynamic when the sorting feature is implemented
   // but until then, we should have the sorting by label and validity_start hardcoded
   const orderBy = [{ label: 'asc' }, { validity_start: 'asc' }];
 
   return {
-    lineFilter: {
-      ...filter,
-    },
-    routeFilter: {
-      ...filter,
-    },
+    lineFilter,
+    routeFilter,
     lineOrderBy: orderBy,
     routeOrderBy: orderBy,
   };


### PR DESCRIPTION
Extend search filters by adding the primaryVehicleMode dropdown to advanced search.

Before that in this PR the GQL filter construction is refactored so that the generated filters from the search criteria are a bit different for `route filter` and `line filter`. Some of the advanced search filters are precisely _line's properties_, but the routes can be filtered with the same criteria, but the GQL filter has to be generated little bit differently. (We need to wrap the GQL filter within `route_line`.

In addition to that had to do some refactoring to EnumDropdown and VehicleModeDropdown to support `AllOption`, so that we can reuse the existing components.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/355)
<!-- Reviewable:end -->
