### PR TITLE
Refactor route geometry layers

### DIFF
--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -22,6 +22,7 @@ import { Maplibre } from './Maplibre';
 import { InfraLinksVectorLayer } from './network';
 import { ObservationDateOverlay } from './ObservationDateOverlay';
 import {
+  DraftRouteGeometryLayer,
   DrawRouteLayer,
   EditRouteMetadataLayer,
   isRouteGeometryLayer,
@@ -239,6 +240,7 @@ export const MapComponent = (
             isSelected={selectedRouteId === item && !hasDraftRouteGeometry}
           />
         ))}
+      <DraftRouteGeometryLayer />
       <RouteEditor
         onDeleteDrawnRoute={() => editorLayerRef.current?.onDeleteRoute()}
         ref={routeEditorRef}

--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -27,8 +27,8 @@ import {
   isRouteGeometryLayer,
   mapLayerIdToRouteId,
   RouteEditor,
-  RouteGeometryLayer,
 } from './routes';
+import { ExistingRouteGeometryLayer } from './routes/ExistingRouteGeometryLayer';
 import { RouteStopsOverlay } from './RouteStopsOverlay';
 import { StopFilterOverlay } from './StopFilterOverlay';
 import { Stops } from './stops';
@@ -233,7 +233,7 @@ export const MapComponent = (
       {showRoute &&
         routeDisplayed &&
         displayedRouteIds?.map((item) => (
-          <RouteGeometryLayer
+          <ExistingRouteGeometryLayer
             key={item}
             routeId={item}
             isSelected={selectedRouteId === item && !hasDraftRouteGeometry}

--- a/ui/src/components/map/routes/DraftRouteGeometryLayer.tsx
+++ b/ui/src/components/map/routes/DraftRouteGeometryLayer.tsx
@@ -1,0 +1,21 @@
+import { useAppSelector } from '../../../hooks';
+import { selectEditedRouteData } from '../../../redux';
+import { RouteGeometryLayer } from './RouteGeometryLayer';
+
+const SNAPPING_LINE_LAYER_ID = 'snapping-line';
+
+export const DraftRouteGeometryLayer = (): JSX.Element => {
+  const { geometry } = useAppSelector(selectEditedRouteData);
+
+  if (!geometry) {
+    return <></>;
+  }
+
+  return (
+    <RouteGeometryLayer
+      layerId={SNAPPING_LINE_LAYER_ID}
+      geometry={geometry}
+      isHighlighted
+    />
+  );
+};

--- a/ui/src/components/map/routes/DrawRouteLayer.tsx
+++ b/ui/src/components/map/routes/DrawRouteLayer.tsx
@@ -149,7 +149,7 @@ const DrawRouteLayerComponent = (
       // we are editing an existing or a template route, but haven't (yet) received the graphql
       // response with its data -> return early
       if (!baseRoute && !creatingNewRoute) {
-        log.error(
+        log.warn(
           'Trying to edit an existing route but could not find a base route (yet)',
         );
         return;
@@ -163,7 +163,7 @@ const DrawRouteLayerComponent = (
         editedRouteData.metaData.validityEnd === undefined ||
         editedRouteData.metaData.priority === undefined
       ) {
-        log.error(
+        log.warn(
           'Trying to update route geometry but route metadata is not (yet) available',
         );
         return;

--- a/ui/src/components/map/routes/ExistingRouteGeometryLayer.tsx
+++ b/ui/src/components/map/routes/ExistingRouteGeometryLayer.tsx
@@ -1,0 +1,54 @@
+import {
+  ReusableComponentsVehicleModeEnum,
+  useGetRouteRenderInfoByIdQuery,
+} from '../../../generated/graphql';
+import { mapRouteResultToRoute } from '../../../graphql';
+import { mapToVariables } from '../../../utils';
+import { mapVehicleModeToRouteColor } from '../../../utils/colors';
+import { RouteGeometryLayer } from './RouteGeometryLayer';
+
+export const ROUTE_LAYER_ID_PREFIX = 'route_id_';
+
+// utilities to allow finding the original route's id based on the layer's id
+export const isRouteGeometryLayer = (layerId: string) =>
+  layerId.startsWith(ROUTE_LAYER_ID_PREFIX);
+export const mapRouteIdToLayerId = (routeId: UUID) =>
+  `${ROUTE_LAYER_ID_PREFIX}${routeId}`;
+export const mapLayerIdToRouteId = (layerId: string) =>
+  layerId.substring(ROUTE_LAYER_ID_PREFIX.length) as UUID;
+
+interface Props {
+  routeId: string;
+  isSelected: boolean;
+}
+
+// This layer fetches a single route's geometry and renders it as a line polygon
+export const ExistingRouteGeometryLayer = ({
+  routeId,
+  isSelected,
+}: Props): JSX.Element => {
+  const routeRenderInfoResult = useGetRouteRenderInfoByIdQuery(
+    mapToVariables({ routeId }),
+  );
+  const routeRenderInfo = mapRouteResultToRoute(routeRenderInfoResult);
+
+  // do not render anything before data is received
+  if (!routeRenderInfo?.route_shape) {
+    return <></>;
+  }
+
+  const vehicleMode =
+    routeRenderInfo.route_line?.primary_vehicle_mode ||
+    ReusableComponentsVehicleModeEnum.Bus;
+
+  const routeColor = mapVehicleModeToRouteColor(vehicleMode);
+
+  return (
+    <RouteGeometryLayer
+      layerId={mapRouteIdToLayerId(routeId)}
+      geometry={routeRenderInfo.route_shape}
+      defaultColor={routeColor}
+      isHighlighted={isSelected}
+    />
+  );
+};

--- a/ui/src/components/map/routes/RouteGeometryLayer.tsx
+++ b/ui/src/components/map/routes/RouteGeometryLayer.tsx
@@ -1,63 +1,35 @@
-import {
-  ReusableComponentsVehicleModeEnum,
-  useGetRouteRenderInfoByIdQuery,
-} from '../../../generated/graphql';
 import { theme } from '../../../generated/theme';
-import { mapRouteResultToRoute } from '../../../graphql';
-import { mapToVariables } from '../../../utils';
 import { LinePolygonLayer } from './LinePolygonLayer';
 
 const { colors } = theme;
 
-export const ROUTE_LAYER_ID_PREFIX = 'route_id_';
-
-// utilities to allow finding the original route's id based on the layer's id
-export const isRouteGeometryLayer = (layerId: string) =>
-  layerId.startsWith(ROUTE_LAYER_ID_PREFIX);
-export const mapRouteIdToLayerId = (routeId: UUID) =>
-  `${ROUTE_LAYER_ID_PREFIX}${routeId}`;
-export const mapLayerIdToRouteId = (layerId: string) =>
-  layerId.substring(ROUTE_LAYER_ID_PREFIX.length) as UUID;
-
-interface RouteGeometryLayerProps {
-  routeId: string;
-  isSelected: boolean;
+interface Props {
+  layerId: string;
+  geometry: GeoJSON.LineString;
+  defaultColor?: string;
+  isHighlighted: boolean;
 }
 
-// This layer fetches a single route's geometry and renders it as a line polygon
+// This layer renders route on map
 export const RouteGeometryLayer = ({
-  routeId,
-  isSelected,
-}: RouteGeometryLayerProps): JSX.Element => {
-  const routeRenderInfoResult = useGetRouteRenderInfoByIdQuery(
-    mapToVariables({ routeId }),
-  );
-  const routeRenderInfo = mapRouteResultToRoute(routeRenderInfoResult);
-
-  // do not render anything before data is received
-  if (!routeRenderInfo?.route_shape) {
-    return <></>;
-  }
-
-  const beforeId = isSelected ? undefined : 'route_base';
-
-  const vehicleMode =
-    routeRenderInfo.route_line?.primary_vehicle_mode ||
-    ReusableComponentsVehicleModeEnum.Bus;
+  layerId,
+  geometry,
+  defaultColor = colors.routes.bus,
+  isHighlighted,
+}: Props): JSX.Element => {
+  const beforeId = isHighlighted ? undefined : 'route_base';
 
   const paint: mapboxgl.LinePaint = {
-    'line-color': isSelected
-      ? colors.selectedMapItem
-      : colors.routes[vehicleMode],
-    'line-width': isSelected ? 9 : 8,
-    'line-opacity': isSelected ? 1 : 0.75,
+    'line-color': isHighlighted ? colors.selectedMapItem : defaultColor,
+    'line-width': isHighlighted ? 9 : 8,
+    'line-opacity': isHighlighted ? 1 : 0.75,
     'line-offset': 6,
   };
 
   return (
     <LinePolygonLayer
-      layerId={mapRouteIdToLayerId(routeId)}
-      geometry={routeRenderInfo.route_shape}
+      layerId={layerId}
+      geometry={geometry}
       paint={paint}
       beforeId={beforeId}
     />

--- a/ui/src/components/map/routes/index.ts
+++ b/ui/src/components/map/routes/index.ts
@@ -1,3 +1,4 @@
+export * from './DraftRouteGeometryLayer';
 export * from './DrawRouteLayer';
 export * from './EditRouteMetadataLayer';
 export * from './EditRouteModal';

--- a/ui/src/components/map/routes/index.ts
+++ b/ui/src/components/map/routes/index.ts
@@ -1,6 +1,7 @@
 export * from './DrawRouteLayer';
 export * from './EditRouteMetadataLayer';
 export * from './EditRouteModal';
+export * from './ExistingRouteGeometryLayer';
 export * from './LinePolygonLayer';
 export * from './RouteEditor';
 export * from './RouteGeometryLayer';

--- a/ui/src/redux/selectors/index.ts
+++ b/ui/src/redux/selectors/index.ts
@@ -58,8 +58,8 @@ export const selectEditedRouteData = createSelector(
 );
 
 export const selectHasDraftRouteGeometry = createSelector(
-  selectMapRouteEditor,
-  (mapRouteEditor) => !!mapRouteEditor.editedRouteData.infraLinks?.length,
+  selectEditedRouteData,
+  (editedRouteData) => !!editedRouteData.geometry,
 );
 
 export const selectSelectedRouteId = createSelector(

--- a/ui/src/redux/slices/mapRouteEditor.ts
+++ b/ui/src/redux/slices/mapRouteEditor.ts
@@ -44,6 +44,10 @@ export interface EditedRouteData {
    * Array of stops that are eligible to be added to the journey pattern
    */
   stopsEligibleForJourneyPattern: RouteStopFieldsFragment[];
+  /**
+   * Draft route geometry
+   */
+  geometry?: GeoJSON.LineString;
 }
 
 export interface MapRouteEditorState {
@@ -83,6 +87,7 @@ const initialState: IState = {
     stopsEligibleForJourneyPattern: [],
     infraLinks: [],
     templateRouteId: undefined,
+    geometry: undefined,
   },
   isRouteMetadataFormOpen: false,
   selectedRouteId: undefined,
@@ -229,6 +234,7 @@ const slice = createSlice({
             includedStopLabels: string[];
             stopsEligibleForJourneyPattern: RouteStopFieldsFragment[];
             infraLinks: RouteInfraLink[];
+            geometry?: GeoJSON.LineString;
           }>
         >,
       ) => {
@@ -236,6 +242,7 @@ const slice = createSlice({
           includedStopLabels,
           stopsEligibleForJourneyPattern,
           infraLinks,
+          geometry,
         } = action.payload;
 
         state.editedRouteData = {
@@ -243,21 +250,25 @@ const slice = createSlice({
           includedStopLabels: uniq(includedStopLabels),
           stopsEligibleForJourneyPattern,
           infraLinks,
+          geometry,
         };
       },
       prepare: ({
         includedStopLabels,
         stopsEligibleForJourneyPattern,
         infraLinks,
+        geometry,
       }: {
         includedStopLabels: string[];
         stopsEligibleForJourneyPattern: RouteStopFieldsFragment[];
         infraLinks: RouteInfraLink[];
+        geometry?: GeoJSON.LineString;
       }) => ({
         payload: mapToStoreType({
           includedStopLabels,
           stopsEligibleForJourneyPattern,
           infraLinks,
+          geometry,
         }),
       }),
     },
@@ -280,6 +291,7 @@ const slice = createSlice({
         journeyPatternStops: [],
         stopsEligibleForJourneyPattern: [],
         infraLinks: [],
+        geometry: undefined,
       };
     },
     /**

--- a/ui/src/utils/colors.ts
+++ b/ui/src/utils/colors.ts
@@ -1,0 +1,17 @@
+import { ReusableComponentsVehicleModeEnum } from '../generated/graphql';
+import { theme } from '../generated/theme';
+
+export const mapVehicleModeToRouteColor = (
+  key: ReusableComponentsVehicleModeEnum,
+) => {
+  const { colors } = theme;
+
+  const routeColors: Record<ReusableComponentsVehicleModeEnum, string> = {
+    [ReusableComponentsVehicleModeEnum.Bus]: colors.routes.bus,
+    [ReusableComponentsVehicleModeEnum.Ferry]: colors.routes.ferry,
+    [ReusableComponentsVehicleModeEnum.Metro]: colors.routes.metro,
+    [ReusableComponentsVehicleModeEnum.Train]: colors.routes.train,
+    [ReusableComponentsVehicleModeEnum.Tram]: colors.routes.tram,
+  };
+  return routeColors[key];
+};

--- a/ui/src/utils/logger.ts
+++ b/ui/src/utils/logger.ts
@@ -6,4 +6,8 @@ export const log = {
     // eslint-disable-next-line no-console
     console.error(...data);
   },
+  warn: (...data: ExplicitAny[]) => {
+    // eslint-disable-next-line no-console
+    console.warn(...data);
+  },
 };

--- a/ui/src/utils/map/mapUtils.ts
+++ b/ui/src/utils/map/mapUtils.ts
@@ -1,5 +1,3 @@
-import { theme } from '../../generated/theme';
-
 // TODO: Can we import these somewhere?
 export type MaplibreGLMap = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 export type Geometry = any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -8,47 +6,6 @@ export const removeLayer = (map: MaplibreGLMap, id: string) => {
   if (map.getLayer(id)) {
     map.removeLayer(id);
   }
-  // when a layer is created with map.addLayer, corresponding
-  // source seems to be also created and we have to remove
-  // also it before we can create new layer with same id
-  if (map.getSource(id)) {
-    map.removeSource(id);
-  }
-};
-
-export const removeRoute = (map: MaplibreGLMap, id: string) => {
-  removeLayer(map, id);
-};
-
-export const addRoute = (
-  map: MaplibreGLMap,
-  id: string,
-  geometry: Geometry,
-) => {
-  // remove possible existing layers with same id
-  removeRoute(map, id);
-  map.addLayer({
-    id,
-    type: 'line',
-    source: {
-      type: 'geojson',
-      data: {
-        type: 'Feature',
-        properties: {},
-        geometry,
-      },
-    },
-    layout: {
-      'line-join': 'round',
-      'line-cap': 'round',
-    },
-    paint: {
-      'line-color': theme.colors.selectedMapItem,
-      'line-width': 8,
-      'line-opacity': 1,
-      'line-offset': 6,
-    },
-  });
 };
 
 export const createGeometryLineBetweenPoints = (


### PR DESCRIPTION
- Always use components for rendering route geometry
- Remove draft route rendering from DrawRouteLayer

- This refactoring helps adding arrow layer to route geometry later on

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/379)
<!-- Reviewable:end -->
