### PR TITLE
Refactor cypress plugin to use one db connection

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -31,12 +31,12 @@ const {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 module.exports = (on, config) => {
+  const db = getDbConnection();
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   on('task', {
     async checkDbConnection() {
       // Example about direct access to db
-      const db = getDbConnection();
       return db
         .raw('SELECT 1')
         .then((res) => {
@@ -56,11 +56,9 @@ module.exports = (on, config) => {
         });
     },
     async truncateDb() {
-      const db = getDbConnection();
       return truncateDb(db);
     },
     async executeRawDbQuery({ query, bindings }) {
-      const db = getDbConnection();
       return db.raw(query, bindings);
     },
     async hasuraApi(request) {
@@ -72,10 +70,10 @@ module.exports = (on, config) => {
     // should be accessed through "hasuraApi" function and this kind
     // of specific functions should be avoided.
     async insertVehicleSubmodOnInfraLinks(request) {
-      return insertVehicleSubmodeOnInfraLink(request);
+      return insertVehicleSubmodeOnInfraLink(db, request);
     },
     async removeVehicleSubmodOnInfraLinks(request) {
-      return removeVehicleSubmodeOnInfraLink(request);
+      return removeVehicleSubmodeOnInfraLink(db, request);
     },
   });
 };

--- a/test-db-manager/src/builders/mutations.ts
+++ b/test-db-manager/src/builders/mutations.ts
@@ -1,6 +1,5 @@
 import { gql } from 'graphql-tag';
 import { DocumentNode } from 'graphql/language/ast';
-import { getDbConnection } from '../DbManager';
 import {
   InfrastructureNetworkInfrastructureLinkInsertInput,
   JourneyPatternJourneyPatternInsertInput,
@@ -213,19 +212,18 @@ export interface VehicleSubmodeOnInfraLinkInsertInput {
 // Thus we have to use raw sql connection for handling those.
 // (Other solution could be renaming the tables.)
 export const insertVehicleSubmodeOnInfraLink = (
+  db,
   infraLinks: VehicleSubmodeOnInfraLinkInsertInput[],
 ) => {
-  const db = getDbConnection();
-
   return db('infrastructure_network.vehicle_submode_on_infrastructure_link')
     .returning(['infrastructure_link_id', 'vehicle_submode'])
     .insert(infraLinks);
 };
 
 export const removeVehicleSubmodeOnInfraLink = (
+  db,
   infraLinks: VehicleSubmodeOnInfraLinkInsertInput[],
 ) => {
-  const db = getDbConnection();
   return db('infrastructure_network.vehicle_submode_on_infrastructure_link')
     .whereIn(
       'infrastructure_link_id',

--- a/ui/src/utils/test-utils/integration-tests/db.ts
+++ b/ui/src/utils/test-utils/integration-tests/db.ts
@@ -1,4 +1,5 @@
 import {
+  getDbConnection,
   hasuraApi,
   InfraLinkAlongRouteInsertInput,
   InfraLinkInsertInput,
@@ -61,11 +62,14 @@ export const insertToDbHelper = async ({
     );
   }
   if (vehicleSubmodeOnInfrastructureLink) {
+    const db = getDbConnection();
     await insertVehicleSubmodeOnInfraLink(
+      db,
       vehicleSubmodeOnInfrastructureLink,
     ).then((res: ExplicitAny) =>
       logOnError('Inserting vehicle submodes on infra links', res),
     );
+    db.destroy();
   }
   if (lines) {
     const mutation = mapToCreateLinesMutation(lines);
@@ -133,11 +137,14 @@ export const removeFromDbHelper = async ({
     await hasuraApi(mutation).then((res) => logOnError('Removing stops', res));
   }
   if (vehicleSubmodeOnInfrastructureLink) {
+    const db = getDbConnection();
     await removeVehicleSubmodeOnInfraLink(
+      db,
       vehicleSubmodeOnInfrastructureLink,
     ).then((res: ExplicitAny) =>
       logOnError('Removing vehicle submodes on infra links', res),
     );
+    db.destroy();
   }
   if (infraLinks) {
     const mutation = mapToDeleteInfraLinksMutation(


### PR DESCRIPTION
Resolves HSLdevcom/jore4#996
Earlier we created new connection for every request and did not close it. This resulted in 'too many clients'. Now we create one connection and use it for all the requests in e2e. For integration tests we need to create the connection and close it in db.ts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/422)
<!-- Reviewable:end -->
