### PR TITLE
Fix MultiLineString error in stop to infra line

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,7 @@
     "@nebula.gl/edit-modes": "0.23.8",
     "@reduxjs/toolkit": "^1.8.0",
     "@seznam/compose-react-refs": "^1.0.6",
+    "@turf/flatten": "^6.5.0",
     "@turf/distance": "^6.5.0",
     "@turf/helpers": "^6.5.0",
     "@turf/nearest-point-on-line": "^6.5.0",

--- a/ui/src/utils/map/lineFromStopToInfraLink.ts
+++ b/ui/src/utils/map/lineFromStopToInfraLink.ts
@@ -1,3 +1,4 @@
+import flatten from '@turf/flatten';
 import { Feature, LineString, point } from '@turf/helpers';
 import nearestPointOnLine from '@turf/nearest-point-on-line';
 import pointToLineDistance from '@turf/point-to-line-distance';
@@ -37,6 +38,15 @@ const findFeaturesForLayerWithRadius = (
     );
   }
   return [];
+};
+
+// Turn any possible MultiLineStrings in the feature into LineStrings
+const getLineStringFromFeature = (feature: Feature<Geometry>) => {
+  const flattened = flatten(feature);
+  if (flattened.features.length > 0) {
+    return flattened.features[0];
+  }
+  return feature.geometry;
 };
 
 export const removeLineFromStopToInfraLink = (map: MaplibreGLMap) => {
@@ -95,7 +105,13 @@ export const drawLineToClosestRoad = (map: MaplibreGLMap, coords: Coords) => {
     // pair each network connection with the distance from the coordinates
     const linesWithDistance: FeatureAndDistance[] = features.map((line) => ({
       feature: line,
-      distance: pointToLineDistance(cursorLocation, line, { units: 'meters' }),
+      distance: pointToLineDistance(
+        cursorLocation,
+        getLineStringFromFeature(line),
+        {
+          units: 'meters',
+        },
+      ),
     }));
 
     // find the nearest network connection


### PR DESCRIPTION
Turn any possible MultiLineStrings into LineStrings when drawing a line from a stop to the nearest infralink.

Resolves https://github.com/HSLdevcom/jore4/issues/960