### PR TITLE
Refactor searchquery handling

### DIFF
--- a/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
+++ b/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
@@ -3,7 +3,6 @@ import uniq from 'lodash/uniq';
 import { useTranslation } from 'react-i18next';
 import { pipe } from 'remeda';
 import {
-  DisplayedSearchResultType,
   useAppDispatch,
   useAppSelector,
   useSearchResults,
@@ -16,6 +15,7 @@ import {
   setIsSelectingRoutesForExportAction,
 } from '../../../redux';
 import { SimpleSmallButton } from '../../../uiComponents';
+import { DisplayedSearchResultType } from '../../../utils';
 
 export const ExportToolbar = (): JSX.Element => {
   const dispatch = useAppDispatch();

--- a/ui/src/components/routes-and-lines/search/ResultList.tsx
+++ b/ui/src/components/routes-and-lines/search/ResultList.tsx
@@ -2,8 +2,9 @@ import {
   LineTableRowFragment,
   RouteAllFieldsFragment,
 } from '../../../generated/graphql';
-import { DisplayedSearchResultType, useAppSelector } from '../../../hooks';
+import { useAppSelector } from '../../../hooks';
 import { selectExport } from '../../../redux';
+import { DisplayedSearchResultType } from '../../../utils';
 import { LinesList } from '../main/LinesList';
 import { RoutesList } from '../main/RoutesList';
 

--- a/ui/src/components/routes-and-lines/search/filters/ResultSelector.tsx
+++ b/ui/src/components/routes-and-lines/search/filters/ResultSelector.tsx
@@ -1,11 +1,8 @@
 import { useTranslation } from 'react-i18next';
-import {
-  DisplayedSearchResultType,
-  useAppDispatch,
-  useSearch,
-} from '../../../../hooks';
+import { useAppDispatch, useSearch } from '../../../../hooks';
 import { resetSelectedRoutesAction } from '../../../../redux';
 import { SimpleSmallButton } from '../../../../uiComponents';
+import { DisplayedSearchResultType } from '../../../../utils';
 
 export const ResultSelector = (): JSX.Element => {
   const { t } = useTranslation();

--- a/ui/src/hooks/search/useSearch.ts
+++ b/ui/src/hooks/search/useSearch.ts
@@ -2,12 +2,8 @@ import { produce } from 'immer';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Priority } from '../../types/Priority';
-import { createQueryParamString } from '../../utils';
-import {
-  DisplayedSearchResultType,
-  FilterConditions,
-  useSearchQueryParser,
-} from './useSearchQueryParser';
+import { createQueryParamString, DisplayedSearchResultType } from '../../utils';
+import { FilterConditions, useSearchQueryParser } from './useSearchQueryParser';
 
 export const useSearch = () => {
   const history = useHistory();

--- a/ui/src/hooks/search/useSearchResults.ts
+++ b/ui/src/hooks/search/useSearchResults.ts
@@ -6,12 +6,10 @@ import {
 } from '../../generated/graphql';
 import {
   constructSearchLinesAndRoutesGqlQueryVariables,
+  DisplayedSearchResultType,
   mapToVariables,
 } from '../../utils';
-import {
-  DisplayedSearchResultType,
-  useSearchQueryParser,
-} from './useSearchQueryParser';
+import { useSearchQueryParser } from './useSearchQueryParser';
 
 const GQL_SEARCH_LINES_AND_ROUTES = gql`
   query SearchLinesAndRoutes(

--- a/ui/src/hooks/urlQuery/useMapQueryParams.ts
+++ b/ui/src/hooks/urlQuery/useMapQueryParams.ts
@@ -2,7 +2,6 @@ import { DateTime } from 'luxon';
 import { useCallback } from 'react';
 import { HELSINKI_CITY_CENTER_COORDINATES } from '../../redux';
 import { Priority } from '../../types/Priority';
-import { parseAndValidatePriorities } from '../search';
 import { useUrlQuery } from './useUrlQuery';
 
 export enum QueryParameterName {
@@ -46,6 +45,7 @@ export const useMapQueryParams = () => {
     getStringParamFromUrlQuery,
     getBooleanParamFromUrlQuery,
     getFloatParamFromUrlQuery,
+    getPriorityArrayFromUrlQuery,
     deleteMultipleFromUrlQuery,
     setMultipleParametersToUrlQuery,
     setToUrlQuery,
@@ -147,8 +147,8 @@ export const useMapQueryParams = () => {
   const showSelectedDaySituation = getBooleanParamFromUrlQuery(
     QueryParameterName.ShowSelectedDaySituation,
   );
-  const priorities = parseAndValidatePriorities(
-    getStringParamFromUrlQuery(QueryParameterName.Priorities) || '',
+  const priorities = getPriorityArrayFromUrlQuery(
+    QueryParameterName.Priorities,
   );
 
   const setRouteId = (id: UUID) => {

--- a/ui/src/hooks/urlQuery/useUrlQuery.ts
+++ b/ui/src/hooks/urlQuery/useUrlQuery.ts
@@ -31,13 +31,15 @@ export const useUrlQuery = () => {
   const history = useHistory();
 
   const setQueryString = useCallback(
-    (queryString: string, replace: boolean) => {
+    (queryString: string, replace: boolean, pathname?: string) => {
       replace
         ? history.replace({
             search: `?${queryString}`,
+            pathname,
           })
         : history.push({
             search: `?${queryString}`,
+            pathname,
           });
     },
     [history],
@@ -104,10 +106,12 @@ export const useUrlQuery = () => {
     ({
       parameters,
       replace = false,
+      pathname = '',
     }: {
       parameters: QueryParameter<QueryParameterTypes>[];
       replace?: boolean;
       debounced?: boolean;
+      pathname?: string;
     }) => {
       const updatedUrlQuery = produce(queryParams, (draft) => {
         parameters.forEach((parameter) => {
@@ -131,7 +135,7 @@ export const useUrlQuery = () => {
       });
       const queryString = qs.stringify(updatedUrlQuery);
 
-      setQueryString(queryString, replace);
+      setQueryString(queryString, replace, pathname);
     },
     [queryParams, setQueryString],
   );

--- a/ui/src/hooks/urlQuery/useUrlQuery.ts
+++ b/ui/src/hooks/urlQuery/useUrlQuery.ts
@@ -6,9 +6,19 @@ import { DateTime } from 'luxon';
 import qs from 'qs';
 import { useCallback, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import { ReusableComponentsVehicleModeEnum } from '../../generated/graphql';
 import { parseDate } from '../../time';
+import { Priority } from '../../types/Priority';
+import { DisplayedSearchResultType } from '../../utils/enum';
 
-type QueryParameter<TType> = { paramName: string; value: TType };
+export type QueryParameter<TType> = { paramName: string; value: TType };
+export type QueryParameterTypes =
+  | string
+  | boolean
+  | DateTime
+  | number
+  | undefined
+  | number[];
 type ParameterWriteOptions = { replace?: boolean };
 
 export const useUrlQuery = () => {
@@ -95,9 +105,7 @@ export const useUrlQuery = () => {
       parameters,
       replace = false,
     }: {
-      parameters: QueryParameter<
-        string | boolean | DateTime | number | undefined | number[]
-      >[];
+      parameters: QueryParameter<QueryParameterTypes>[];
       replace?: boolean;
       debounced?: boolean;
     }) => {
@@ -141,6 +149,44 @@ export const useUrlQuery = () => {
     setToUrlQuery({ paramName, value: value.join(','), replace });
   };
 
+  /** Returns a query parameter in Priority array type */
+  const getPriorityArrayFromUrlQuery = (paramName: string): Priority[] => {
+    return (queryParams[paramName] as string)
+      ?.split(',')
+      ?.map((p) => parseInt(p, 10))
+      ?.filter((p) => Object.values(Priority).includes(p));
+  };
+
+  /** Returns a query parameter in ReusableComponentsVehicleModeEnum if exists,
+   * otherwise returns undefined
+   */
+  const getReusableComponentsVehicleModeEnumFromUrlQuery = (
+    paramName: string,
+  ): ReusableComponentsVehicleModeEnum | undefined => {
+    const vehicleMode = queryParams[paramName];
+
+    return Object.values(ReusableComponentsVehicleModeEnum).includes(
+      vehicleMode as ReusableComponentsVehicleModeEnum,
+    )
+      ? (vehicleMode as ReusableComponentsVehicleModeEnum)
+      : undefined;
+  };
+
+  /** Returns a query parameter in DisplayedSearchResultType if exists,
+   * otherwise returns undefined
+   */
+  const getDisplayedSearchResultTypeFromUrlQuery = (
+    paramName: string,
+  ): DisplayedSearchResultType | undefined => {
+    const searchResultType = queryParams[paramName];
+
+    return Object.values(DisplayedSearchResultType).includes(
+      searchResultType as DisplayedSearchResultType,
+    )
+      ? (searchResultType as DisplayedSearchResultType)
+      : undefined;
+  };
+
   /** Returns a query parameter in boolean type */
   const getStringParamFromUrlQuery = (paramName: string) => {
     return (queryParams[paramName] as string) || undefined;
@@ -160,6 +206,7 @@ export const useUrlQuery = () => {
     },
     [queryParams],
   );
+
   /** Returns float query parameter if exists, otherwise returns null */
   const getFloatParamFromUrlQuery = (paramName: string) => {
     return queryParams[paramName]
@@ -219,6 +266,9 @@ export const useUrlQuery = () => {
     setBooleanToUrlQuery,
     setDateTimeToUrlQuery,
     setArrayToUrlQuery,
+    getPriorityArrayFromUrlQuery,
+    getReusableComponentsVehicleModeEnumFromUrlQuery,
+    getDisplayedSearchResultTypeFromUrlQuery,
     getStringParamFromUrlQuery,
     getBooleanParamFromUrlQuery,
     getDateTimeFromUrlQuery,

--- a/ui/src/utils/enum.ts
+++ b/ui/src/utils/enum.ts
@@ -11,3 +11,9 @@ export function getEnumValues(inputEnum: Object): string[] {
 export enum AllOptionEnum {
   All = 'all',
 }
+
+/** Enum for different search result options */
+export enum DisplayedSearchResultType {
+  Routes = 'routes',
+  Lines = 'lines',
+}

--- a/ui/src/utils/search.ts
+++ b/ui/src/utils/search.ts
@@ -8,11 +8,7 @@ import {
   RouteRouteOrderBy,
   SearchLinesAndRoutesQueryVariables,
 } from '../generated/graphql';
-import {
-  DeserializedQueryStringParameters,
-  SearchConditions,
-  SearchParameters,
-} from '../hooks/search/useSearchQueryParser';
+import { SearchConditions } from '../hooks/search/useSearchQueryParser';
 import { Priority } from '../types/Priority';
 import { AllOptionEnum } from './enum';
 
@@ -203,22 +199,4 @@ export const constructSearchLinesAndRoutesGqlQueryVariables = (
     lineOrderBy,
     routeOrderBy,
   };
-};
-
-export const createQueryParamString = (paramObject: SearchParameters) => {
-  const combinedObject: DeserializedQueryStringParameters = {
-    ...paramObject.filter,
-    ...paramObject.search,
-  };
-
-  let paramString = '?';
-  Object.keys(combinedObject).forEach((key) => {
-    if (paramString.length > 1) {
-      paramString += '&';
-    }
-    paramString += `${key}=${
-      combinedObject[key as keyof DeserializedQueryStringParameters]
-    }`;
-  });
-  return paramString;
 };


### PR DESCRIPTION
Nowadays we have useUrlQuery which is responsible for handling getting and setting properties to URL query parameters. This PR refactors search hooks to use this hook instead of handling the serialization, deserialization and pushing the properties to query parameters itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/361)
<!-- Reviewable:end -->
