### PR TITLE
Fix route label list overflowing in stop edit popover

### DIFF
--- a/ui/src/components/map/stops/DeleteStopConfirmationDialog.tsx
+++ b/ui/src/components/map/stops/DeleteStopConfirmationDialog.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeleteChanges } from '../../../hooks';
 import { ConfirmationDialog } from '../../../uiComponents';
+import { buildRouteLabelListString } from './EditStopConfirmationDialog';
 
 interface Props {
   isOpen: boolean;
@@ -30,8 +31,9 @@ export const DeleteStopConfirmationDialog: React.FC<Props> = ({
 
     // if stop is deleted from some routes, list them
     if (changes.deleteStopFromRoutes.length > 0) {
-      const routeLabels = changes.deleteStopFromRoutes.map(
-        (item) => item.label,
+      const routeLabels = buildRouteLabelListString(
+        changes.deleteStopFromRoutes,
+        t,
       );
       const removedRoutesText = t('confirmDeleteStopDialog.removedFromRoutes', {
         routeLabels,

--- a/ui/src/components/map/stops/EditStopConfirmationDialog.tsx
+++ b/ui/src/components/map/stops/EditStopConfirmationDialog.tsx
@@ -1,5 +1,7 @@
+import countBy from 'lodash/countBy';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { TFunction, useTranslation } from 'react-i18next';
+import { RouteRoute } from '../../../generated/graphql';
 import { EditChanges } from '../../../hooks';
 import { ConfirmationDialog } from '../../../uiComponents';
 
@@ -10,6 +12,32 @@ interface Props {
   className?: string;
   editChanges: EditChanges;
 }
+
+/**
+ * Builds a string list from provided routes' labels separated by comma.
+ * If multiple instances of a route are in the provided route array,
+ * add count of route instances after the label.
+ *
+ * Example output: "65x, 65y (5 versions), 65z (3 versions)"
+ */
+export const buildRouteLabelListString = (
+  routes: RouteRoute[],
+  t: TFunction,
+) => {
+  const labelsCounted = countBy(routes, 'label');
+
+  return Object.entries(labelsCounted)
+    .map(([routeLabel, labelCount]) =>
+      // Only display count if it is greater than 1
+      labelCount > 1
+        ? t('confirmEditStopDialog.routeWithNVersions', {
+            routeLabel,
+            labelCount,
+          })
+        : routeLabel,
+    )
+    .join(', ');
+};
 
 /** Renders a confirmation dialog for confirming changes when a stop is edited */
 export const EditStopConfirmationDialog: React.FC<Props> = ({
@@ -30,8 +58,9 @@ export const EditStopConfirmationDialog: React.FC<Props> = ({
 
     // if stop is deleted from some routes, list them
     if (changes.deleteStopFromRoutes.length > 0) {
-      const routeLabels = changes.deleteStopFromRoutes.map(
-        (item) => item.label,
+      const routeLabels = buildRouteLabelListString(
+        changes.deleteStopFromRoutes,
+        t,
       );
       const removedRoutesText = t('confirmEditStopDialog.removedFromRoutes', {
         routeLabels,

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -147,6 +147,7 @@
     "title": "Confirm changes",
     "description": "Confirm stop changes ({{ stopLabel }})",
     "removedFromRoutes": "The stop will be removed from the following routes: {{ routeLabels }}",
+    "routeWithNVersions": "{{ routeLabel }} ({{ labelCount }} versions)",
     "confirmText": "OK"
   },
   "priority": {

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -147,6 +147,7 @@
     "title": "Vahvista muutos",
     "description": "Vahvista pysäkin muokkaus ({{ stopLabel }})",
     "removedFromRoutes": "Pysäkki poistetaan seuraavilta reiteiltä: {{ routeLabels }}",
+    "routeWithNVersions": "{{ routeLabel }} ({{ labelCount }} versiota)",
     "confirmText": "OK"
   },
   "priority": {


### PR DESCRIPTION
Resolves HSLdevcom/jore4#922

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/371)
<!-- Reviewable:end -->
