### PR TITLE
Adjust stop filters on map according to stop changes

### DIFF
--- a/ui/src/components/map/stops/EditStopLayer.tsx
+++ b/ui/src/components/map/stops/EditStopLayer.tsx
@@ -15,6 +15,7 @@ import {
   useCreateStop,
   useDeleteStop,
   useEditStop,
+  useFilterStops,
   useLoader,
   useObservationDateQueryParam,
 } from '../../../hooks';
@@ -70,6 +71,7 @@ export const EditStopLayer: React.FC<Props> = React.forwardRef(
     const { t } = useTranslation();
     const { updateObservationDateByValidityPeriodIfNeeded } =
       useObservationDateQueryParam();
+    const { updateStopPriorityFilterIfNeeded } = useFilterStops();
 
     const setSelectedStopId = useAppAction(setSelectedStopIdAction);
     const setEditedStopData = useAppAction(setEditedStopDataAction);
@@ -197,6 +199,7 @@ export const EditStopLayer: React.FC<Props> = React.forwardRef(
 
         showSuccessToast(t('stops.saveSuccess'));
         updateObservationDateByValidityPeriodIfNeeded(changes.stopToCreate);
+        updateStopPriorityFilterIfNeeded(changes.stopToCreate.priority);
         onFinishEditing();
       } catch (err) {
         defaultErrorHandler(err as Error);
@@ -221,6 +224,7 @@ export const EditStopLayer: React.FC<Props> = React.forwardRef(
 
         showSuccessToast(t('stops.editSuccess'));
         updateObservationDateByValidityPeriodIfNeeded(changes.editedStop);
+        updateStopPriorityFilterIfNeeded(changes.editedStop.priority);
         onFinishEditing();
       } catch (err) {
         defaultErrorHandler(err as Error);

--- a/ui/src/hooks/stops/useFilterStops.ts
+++ b/ui/src/hooks/stops/useFilterStops.ts
@@ -15,6 +15,7 @@ import {
   isCurrentEntity,
   isFutureEntity,
   isPastEntity,
+  showWarningToast,
 } from '../../utils';
 import { useAppDispatch, useAppSelector } from '../redux';
 import { useObservationDateQueryParam } from '../urlQuery';
@@ -217,6 +218,44 @@ export const useFilterStops = () => {
     dispatch(setShowStopFilterOverlayAction(!showStopFilterOverlay));
   }, [dispatch, showStopFilterOverlay]);
 
+  const mapPriorityToFilterType = (priority: Priority) => {
+    switch (priority) {
+      case Priority.Standard:
+        return FilterType.ShowStandardStops;
+      case Priority.Temporary:
+        return FilterType.ShowTemporaryStops;
+      case Priority.Draft:
+      default:
+        return FilterType.ShowDraftStops;
+    }
+  };
+
+  /**
+   * If the given priority stops are currently being filtered out from the view
+   * -> adjust the priority filters so that the given priority stops are shown and
+   * also deactivate the 'showHighestPriorityCurrentStops' filter.
+   * -> Show the user toast message about the adjustment.
+   */
+  const updateStopPriorityFilterIfNeeded = (priority: Priority) => {
+    const filterType = mapPriorityToFilterType(priority);
+
+    if (!stopFilters[filterType]) {
+      dispatch(
+        setStopFilterAction({
+          filterType,
+          isActive: true,
+        }),
+      );
+      dispatch(
+        setStopFilterAction({
+          filterType: FilterType.ShowHighestPriorityCurrentStops,
+          isActive: false,
+        }),
+      );
+      showWarningToast(t('filters.stopFiltersAdjusted'));
+    }
+  };
+
   return {
     filter,
     timeBasedFilterItems,
@@ -225,5 +264,6 @@ export const useFilterStops = () => {
     toggleShowFilters,
     toggleFunction,
     isFilterActive,
+    updateStopPriorityFilterIfNeeded,
   };
 };

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -241,7 +241,8 @@
     "draft": "Draft",
     "highestPriorityCurrent": "Show situation on the selected date",
     "observationDate": "Observation date",
-    "observationDateAdjusted": "Observation date adjusted"
+    "observationDateAdjusted": "Observation date adjusted",
+    "stopFiltersAdjusted": "Stop filters adjusted"
   },
   "search": {
     "advancedSearchTitle": "Advanced search",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -241,7 +241,8 @@
     "draft": "Luonnokset",
     "highestPriorityCurrent": "Näytä tilanne valittuna päivänä",
     "observationDate": "Tarkasteluhetki",
-    "observationDateAdjusted": "Tarkasteluhetkeä muutettu"
+    "observationDateAdjusted": "Tarkasteluhetkeä muutettu",
+    "stopFiltersAdjusted": "Pysäkkien suodattimia muutettu"
   },
   "search": {
     "advancedSearchTitle": "Tarkenna",


### PR DESCRIPTION
Resolves HSLdevcom/jore4#879
When editing or creating a new stop, we make sure that after the edit / creation the stop won't dissapear due to map stop filtering. So if we for example create a stop with draft priority and the drafts are not currently shown on map -> change the filters so that drafts are also shown on map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/414)
<!-- Reviewable:end -->
