### PR TITLE
Change obserationDate query param init to optional

### DIFF
--- a/ui/src/hooks/urlQuery/useObservationDateQueryParam.ts
+++ b/ui/src/hooks/urlQuery/useObservationDateQueryParam.ts
@@ -7,7 +7,17 @@ import { showWarningToast } from '../../utils';
 import { QueryParameterName } from './useMapQueryParams';
 import { useUrlQuery } from './useUrlQuery';
 
-export const useObservationDateQueryParam = () => {
+interface Props {
+  initialize?: boolean;
+}
+
+/**
+ * Query parameter hook for setting and getting observationDate. Initialization
+ * of this query parameter can be set to false if you don't want to initialize it.
+ */
+export const useObservationDateQueryParam = (
+  { initialize }: Props = { initialize: true },
+) => {
   const { getDateTimeFromUrlQuery, setDateTimeToUrlQuery, queryParams } =
     useUrlQuery();
   const { t } = useTranslation();
@@ -68,8 +78,10 @@ export const useObservationDateQueryParam = () => {
   }, [defaultDate, observationDate, queryParams.observationDate]);
 
   useEffect(() => {
-    initializeObservationDate();
-  }, [initializeObservationDate]);
+    if (initialize) {
+      initializeObservationDate();
+    }
+  }, [initialize, initializeObservationDate]);
 
   return {
     observationDate,

--- a/ui/src/hooks/useShowRoutesOnModal.ts
+++ b/ui/src/hooks/useShowRoutesOnModal.ts
@@ -44,7 +44,7 @@ export const useShowRoutesOnModal = () => {
   const dispatch = useAppDispatch();
   const { openMapWithParameters } = useMapQueryParams();
   const { observationDate: listViewObservationDate } =
-    useObservationDateQueryParam();
+    useObservationDateQueryParam({ initialize: false });
 
   const showRoutesOnModal = ({
     viewPortParams,


### PR DESCRIPTION
Before this the observationDate was initialized automatically to query parameters if the component uses the useObservationDateQueryParam hook. The initialization is unwanted if the component only wants to read the observationDate, and the value is optional. For example in this case the useShowRoutesOnModal hook only uses the observationDate if it is already there. But we do not want to initialize it if it is not there.

We used useShowRoutesOnModal hook with every route and line row, which ment that the observationDate query parameter was initialized n times, where n is the amount of rows rendered..

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/356)
<!-- Reviewable:end -->
