### PR TITLE
Add script for running environment in e2e mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Edit `start-dependencies.sh` script if you want to start only certain subset of 
 For overriding settings defined in base docker-compose file just edit
 `docker/docker-compose.custom.yml` and run `./start-dependencies.sh` again.
 If you wish to persist the data in the database, start dependencies with `./start-dependencies.sh --volume`
+If you wish to start the environment in e2e test mode (i.e. without seed data), start dependencies with `./start-dependencies.sh --e2e`
 Docker containers can be stopped gracefully by running `./stop-dependencies.sh`
 If docker setup seems to be in somehow non-working state, you can remove all containers by running `docker rm --force $(docker ps -aq)` and then start dependencies again.
 

--- a/start-dependencies.sh
+++ b/start-dependencies.sh
@@ -48,7 +48,12 @@ function check_pinned_hasura {
 }
 
 function start_docker_bundle {
-  if [[ "${1:-x}" == "--volume" ]]
+  if [[ "${1:-x}" == "--e2e" ]]
+  then
+    # for e2e tests, no additional changes are made to the compose setup
+    DOCKER_COMPOSE_CMD="docker-compose -f ./docker/docker-compose.yml"
+    echo $DOCKER_COMPOSE_CMD
+  elif [[ "${1:-x}" == "--volume" ]]
   then
     # start the testdb with mounted volume
     DOCKER_COMPOSE_CMD="docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.testdb-volume.yml -f ./docker/docker-compose.custom.yml"
@@ -64,4 +69,4 @@ function start_docker_bundle {
 
 download_docker_bundle
 check_pinned_hasura
-start_docker_bundle
+start_docker_bundle "${1:-x}"


### PR DESCRIPTION
We do not want to have seed data in our environment when developing e2e tests, thus using the default docker-compose bundle

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/403)
<!-- Reviewable:end -->
