### PR TITLE
Fix route creation with open validity end

### DIFF
--- a/ui/src/components/map/routes/DrawRouteLayer.tsx
+++ b/ui/src/components/map/routes/DrawRouteLayer.tsx
@@ -159,9 +159,9 @@ const DrawRouteLayerComponent = (
       // (when editing, fetch it from graphql; when creating, filled in through form)
       if (
         !editedRouteData.metaData ||
-        !editedRouteData.metaData.validityStart ||
-        !editedRouteData.metaData.validityEnd ||
-        !editedRouteData.metaData.priority
+        editedRouteData.metaData.validityStart === undefined ||
+        editedRouteData.metaData.validityEnd === undefined ||
+        editedRouteData.metaData.priority === undefined
       ) {
         log.error(
           'Trying to update route geometry but route metadata is not (yet) available',


### PR DESCRIPTION
When setting the validity end for a route to "open end", it is set to 'null'. This was accidentally caught by a check, which was supposed to verify that the route data was set at all, because it tested for falsiness instead of 'undefined'.

This commit fixes the check to explicitly test for '=== undefined'.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/393)
<!-- Reviewable:end -->
