### PR TITLE
Use component specific attribute fetching for table rows

### DIFF
--- a/cypress/pageObjects/EditRouteModal.ts
+++ b/cypress/pageObjects/EditRouteModal.ts
@@ -5,9 +5,11 @@ export class EditRouteModal {
    * https://docs.cypress.io/api/commands/click#Arguments
    */
   save(forceAction = false) {
-    return cy
-      .getByTestId('EditRouteModal')
+    cy.getByTestId('EditRouteModal')
       .findByTestId('Modal::saveButton')
       .click({ force: forceAction });
+
+    // After save the edit route modal should close
+    cy.getByTestId('EditRouteModal').should('not.exist');
   }
 }

--- a/ui/src/components/routes-and-lines/main/LineTableRow.tsx
+++ b/ui/src/components/routes-and-lines/main/LineTableRow.tsx
@@ -20,7 +20,10 @@ interface Props {
 
 const GQL_LINE_TABLE_ROW = gql`
   fragment line_table_row on route_line {
-    ...line_all_fields
+    name_i18n
+    short_name_i18n
+    priority
+    ...line_information_for_map
     line_routes {
       ...route_information_for_map
     }

--- a/ui/src/components/routes-and-lines/main/RouteLineTableRow.tsx
+++ b/ui/src/components/routes-and-lines/main/RouteLineTableRow.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import {
   LineTableRowFragment,
-  RouteAllFieldsFragment,
+  RouteTableRowFragment,
 } from '../../../generated/graphql';
 import { useAlertsAndHighLights } from '../../../hooks';
 import { Column, Row, Visible } from '../../../layoutComponents';
@@ -15,7 +15,7 @@ interface Props {
   onLocatorButtonClick?: () => void;
   locatorButtonTestId: string;
   lineId: UUID;
-  rowItem: RouteAllFieldsFragment | LineTableRowFragment;
+  rowItem: LineTableRowFragment | RouteTableRowFragment;
   isSelected?: boolean;
   onSelectChanged?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   selectionDisabled?: boolean;

--- a/ui/src/components/routes-and-lines/main/RouteTableRow.tsx
+++ b/ui/src/components/routes-and-lines/main/RouteTableRow.tsx
@@ -1,4 +1,5 @@
-import { RouteAllFieldsFragment } from '../../../generated/graphql';
+import { gql } from '@apollo/client';
+import { RouteTableRowFragment } from '../../../generated/graphql';
 import {
   useAppDispatch,
   useAppSelector,
@@ -11,9 +12,19 @@ import {
 } from '../../../redux';
 import { RouteLineTableRow } from './RouteLineTableRow';
 
+const GQL_ROUTE_TABLE_ROW = gql`
+  fragment route_table_row on route_route {
+    ...route_information_for_map
+    name_i18n
+    direction
+    priority
+    on_line_id
+  }
+`;
+
 interface Props {
   className?: string;
-  route: RouteAllFieldsFragment;
+  route: RouteTableRowFragment;
   isSelectable?: boolean;
 }
 

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
@@ -1,17 +1,40 @@
+import { gql } from '@apollo/client';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useListChangingRoutesQuery,
   useListOwnLinesQuery,
 } from '../../../generated/graphql';
-import {
-  mapListOwnLinesResult,
-  mapRouteResultToRoutes,
-} from '../../../graphql';
 import { LinesList } from './LinesList';
 import { ListFooter } from './ListFooter';
 import { ListHeader } from './ListHeader';
 import { RoutesList } from './RoutesList';
+
+// TODO: This list is currently only for visual purpose and will be so until
+// we get user data to our system. Until then, we just list all routes
+const GQL_LIST_CHANGING_ROUTES = gql`
+  query ListChangingRoutes($limit: Int) {
+    route_route(
+      limit: $limit
+      order_by: [{ label: asc }, { validity_start: asc }]
+    ) {
+      ...route_table_row
+    }
+  }
+`;
+
+// TODO: This list is currently only for visual purpose and will be so until
+// we get user data to our system. Until then, we just list all lines
+const GQL_LIST_OWN_LINES = gql`
+  query ListOwnLines($limit: Int = 10) {
+    route_line(
+      limit: $limit
+      order_by: [{ label: asc }, { validity_start: asc }]
+    ) {
+      ...line_table_row
+    }
+  }
+`;
 
 export const RoutesAndLinesLists = (): JSX.Element => {
   const { t } = useTranslation();
@@ -25,11 +48,12 @@ export const RoutesAndLinesLists = (): JSX.Element => {
   const changingRoutesResult = useListChangingRoutesQuery({
     variables: { limit: changingRoutesLimit },
   });
-  const changingRoutes = mapRouteResultToRoutes(changingRoutesResult);
+
+  const changingRoutes = changingRoutesResult.data?.route_route || [];
 
   // own lines
   const ownLinesResult = useListOwnLinesQuery();
-  const ownLines = mapListOwnLinesResult(ownLinesResult);
+  const ownLines = ownLinesResult.data?.route_line || [];
 
   return (
     <div>

--- a/ui/src/components/routes-and-lines/main/RoutesList.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesList.tsx
@@ -1,9 +1,9 @@
-import { RouteAllFieldsFragment } from '../../../generated/graphql';
+import { RouteTableRowFragment } from '../../../generated/graphql';
 import { RoutesTable } from './RoutesTable';
 import { RouteTableRow } from './RouteTableRow';
 
 type Props = {
-  routes?: RouteAllFieldsFragment[];
+  routes?: RouteTableRowFragment[];
   areItemsSelectable?: boolean;
 };
 
@@ -16,7 +16,7 @@ export const RoutesList = ({
   areItemsSelectable = false,
 }: Props): JSX.Element => (
   <RoutesTable testId={testIds.table}>
-    {routes?.map((item: RouteAllFieldsFragment) => (
+    {routes?.map((item: RouteTableRowFragment) => (
       <RouteTableRow
         key={item.route_id}
         route={item}

--- a/ui/src/components/routes-and-lines/main/RoutesTable.spec.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesTable.spec.tsx
@@ -1,16 +1,10 @@
 import { buildLocalizedString, buildRoute } from '@hsl/jore4-test-db-manager';
 import {
-  ListChangingRoutesQuery,
+  LineTableRowFragment,
   RouteDirectionEnum,
-  RouteLine,
-  RouteRoute,
-  useListOwnLinesQuery,
+  RouteTableRowFragment,
 } from '../../../generated/graphql';
-import {
-  GqlQueryResult,
-  mapListOwnLinesResult,
-  mapRouteResultToRoutes,
-} from '../../../graphql';
+import { Priority } from '../../../types/Priority';
 import { render } from '../../../utils/test-utils';
 import { LineTableRow } from './LineTableRow';
 import { RoutesTable } from './RoutesTable';
@@ -21,39 +15,23 @@ describe(`<${RoutesTable.name} />`, () => {
   const route1Id = '03d55414-e5cf-4cce-9faf-d86ccb7e5f98';
   const lineId = '101f800c-39ed-4d85-8ece-187cd9fe1c5e';
 
-  // this response is copy-pasted from the actual graphql response
-  const routesResponseMock: GqlQueryResult<ListChangingRoutesQuery> = {
-    data: {
-      route_route: [
-        {
-          __typename: 'route_route',
-          ...buildRoute({ label: '1' }),
-          route_id: route1Id,
-          on_line_id: lineId,
-          priority: 10,
-          direction: RouteDirectionEnum.Outbound,
-          route_line: {
-            line_id: lineId,
-            label: '65',
-            name_i18n: buildLocalizedString(
-              'Rautatientori - Kätilöopisto - Veräjälaakso',
-            ),
-            short_name_i18n: buildLocalizedString(
-              'Rautatientori - Veräjälaakso',
-            ),
-            __typename: 'route_line',
-          },
-        },
-      ],
+  const routesResponseMock: RouteTableRowFragment[] = [
+    {
+      __typename: 'route_route',
+      ...buildRoute({ label: '1' }),
+      route_id: route1Id,
+      on_line_id: lineId,
+      priority: 10,
+      direction: RouteDirectionEnum.Outbound,
     },
-  };
+  ];
 
   test('Renders the table with route data', async () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const routes = mapRouteResultToRoutes(routesResponseMock)!;
+    const routes = routesResponseMock!;
     const { asFragment } = render(
       <RoutesTable testId={testId}>
-        {routes.map((item: RouteRoute) => (
+        {routes.map((item: RouteTableRowFragment) => (
           <RouteTableRow key={item.route_id} route={item} />
         ))}
       </RoutesTable>,
@@ -62,48 +40,51 @@ describe(`<${RoutesTable.name} />`, () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  // this response is copy-pasted from the actual graphql response
-  const linesResponseMock = {
-    data: {
-      route_line: [
-        {
-          line_id: '101f800c-39ed-4d85-8ece-187cd9fe1c5e',
-          label: '65',
-          name_i18n: buildLocalizedString('Rautatientori - Veräjälaakso'),
-          short_name_i18n: buildLocalizedString('Rautatientori - Veräjälaakso'),
-          __typename: 'route_line',
-        },
-        {
-          line_id: '9058c328-efdd-412c-9b2b-37b0f6a2c6fb',
-          label: '71',
-          name_i18n: buildLocalizedString('Rautatientori - Malmi as.'),
-          short_name_i18n: buildLocalizedString('Rautatientori - Malmi as.'),
-          __typename: 'route_line',
-        },
-        {
-          line_id: 'bbd1cb29-74c3-4fa1-ac86-918d7fa96fe2',
-          label: '785K',
-          name_i18n: buildLocalizedString('Rautatientori - Nikkilä'),
-          short_name_i18n: buildLocalizedString('Rautatientori - Nikkilä'),
-          __typename: 'route_line',
-        },
-        {
-          line_id: 'db748c5c-42e3-429f-baa0-e0db227dc2c8',
-          label: '1234',
-          name_i18n: buildLocalizedString('Erottaja - Arkkadiankatu'),
-          short_name_i18n: buildLocalizedString('Erottaja - Arkkadiankatu'),
-          __typename: 'route_line',
-        },
-      ],
+  const linesResponseMock: LineTableRowFragment[] = [
+    {
+      line_id: '101f800c-39ed-4d85-8ece-187cd9fe1c5e',
+      label: '65',
+      priority: Priority.Standard,
+      name_i18n: buildLocalizedString('Rautatientori - Veräjälaakso'),
+      short_name_i18n: buildLocalizedString('Rautatientori - Veräjälaakso'),
+      line_routes: [],
+      __typename: 'route_line',
     },
-  } as ReturnType<typeof useListOwnLinesQuery>;
+    {
+      line_id: '9058c328-efdd-412c-9b2b-37b0f6a2c6fb',
+      label: '71',
+      priority: Priority.Standard,
+      name_i18n: buildLocalizedString('Rautatientori - Malmi as.'),
+      short_name_i18n: buildLocalizedString('Rautatientori - Malmi as.'),
+      line_routes: [],
+      __typename: 'route_line',
+    },
+    {
+      line_id: 'bbd1cb29-74c3-4fa1-ac86-918d7fa96fe2',
+      label: '785K',
+      priority: Priority.Standard,
+      name_i18n: buildLocalizedString('Rautatientori - Nikkilä'),
+      short_name_i18n: buildLocalizedString('Rautatientori - Nikkilä'),
+      line_routes: [],
+      __typename: 'route_line',
+    },
+    {
+      line_id: 'db748c5c-42e3-429f-baa0-e0db227dc2c8',
+      label: '1234',
+      priority: Priority.Standard,
+      name_i18n: buildLocalizedString('Erottaja - Arkkadiankatu'),
+      short_name_i18n: buildLocalizedString('Erottaja - Arkkadiankatu'),
+      line_routes: [],
+      __typename: 'route_line',
+    },
+  ];
 
   test('Renders the table with line data', async () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const lines = mapListOwnLinesResult(linesResponseMock)!;
+    const lines = linesResponseMock!;
     const { asFragment } = render(
       <RoutesTable testId={testId}>
-        {lines.map((item: RouteLine) => (
+        {lines.map((item: LineTableRowFragment) => (
           <LineTableRow key={item.line_id} line={item} />
         ))}
       </RoutesTable>,

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -11218,23 +11218,79 @@ export type StopPopupInfoFragment = {
 
 export type LineTableRowFragment = {
   __typename?: 'route_line';
-  line_id: UUID;
   name_i18n: LocalizedString;
   short_name_i18n: LocalizedString;
-  primary_vehicle_mode: ReusableComponentsVehicleModeEnum;
-  type_of_line: RouteTypeOfLineEnum;
-  transport_target: HslRouteTransportTargetEnum;
+  priority: number;
+  line_id: UUID;
+  label: string;
   validity_start?: luxon.DateTime | null | undefined;
   validity_end?: luxon.DateTime | null | undefined;
-  priority: number;
-  label: string;
   line_routes: Array<{
     __typename?: 'route_route';
+    route_id: UUID;
+    route_shape?: GeoJSON.LineString | null | undefined;
+    label: string;
+    validity_start?: luxon.DateTime | null | undefined;
+    validity_end?: luxon.DateTime | null | undefined;
+  }>;
+};
+
+export type RouteTableRowFragment = {
+  __typename?: 'route_route';
+  name_i18n: LocalizedString;
+  direction: RouteDirectionEnum;
+  priority: number;
+  on_line_id: UUID;
+  route_id: UUID;
+  label: string;
+  route_shape?: GeoJSON.LineString | null | undefined;
+  validity_start?: luxon.DateTime | null | undefined;
+  validity_end?: luxon.DateTime | null | undefined;
+};
+
+export type ListChangingRoutesQueryVariables = Exact<{
+  limit?: Maybe<Scalars['Int']>;
+}>;
+
+export type ListChangingRoutesQuery = {
+  __typename?: 'query_root';
+  route_route: Array<{
+    __typename?: 'route_route';
+    name_i18n: LocalizedString;
+    direction: RouteDirectionEnum;
+    priority: number;
+    on_line_id: UUID;
     route_id: UUID;
     label: string;
     route_shape?: GeoJSON.LineString | null | undefined;
     validity_start?: luxon.DateTime | null | undefined;
     validity_end?: luxon.DateTime | null | undefined;
+  }>;
+};
+
+export type ListOwnLinesQueryVariables = Exact<{
+  limit?: Maybe<Scalars['Int']>;
+}>;
+
+export type ListOwnLinesQuery = {
+  __typename?: 'query_root';
+  route_line: Array<{
+    __typename?: 'route_line';
+    name_i18n: LocalizedString;
+    short_name_i18n: LocalizedString;
+    priority: number;
+    line_id: UUID;
+    label: string;
+    validity_start?: luxon.DateTime | null | undefined;
+    validity_end?: luxon.DateTime | null | undefined;
+    line_routes: Array<{
+      __typename?: 'route_route';
+      route_id: UUID;
+      route_shape?: GeoJSON.LineString | null | undefined;
+      label: string;
+      validity_start?: luxon.DateTime | null | undefined;
+      validity_end?: luxon.DateTime | null | undefined;
+    }>;
   }>;
 };
 
@@ -11796,62 +11852,6 @@ export type RouteWithInfrastructureLinksFragment = {
         on_route_id: UUID;
       };
     }>;
-  }>;
-};
-
-export type ListOwnLinesQueryVariables = Exact<{
-  limit?: Maybe<Scalars['Int']>;
-}>;
-
-export type ListOwnLinesQuery = {
-  __typename?: 'query_root';
-  route_line: Array<{
-    __typename?: 'route_line';
-    line_id: UUID;
-    name_i18n: LocalizedString;
-    short_name_i18n: LocalizedString;
-    primary_vehicle_mode: ReusableComponentsVehicleModeEnum;
-    type_of_line: RouteTypeOfLineEnum;
-    transport_target: HslRouteTransportTargetEnum;
-    validity_start?: luxon.DateTime | null | undefined;
-    validity_end?: luxon.DateTime | null | undefined;
-    priority: number;
-    label: string;
-    line_routes: Array<{ __typename?: 'route_route'; route_id: UUID }>;
-  }>;
-};
-
-export type ListChangingRoutesQueryVariables = Exact<{
-  limit?: Maybe<Scalars['Int']>;
-}>;
-
-export type ListChangingRoutesQuery = {
-  __typename?: 'query_root';
-  route_route: Array<{
-    __typename?: 'route_route';
-    route_id: UUID;
-    name_i18n: LocalizedString;
-    description_i18n?: LocalizedString | null | undefined;
-    origin_name_i18n: LocalizedString;
-    origin_short_name_i18n: LocalizedString;
-    destination_name_i18n: LocalizedString;
-    destination_short_name_i18n: LocalizedString;
-    route_shape?: GeoJSON.LineString | null | undefined;
-    on_line_id: UUID;
-    validity_start?: luxon.DateTime | null | undefined;
-    validity_end?: luxon.DateTime | null | undefined;
-    priority: number;
-    label: string;
-    direction: RouteDirectionEnum;
-    route_line: {
-      __typename?: 'route_line';
-      line_id: UUID;
-      label: string;
-      name_i18n: LocalizedString;
-      short_name_i18n: LocalizedString;
-      validity_start?: luxon.DateTime | null | undefined;
-      validity_end?: luxon.DateTime | null | undefined;
-    };
   }>;
 };
 
@@ -13604,21 +13604,18 @@ export type SearchLinesAndRoutesQuery = {
   __typename?: 'query_root';
   route_line: Array<{
     __typename?: 'route_line';
-    line_id: UUID;
     name_i18n: LocalizedString;
     short_name_i18n: LocalizedString;
-    primary_vehicle_mode: ReusableComponentsVehicleModeEnum;
-    type_of_line: RouteTypeOfLineEnum;
-    transport_target: HslRouteTransportTargetEnum;
+    priority: number;
+    line_id: UUID;
+    label: string;
     validity_start?: luxon.DateTime | null | undefined;
     validity_end?: luxon.DateTime | null | undefined;
-    priority: number;
-    label: string;
     line_routes: Array<{
       __typename?: 'route_route';
       route_id: UUID;
-      label: string;
       route_shape?: GeoJSON.LineString | null | undefined;
+      label: string;
       validity_start?: luxon.DateTime | null | undefined;
       validity_end?: luxon.DateTime | null | undefined;
     }>;
@@ -13871,18 +13868,16 @@ export const StopPopupInfoFragmentDoc = gql`
     measured_location
   }
 `;
-export const LineAllFieldsFragmentDoc = gql`
-  fragment line_all_fields on route_line {
+export const LineInformationForMapFragmentDoc = gql`
+  fragment line_information_for_map on route_line {
     line_id
-    name_i18n
-    short_name_i18n
-    primary_vehicle_mode
-    type_of_line
-    transport_target
+    label
     validity_start
     validity_end
-    priority
-    label
+    line_routes {
+      route_id
+      route_shape
+    }
   }
 `;
 export const RouteInformationForMapFragmentDoc = gql`
@@ -13896,12 +13891,25 @@ export const RouteInformationForMapFragmentDoc = gql`
 `;
 export const LineTableRowFragmentDoc = gql`
   fragment line_table_row on route_line {
-    ...line_all_fields
+    name_i18n
+    short_name_i18n
+    priority
+    ...line_information_for_map
     line_routes {
       ...route_information_for_map
     }
   }
-  ${LineAllFieldsFragmentDoc}
+  ${LineInformationForMapFragmentDoc}
+  ${RouteInformationForMapFragmentDoc}
+`;
+export const RouteTableRowFragmentDoc = gql`
+  fragment route_table_row on route_route {
+    ...route_information_for_map
+    name_i18n
+    direction
+    priority
+    on_line_id
+  }
   ${RouteInformationForMapFragmentDoc}
 `;
 export const PassingTimeByStopFragmentDoc = gql`
@@ -14093,6 +14101,20 @@ export const RouteWithJourneyPatternStopsFragmentDoc = gql`
   ${RouteAllFieldsFragmentDoc}
   ${JourneyPatternWithStopsFragmentDoc}
 `;
+export const LineAllFieldsFragmentDoc = gql`
+  fragment line_all_fields on route_line {
+    line_id
+    name_i18n
+    short_name_i18n
+    primary_vehicle_mode
+    type_of_line
+    transport_target
+    validity_start
+    validity_end
+    priority
+    label
+  }
+`;
 export const RouteWithInfrastructureLinksFragmentDoc = gql`
   fragment route_with_infrastructure_links on route_route {
     ...route_with_journey_pattern_stops
@@ -14168,18 +14190,6 @@ export const LineForComboboxFragmentDoc = gql`
     label
     validity_start
     validity_end
-  }
-`;
-export const LineInformationForMapFragmentDoc = gql`
-  fragment line_information_for_map on route_line {
-    line_id
-    label
-    validity_start
-    validity_end
-    line_routes {
-      route_id
-      route_shape
-    }
   }
 `;
 export const DayTypeAllFieldsFragmentDoc = gql`
@@ -14277,6 +14287,130 @@ export type GetRouteWithInfrastructureLinksLazyQueryHookResult = ReturnType<
 export type GetRouteWithInfrastructureLinksQueryResult = Apollo.QueryResult<
   GetRouteWithInfrastructureLinksQuery,
   GetRouteWithInfrastructureLinksQueryVariables
+>;
+export const ListChangingRoutesDocument = gql`
+  query ListChangingRoutes($limit: Int) {
+    route_route(
+      limit: $limit
+      order_by: [{ label: asc }, { validity_start: asc }]
+    ) {
+      ...route_table_row
+    }
+  }
+  ${RouteTableRowFragmentDoc}
+`;
+
+/**
+ * __useListChangingRoutesQuery__
+ *
+ * To run a query within a React component, call `useListChangingRoutesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useListChangingRoutesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useListChangingRoutesQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *   },
+ * });
+ */
+export function useListChangingRoutesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    ListChangingRoutesQuery,
+    ListChangingRoutesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ListChangingRoutesQuery,
+    ListChangingRoutesQueryVariables
+  >(ListChangingRoutesDocument, options);
+}
+export function useListChangingRoutesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ListChangingRoutesQuery,
+    ListChangingRoutesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ListChangingRoutesQuery,
+    ListChangingRoutesQueryVariables
+  >(ListChangingRoutesDocument, options);
+}
+export type ListChangingRoutesQueryHookResult = ReturnType<
+  typeof useListChangingRoutesQuery
+>;
+export type ListChangingRoutesLazyQueryHookResult = ReturnType<
+  typeof useListChangingRoutesLazyQuery
+>;
+export type ListChangingRoutesQueryResult = Apollo.QueryResult<
+  ListChangingRoutesQuery,
+  ListChangingRoutesQueryVariables
+>;
+export const ListOwnLinesDocument = gql`
+  query ListOwnLines($limit: Int = 10) {
+    route_line(
+      limit: $limit
+      order_by: [{ label: asc }, { validity_start: asc }]
+    ) {
+      ...line_table_row
+    }
+  }
+  ${LineTableRowFragmentDoc}
+`;
+
+/**
+ * __useListOwnLinesQuery__
+ *
+ * To run a query within a React component, call `useListOwnLinesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useListOwnLinesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useListOwnLinesQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *   },
+ * });
+ */
+export function useListOwnLinesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    ListOwnLinesQuery,
+    ListOwnLinesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ListOwnLinesQuery, ListOwnLinesQueryVariables>(
+    ListOwnLinesDocument,
+    options,
+  );
+}
+export function useListOwnLinesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ListOwnLinesQuery,
+    ListOwnLinesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ListOwnLinesQuery, ListOwnLinesQueryVariables>(
+    ListOwnLinesDocument,
+    options,
+  );
+}
+export type ListOwnLinesQueryHookResult = ReturnType<
+  typeof useListOwnLinesQuery
+>;
+export type ListOwnLinesLazyQueryHookResult = ReturnType<
+  typeof useListOwnLinesLazyQuery
+>;
+export type ListOwnLinesQueryResult = Apollo.QueryResult<
+  ListOwnLinesQuery,
+  ListOwnLinesQueryVariables
 >;
 export const GetVehicleJourneysDocument = gql`
   query GetVehicleJourneys {
@@ -14804,137 +14938,6 @@ export type GetScheduledStopPointWithViaInfoLazyQueryHookResult = ReturnType<
 export type GetScheduledStopPointWithViaInfoQueryResult = Apollo.QueryResult<
   GetScheduledStopPointWithViaInfoQuery,
   GetScheduledStopPointWithViaInfoQueryVariables
->;
-export const ListOwnLinesDocument = gql`
-  query ListOwnLines($limit: Int = 10) {
-    route_line(
-      limit: $limit
-      order_by: [{ label: asc }, { validity_start: asc }]
-    ) {
-      ...line_all_fields
-      line_routes {
-        route_id
-      }
-    }
-  }
-  ${LineAllFieldsFragmentDoc}
-`;
-
-/**
- * __useListOwnLinesQuery__
- *
- * To run a query within a React component, call `useListOwnLinesQuery` and pass it any options that fit your needs.
- * When your component renders, `useListOwnLinesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useListOwnLinesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *   },
- * });
- */
-export function useListOwnLinesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    ListOwnLinesQuery,
-    ListOwnLinesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ListOwnLinesQuery, ListOwnLinesQueryVariables>(
-    ListOwnLinesDocument,
-    options,
-  );
-}
-export function useListOwnLinesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    ListOwnLinesQuery,
-    ListOwnLinesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ListOwnLinesQuery, ListOwnLinesQueryVariables>(
-    ListOwnLinesDocument,
-    options,
-  );
-}
-export type ListOwnLinesQueryHookResult = ReturnType<
-  typeof useListOwnLinesQuery
->;
-export type ListOwnLinesLazyQueryHookResult = ReturnType<
-  typeof useListOwnLinesLazyQuery
->;
-export type ListOwnLinesQueryResult = Apollo.QueryResult<
-  ListOwnLinesQuery,
-  ListOwnLinesQueryVariables
->;
-export const ListChangingRoutesDocument = gql`
-  query ListChangingRoutes($limit: Int) {
-    route_route(
-      limit: $limit
-      order_by: [{ label: asc }, { validity_start: asc }]
-    ) {
-      ...route_all_fields
-      route_line {
-        ...line_default_fields
-      }
-    }
-  }
-  ${RouteAllFieldsFragmentDoc}
-  ${LineDefaultFieldsFragmentDoc}
-`;
-
-/**
- * __useListChangingRoutesQuery__
- *
- * To run a query within a React component, call `useListChangingRoutesQuery` and pass it any options that fit your needs.
- * When your component renders, `useListChangingRoutesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useListChangingRoutesQuery({
- *   variables: {
- *      limit: // value for 'limit'
- *   },
- * });
- */
-export function useListChangingRoutesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    ListChangingRoutesQuery,
-    ListChangingRoutesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    ListChangingRoutesQuery,
-    ListChangingRoutesQueryVariables
-  >(ListChangingRoutesDocument, options);
-}
-export function useListChangingRoutesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    ListChangingRoutesQuery,
-    ListChangingRoutesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    ListChangingRoutesQuery,
-    ListChangingRoutesQueryVariables
-  >(ListChangingRoutesDocument, options);
-}
-export type ListChangingRoutesQueryHookResult = ReturnType<
-  typeof useListChangingRoutesQuery
->;
-export type ListChangingRoutesLazyQueryHookResult = ReturnType<
-  typeof useListChangingRoutesLazyQuery
->;
-export type ListChangingRoutesQueryResult = Apollo.QueryResult<
-  ListChangingRoutesQuery,
-  ListChangingRoutesQueryVariables
 >;
 export const GetLineDetailsByIdDocument = gql`
   query GetLineDetailsById($line_id: uuid!) {
@@ -17471,6 +17474,23 @@ export function useGetRouteWithInfrastructureLinksAsyncQuery() {
 export type GetRouteWithInfrastructureLinksAsyncQueryHookResult = ReturnType<
   typeof useGetRouteWithInfrastructureLinksAsyncQuery
 >;
+export function useListChangingRoutesAsyncQuery() {
+  return useAsyncQuery<
+    ListChangingRoutesQuery,
+    ListChangingRoutesQueryVariables
+  >(ListChangingRoutesDocument);
+}
+export type ListChangingRoutesAsyncQueryHookResult = ReturnType<
+  typeof useListChangingRoutesAsyncQuery
+>;
+export function useListOwnLinesAsyncQuery() {
+  return useAsyncQuery<ListOwnLinesQuery, ListOwnLinesQueryVariables>(
+    ListOwnLinesDocument,
+  );
+}
+export type ListOwnLinesAsyncQueryHookResult = ReturnType<
+  typeof useListOwnLinesAsyncQuery
+>;
 export function useGetVehicleJourneysAsyncQuery() {
   return useAsyncQuery<
     GetVehicleJourneysQuery,
@@ -17515,23 +17535,6 @@ export function useGetScheduledStopPointWithViaInfoAsyncQuery() {
 }
 export type GetScheduledStopPointWithViaInfoAsyncQueryHookResult = ReturnType<
   typeof useGetScheduledStopPointWithViaInfoAsyncQuery
->;
-export function useListOwnLinesAsyncQuery() {
-  return useAsyncQuery<ListOwnLinesQuery, ListOwnLinesQueryVariables>(
-    ListOwnLinesDocument,
-  );
-}
-export type ListOwnLinesAsyncQueryHookResult = ReturnType<
-  typeof useListOwnLinesAsyncQuery
->;
-export function useListChangingRoutesAsyncQuery() {
-  return useAsyncQuery<
-    ListChangingRoutesQuery,
-    ListChangingRoutesQueryVariables
-  >(ListChangingRoutesDocument);
-}
-export type ListChangingRoutesAsyncQueryHookResult = ReturnType<
-  typeof useListChangingRoutesAsyncQuery
 >;
 export function useGetLineDetailsByIdAsyncQuery() {
   return useAsyncQuery<

--- a/ui/src/graphql/route.ts
+++ b/ui/src/graphql/route.ts
@@ -11,7 +11,6 @@ import {
   RouteRoute,
   RouteWithJourneyPatternStopsFragment,
   ServicePatternScheduledStopPoint,
-  useListOwnLinesQuery,
 } from '../generated/graphql';
 import { GqlQueryResult, isGqlEntity } from './types';
 
@@ -107,39 +106,6 @@ const ROUTES_WITH_INFRASTRUCTURE_LINKS = gql`
         shape
       }
       is_traversal_forwards
-    }
-  }
-`;
-
-// TODO this is just listing all lines for now
-const LIST_OWN_LINES = gql`
-  query ListOwnLines($limit: Int = 10) {
-    route_line(
-      limit: $limit
-      order_by: [{ label: asc }, { validity_start: asc }]
-    ) {
-      ...line_all_fields
-      line_routes {
-        route_id
-      }
-    }
-  }
-`;
-export const mapListOwnLinesResult = (
-  result: ReturnType<typeof useListOwnLinesQuery>,
-) => result.data?.route_line as RouteLine[];
-
-// TODO this will list all routes for now
-const LIST_CHANGING_ROUTES = gql`
-  query ListChangingRoutes($limit: Int) {
-    route_route(
-      limit: $limit
-      order_by: [{ label: asc }, { validity_start: asc }]
-    ) {
-      ...route_all_fields
-      route_line {
-        ...line_default_fields
-      }
     }
   }
 `;

--- a/ui/src/hooks/ui/useAlertsAndHighLights.ts
+++ b/ui/src/hooks/ui/useAlertsAndHighLights.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import {
-  LineAllFieldsFragment,
-  RouteAllFieldsFragment,
+  LineTableRowFragment,
+  RouteTableRowFragment,
   ScheduledStopPointDefaultFieldsFragment,
 } from '../../generated/graphql';
 import { parseDate } from '../../time';
@@ -17,8 +17,8 @@ enum AlertLevel {
 export const useAlertsAndHighLights = () => {
   const getAlertLevel = (
     input:
-      | RouteAllFieldsFragment
-      | LineAllFieldsFragment
+      | RouteTableRowFragment
+      | LineTableRowFragment
       | ScheduledStopPointDefaultFieldsFragment,
   ): AlertLevel => {
     // TODO: this logic is actually pretty far from the desired functionality, but at least


### PR DESCRIPTION
We fetched ...route_all_fields and ...line_all_fields for component that does not need all the fields. It is better to use the component specific fragments. This will also make it easier to re-use this component when we specify only the fields that are needed. Otherwise we would have to fetch all the fields every time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/386)
<!-- Reviewable:end -->
