### PR TITLE
Do not load arrow image multiple times

### DIFF
--- a/ui/src/utils/map/mapUtils.ts
+++ b/ui/src/utils/map/mapUtils.ts
@@ -24,12 +24,29 @@ export const createGeometryLineBetweenPoints = (
 export const loadMapAssets = (mapRef: React.RefObject<MapRef>) => {
   const map = mapRef.current?.getMap();
 
-  map?.loadImage('/img/arrow-right.png', (error: unknown, image: unknown) => {
-    if (error) throw error;
+  const imageAssets: { name: string; fileUrl: string }[] = [
+    { name: 'arrow', fileUrl: '/img/arrow-right.png' },
+  ];
 
-    // Enable sdf to make enable icon coloring.
-    // https://docs.mapbox.com/help/troubleshooting/using-recolorable-images-in-mapbox-maps/
-    if (!map.hasImage('arrow')) map.addImage('arrow', image, { sdf: true });
+  imageAssets.forEach((asset) => {
+    if (map?.hasImage(asset.name)) {
+      return;
+    }
+
+    map?.loadImage(asset.fileUrl, (error: unknown, image: unknown) => {
+      if (error) {
+        throw error;
+      }
+
+      // Even though we have already checked if the map has the image,
+      // we need to check it again here because this code is inside event callback
+      // which could be called multiple times before the map actually has the image
+      if (!map.hasImage(asset.name)) {
+        // Enable Signed Distance Fields (sdf) to make enable icon coloring.
+        // https://docs.mapbox.com/help/troubleshooting/using-recolorable-images-in-mapbox-maps/
+        map.addImage(asset.name, image, { sdf: true });
+      }
+    });
   });
 };
 


### PR DESCRIPTION
- Previously right-arrow.png was loaded tons of times because loadMapAssets function was called on every map update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/416)
<!-- Reviewable:end -->
