### PR TITLE
Timetables table row styling improvements

### DIFF
--- a/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
@@ -41,6 +41,16 @@ export const VehicleServiceTable = ({
     return bgColors[key];
   };
 
+  const getOddRowColor = (key: TimetablePriority) => {
+    const bgColors: Record<TimetablePriority, string> = {
+      [TimetablePriority.Standard]: 'bg-hsl-neutral-blue',
+      [TimetablePriority.Temporary]: 'bg-hsl-neutral-blue',
+      [TimetablePriority.Special]: 'bg-hsl-neutral-blue',
+      [TimetablePriority.Draft]: 'bg-background',
+    };
+    return bgColors[key];
+  };
+
   const passingTimesByHour = pipe(
     vehicleServices,
     (services) => services.flatMap((item) => item.blocks),
@@ -81,10 +91,14 @@ export const VehicleServiceTable = ({
       </Row>
 
       <Visible visible={hasVehicleServices}>
-        <table data-testid={testIds.timetable}>
-          <tbody>
+        <table data-testid={testIds.timetable} className="flex">
+          <tbody className=" w-full">
             {rowData.map((item) => (
-              <VehicleServiceTableRow key={item.hours} data={item} />
+              <VehicleServiceTableRow
+                key={item.hours}
+                data={item}
+                oddRowColor={getOddRowColor(priority)}
+              />
             ))}
           </tbody>
         </table>

--- a/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTableRow.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTableRow.tsx
@@ -1,22 +1,26 @@
 import { padToTwoDigits } from '../../../../time';
 
-interface Props {
-  data: VehicleServiceRowData;
-}
-
 export interface VehicleServiceRowData {
   hours: number;
   minutes: number[];
 }
 
-export const VehicleServiceTableRow = ({ data }: Props): JSX.Element => {
+interface Props {
+  data: VehicleServiceRowData;
+  oddRowColor: string;
+}
+
+export const VehicleServiceTableRow = ({
+  data,
+  oddRowColor = '',
+}: Props): JSX.Element => {
   const { hours, minutes } = data;
   return (
-    <tr className="odd:bg-hsl-neutral-blue">
-      <td className="border-r border-dark-grey px-4">
+    <tr className={`flex items-stretch odd:${oddRowColor}`}>
+      <td className="px-4">
         <h4>{padToTwoDigits(hours)}</h4>
       </td>
-      <td className="w-full space-x-3 pl-3 text-sm">
+      <td className="flex flex-wrap content-center gap-x-3 border-l border-dark-grey pl-3 text-sm">
         {minutes.map((item) => (
           <span key={item}>{padToTwoDigits(item)}</span>
         ))}


### PR DESCRIPTION
- fix item alignments when there more items than can be fit on one row
- add special zebra stripe color for drafts

Related to HSLdevcom/jore4#950

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/394)
<!-- Reviewable:end -->
