### PR TITLE
Automatically make displayed route selected on map

### DIFF
--- a/ui/src/hooks/useShowRoutesOnModal.ts
+++ b/ui/src/hooks/useShowRoutesOnModal.ts
@@ -5,7 +5,7 @@ import {
   Maybe,
   RouteInformationForMapFragment,
 } from '../generated/graphql';
-import { resetMapEditorStateAction } from '../redux';
+import { resetMapEditorStateAction, setSelectedRouteIdAction } from '../redux';
 import { isDateInRange } from '../time';
 import { Priority } from '../types/Priority';
 import { getRouteShapeFirstCoordinates } from '../utils/routeShape';
@@ -99,6 +99,11 @@ export const useShowRoutesOnModal = () => {
         longitude,
       },
     });
+
+    // Automatically select the route on map
+    // to highlight it and its stops and to view route info in overlay
+    // without user having to click route geometry first.
+    dispatch(setSelectedRouteIdAction(route.route_id));
   };
 
   const showRouteOnMapByLineLabel = (line: LineInformationForMapFragment) => {
@@ -131,6 +136,11 @@ export const useShowRoutesOnModal = () => {
       validityEnd: route.validity_end,
       viewPortParams: { latitude, longitude },
     });
+
+    // Automatically select the route on map
+    // to highlight it and its stops and to view route info in overlay
+    // without user having to click route geometry first.
+    dispatch(setSelectedRouteIdAction(route.route_id));
   };
 
   return {


### PR DESCRIPTION
- If route is clicked for display on map, make it initially selected on map. If multiple route directions exist, select the route direction that was clicked.

Resolves HSLdevcom/jore4#991

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/364)
<!-- Reviewable:end -->
