### PR TITLE
Add timetables search

### DIFF
--- a/ui/src/components/common/search/ResultList.tsx
+++ b/ui/src/components/common/search/ResultList.tsx
@@ -1,6 +1,6 @@
 import {
   LineTableRowFragment,
-  RouteAllFieldsFragment,
+  RouteTableRowFragment,
 } from '../../../generated/graphql';
 import { useAppSelector } from '../../../hooks';
 import { selectExport } from '../../../redux';
@@ -11,8 +11,8 @@ import { RoutesList } from './RoutesList';
 
 interface Props {
   lines?: LineTableRowFragment[];
-  routes?: RouteAllFieldsFragment[];
   basePath: Path;
+  routes?: RouteTableRowFragment[];
   displayedData: DisplayedSearchResultType;
 }
 

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesMainPage.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesMainPage.tsx
@@ -8,7 +8,7 @@ import { Container, Row } from '../../../layoutComponents';
 import { FilterType, resetMapState } from '../../../redux';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { SimpleButton } from '../../../uiComponents';
-import { SearchContainer } from '../search/SearchContainer';
+import { RoutesAndLinesSearchContainer } from '../search/RoutesAndLinesSearchContainer';
 import { RoutesAndLinesLists } from './RoutesAndLinesLists';
 
 const testIds = {
@@ -49,7 +49,7 @@ export const RoutesAndLinesMainPage = (): JSX.Element => {
           {t('lines.createNew')}
         </SimpleButton>
       </Row>
-      <SearchContainer />
+      <RoutesAndLinesSearchContainer />
       <RoutesAndLinesLists />
     </Container>
   );

--- a/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
+++ b/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
@@ -5,7 +5,7 @@ import { pipe } from 'remeda';
 import {
   useAppDispatch,
   useAppSelector,
-  useSearchResults,
+  useRoutesAndLinesSearchResults,
 } from '../../../hooks';
 import { Row, Visible } from '../../../layoutComponents';
 import {
@@ -21,7 +21,8 @@ export const ExportToolbar = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
-  const { resultCount, resultType, routes, lines } = useSearchResults();
+  const { resultCount, resultType, routes, lines } =
+    useRoutesAndLinesSearchResults();
   const { isSelectingRoutesForExport, selectedRouteLabels } =
     useAppSelector(selectExport);
 

--- a/ui/src/components/routes-and-lines/search/RoutesAndLinesSearchContainer.tsx
+++ b/ui/src/components/routes-and-lines/search/RoutesAndLinesSearchContainer.tsx
@@ -12,7 +12,7 @@ import { LineTypeDropdown } from '../../forms/line/LineTypeDropdown';
 import { VehicleModeDropdown } from '../../forms/line/VehicleModeDropdown';
 import { PriorityCondition } from './conditions/PriorityCondition';
 
-export const SearchContainer = (): JSX.Element => {
+export const RoutesAndLinesSearchContainer = (): JSX.Element => {
   const { searchConditions, setSearchCondition, handleSearch } = useSearch({
     basePath: Path.routes,
   });

--- a/ui/src/components/routes-and-lines/search/RoutesAndLinesSearchResultPage.tsx
+++ b/ui/src/components/routes-and-lines/search/RoutesAndLinesSearchResultPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useSearch, useSearchResults } from '../../../hooks';
+import { useRoutesAndLinesSearchResults, useSearch } from '../../../hooks';
 import { usePagination } from '../../../hooks/usePagination';
 import { Container, Row, Visible } from '../../../layoutComponents';
 import { Path } from '../../../router/routeDetails';
@@ -7,16 +7,16 @@ import { CloseIconButton, Pagination } from '../../../uiComponents';
 import { ResultList } from '../../common/search/ResultList';
 import { ExportToolbar } from './ExportToolbar';
 import { FiltersContainer } from './filters/FiltersContainer';
-import { SearchContainer } from './SearchContainer';
+import { RoutesAndLinesSearchContainer } from './RoutesAndLinesSearchContainer';
 
-export const SearchResultPage = (): JSX.Element => {
+export const RoutesAndLinesSearchResultPage = (): JSX.Element => {
   const { handleClose, queryParameters } = useSearch({
     basePath: Path.routes,
   });
-  const { resultCount } = useSearchResults();
+  const { resultCount } = useRoutesAndLinesSearchResults();
   const { t } = useTranslation();
   const { getPaginatedData } = usePagination();
-  const { lines, routes } = useSearchResults();
+  const { lines, routes } = useRoutesAndLinesSearchResults();
   const itemsPerPage = 10;
 
   const displayedLines = getPaginatedData(lines, itemsPerPage);
@@ -36,7 +36,7 @@ export const SearchResultPage = (): JSX.Element => {
           onClick={handleClose}
         />
       </Row>
-      <SearchContainer />
+      <RoutesAndLinesSearchContainer />
       <FiltersContainer />
       <ExportToolbar />
       <ResultList

--- a/ui/src/components/timetables/index.ts
+++ b/ui/src/components/timetables/index.ts
@@ -1,2 +1,3 @@
 export * from './main';
+export * from './search';
 export * from './vehicle-schedule-details';

--- a/ui/src/components/timetables/main/TimetablesMainPage.tsx
+++ b/ui/src/components/timetables/main/TimetablesMainPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Container } from '../../../layoutComponents';
-import { SimpleButton } from '../../../uiComponents';
+import { TimetablesSearchContainer } from '../search';
 
 export const TimetablesMainPage = (): JSX.Element => {
   const { t } = useTranslation();
@@ -8,10 +8,7 @@ export const TimetablesMainPage = (): JSX.Element => {
   return (
     <Container>
       <h1>{t('timetables.timetables')}</h1>
-      <p>Placeholder page. Nothing to see here... yet.</p>
-      <SimpleButton containerClassName="mt-4" href="/lines/example/timetables">
-        Example timetable
-      </SimpleButton>
+      <TimetablesSearchContainer />
     </Container>
   );
 };

--- a/ui/src/components/timetables/search/TimetablesSearchContainer.tsx
+++ b/ui/src/components/timetables/search/TimetablesSearchContainer.tsx
@@ -1,0 +1,62 @@
+import { useTranslation } from 'react-i18next';
+import { SearchQueryParameterNames, useSearch } from '../../../hooks';
+import { useToggle } from '../../../hooks/useToggle';
+import { Column, Container, Row, Visible } from '../../../layoutComponents';
+import { Path } from '../../../router/routeDetails';
+import { ChevronToggle, SimpleButton } from '../../../uiComponents';
+import { SearchInput } from '../../common/search/SearchInput';
+
+export const TimetablesSearchContainer = (): JSX.Element => {
+  const { searchConditions, setSearchCondition, handleSearch } = useSearch({
+    basePath: Path.timetables,
+  });
+  const { t } = useTranslation();
+
+  const [isExpanded, toggleIsExpanded] = useToggle();
+  const testIds = {
+    searchInput: 'SearchContainer::SearchInput',
+  };
+
+  const onChangeLabel = (value: string) => {
+    setSearchCondition(SearchQueryParameterNames.Label, value);
+  };
+
+  return (
+    <Container className="py-10">
+      <Row className="justify-center bg-background py-4">
+        <Column className="w-2/4">
+          <Row>
+            <label htmlFor="label">{t('search.searchLabel')}</label>
+          </Row>
+          <Row className="space-x-4">
+            <SearchInput
+              testId={testIds.searchInput}
+              value={searchConditions.label}
+              onSearch={handleSearch}
+              onChange={onChangeLabel}
+            />
+            <ChevronToggle isToggled={isExpanded} onClick={toggleIsExpanded} />
+          </Row>
+        </Column>
+      </Row>
+      <Visible visible={isExpanded}>
+        <div className="space-y-5 border-2 border-background p-10">
+          <h2>{t('search.advancedSearchTitle')}</h2>
+          Nothing here yet..
+        </div>
+        <Row className="flex justify-end bg-background py-4">
+          <SimpleButton
+            containerClassName="mr-6"
+            inverted
+            onClick={toggleIsExpanded}
+          >
+            {t('hide')}
+          </SimpleButton>
+          <SimpleButton containerClassName="mr-6" onClick={handleSearch}>
+            {t('search.search')}
+          </SimpleButton>
+        </Row>
+      </Visible>
+    </Container>
+  );
+};

--- a/ui/src/components/timetables/search/TimetablesSearchResultPage.tsx
+++ b/ui/src/components/timetables/search/TimetablesSearchResultPage.tsx
@@ -1,0 +1,61 @@
+import { useTranslation } from 'react-i18next';
+import { useSearch } from '../../../hooks';
+import { useTimetablesSearchResults } from '../../../hooks/search/useTimetablesSearchResults';
+import { usePagination } from '../../../hooks/usePagination';
+import { Container, Row, Visible } from '../../../layoutComponents';
+import { Path } from '../../../router/routeDetails';
+import { CloseIconButton, Pagination } from '../../../uiComponents';
+import { ResultList } from '../../common/search/ResultList';
+import { ResultSelector } from '../../common/search/ResultSelector';
+import { TimetablesSearchContainer } from './TimetablesSearchContainer';
+
+export const TimetablesSearchResultPage = (): JSX.Element => {
+  const { handleClose, queryParameters } = useSearch({
+    basePath: Path.timetables,
+  });
+  const { routes, lines, resultCount } = useTimetablesSearchResults();
+  const { t } = useTranslation();
+  const { getPaginatedData } = usePagination();
+  const itemsPerPage = 10;
+
+  // const displayedLines = getPaginatedData(lines, itemsPerPage);
+  const displayedRoutes = getPaginatedData(routes, itemsPerPage);
+
+  const testIds = {
+    container: 'SearchResultsPage::Container',
+  };
+
+  return (
+    <Container testId={testIds.container}>
+      <Row>
+        <h2>{`${t('search.searchResultsTitle')} | ${t(
+          'timetables.timetables',
+        )}`}</h2>
+        <CloseIconButton
+          label={t('close')}
+          className="ml-auto text-base font-bold text-brand"
+          onClick={handleClose}
+        />
+      </Row>
+      <TimetablesSearchContainer />
+      <Row className="my-4">
+        <ResultSelector basePath={Path.timetables} />
+      </Row>
+      <ResultList
+        routes={displayedRoutes}
+        lines={lines}
+        basePath={Path.lineTimetables}
+        displayedData={queryParameters.filter.displayedData}
+      />
+      <Visible visible={!!resultCount}>
+        <div className="grid grid-cols-4">
+          <Pagination
+            className="col-span-2 col-start-2 pt-4"
+            itemsPerPage={itemsPerPage}
+            totalItemsCount={resultCount}
+          />
+        </div>
+      </Visible>
+    </Container>
+  );
+};

--- a/ui/src/components/timetables/search/TimetablesSearchResultPage.tsx
+++ b/ui/src/components/timetables/search/TimetablesSearchResultPage.tsx
@@ -41,6 +41,11 @@ export const TimetablesSearchResultPage = (): JSX.Element => {
       <Row className="my-4">
         <ResultSelector basePath={Path.timetables} />
       </Row>
+      <h2 className="my-4 ml-2">
+        {t('search.resultCount', {
+          resultCount,
+        })}
+      </h2>
       <ResultList
         routes={displayedRoutes}
         lines={lines}

--- a/ui/src/components/timetables/search/index.ts
+++ b/ui/src/components/timetables/search/index.ts
@@ -1,0 +1,2 @@
+export * from './TimetablesSearchContainer';
+export * from './TimetablesSearchResultPage';

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -13639,6 +13639,118 @@ export type SearchLinesAndRoutesQuery = {
   }>;
 };
 
+export type TimetablesLineListInformationFragment = {
+  __typename?: 'route_line';
+  line_id: UUID;
+  label: string;
+  name_i18n: LocalizedString;
+  priority: number;
+  short_name_i18n: LocalizedString;
+  line_routes: Array<{
+    __typename?: 'route_route';
+    route_id: UUID;
+    label: string;
+    route_shape?: GeoJSON.LineString | null | undefined;
+  }>;
+};
+
+export type TimetablesRouteListInformationFragment = {
+  __typename?: 'route_route';
+  route_id: UUID;
+  name_i18n: LocalizedString;
+  label: string;
+  direction: RouteDirectionEnum;
+  validity_start?: luxon.DateTime | null | undefined;
+  validity_end?: luxon.DateTime | null | undefined;
+  on_line_id: UUID;
+  priority: number;
+  route_shape?: GeoJSON.LineString | null | undefined;
+  route_line: {
+    __typename?: 'route_line';
+    line_id: UUID;
+    label: string;
+    name_i18n: LocalizedString;
+    priority: number;
+    short_name_i18n: LocalizedString;
+    line_routes: Array<{
+      __typename?: 'route_route';
+      route_id: UUID;
+      label: string;
+      route_shape?: GeoJSON.LineString | null | undefined;
+    }>;
+  };
+};
+
+export type SearchJourneyPatternIdsQueryVariables = Exact<{
+  filter?: Maybe<JourneyPatternJourneyPatternBoolExp>;
+}>;
+
+export type SearchJourneyPatternIdsQuery = {
+  __typename?: 'query_root';
+  journey_pattern_journey_pattern: Array<{
+    __typename?: 'journey_pattern_journey_pattern';
+    journey_pattern_id: UUID;
+  }>;
+};
+
+export type SearchTimetablesByJourneyPatternIdsQueryVariables = Exact<{
+  journeyPatternIds?: Maybe<Array<Scalars['uuid']> | Scalars['uuid']>;
+}>;
+
+export type SearchTimetablesByJourneyPatternIdsQuery = {
+  __typename?: 'query_root';
+  timetables?:
+    | {
+        __typename?: 'timetables_timetables_query';
+        timetables_vehicle_journey_vehicle_journey: Array<{
+          __typename?: 'timetables_vehicle_journey_vehicle_journey';
+          vehicle_journey_id: UUID;
+          journey_pattern_ref: {
+            __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+            journey_pattern_ref_id: UUID;
+            journey_pattern_instance?:
+              | {
+                  __typename?: 'journey_pattern_journey_pattern';
+                  journey_pattern_id: UUID;
+                  journey_pattern_route?:
+                    | {
+                        __typename?: 'route_route';
+                        route_id: UUID;
+                        name_i18n: LocalizedString;
+                        label: string;
+                        direction: RouteDirectionEnum;
+                        validity_start?: luxon.DateTime | null | undefined;
+                        validity_end?: luxon.DateTime | null | undefined;
+                        on_line_id: UUID;
+                        priority: number;
+                        route_shape?: GeoJSON.LineString | null | undefined;
+                        route_line: {
+                          __typename?: 'route_line';
+                          line_id: UUID;
+                          label: string;
+                          name_i18n: LocalizedString;
+                          priority: number;
+                          short_name_i18n: LocalizedString;
+                          line_routes: Array<{
+                            __typename?: 'route_route';
+                            route_id: UUID;
+                            label: string;
+                            route_shape?: GeoJSON.LineString | null | undefined;
+                          }>;
+                        };
+                      }
+                    | null
+                    | undefined;
+                }
+              | null
+              | undefined;
+          };
+        }>;
+      }
+    | null
+    | undefined;
+};
+
 export type GetLinesForComboboxQueryVariables = Exact<{
   labelPattern: Scalars['String'];
   date: Scalars['date'];
@@ -14182,6 +14294,37 @@ export const RouteWithInfrastructureLinksWithStopsFragmentDoc = gql`
   ${RouteWithJourneyPatternStopsFragmentDoc}
   ${LineAllFieldsFragmentDoc}
   ${InfraLinkAlongRouteWithStopsFragmentDoc}
+`;
+export const TimetablesLineListInformationFragmentDoc = gql`
+  fragment timetables_line_list_information on route_line {
+    line_id
+    label
+    name_i18n
+    priority
+    short_name_i18n
+    line_routes {
+      route_id
+      label
+      route_shape
+    }
+  }
+`;
+export const TimetablesRouteListInformationFragmentDoc = gql`
+  fragment timetables_route_list_information on route_route {
+    route_id
+    name_i18n
+    label
+    direction
+    validity_start
+    validity_end
+    on_line_id
+    priority
+    route_shape
+    route_line {
+      ...timetables_line_list_information
+    }
+  }
+  ${TimetablesLineListInformationFragmentDoc}
 `;
 export const LineForComboboxFragmentDoc = gql`
   fragment line_for_combobox on route_line {
@@ -17121,6 +17264,142 @@ export type SearchLinesAndRoutesQueryResult = Apollo.QueryResult<
   SearchLinesAndRoutesQuery,
   SearchLinesAndRoutesQueryVariables
 >;
+export const SearchJourneyPatternIdsDocument = gql`
+  query SearchJourneyPatternIds(
+    $filter: journey_pattern_journey_pattern_bool_exp
+  ) {
+    journey_pattern_journey_pattern(where: $filter) {
+      journey_pattern_id
+    }
+  }
+`;
+
+/**
+ * __useSearchJourneyPatternIdsQuery__
+ *
+ * To run a query within a React component, call `useSearchJourneyPatternIdsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSearchJourneyPatternIdsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSearchJourneyPatternIdsQuery({
+ *   variables: {
+ *      filter: // value for 'filter'
+ *   },
+ * });
+ */
+export function useSearchJourneyPatternIdsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    SearchJourneyPatternIdsQuery,
+    SearchJourneyPatternIdsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SearchJourneyPatternIdsQuery,
+    SearchJourneyPatternIdsQueryVariables
+  >(SearchJourneyPatternIdsDocument, options);
+}
+export function useSearchJourneyPatternIdsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SearchJourneyPatternIdsQuery,
+    SearchJourneyPatternIdsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SearchJourneyPatternIdsQuery,
+    SearchJourneyPatternIdsQueryVariables
+  >(SearchJourneyPatternIdsDocument, options);
+}
+export type SearchJourneyPatternIdsQueryHookResult = ReturnType<
+  typeof useSearchJourneyPatternIdsQuery
+>;
+export type SearchJourneyPatternIdsLazyQueryHookResult = ReturnType<
+  typeof useSearchJourneyPatternIdsLazyQuery
+>;
+export type SearchJourneyPatternIdsQueryResult = Apollo.QueryResult<
+  SearchJourneyPatternIdsQuery,
+  SearchJourneyPatternIdsQueryVariables
+>;
+export const SearchTimetablesByJourneyPatternIdsDocument = gql`
+  query SearchTimetablesByJourneyPatternIds($journeyPatternIds: [uuid!]) {
+    timetables {
+      timetables_vehicle_journey_vehicle_journey(
+        where: {
+          journey_pattern_ref: {
+            journey_pattern_id: { _in: $journeyPatternIds }
+          }
+        }
+      ) {
+        vehicle_journey_id
+        journey_pattern_ref {
+          journey_pattern_ref_id
+          journey_pattern_instance {
+            journey_pattern_id
+            journey_pattern_route {
+              ...timetables_route_list_information
+            }
+          }
+        }
+      }
+    }
+  }
+  ${TimetablesRouteListInformationFragmentDoc}
+`;
+
+/**
+ * __useSearchTimetablesByJourneyPatternIdsQuery__
+ *
+ * To run a query within a React component, call `useSearchTimetablesByJourneyPatternIdsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSearchTimetablesByJourneyPatternIdsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSearchTimetablesByJourneyPatternIdsQuery({
+ *   variables: {
+ *      journeyPatternIds: // value for 'journeyPatternIds'
+ *   },
+ * });
+ */
+export function useSearchTimetablesByJourneyPatternIdsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    SearchTimetablesByJourneyPatternIdsQuery,
+    SearchTimetablesByJourneyPatternIdsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    SearchTimetablesByJourneyPatternIdsQuery,
+    SearchTimetablesByJourneyPatternIdsQueryVariables
+  >(SearchTimetablesByJourneyPatternIdsDocument, options);
+}
+export function useSearchTimetablesByJourneyPatternIdsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    SearchTimetablesByJourneyPatternIdsQuery,
+    SearchTimetablesByJourneyPatternIdsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    SearchTimetablesByJourneyPatternIdsQuery,
+    SearchTimetablesByJourneyPatternIdsQueryVariables
+  >(SearchTimetablesByJourneyPatternIdsDocument, options);
+}
+export type SearchTimetablesByJourneyPatternIdsQueryHookResult = ReturnType<
+  typeof useSearchTimetablesByJourneyPatternIdsQuery
+>;
+export type SearchTimetablesByJourneyPatternIdsLazyQueryHookResult = ReturnType<
+  typeof useSearchTimetablesByJourneyPatternIdsLazyQuery
+>;
+export type SearchTimetablesByJourneyPatternIdsQueryResult = Apollo.QueryResult<
+  SearchTimetablesByJourneyPatternIdsQuery,
+  SearchTimetablesByJourneyPatternIdsQueryVariables
+>;
 export const GetLinesForComboboxDocument = gql`
   query GetLinesForCombobox($labelPattern: String!, $date: date!) {
     route_line(
@@ -17750,6 +18029,23 @@ export function useSearchLinesAndRoutesAsyncQuery() {
 export type SearchLinesAndRoutesAsyncQueryHookResult = ReturnType<
   typeof useSearchLinesAndRoutesAsyncQuery
 >;
+export function useSearchJourneyPatternIdsAsyncQuery() {
+  return useAsyncQuery<
+    SearchJourneyPatternIdsQuery,
+    SearchJourneyPatternIdsQueryVariables
+  >(SearchJourneyPatternIdsDocument);
+}
+export type SearchJourneyPatternIdsAsyncQueryHookResult = ReturnType<
+  typeof useSearchJourneyPatternIdsAsyncQuery
+>;
+export function useSearchTimetablesByJourneyPatternIdsAsyncQuery() {
+  return useAsyncQuery<
+    SearchTimetablesByJourneyPatternIdsQuery,
+    SearchTimetablesByJourneyPatternIdsQueryVariables
+  >(SearchTimetablesByJourneyPatternIdsDocument);
+}
+export type SearchTimetablesByJourneyPatternIdsAsyncQueryHookResult =
+  ReturnType<typeof useSearchTimetablesByJourneyPatternIdsAsyncQuery>;
 export function useGetLinesForComboboxAsyncQuery() {
   return useAsyncQuery<
     GetLinesForComboboxQuery,

--- a/ui/src/hooks/search/index.ts
+++ b/ui/src/hooks/search/index.ts
@@ -1,3 +1,3 @@
+export * from './useRoutesAndLinesSearchQueryParser';
+export * from './useRoutesAndLinesSearchResults';
 export * from './useSearch';
-export * from './useSearchQueryParser';
-export * from './useSearchResults';

--- a/ui/src/hooks/search/useRoutesAndLinesSearchQueryParser.ts
+++ b/ui/src/hooks/search/useRoutesAndLinesSearchQueryParser.ts
@@ -7,7 +7,7 @@ import { Priority } from '../../types/Priority';
 import { AllOptionEnum, DisplayedSearchResultType } from '../../utils/enum';
 import { useUrlQuery } from '../urlQuery/useUrlQuery';
 
-export type SearchConditions = {
+export type RoutesAndLinesSearchConditions = {
   priorities: Priority[];
   label: string;
   primaryVehicleMode?: ReusableComponentsVehicleModeEnum | AllOptionEnum;
@@ -24,7 +24,7 @@ export type FilterConditions = {
  * conditions separately
  */
 export type SearchParameters = {
-  search: SearchConditions;
+  search: RoutesAndLinesSearchConditions;
   filter: FilterConditions;
 };
 
@@ -67,7 +67,7 @@ const DEFAULT_DISPLAYED_DATA = DisplayedSearchResultType.Lines;
 const DEFAULT_LABEL = '';
 const DEFAULT_OBSERVATION_DATE = DateTime.now().startOf('day');
 
-export const useSearchQueryParser = () => {
+export const useRoutesAndLinesSearchQueryParser = () => {
   const {
     getStringParamFromUrlQuery,
     getPriorityArrayFromUrlQuery,

--- a/ui/src/hooks/search/useRoutesAndLinesSearchResults.ts
+++ b/ui/src/hooks/search/useRoutesAndLinesSearchResults.ts
@@ -9,7 +9,7 @@ import {
   DisplayedSearchResultType,
   mapToVariables,
 } from '../../utils';
-import { useSearchQueryParser } from './useSearchQueryParser';
+import { useRoutesAndLinesSearchQueryParser } from './useRoutesAndLinesSearchQueryParser';
 
 const GQL_SEARCH_LINES_AND_ROUTES = gql`
   query SearchLinesAndRoutes(
@@ -27,13 +27,13 @@ const GQL_SEARCH_LINES_AND_ROUTES = gql`
   }
 `;
 
-export const useSearchResults = (): {
+export const useRoutesAndLinesSearchResults = (): {
   lines: LineTableRowFragment[];
   routes: RouteAllFieldsFragment[];
   resultCount: number;
   resultType: DisplayedSearchResultType;
 } => {
-  const parsedSearchQueryParameters = useSearchQueryParser();
+  const parsedSearchQueryParameters = useRoutesAndLinesSearchQueryParser();
 
   const searchQueryVariables = buildSearchLinesAndRoutesGqlQueryVariables(
     parsedSearchQueryParameters.search,

--- a/ui/src/hooks/search/useSearch.ts
+++ b/ui/src/hooks/search/useSearch.ts
@@ -7,8 +7,8 @@ import { QueryParameter, QueryParameterTypes, useUrlQuery } from '../urlQuery';
 import {
   DeserializedQueryStringParameters,
   FilterConditions,
-  useSearchQueryParser,
-} from './useSearchQueryParser';
+  useRoutesAndLinesSearchQueryParser,
+} from './useRoutesAndLinesSearchQueryParser';
 
 /**
  * Common search hook. Takes basePath as parameter, which will be used when
@@ -18,7 +18,7 @@ import {
  * '/routes-and-lines'
  */
 export const useSearch = ({ basePath }: { basePath: string }) => {
-  const queryParameters = useSearchQueryParser();
+  const queryParameters = useRoutesAndLinesSearchQueryParser();
   const { setMultipleParametersToUrlQuery } = useUrlQuery();
 
   const [searchConditions, setSearchConditions] = useState(

--- a/ui/src/hooks/search/useTimetablesSearchQueryParser.ts
+++ b/ui/src/hooks/search/useTimetablesSearchQueryParser.ts
@@ -1,0 +1,69 @@
+import { DisplayedSearchResultType } from '../../utils/enum';
+import { useUrlQuery } from '../urlQuery/useUrlQuery';
+
+export type TimetablesSearchConditions = {
+  label: string;
+};
+
+export type TimetablesFilterConditions = {
+  displayedData: DisplayedSearchResultType;
+};
+
+/**
+ * Search parameter object with search conditions and filter
+ * conditions separately
+ */
+export type TimetablesSearchParameters = {
+  search: TimetablesSearchConditions;
+  filter: TimetablesFilterConditions;
+};
+
+/**
+ * Query string object where parameters are in string format
+ */
+export type TimetablesQueryStringParameters = {
+  label: string;
+  displayedData: string;
+};
+
+/**
+ * Query string object where parameters are deserialized and validated
+ * in their correct format
+ */
+export type TimetablesDeserializedQueryStringParameters = {
+  label: string;
+  displayedData: DisplayedSearchResultType;
+};
+
+export enum SearchQueryParameterNames {
+  Label = 'label',
+  DisplayedData = 'displayedData',
+}
+
+const DEFAULT_DISPLAYED_DATA = DisplayedSearchResultType.Lines;
+const DEFAULT_LABEL = '';
+
+export const useTimetablesSearchQueryParser =
+  (): TimetablesSearchParameters => {
+    const {
+      getStringParamFromUrlQuery,
+      getDisplayedSearchResultTypeFromUrlQuery,
+    } = useUrlQuery();
+    const label =
+      getStringParamFromUrlQuery(SearchQueryParameterNames.Label) ??
+      DEFAULT_LABEL;
+
+    const displayedData =
+      getDisplayedSearchResultTypeFromUrlQuery(
+        SearchQueryParameterNames.DisplayedData,
+      ) ?? DEFAULT_DISPLAYED_DATA;
+
+    return {
+      search: {
+        label,
+      },
+      filter: {
+        displayedData,
+      },
+    };
+  };

--- a/ui/src/hooks/search/useTimetablesSearchResults.ts
+++ b/ui/src/hooks/search/useTimetablesSearchResults.ts
@@ -1,0 +1,177 @@
+import { gql } from '@apollo/client';
+import { uniqBy } from 'lodash';
+import {
+  TimetablesLineListInformationFragment,
+  TimetablesRouteListInformationFragment,
+  useSearchJourneyPatternIdsQuery,
+  useSearchTimetablesByJourneyPatternIdsQuery,
+} from '../../generated/graphql';
+import {
+  buildSearchTimetablesByJourneyPatternIdsQueryVariables,
+  DisplayedSearchResultType,
+  mapToVariables,
+} from '../../utils';
+import { useTimetablesSearchQueryParser } from './useTimetablesSearchQueryParser';
+
+const GQL_TIMETABLES_LINE_LIST_INFORMATION_FRAGMENT = gql`
+  fragment timetables_line_list_information on route_line {
+    line_id
+    label
+    name_i18n
+    priority
+    short_name_i18n
+    line_routes {
+      route_id
+      label
+      route_shape
+    }
+  }
+`;
+
+const GQL_TIMETABLES_ROUTE_LIST_INFORMATION_FRAGMENT = gql`
+  fragment timetables_route_list_information on route_route {
+    route_id
+    name_i18n
+    label
+    direction
+    validity_start
+    validity_end
+    on_line_id
+    priority
+    route_shape
+    route_line {
+      ...timetables_line_list_information
+    }
+  }
+`;
+
+const GQL_SEARCH_JOURNEY_PATTERN_IDS = gql`
+  query SearchJourneyPatternIds(
+    $filter: journey_pattern_journey_pattern_bool_exp
+  ) {
+    journey_pattern_journey_pattern(where: $filter) {
+      journey_pattern_id
+    }
+  }
+`;
+
+const GQL_SEARCH_TIMETABLES_BY_JOURNEY_PATTERN_IDS = gql`
+  query SearchTimetablesByJourneyPatternIds($journeyPatternIds: [uuid!]) {
+    timetables {
+      timetables_vehicle_journey_vehicle_journey(
+        where: {
+          journey_pattern_ref: {
+            journey_pattern_id: { _in: $journeyPatternIds }
+          }
+        }
+      ) {
+        vehicle_journey_id
+        journey_pattern_ref {
+          journey_pattern_ref_id
+          journey_pattern_instance {
+            journey_pattern_id
+            journey_pattern_route {
+              ...timetables_route_list_information
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const useTimetablesSearchResults = (): {
+  lines: TimetablesLineListInformationFragment[];
+  routes: TimetablesRouteListInformationFragment[];
+  resultCount: number;
+  // resultType: DisplayedSearchResultType;
+} => {
+  const parsedSearchQueryParameters = useTimetablesSearchQueryParser();
+
+  // We need to keep the queries and their results separate, so that
+  // the routes and lines result sets corresponds to search criteria
+  // NOTE: When implementing search criteria that are related to attributes in
+  // routes-and-lines database, apply those filters in this query
+  const routesSearchQueryVariables =
+    buildSearchTimetablesByJourneyPatternIdsQueryVariables(
+      parsedSearchQueryParameters.search,
+      true,
+    );
+  const linesSearchQueryVariables =
+    buildSearchTimetablesByJourneyPatternIdsQueryVariables(
+      parsedSearchQueryParameters.search,
+      false,
+    );
+
+  // Fetch all journey pattern ids that corresponds to search criteria
+  const routesJourneyPatternIdsResult = useSearchJourneyPatternIdsQuery(
+    mapToVariables(routesSearchQueryVariables),
+  );
+  const linesJourneyPatternIdsResult = useSearchJourneyPatternIdsQuery(
+    mapToVariables(linesSearchQueryVariables),
+  );
+
+  const routesJourneyPatternIds =
+    routesJourneyPatternIdsResult.data?.journey_pattern_journey_pattern.map(
+      (jp) => jp.journey_pattern_id,
+    ) || [];
+  const linesJourneyPatternIds =
+    linesJourneyPatternIdsResult.data?.journey_pattern_journey_pattern.map(
+      (jp) => jp.journey_pattern_id,
+    ) || [];
+
+  // Fetch timetables that exists for the given journeyPatternIs
+  // NOTE: When implementing search criteria that are related to attributes in
+  // timetables database, apply those filters in this query
+  const routesResult = useSearchTimetablesByJourneyPatternIdsQuery(
+    mapToVariables({ journeyPatternIds: routesJourneyPatternIds }),
+  );
+  const linesResult = useSearchTimetablesByJourneyPatternIdsQuery(
+    mapToVariables({ journeyPatternIds: linesJourneyPatternIds }),
+  );
+
+  // Map the route information from the result set
+  const routesByVehicleJourneys =
+    routesResult.data?.timetables?.timetables_vehicle_journey_vehicle_journey.map(
+      (journey) =>
+        journey.journey_pattern_ref.journey_pattern_instance
+          ?.journey_pattern_route as TimetablesRouteListInformationFragment,
+    );
+
+  // Map line information from the result set
+  const linesByVehicleJourneys =
+    linesResult.data?.timetables?.timetables_vehicle_journey_vehicle_journey.map(
+      (journey) =>
+        journey.journey_pattern_ref.journey_pattern_instance
+          ?.journey_pattern_route
+          ?.route_line as TimetablesLineListInformationFragment,
+    );
+
+  // Remove duplicate entries, because we only need one entry per route / line.
+  const distinctRoutes = uniqBy(
+    routesByVehicleJourneys,
+    (route) => route.route_id,
+  );
+  const distinctLines = uniqBy(linesByVehicleJourneys, (line) => line.line_id);
+
+  const getResultCount = () => {
+    switch (parsedSearchQueryParameters.filter.displayedData) {
+      case DisplayedSearchResultType.Lines:
+        return distinctLines.length;
+      case DisplayedSearchResultType.Routes:
+        return distinctRoutes?.length;
+      default:
+        // eslint-disable-next-line no-console
+        console.error(
+          `Error: ${parsedSearchQueryParameters.filter.displayedData} does not exist.`,
+        );
+        return 0;
+    }
+  };
+
+  return {
+    routes: distinctRoutes,
+    lines: distinctLines,
+    resultCount: getResultCount(),
+  };
+};

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -9,7 +9,7 @@ import { EditRoutePage } from '../components/routes-and-lines/edit-route/EditRou
 import { LineDetailsPage } from '../components/routes-and-lines/line-details/LineDetailsPage';
 import { LineDraftsPage } from '../components/routes-and-lines/line-drafts/LineDraftsPage';
 import { RoutesAndLinesMainPage } from '../components/routes-and-lines/main/RoutesAndLinesMainPage';
-import { SearchResultPage } from '../components/routes-and-lines/search/SearchResultPage';
+import { RoutesAndLinesSearchResultPage } from '../components/routes-and-lines/search/RoutesAndLinesSearchResultPage';
 import {
   TimetablesMainPage,
   TimetablesSearchResultPage,
@@ -48,7 +48,7 @@ export const Router: FunctionComponent = () => {
     [Path.routesSearch]: {
       _routerRoute: Path.routesSearch,
       _exact: true,
-      component: SearchResultPage,
+      component: RoutesAndLinesSearchResultPage,
     },
     [Path.timetablesSearch]: {
       _routerRoute: Path.timetablesSearch,

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -12,6 +12,7 @@ import { RoutesAndLinesMainPage } from '../components/routes-and-lines/main/Rout
 import { SearchResultPage } from '../components/routes-and-lines/search/SearchResultPage';
 import {
   TimetablesMainPage,
+  TimetablesSearchResultPage,
   VehicleScheduleDetailsPage,
 } from '../components/timetables';
 import { Main } from '../pages/Main';
@@ -48,6 +49,11 @@ export const Router: FunctionComponent = () => {
       _routerRoute: Path.routesSearch,
       _exact: true,
       component: SearchResultPage,
+    },
+    [Path.timetablesSearch]: {
+      _routerRoute: Path.timetablesSearch,
+      _exact: true,
+      component: TimetablesSearchResultPage,
     },
     [Path.editRoute]: {
       _routerRoute: Path.editRoute,

--- a/ui/src/router/routeDetails.ts
+++ b/ui/src/router/routeDetails.ts
@@ -5,12 +5,13 @@ export enum Path {
   routes = '/routes',
   timetables = '/timetables',
   routesSearch = '/routes/search',
+  timetablesSearch = '/timetables/search',
   editRoute = '/routes/:id/edit',
   createLine = '/lines/create',
   lineDetails = '/lines/:id',
   lineDrafts = '/lines/:label/drafts',
   editLine = '/lines/:id/edit',
-  lineTimetables = '/lines/:id/timetables',
+  lineTimetables = '/timetables/lines/:id',
   fallback = '*',
 }
 
@@ -39,6 +40,11 @@ export const routeDetails: Record<Path, RouteDetail> = {
   [Path.routesSearch]: {
     getLink: () => Path.routesSearch,
     translationKey: 'routes.routesSearchResult',
+    includeInNav: false,
+  },
+  [Path.timetablesSearch]: {
+    getLink: () => Path.timetablesSearch,
+    translationKey: 'routes.timetablesSearchResult',
     includeInNav: false,
   },
   [Path.editRoute]: {

--- a/ui/src/utils/search.ts
+++ b/ui/src/utils/search.ts
@@ -6,9 +6,11 @@ import {
   RouteRouteBoolExp,
   RouteRouteOrderBy,
   RouteTypeOfLineEnum,
+  SearchJourneyPatternIdsQueryVariables,
   SearchLinesAndRoutesQueryVariables,
 } from '../generated/graphql';
 import { SearchConditions } from '../hooks/search/useSearchQueryParser';
+import { TimetablesSearchConditions } from '../hooks/search/useTimetablesSearchQueryParser';
 import { AllOptionEnum } from './enum';
 import {
   buildActiveDateGqlFilter,
@@ -124,5 +126,42 @@ export const buildSearchLinesAndRoutesGqlQueryVariables = (
     routeFilter,
     lineOrderBy,
     routeOrderBy,
+  };
+};
+
+export const buildTimetablesSearchCondtionGqlFilters = (
+  searchConditions: TimetablesSearchConditions,
+  buildRouteFilter: boolean,
+) => {
+  return {
+    journey_pattern_route: {
+      ...(buildRouteFilter
+        ? buildOptionalSearchConditionGqlFilter<string>(
+            mapToSqlLikeValue(searchConditions.label),
+            buildLabelLikeGqlFilter,
+          )
+        : {
+            route_line: {
+              ...buildOptionalSearchConditionGqlFilter<string>(
+                mapToSqlLikeValue(searchConditions.label),
+                buildLabelLikeGqlFilter,
+              ),
+            },
+          }),
+    },
+  };
+};
+
+export const buildSearchTimetablesByJourneyPatternIdsQueryVariables = (
+  searchConditions: TimetablesSearchConditions,
+  buildRouteVariables: boolean,
+): SearchJourneyPatternIdsQueryVariables => {
+  const filter = buildTimetablesSearchCondtionGqlFilters(
+    searchConditions,
+    buildRouteVariables,
+  );
+
+  return {
+    filter,
   };
 };

--- a/ui/src/utils/search.ts
+++ b/ui/src/utils/search.ts
@@ -9,7 +9,7 @@ import {
   SearchJourneyPatternIdsQueryVariables,
   SearchLinesAndRoutesQueryVariables,
 } from '../generated/graphql';
-import { SearchConditions } from '../hooks/search/useSearchQueryParser';
+import { RoutesAndLinesSearchConditions } from '../hooks/search/useRoutesAndLinesSearchQueryParser';
 import { TimetablesSearchConditions } from '../hooks/search/useTimetablesSearchQueryParser';
 import { AllOptionEnum } from './enum';
 import {
@@ -61,14 +61,14 @@ const handleLinePropertyGqlFilters = ({
   };
 };
 
-/** Builds the search condition GQL filters for either route or line and
+/** Builds the Routes and Lines search condition GQL filters for either route or line and
  * buildRouteFilter parameter is used to determine which one.
  */
-const buildSearchConditionGqlFilters = ({
+const buildRoutesAndLinesSearchConditionGqlFilters = ({
   searchConditions,
   buildRouteFilter,
 }: {
-  searchConditions: SearchConditions;
+  searchConditions: RoutesAndLinesSearchConditions;
   buildRouteFilter: boolean;
 }): RouteRouteBoolExp | RouteLineBoolExp => {
   return {
@@ -98,14 +98,14 @@ const buildSearchConditionGqlFilters = ({
 };
 
 export const buildSearchLinesAndRoutesGqlQueryVariables = (
-  searchConditions: SearchConditions,
+  searchConditions: RoutesAndLinesSearchConditions,
 ): SearchLinesAndRoutesQueryVariables => {
-  const lineFilter = buildSearchConditionGqlFilters({
+  const lineFilter = buildRoutesAndLinesSearchConditionGqlFilters({
     searchConditions,
     buildRouteFilter: false,
   });
 
-  const routeFilter = buildSearchConditionGqlFilters({
+  const routeFilter = buildRoutesAndLinesSearchConditionGqlFilters({
     searchConditions,
     buildRouteFilter: true,
   });


### PR DESCRIPTION
Add timetables search
Other:
- Change ResultList routes typing from RouteAllFieldsFragment[] to RouteTableRowFragment[]
- Change path to line timetables details to '/timetables/lines/:id'
- Specify file and variable namings for RoutesAndLines search (separate commit).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/396)
<!-- Reviewable:end -->
