### PR TITLE
Fix loader on save and create stop

### DIFF
--- a/cypress/e2e/editStop.cy.ts
+++ b/cypress/e2e/editStop.cy.ts
@@ -145,15 +145,7 @@ describe('Stop editing tests', () => {
 
       toast.checkSuccessToastHasMessage('Pysäkki muokattu');
 
-      // Workaround to get the updated coordinates to show in the stop edit modal.
-      // TODO: Find a better way to make the coordinates update faster in the modal.
-      map.visit({
-        zoom: 15,
-        lat: testCoordinates1.lat,
-        lng: testCoordinates1.lng,
-      });
-
-      mapFilterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
+      map.getLoader().should('not.exist');
 
       map.getStopByStopLabel(stops[0].label).click();
 

--- a/cypress/pageObjects/Map.ts
+++ b/cypress/pageObjects/Map.ts
@@ -71,4 +71,8 @@ export class Map {
     }
     return cy.visit('/routes?mapOpen=true');
   }
+
+  getLoader() {
+    return cy.getByTestId('MapLoader::loader');
+  }
 }

--- a/ui/src/components/map/MapLoader.tsx
+++ b/ui/src/components/map/MapLoader.tsx
@@ -3,8 +3,13 @@ import { selectIsMapOperationLoading } from '../../redux';
 import { LoadingOverlay } from '../../uiComponents';
 
 export const MapLoader = () => {
+  const testIds = {
+    loader: 'MapLoader::loader',
+  };
   const { isMapOpen } = useMapQueryParams();
   const isLoading = useAppSelector(selectIsMapOperationLoading);
 
-  return <LoadingOverlay visible={isMapOpen && isLoading} />;
+  return (
+    <LoadingOverlay testId={testIds.loader} visible={isMapOpen && isLoading} />
+  );
 };

--- a/ui/src/components/map/stops/EditStopLayer.tsx
+++ b/ui/src/components/map/stops/EditStopLayer.tsx
@@ -201,7 +201,6 @@ export const EditStopLayer: React.FC<Props> = React.forwardRef(
       } catch (err) {
         defaultErrorHandler(err as Error);
       }
-      setIsLoadingSaveStop(false);
     };
 
     const doEditStop = async (changes: EditChanges) => {
@@ -227,7 +226,6 @@ export const EditStopLayer: React.FC<Props> = React.forwardRef(
         defaultErrorHandler(err as Error);
       }
       dispatch(setIsMoveStopModeEnabledAction(false));
-      setIsLoadingSaveStop(false);
     };
 
     // we are removing stop that is already stored to backend

--- a/ui/src/components/map/stops/Stops.tsx
+++ b/ui/src/components/map/stops/Stops.tsx
@@ -71,6 +71,8 @@ export const Stops = React.forwardRef((props, ref) => {
 
   const { setIsLoading } = useLoader(Operation.FetchStops);
 
+  const { setIsLoading: setIsLoadingSaveStop } = useLoader(Operation.SaveStop);
+
   const { getStopVehicleMode, getStopHighlighted } = useMapStops();
 
   const viewport = useAppSelector(selectMapViewport);
@@ -139,6 +141,7 @@ export const Stops = React.forwardRef((props, ref) => {
     // the newly created stop should become a regular stop from a draft
     // also, the recently edited stop's data is refetched
     await stopsResult.refetch();
+    setIsLoadingSaveStop(false);
   };
 
   return (


### PR DESCRIPTION
Resolves HSLdevcom/jore4#1028

Before this the loader disappeared after the initial mutation was done, but we need it to be present until the stop data is refetched.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/413)
<!-- Reviewable:end -->
