### PR TITLE
Pin the latest version of map-matching service

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -15,4 +15,4 @@ services:
 
   jore4-mapmatching:
     # pinning map-maching API to compatible version
-    image: "hsldevcom/jore4-map-matching:main--20220714-0488cf186532cd2446d75edc4c2e69b43277ab8a"
+    image: "hsldevcom/jore4-map-matching:main--20221024-3ebdfd21ca3213a5d28f8cdf050718c036e8a9ab"


### PR DESCRIPTION
Pin the latest version of map-matching service in order to add support for routing via closed-loop road links.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/387)
<!-- Reviewable:end -->
