### PR TITLE
Add timetables search

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -4,7 +4,7 @@ services:
     # Link to available jore4-hasura images in Docker Hub:
     # https://hub.docker.com/r/hsldevcom/jore4-hasura/tags?page=1&ordering=last_updated
     # The :seed-data tag contains the latest main-build image with seed data.
-    image: 'hsldevcom/jore4-hasura:seed-main--20221108-0c6329f8767ac5697e7ea83135570d66da0b7bbd'
+    image: 'hsldevcom/jore4-hasura:seed-main--20221116-9b166a43f9f14535b126f1e10cf1ff26051719e3'
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -1431,6 +1431,8 @@ export type JourneyPatternJourneyPattern = {
   __typename?: 'journey_pattern_journey_pattern';
   /** The ID of the journey pattern. */
   journey_pattern_id: Scalars['uuid'];
+  journey_pattern_refs: Array<TimetablesJourneyPatternJourneyPatternRef>;
+  journey_pattern_refs_aggregate: TimetablesJourneyPatternJourneyPatternRefAggregate;
   /** An object relationship */
   journey_pattern_route?: Maybe<RouteRoute>;
   /** The ID of the route the journey pattern is on. */
@@ -1439,6 +1441,28 @@ export type JourneyPatternJourneyPattern = {
   scheduled_stop_point_in_journey_patterns: Array<JourneyPatternScheduledStopPointInJourneyPattern>;
   /** An aggregate relationship */
   scheduled_stop_point_in_journey_patterns_aggregate: JourneyPatternScheduledStopPointInJourneyPatternAggregate;
+};
+
+/** The journey patterns, i.e. the ordered lists of stops and timing points along routes: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:813 */
+export type JourneyPatternJourneyPatternJourneyPatternRefsArgs = {
+  distinct_on?: Maybe<
+    Array<TimetablesJourneyPatternJourneyPatternRefSelectColumn>
+  >;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<TimetablesJourneyPatternJourneyPatternRefOrderBy>>;
+  where?: Maybe<TimetablesJourneyPatternJourneyPatternRefBoolExp>;
+};
+
+/** The journey patterns, i.e. the ordered lists of stops and timing points along routes: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:813 */
+export type JourneyPatternJourneyPatternJourneyPatternRefsAggregateArgs = {
+  distinct_on?: Maybe<
+    Array<TimetablesJourneyPatternJourneyPatternRefSelectColumn>
+  >;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<TimetablesJourneyPatternJourneyPatternRefOrderBy>>;
+  where?: Maybe<TimetablesJourneyPatternJourneyPatternRefBoolExp>;
 };
 
 /** The journey patterns, i.e. the ordered lists of stops and timing points along routes: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:813 */

--- a/ui/graphql.schema.json
+++ b/ui/graphql.schema.json
@@ -9721,6 +9721,200 @@
             "deprecationReason": null
           },
           {
+            "name": "journey_pattern_refs",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_journey_pattern_journey_pattern_ref_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_journey_pattern_journey_pattern_ref_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_journey_pattern_journey_pattern_ref_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_journey_pattern_journey_pattern_ref",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "journey_pattern_refs_aggregate",
+            "description": null,
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_journey_pattern_journey_pattern_ref_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_journey_pattern_journey_pattern_ref_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_journey_pattern_journey_pattern_ref_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "timetables_journey_pattern_journey_pattern_ref_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "journey_pattern_route",
             "description": "An object relationship",
             "args": [],

--- a/ui/src/components/common/LineDetailsButton.tsx
+++ b/ui/src/components/common/LineDetailsButton.tsx
@@ -1,0 +1,35 @@
+import { useHistory } from 'react-router-dom';
+import { Path, routeDetails } from '../../router/routeDetails';
+import { IconButton } from '../../uiComponents/IconButton';
+import { commonHoverStyle } from '../../uiComponents/SimpleButton';
+
+const testIds = {
+  button: 'LocatorButton::button',
+};
+
+interface Props {
+  testId?: string;
+  lineId: UUID;
+  className?: string;
+}
+
+export const LineDetailsButton = ({
+  testId,
+  lineId,
+  className = '',
+}: Props): JSX.Element => {
+  const history = useHistory();
+  const onClick = () => {
+    history.push({
+      pathname: routeDetails[Path.lineDetails].getLink(lineId),
+    });
+  };
+  return (
+    <IconButton
+      className={`h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand ${commonHoverStyle} ${className}`}
+      onClick={onClick}
+      icon={<i className="icon-bus-alt" />}
+      testId={testId || testIds.button}
+    />
+  );
+};

--- a/ui/src/components/common/LineTimetablesButton.tsx
+++ b/ui/src/components/common/LineTimetablesButton.tsx
@@ -1,0 +1,40 @@
+import { useHistory } from 'react-router-dom';
+import { Path, routeDetails } from '../../router/routeDetails';
+import { commonHoverStyle, IconButton } from '../../uiComponents';
+
+const testIds = {
+  button: 'LocatorButton::button',
+};
+
+interface Props {
+  testId?: string;
+  disabled?: boolean;
+  lineId: UUID;
+  className?: string;
+}
+
+export const LineTimetablesButton = ({
+  testId,
+  disabled,
+  lineId,
+  className = '',
+}: Props): JSX.Element => {
+  const disabledStyle = '!bg-background opacity-70 pointer-events-none';
+  const history = useHistory();
+  const onClick = () => {
+    history.push({
+      pathname: routeDetails[Path.lineTimetables].getLink(lineId),
+    });
+  };
+  return (
+    <IconButton
+      className={`h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand ${commonHoverStyle} ${
+        disabled ? disabledStyle : ''
+      } ${className}`}
+      onClick={onClick}
+      disabled={disabled}
+      icon={<i className="icon-calendar" />}
+      testId={testId || testIds.button}
+    />
+  );
+};

--- a/ui/src/components/common/RouteTableRow.tsx
+++ b/ui/src/components/common/RouteTableRow.tsx
@@ -10,7 +10,11 @@ import {
   selectExport,
   selectRouteLabelAction,
 } from '../../redux';
-import { RouteLineTableRow } from './RouteLineTableRow';
+import { routeHasTimetables } from '../../utils/route';
+import {
+  RouteLineTableRow,
+  RouteLineTableRowVariant,
+} from './RouteLineTableRow';
 
 const GQL_ROUTE_TABLE_ROW = gql`
   fragment route_table_row on route_route {
@@ -19,14 +23,23 @@ const GQL_ROUTE_TABLE_ROW = gql`
     direction
     priority
     on_line_id
+    route_journey_patterns {
+      journey_pattern_id
+      journey_pattern_refs {
+        journey_pattern_ref_id
+        vehicle_journeys {
+          vehicle_journey_id
+        }
+      }
+    }
   }
 `;
 
 interface Props {
   className?: string;
   route: RouteTableRowFragment;
-  linkTo: string;
   isSelectable?: boolean;
+  rowVariant: RouteLineTableRowVariant;
 }
 
 /**
@@ -37,8 +50,8 @@ interface Props {
 export const RouteTableRow = ({
   className = '',
   route,
-  linkTo,
   isSelectable = false,
+  rowVariant,
 }: Props): JSX.Element => {
   const { showRouteOnMap } = useShowRoutesOnModal();
   const dispatch = useAppDispatch();
@@ -57,12 +70,13 @@ export const RouteTableRow = ({
     dispatch(selectAction(route.label));
   };
 
-  const isSelected = selectedRouteLabels.includes(route.label);
+  const hasTimetables = routeHasTimetables(route);
 
+  const isSelected = selectedRouteLabels.includes(route.label);
   return (
     <RouteLineTableRow
       rowItem={route}
-      linkTo={linkTo}
+      rowVariant={rowVariant}
       onLocatorButtonClick={
         route.route_shape /* some routes imported from jore3 are missing the geometry */
           ? onClickShowRouteOnMap
@@ -70,7 +84,9 @@ export const RouteTableRow = ({
       }
       locatorButtonTestId="RouteTableRow::showRoute"
       className={className}
+      lineId={route.on_line_id}
       isSelected={isSelected}
+      hasTimetables={hasTimetables}
       onSelectChanged={isSelectable ? onSelectChanged : undefined}
     />
   );

--- a/ui/src/components/common/search/LinesList.tsx
+++ b/ui/src/components/common/search/LinesList.tsx
@@ -1,12 +1,11 @@
-import { LineTableRow } from '..';
+import { LineTableRow, RouteLineTableRowVariant } from '..';
 import { LineTableRowFragment } from '../../../generated/graphql';
-import { Path, routeDetails } from '../../../router/routeDetails';
 import { RoutesTable } from '../../routes-and-lines/main/RoutesTable';
 
 type Props = {
   lines?: LineTableRowFragment[];
-  basePath: Path;
   areItemsSelectable?: boolean;
+  rowVariant: RouteLineTableRowVariant;
 };
 
 const testIds = {
@@ -15,14 +14,14 @@ const testIds = {
 
 export const LinesList = ({
   lines,
-  basePath,
   areItemsSelectable = false,
+  rowVariant,
 }: Props): JSX.Element => (
   <RoutesTable testId={testIds.table}>
     {lines?.map((item: LineTableRowFragment) => (
       <LineTableRow
+        rowVariant={rowVariant}
         key={item.line_id}
-        linkTo={routeDetails[basePath].getLink(item.line_id)}
         line={item}
         isSelectable={areItemsSelectable}
       />

--- a/ui/src/components/common/search/ResultList.tsx
+++ b/ui/src/components/common/search/ResultList.tsx
@@ -1,19 +1,19 @@
 import {
   LineTableRowFragment,
-  RouteAllFieldsFragment,
+  RouteTableRowFragment,
 } from '../../../generated/graphql';
 import { useAppSelector } from '../../../hooks';
 import { selectExport } from '../../../redux';
-import { Path } from '../../../router/routeDetails';
 import { DisplayedSearchResultType } from '../../../utils';
+import { RouteLineTableRowVariant } from '../RouteLineTableRow';
 import { LinesList } from './LinesList';
 import { RoutesList } from './RoutesList';
 
 interface Props {
   lines?: LineTableRowFragment[];
-  routes?: RouteAllFieldsFragment[];
-  basePath: Path;
+  routes?: RouteTableRowFragment[];
   displayedData: DisplayedSearchResultType;
+  rowVariant: RouteLineTableRowVariant;
 }
 
 /** Depending on displayedData this component will return the
@@ -22,8 +22,8 @@ interface Props {
 export const ResultList = ({
   lines,
   routes,
-  basePath,
   displayedData,
+  rowVariant,
 }: Props): JSX.Element => {
   const { isSelectingRoutesForExport } = useAppSelector(selectExport);
 
@@ -31,15 +31,15 @@ export const ResultList = ({
     case DisplayedSearchResultType.Lines:
       return (
         <LinesList
-          basePath={basePath}
           lines={lines}
+          rowVariant={rowVariant}
           areItemsSelectable={isSelectingRoutesForExport}
         />
       );
     case DisplayedSearchResultType.Routes:
       return (
         <RoutesList
-          basePath={basePath}
+          rowVariant={rowVariant}
           routes={routes}
           areItemsSelectable={isSelectingRoutesForExport}
         />

--- a/ui/src/components/common/search/ResultList.tsx
+++ b/ui/src/components/common/search/ResultList.tsx
@@ -12,22 +12,22 @@ import { RoutesList } from './RoutesList';
 interface Props {
   lines?: LineTableRowFragment[];
   routes?: RouteTableRowFragment[];
-  displayedData: DisplayedSearchResultType;
+  displayedType: DisplayedSearchResultType;
   rowVariant: RouteLineTableRowVariant;
 }
 
-/** Depending on displayedData this component will return the
+/** Depending on displayedType this component will return the
  * corresponding list element
  */
 export const ResultList = ({
   lines,
   routes,
-  displayedData,
+  displayedType,
   rowVariant,
 }: Props): JSX.Element => {
   const { isSelectingRoutesForExport } = useAppSelector(selectExport);
 
-  switch (displayedData) {
+  switch (displayedType) {
     case DisplayedSearchResultType.Lines:
       return (
         <LinesList
@@ -46,7 +46,7 @@ export const ResultList = ({
       );
     default:
       // eslint-disable-next-line no-console
-      console.error(`Error: ${displayedData} does not exist.`);
+      console.error(`Error: ${displayedType} does not exist.`);
       return <></>;
   }
 };

--- a/ui/src/components/common/search/ResultSelector.tsx
+++ b/ui/src/components/common/search/ResultSelector.tsx
@@ -4,14 +4,10 @@ import { resetSelectedRoutesAction } from '../../../redux';
 import { SimpleSmallButton } from '../../../uiComponents';
 import { DisplayedSearchResultType } from '../../../utils';
 
-export const ResultSelector = ({
-  basePath,
-}: {
-  basePath: string;
-}): JSX.Element => {
+export const ResultSelector = (): JSX.Element => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const { queryParameters, setFilter } = useSearch({ basePath });
+  const { queryParameters, setFilter } = useSearch();
   const { displayedData } = queryParameters.filter;
 
   const displayRoutes = () => {

--- a/ui/src/components/common/search/ResultSelector.tsx
+++ b/ui/src/components/common/search/ResultSelector.tsx
@@ -1,5 +1,9 @@
 import { useTranslation } from 'react-i18next';
-import { useAppDispatch, useSearch } from '../../../hooks';
+import {
+  SearchQueryParameterNames,
+  useAppDispatch,
+  useSearch,
+} from '../../../hooks';
 import { resetSelectedRoutesAction } from '../../../redux';
 import { SimpleSmallButton } from '../../../uiComponents';
 import { DisplayedSearchResultType } from '../../../utils';
@@ -8,15 +12,21 @@ export const ResultSelector = (): JSX.Element => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const { queryParameters, setFilter } = useSearch();
-  const { displayedData } = queryParameters.filter;
+  const { displayedType } = queryParameters.filter;
 
   const displayRoutes = () => {
     dispatch(resetSelectedRoutesAction());
-    setFilter('displayedData', DisplayedSearchResultType.Routes);
+    setFilter(
+      SearchQueryParameterNames.DisplayedType,
+      DisplayedSearchResultType.Routes,
+    );
   };
   const displayLines = () => {
     dispatch(resetSelectedRoutesAction());
-    setFilter('displayedData', DisplayedSearchResultType.Lines);
+    setFilter(
+      SearchQueryParameterNames.DisplayedType,
+      DisplayedSearchResultType.Lines,
+    );
   };
   const testIds = {
     linesResultsButton: 'ResultSelector::lines',
@@ -26,14 +36,14 @@ export const ResultSelector = (): JSX.Element => {
   return (
     <div className="space-x-2">
       <SimpleSmallButton
-        inverted={displayedData !== DisplayedSearchResultType.Lines}
+        inverted={displayedType !== DisplayedSearchResultType.Lines}
         onClick={displayLines}
         label={t('lines.lines')}
         testId={testIds.linesResultsButton}
       />
       <SimpleSmallButton
         onClick={displayRoutes}
-        inverted={displayedData !== DisplayedSearchResultType.Routes}
+        inverted={displayedType !== DisplayedSearchResultType.Routes}
         label={t('lines.routes')}
         testId={testIds.routesResultsButton}
       />

--- a/ui/src/components/common/search/RoutesList.tsx
+++ b/ui/src/components/common/search/RoutesList.tsx
@@ -1,12 +1,11 @@
-import { RouteTableRow } from '..';
+import { RouteLineTableRowVariant, RouteTableRow } from '..';
 import { RouteTableRowFragment } from '../../../generated/graphql';
-import { Path, routeDetails } from '../../../router/routeDetails';
 import { RoutesTable } from '../../routes-and-lines/main/RoutesTable';
 
 type Props = {
   routes?: RouteTableRowFragment[];
-  basePath: Path;
   areItemsSelectable?: boolean;
+  rowVariant: RouteLineTableRowVariant;
 };
 
 const testIds = {
@@ -15,14 +14,14 @@ const testIds = {
 
 export const RoutesList = ({
   routes,
-  basePath,
   areItemsSelectable = false,
+  rowVariant,
 }: Props): JSX.Element => (
   <RoutesTable testId={testIds.table}>
     {routes?.map((item: RouteTableRowFragment) => (
       <RouteTableRow
+        rowVariant={rowVariant}
         key={item.route_id}
-        linkTo={routeDetails[basePath].getLink(item.on_line_id)}
         route={item}
         isSelectable={areItemsSelectable}
       />

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesLists.tsx
@@ -5,7 +5,7 @@ import {
   useListChangingRoutesQuery,
   useListOwnLinesQuery,
 } from '../../../generated/graphql';
-import { Path } from '../../../router/routeDetails';
+import { RouteLineTableRowVariant } from '../../common';
 import { LinesList } from '../../common/search/LinesList';
 import { RoutesList } from '../../common/search/RoutesList';
 import { ListFooter } from './ListFooter';
@@ -66,10 +66,16 @@ export const RoutesAndLinesLists = (): JSX.Element => {
         onLimitChange={setChangingRoutesLimit}
         className="mb-5"
       />
-      <RoutesList basePath={Path.lineDetails} routes={changingRoutes} />
+      <RoutesList
+        rowVariant={RouteLineTableRowVariant.RoutesAndLines}
+        routes={changingRoutes}
+      />
       <ListFooter onLimitChange={setChangingRoutesLimit} className="mt-8" />
       <h2 className="mb-14 mt-12">{t('lines.lines')}</h2>
-      <LinesList basePath={Path.lineDetails} lines={ownLines} />
+      <LinesList
+        rowVariant={RouteLineTableRowVariant.RoutesAndLines}
+        lines={ownLines}
+      />
     </div>
   );
 };

--- a/ui/src/components/routes-and-lines/main/RoutesTable.spec.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesTable.spec.tsx
@@ -4,10 +4,9 @@ import {
   RouteDirectionEnum,
   RouteTableRowFragment,
 } from '../../../generated/graphql';
-import { Path, routeDetails } from '../../../router/routeDetails';
 import { Priority } from '../../../types/Priority';
 import { render } from '../../../utils/test-utils';
-import { RouteTableRow } from '../../common';
+import { RouteLineTableRowVariant, RouteTableRow } from '../../common';
 import { LineTableRow } from '../../common/LineTableRow';
 import { RoutesTable } from './RoutesTable';
 
@@ -24,6 +23,7 @@ describe(`<${RoutesTable.name} />`, () => {
       on_line_id: lineId,
       priority: 10,
       direction: RouteDirectionEnum.Outbound,
+      route_journey_patterns: [],
     },
   ];
 
@@ -34,9 +34,27 @@ describe(`<${RoutesTable.name} />`, () => {
       <RoutesTable testId={testId}>
         {routes.map((item: RouteTableRowFragment) => (
           <RouteTableRow
+            rowVariant={RouteLineTableRowVariant.RoutesAndLines}
             key={item.route_id}
             route={item}
-            linkTo={routeDetails[Path.lineDetails].getLink(item.on_line_id)}
+          />
+        ))}
+      </RoutesTable>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('Renders the table with route data (timetables)', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const routes = routesResponseMock!;
+    const { asFragment } = render(
+      <RoutesTable testId={testId}>
+        {routes.map((item: RouteTableRowFragment) => (
+          <RouteTableRow
+            rowVariant={RouteLineTableRowVariant.Timetables}
+            key={item.route_id}
+            route={item}
           />
         ))}
       </RoutesTable>,
@@ -91,9 +109,9 @@ describe(`<${RoutesTable.name} />`, () => {
       <RoutesTable testId={testId}>
         {lines.map((item: LineTableRowFragment) => (
           <LineTableRow
+            rowVariant={RouteLineTableRowVariant.RoutesAndLines}
             key={item.line_id}
             line={item}
-            linkTo={routeDetails[Path.lineDetails].getLink(item.line_id)}
           />
         ))}
       </RoutesTable>,

--- a/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
@@ -21,6 +21,7 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           class="w-full py-4 border-y border-y-light-grey"
         >
           <a
+            class=""
             href="/lines/101f800c-39ed-4d85-8ece-187cd9fe1c5e"
           >
             <div
@@ -29,9 +30,16 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <h2>
-                  65
-                </h2>
+                <div
+                  class="flex flex-row "
+                >
+                  <h2>
+                    65
+                  </h2>
+                  <i
+                    class="icon-bus-alt text-2xl text-tweaked-brand"
+                  />
+                </div>
                 <p>
                   Rautatientori - Veräjälaakso
                 </p>
@@ -52,6 +60,20 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           </a>
         </td>
         <td
+          class="w-1/12 pl-6 text-right align-middle border-y border-y-light-grey"
+        >
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="LocatorButton::button"
+            disabled=""
+            type="button"
+          >
+            <i
+              class="icon-calendar inline text-center"
+            />
+          </button>
+        </td>
+        <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
           <button
@@ -94,6 +116,7 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           class="w-full py-4 border-y border-y-light-grey"
         >
           <a
+            class=""
             href="/lines/9058c328-efdd-412c-9b2b-37b0f6a2c6fb"
           >
             <div
@@ -102,9 +125,16 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <h2>
-                  71
-                </h2>
+                <div
+                  class="flex flex-row "
+                >
+                  <h2>
+                    71
+                  </h2>
+                  <i
+                    class="icon-bus-alt text-2xl text-tweaked-brand"
+                  />
+                </div>
                 <p>
                   Rautatientori - Malmi as.
                 </p>
@@ -125,6 +155,20 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           </a>
         </td>
         <td
+          class="w-1/12 pl-6 text-right align-middle border-y border-y-light-grey"
+        >
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="LocatorButton::button"
+            disabled=""
+            type="button"
+          >
+            <i
+              class="icon-calendar inline text-center"
+            />
+          </button>
+        </td>
+        <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
           <button
@@ -167,6 +211,7 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           class="w-full py-4 border-y border-y-light-grey"
         >
           <a
+            class=""
             href="/lines/bbd1cb29-74c3-4fa1-ac86-918d7fa96fe2"
           >
             <div
@@ -175,9 +220,16 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <h2>
-                  785K
-                </h2>
+                <div
+                  class="flex flex-row "
+                >
+                  <h2>
+                    785K
+                  </h2>
+                  <i
+                    class="icon-bus-alt text-2xl text-tweaked-brand"
+                  />
+                </div>
                 <p>
                   Rautatientori - Nikkilä
                 </p>
@@ -198,6 +250,20 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           </a>
         </td>
         <td
+          class="w-1/12 pl-6 text-right align-middle border-y border-y-light-grey"
+        >
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="LocatorButton::button"
+            disabled=""
+            type="button"
+          >
+            <i
+              class="icon-calendar inline text-center"
+            />
+          </button>
+        </td>
+        <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
           <button
@@ -240,6 +306,7 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           class="w-full py-4 border-y border-y-light-grey"
         >
           <a
+            class=""
             href="/lines/db748c5c-42e3-429f-baa0-e0db227dc2c8"
           >
             <div
@@ -248,9 +315,16 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <h2>
-                  1234
-                </h2>
+                <div
+                  class="flex flex-row "
+                >
+                  <h2>
+                    1234
+                  </h2>
+                  <i
+                    class="icon-bus-alt text-2xl text-tweaked-brand"
+                  />
+                </div>
                 <p>
                   Erottaja - Arkkadiankatu
                 </p>
@@ -269,6 +343,20 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
               </div>
             </div>
           </a>
+        </td>
+        <td
+          class="w-1/12 pl-6 text-right align-middle border-y border-y-light-grey"
+        >
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="LocatorButton::button"
+            disabled=""
+            type="button"
+          >
+            <i
+              class="icon-calendar inline text-center"
+            />
+          </button>
         </td>
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
@@ -325,6 +413,7 @@ exports[`<RoutesTable /> Renders the table with route data (routes and lines) 1`
           class="w-full py-4 border-y border-y-light-grey"
         >
           <a
+            class=""
             href="/lines/101f800c-39ed-4d85-8ece-187cd9fe1c5e"
           >
             <div
@@ -333,9 +422,16 @@ exports[`<RoutesTable /> Renders the table with route data (routes and lines) 1`
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
-                <h2>
-                  1
-                </h2>
+                <div
+                  class="flex flex-row "
+                >
+                  <h2>
+                    1
+                  </h2>
+                  <i
+                    class="icon-bus-alt text-2xl text-tweaked-brand"
+                  />
+                </div>
                 <p>
                   route 1
                 </p>
@@ -354,6 +450,127 @@ exports[`<RoutesTable /> Renders the table with route data (routes and lines) 1`
               </div>
             </div>
           </a>
+        </td>
+        <td
+          class="w-1/12 pl-6 text-right align-middle border-y border-y-light-grey"
+        >
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="LocatorButton::button"
+            disabled=""
+            type="button"
+          >
+            <i
+              class="icon-calendar inline text-center"
+            />
+          </button>
+        </td>
+        <td
+          class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
+        >
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="RouteTableRow::showRoute"
+            disabled=""
+            type="button"
+          >
+            <svg
+              class="text-2xl inline text-center"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+              />
+            </svg>
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;
+
+exports[`<RoutesTable /> Renders the table with route data (timetables) 1`] = `
+<DocumentFragment>
+  <table
+    class="h-1 w-full "
+    data-testid="routesTable1"
+  >
+    <tbody>
+      <tr
+        class=""
+      >
+        <td
+          class="border-l-10 border-hsl-dark-green border-y border-y-light-grey p-4"
+        >
+          <i
+            class="icon-_-placeholder my-auto flex text-3xl"
+          />
+        </td>
+        <td
+          class="w-full py-4 border-y border-y-light-grey"
+        >
+          <a
+            class="pointer-events-none text-zinc-400"
+            href="/timetables/lines/101f800c-39ed-4d85-8ece-187cd9fe1c5e"
+          >
+            <div
+              class="flex flex-row items-center"
+            >
+              <div
+                class="flex flex-col w-1/2 font-bold"
+              >
+                <div
+                  class="flex flex-row "
+                >
+                  <h2>
+                    1
+                  </h2>
+                  <i
+                    class="icon-calendar text-2xl text-zinc-400"
+                  />
+                </div>
+                <p>
+                  route 1
+                </p>
+              </div>
+              <div
+                class="flex flex-col w-1/2 text-right"
+              >
+                <p
+                  class="font-bold"
+                >
+                  Voimassa 1.1.1970 - 31.12.2050
+                </p>
+                <p>
+                  !Muokattu dd.mm.yyyy hh:mm | S. Suunnittelija
+                </p>
+              </div>
+            </div>
+          </a>
+        </td>
+        <td
+          class="w-1/12 pl-6 text-right align-middle border-y border-y-light-grey"
+        >
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand "
+            data-testid="LocatorButton::button"
+            type="button"
+          >
+            <i
+              class="icon-bus-alt inline text-center"
+            />
+          </button>
         </td>
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"

--- a/ui/src/components/routes-and-lines/search/SearchContainer.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchContainer.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { SearchQueryParameterNames, useSearch } from '../../../hooks';
 import { useToggle } from '../../../hooks/useToggle';
 import { Column, Container, Row, Visible } from '../../../layoutComponents';
-import { Path } from '../../../router/routeDetails';
 import { ChevronToggle, SimpleButton } from '../../../uiComponents';
 import { AllOptionEnum } from '../../../utils';
 import { SearchInput } from '../../common/search';
@@ -13,9 +12,7 @@ import { VehicleModeDropdown } from '../../forms/line/VehicleModeDropdown';
 import { PriorityCondition } from './conditions/PriorityCondition';
 
 export const SearchContainer = (): JSX.Element => {
-  const { searchConditions, setSearchCondition, handleSearch } = useSearch({
-    basePath: Path.routes,
-  });
+  const { searchConditions, setSearchCondition, handleSearch } = useSearch();
   const { t } = useTranslation();
 
   const [isExpanded, toggleIsExpanded] = useToggle();

--- a/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
@@ -64,7 +64,7 @@ export const SearchResultPage = (): JSX.Element => {
         lines={displayedLines}
         routes={displayedRoutes}
         rowVariant={displayInformation.rowVariant}
-        displayedData={queryParameters.filter.displayedType}
+        displayedType={queryParameters.filter.displayedType}
       />
       <Visible visible={!!resultCount}>
         <div className="grid grid-cols-4">

--- a/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
@@ -1,22 +1,23 @@
 import { useTranslation } from 'react-i18next';
 import { useSearch, useSearchResults } from '../../../hooks';
+import { useBasePath } from '../../../hooks/useBasePath';
 import { usePagination } from '../../../hooks/usePagination';
 import { Container, Row, Visible } from '../../../layoutComponents';
 import { Path } from '../../../router/routeDetails';
 import { CloseIconButton, Pagination } from '../../../uiComponents';
+import { RouteLineTableRowVariant } from '../../common/RouteLineTableRow';
 import { ResultList } from '../../common/search/ResultList';
 import { ExportToolbar } from './ExportToolbar';
 import { FiltersContainer } from './filters/FiltersContainer';
 import { SearchContainer } from './SearchContainer';
 
 export const SearchResultPage = (): JSX.Element => {
-  const { handleClose, queryParameters } = useSearch({
-    basePath: Path.routes,
-  });
+  const { handleClose, queryParameters } = useSearch();
   const { resultCount } = useSearchResults();
   const { t } = useTranslation();
   const { getPaginatedData } = usePagination();
   const { lines, routes } = useSearchResults();
+  const { basePath } = useBasePath();
   const itemsPerPage = 10;
 
   const displayedLines = getPaginatedData(lines, itemsPerPage);
@@ -26,10 +27,30 @@ export const SearchResultPage = (): JSX.Element => {
     container: 'SearchResultsPage::Container',
   };
 
+  const determineDisplayInformation = () => {
+    switch (basePath) {
+      case Path.timetables:
+        return {
+          title: t('timetables.timetables'),
+          rowVariant: RouteLineTableRowVariant.Timetables,
+        };
+      case Path.routes:
+      default:
+        return {
+          title: t('routes.routes'),
+          rowVariant: RouteLineTableRowVariant.RoutesAndLines,
+        };
+    }
+  };
+
+  const displayInformation = determineDisplayInformation();
+
   return (
     <Container testId={testIds.container}>
       <Row>
-        <h2>{`${t('search.searchResultsTitle')} | ${t('routes.routes')}`}</h2>
+        <h2>{`${t('search.searchResultsTitle')} | ${
+          displayInformation.title
+        }`}</h2>
         <CloseIconButton
           label={t('close')}
           className="ml-auto text-base font-bold text-brand"
@@ -42,8 +63,8 @@ export const SearchResultPage = (): JSX.Element => {
       <ResultList
         lines={displayedLines}
         routes={displayedRoutes}
-        basePath={Path.lineDetails}
-        displayedData={queryParameters.filter.displayedData}
+        rowVariant={displayInformation.rowVariant}
+        displayedData={queryParameters.filter.displayedType}
       />
       <Visible visible={!!resultCount}>
         <div className="grid grid-cols-4">

--- a/ui/src/components/routes-and-lines/search/filters/FiltersContainer.tsx
+++ b/ui/src/components/routes-and-lines/search/filters/FiltersContainer.tsx
@@ -1,9 +1,8 @@
 import { Row } from '../../../../layoutComponents';
-import { Path } from '../../../../router/routeDetails';
 import { ResultSelector } from '../../../common/search/ResultSelector';
 
 export const FiltersContainer = (): JSX.Element => (
   <Row className="my-4">
-    <ResultSelector basePath={Path.routes} />
+    <ResultSelector />
   </Row>
 );

--- a/ui/src/components/timetables/main/TimetablesMainPage.tsx
+++ b/ui/src/components/timetables/main/TimetablesMainPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Container } from '../../../layoutComponents';
-import { SimpleButton } from '../../../uiComponents';
+import { SearchContainer } from '../../routes-and-lines/search/SearchContainer';
 
 export const TimetablesMainPage = (): JSX.Element => {
   const { t } = useTranslation();
@@ -8,10 +8,7 @@ export const TimetablesMainPage = (): JSX.Element => {
   return (
     <Container>
       <h1>{t('timetables.timetables')}</h1>
-      <p>Placeholder page. Nothing to see here... yet.</p>
-      <SimpleButton containerClassName="mt-4" href="/lines/example/timetables">
-        Example timetable
-      </SimpleButton>
+      <SearchContainer />
     </Container>
   );
 };

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -1435,6 +1435,8 @@ export type JourneyPatternJourneyPattern = {
   __typename?: 'journey_pattern_journey_pattern';
   /** The ID of the journey pattern. */
   journey_pattern_id: Scalars['uuid'];
+  journey_pattern_refs: Array<TimetablesJourneyPatternJourneyPatternRef>;
+  journey_pattern_refs_aggregate: TimetablesJourneyPatternJourneyPatternRefAggregate;
   /** An object relationship */
   journey_pattern_route?: Maybe<RouteRoute>;
   /** The ID of the route the journey pattern is on. */
@@ -1443,6 +1445,28 @@ export type JourneyPatternJourneyPattern = {
   scheduled_stop_point_in_journey_patterns: Array<JourneyPatternScheduledStopPointInJourneyPattern>;
   /** An aggregate relationship */
   scheduled_stop_point_in_journey_patterns_aggregate: JourneyPatternScheduledStopPointInJourneyPatternAggregate;
+};
+
+/** The journey patterns, i.e. the ordered lists of stops and timing points along routes: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:813 */
+export type JourneyPatternJourneyPatternJourneyPatternRefsArgs = {
+  distinct_on?: Maybe<
+    Array<TimetablesJourneyPatternJourneyPatternRefSelectColumn>
+  >;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<TimetablesJourneyPatternJourneyPatternRefOrderBy>>;
+  where?: Maybe<TimetablesJourneyPatternJourneyPatternRefBoolExp>;
+};
+
+/** The journey patterns, i.e. the ordered lists of stops and timing points along routes: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:813 */
+export type JourneyPatternJourneyPatternJourneyPatternRefsAggregateArgs = {
+  distinct_on?: Maybe<
+    Array<TimetablesJourneyPatternJourneyPatternRefSelectColumn>
+  >;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<TimetablesJourneyPatternJourneyPatternRefOrderBy>>;
+  where?: Maybe<TimetablesJourneyPatternJourneyPatternRefBoolExp>;
 };
 
 /** The journey patterns, i.e. the ordered lists of stops and timing points along routes: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:813 */
@@ -11450,6 +11474,18 @@ export type LineTableRowFragment = {
     label: string;
     validity_start?: luxon.DateTime | null | undefined;
     validity_end?: luxon.DateTime | null | undefined;
+    route_journey_patterns: Array<{
+      __typename?: 'journey_pattern_journey_pattern';
+      journey_pattern_id: UUID;
+      journey_pattern_refs: Array<{
+        __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+        journey_pattern_ref_id: UUID;
+        vehicle_journeys: Array<{
+          __typename?: 'timetables_vehicle_journey_vehicle_journey';
+          vehicle_journey_id: UUID;
+        }>;
+      }>;
+    }>;
   }>;
 };
 
@@ -11464,6 +11500,18 @@ export type RouteTableRowFragment = {
   route_shape?: GeoJSON.LineString | null | undefined;
   validity_start?: luxon.DateTime | null | undefined;
   validity_end?: luxon.DateTime | null | undefined;
+  route_journey_patterns: Array<{
+    __typename?: 'journey_pattern_journey_pattern';
+    journey_pattern_id: UUID;
+    journey_pattern_refs: Array<{
+      __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+      journey_pattern_ref_id: UUID;
+      vehicle_journeys: Array<{
+        __typename?: 'timetables_vehicle_journey_vehicle_journey';
+        vehicle_journey_id: UUID;
+      }>;
+    }>;
+  }>;
 };
 
 export type RouteMetadataFragment = {
@@ -11586,6 +11634,18 @@ export type ListChangingRoutesQuery = {
     route_shape?: GeoJSON.LineString | null | undefined;
     validity_start?: luxon.DateTime | null | undefined;
     validity_end?: luxon.DateTime | null | undefined;
+    route_journey_patterns: Array<{
+      __typename?: 'journey_pattern_journey_pattern';
+      journey_pattern_id: UUID;
+      journey_pattern_refs: Array<{
+        __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+        journey_pattern_ref_id: UUID;
+        vehicle_journeys: Array<{
+          __typename?: 'timetables_vehicle_journey_vehicle_journey';
+          vehicle_journey_id: UUID;
+        }>;
+      }>;
+    }>;
   }>;
 };
 
@@ -11611,6 +11671,18 @@ export type ListOwnLinesQuery = {
       label: string;
       validity_start?: luxon.DateTime | null | undefined;
       validity_end?: luxon.DateTime | null | undefined;
+      route_journey_patterns: Array<{
+        __typename?: 'journey_pattern_journey_pattern';
+        journey_pattern_id: UUID;
+        journey_pattern_refs: Array<{
+          __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+          journey_pattern_ref_id: UUID;
+          vehicle_journeys: Array<{
+            __typename?: 'timetables_vehicle_journey_vehicle_journey';
+            vehicle_journey_id: UUID;
+          }>;
+        }>;
+      }>;
     }>;
   }>;
 };
@@ -13966,24 +14038,43 @@ export type SearchLinesAndRoutesQuery = {
       label: string;
       validity_start?: luxon.DateTime | null | undefined;
       validity_end?: luxon.DateTime | null | undefined;
+      route_journey_patterns: Array<{
+        __typename?: 'journey_pattern_journey_pattern';
+        journey_pattern_id: UUID;
+        journey_pattern_refs: Array<{
+          __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+          journey_pattern_ref_id: UUID;
+          vehicle_journeys: Array<{
+            __typename?: 'timetables_vehicle_journey_vehicle_journey';
+            vehicle_journey_id: UUID;
+          }>;
+        }>;
+      }>;
     }>;
   }>;
   route_route: Array<{
     __typename?: 'route_route';
-    route_id: UUID;
     name_i18n: LocalizedString;
-    description_i18n?: LocalizedString | null | undefined;
-    origin_name_i18n: LocalizedString;
-    origin_short_name_i18n: LocalizedString;
-    destination_name_i18n: LocalizedString;
-    destination_short_name_i18n: LocalizedString;
-    route_shape?: GeoJSON.LineString | null | undefined;
+    direction: RouteDirectionEnum;
+    priority: number;
     on_line_id: UUID;
+    route_id: UUID;
+    label: string;
+    route_shape?: GeoJSON.LineString | null | undefined;
     validity_start?: luxon.DateTime | null | undefined;
     validity_end?: luxon.DateTime | null | undefined;
-    priority: number;
-    label: string;
-    direction: RouteDirectionEnum;
+    route_journey_patterns: Array<{
+      __typename?: 'journey_pattern_journey_pattern';
+      journey_pattern_id: UUID;
+      journey_pattern_refs: Array<{
+        __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+        journey_pattern_ref_id: UUID;
+        vehicle_journeys: Array<{
+          __typename?: 'timetables_vehicle_journey_vehicle_journey';
+          vehicle_journey_id: UUID;
+        }>;
+      }>;
+    }>;
   }>;
 };
 
@@ -14308,6 +14399,15 @@ export const LineTableRowFragmentDoc = gql`
     ...line_information_for_map
     line_routes {
       ...route_information_for_map
+      route_journey_patterns {
+        journey_pattern_id
+        journey_pattern_refs {
+          journey_pattern_ref_id
+          vehicle_journeys {
+            vehicle_journey_id
+          }
+        }
+      }
     }
   }
   ${LineInformationForMapFragmentDoc}
@@ -14320,6 +14420,15 @@ export const RouteTableRowFragmentDoc = gql`
     direction
     priority
     on_line_id
+    route_journey_patterns {
+      journey_pattern_id
+      journey_pattern_refs {
+        journey_pattern_ref_id
+        vehicle_journeys {
+          vehicle_journey_id
+        }
+      }
+    }
   }
   ${RouteInformationForMapFragmentDoc}
 `;
@@ -17514,11 +17623,11 @@ export const SearchLinesAndRoutesDocument = gql`
       ...line_table_row
     }
     route_route(where: $routeFilter, order_by: $routeOrderBy) {
-      ...route_all_fields
+      ...route_table_row
     }
   }
   ${LineTableRowFragmentDoc}
-  ${RouteAllFieldsFragmentDoc}
+  ${RouteTableRowFragmentDoc}
 `;
 
 /**

--- a/ui/src/hooks/search/useSearch.ts
+++ b/ui/src/hooks/search/useSearch.ts
@@ -4,20 +4,15 @@ import { useState } from 'react';
 import { Priority } from '../../types/Priority';
 import { DisplayedSearchResultType } from '../../utils';
 import { QueryParameter, QueryParameterTypes, useUrlQuery } from '../urlQuery';
+import { useBasePath } from '../useBasePath';
 import {
   DeserializedQueryStringParameters,
   FilterConditions,
   useSearchQueryParser,
 } from './useSearchQueryParser';
 
-/**
- * Common search hook. Takes basePath as parameter, which will be used when
- * handling filter setting, searching and closing.
- * For example using 'routes-and-lines' as basePath will direct searches to
- * '/routes-and-lines/search' and closing the search will direct to
- * '/routes-and-lines'
- */
-export const useSearch = ({ basePath }: { basePath: string }) => {
+export const useSearch = () => {
+  const { basePath } = useBasePath();
   const queryParameters = useSearchQueryParser();
   const { setMultipleParametersToUrlQuery } = useUrlQuery();
 

--- a/ui/src/hooks/search/useSearchQueryParser.ts
+++ b/ui/src/hooks/search/useSearchQueryParser.ts
@@ -16,7 +16,7 @@ export type SearchConditions = {
 };
 
 export type FilterConditions = {
-  displayedData: DisplayedSearchResultType;
+  displayedType: DisplayedSearchResultType;
 };
 
 /**
@@ -36,7 +36,7 @@ export type QueryStringParameters = {
   label: string;
   primaryVehicleMode?: string;
   typeOfLine?: string;
-  displayedData: string;
+  displayedType: string;
 };
 
 /**
@@ -48,14 +48,14 @@ export type DeserializedQueryStringParameters = {
   label: string;
   primaryVehicleMode?: ReusableComponentsVehicleModeEnum | AllOptionEnum;
   typeOfLine?: RouteTypeOfLineEnum | AllOptionEnum;
-  displayedData: DisplayedSearchResultType;
+  displayedType: DisplayedSearchResultType;
 };
 
 export enum SearchQueryParameterNames {
   Label = 'label',
   Priorities = 'priorities',
   PrimaryVehicleMode = 'primaryVehicleMode',
-  DisplayedData = 'displayedData',
+  DisplayedType = 'displayedType',
   TypeOfLine = 'typeOfLine',
   ObservationDate = 'observationDate',
 }
@@ -93,9 +93,9 @@ export const useSearchQueryParser = () => {
     getRouteTypeOfLineEnumFromUrlQuery(SearchQueryParameterNames.TypeOfLine) ??
     DEFAULT_TYPE_OF_LINE;
 
-  const displayedData =
+  const displayedType =
     getDisplayedSearchResultTypeFromUrlQuery(
-      SearchQueryParameterNames.DisplayedData,
+      SearchQueryParameterNames.DisplayedType,
     ) ?? DEFAULT_DISPLAYED_DATA;
   const observationDate =
     getDateTimeFromUrlQuery(SearchQueryParameterNames.ObservationDate) ??
@@ -110,7 +110,7 @@ export const useSearchQueryParser = () => {
       observationDate,
     },
     filter: {
-      displayedData,
+      displayedType,
     },
   };
 };

--- a/ui/src/hooks/search/useSearchResults.ts
+++ b/ui/src/hooks/search/useSearchResults.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 import {
   LineTableRowFragment,
-  RouteAllFieldsFragment,
+  RouteTableRowFragment,
   useSearchLinesAndRoutesQuery,
 } from '../../generated/graphql';
 import {
@@ -22,14 +22,14 @@ const GQL_SEARCH_LINES_AND_ROUTES = gql`
       ...line_table_row
     }
     route_route(where: $routeFilter, order_by: $routeOrderBy) {
-      ...route_all_fields
+      ...route_table_row
     }
   }
 `;
 
 export const useSearchResults = (): {
   lines: LineTableRowFragment[];
-  routes: RouteAllFieldsFragment[];
+  routes: RouteTableRowFragment[];
   resultCount: number;
   resultType: DisplayedSearchResultType;
 } => {
@@ -44,7 +44,7 @@ export const useSearchResults = (): {
   );
 
   const lines = (result.data?.route_line || []) as LineTableRowFragment[];
-  const routes = (result.data?.route_route || []) as RouteAllFieldsFragment[];
+  const routes = (result.data?.route_route || []) as RouteTableRowFragment[];
 
   const getResultCount = () => {
     switch (parsedSearchQueryParameters.filter.displayedData) {

--- a/ui/src/hooks/search/useSearchResults.ts
+++ b/ui/src/hooks/search/useSearchResults.ts
@@ -47,7 +47,7 @@ export const useSearchResults = (): {
   const routes = (result.data?.route_route || []) as RouteTableRowFragment[];
 
   const getResultCount = () => {
-    switch (parsedSearchQueryParameters.filter.displayedData) {
+    switch (parsedSearchQueryParameters.filter.displayedType) {
       case DisplayedSearchResultType.Lines:
         return lines?.length;
       case DisplayedSearchResultType.Routes:
@@ -55,7 +55,7 @@ export const useSearchResults = (): {
       default:
         // eslint-disable-next-line no-console
         console.error(
-          `Error: ${parsedSearchQueryParameters.filter.displayedData} does not exist.`,
+          `Error: ${parsedSearchQueryParameters.filter.displayedType} does not exist.`,
         );
         return 0;
     }
@@ -65,6 +65,6 @@ export const useSearchResults = (): {
     lines,
     routes,
     resultCount: getResultCount(),
-    resultType: parsedSearchQueryParameters.filter.displayedData,
+    resultType: parsedSearchQueryParameters.filter.displayedType,
   };
 };

--- a/ui/src/hooks/useBasePath.ts
+++ b/ui/src/hooks/useBasePath.ts
@@ -1,0 +1,14 @@
+import { useHistory } from 'react-router-dom';
+import { Path } from '../router/routeDetails';
+
+/**
+ * Hook for getting the basePath from URL.
+ * Base path is the first part of the URL path.
+ * E.g. in '/routes/search?observationDate=2022-12-07' the basePath is '/routes'
+ */
+export const useBasePath = (): { basePath: Path } => {
+  const history = useHistory();
+  const basePath = `/${history.location.pathname.split('/')[1]}` as Path;
+
+  return { basePath };
+};

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -49,6 +49,11 @@ export const Router: FunctionComponent = () => {
       _exact: true,
       component: SearchResultPage,
     },
+    [Path.timetablesSearch]: {
+      _routerRoute: Path.timetablesSearch,
+      _exact: true,
+      component: SearchResultPage,
+    },
     [Path.editRoute]: {
       _routerRoute: Path.editRoute,
       _exact: true,

--- a/ui/src/router/routeDetails.ts
+++ b/ui/src/router/routeDetails.ts
@@ -5,12 +5,13 @@ export enum Path {
   routes = '/routes',
   timetables = '/timetables',
   routesSearch = '/routes/search',
+  timetablesSearch = '/timetables/search',
   editRoute = '/routes/:id/edit',
   createLine = '/lines/create',
   lineDetails = '/lines/:id',
   lineDrafts = '/lines/:label/drafts',
   editLine = '/lines/:id/edit',
-  lineTimetables = '/lines/:id/timetables',
+  lineTimetables = '/timetables/lines/:id',
   fallback = '*',
 }
 
@@ -39,6 +40,11 @@ export const routeDetails: Record<Path, RouteDetail> = {
   [Path.routesSearch]: {
     getLink: () => Path.routesSearch,
     translationKey: 'routes.routesSearchResult',
+    includeInNav: false,
+  },
+  [Path.timetablesSearch]: {
+    getLink: () => Path.timetablesSearch,
+    translationKey: 'routes.timetablesSearchResult',
     includeInNav: false,
   },
   [Path.editRoute]: {

--- a/ui/src/utils/route.ts
+++ b/ui/src/utils/route.ts
@@ -1,0 +1,14 @@
+import { RouteTableRowFragment } from '../generated/graphql';
+
+/**
+ * Checks if the route has any vehicle_journey's existing. If there is
+ * that means that the route has timetables.
+ */
+export const routeHasTimetables = (
+  route: Pick<RouteTableRowFragment, 'route_journey_patterns'>,
+) =>
+  route.route_journey_patterns.some((routeJourneyPattern) =>
+    routeJourneyPattern.journey_pattern_refs.some(
+      (journeyPatternRefs) => journeyPatternRefs.vehicle_journeys.length,
+    ),
+  );


### PR DESCRIPTION
- We use the same components for timetables- and routes and lines -search. The functionality will
be different depending on in which path we are ('/timetables' or '/routes').
- Change 'Path.lineTimetables' from '/lines/:id/timetables' to '/timetables/lines/:id'
- It is now RouteLineTableRow's responsibility to check if the basePath is 'timetable'. If it is
anything else, we render RoutesAndLines version of the line. This means that the main functionality
(click the row) will take the user to line details and the row will render button to tak the user
to line timetables.
-Rename queryparameter 'displayedData' to 'displayedType'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/407)
<!-- Reviewable:end -->
