### PR TITLE
Improve timetable seed data

### DIFF
--- a/test-db-manager/README.md
+++ b/test-db-manager/README.md
@@ -15,4 +15,7 @@ It is implemented as separate package so that it can be used in different situat
 Note that most of the seed data is defined in `jore4-hasura` repository, in plain SQL statements.
 Anyway, we needed to have some timetables seed data for UI development, and as it has many uuid references it is really difficult to do with SQL.
 Thus it was decided to define it here.
-Same dataset can be also used in e2e/integration tests if needed.
+Same dataset can be also used in e2e/integration tests if needed, but in that case we might have to provide UUID's for test data somehow in order to be able to remove that data after tests.
+
+Currently there is no easy way to remove seeded data.
+Because of that, if seed data is changed it is recommended to delete all data from local db (by removing related docker volumes and by restarting docker environment) and start from empty db.

--- a/test-db-manager/package.json
+++ b/test-db-manager/package.json
@@ -22,12 +22,14 @@
     "graphql": "^15.5.3",
     "graphql-tag": "^2.12.6",
     "knex": "^2.1.0",
+    "lodash": "^4.17.21",
     "luxon": "^2.3.0",
     "pg": "^8.7.3",
     "rollup": "^2.75.5",
     "rollup-plugin-dts": "^4.2.2",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.2",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/pg": "^8.6.5"

--- a/test-db-manager/rollup.config.js
+++ b/test-db-manager/rollup.config.js
@@ -4,7 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
 
 const commonPlugins = [
-  nodeResolve(),
+  nodeResolve({ exportConditions: ['node'] }),
   commonjs({
     include: ['./index.js', /node_modules/],
   }),

--- a/test-db-manager/src/datasets/timetables/stopsInJourneyPatternRefs.ts
+++ b/test-db-manager/src/datasets/timetables/stopsInJourneyPatternRefs.ts
@@ -1,62 +1,55 @@
+import padStart from 'lodash/padStart';
+import range from 'lodash/range';
+import { v4 as uuid } from 'uuid';
 import { StopInJourneyPatternRefInsertInput } from '../../types';
 import { seedJourneyPatternRefs } from './journeyPatternRefs';
 
+const buildStopInJourneyPatternRef = ({
+  id = uuid(),
+  journeyPatternRefId,
+  label,
+  sequenceNumber,
+}: {
+  id?: UUID;
+  journeyPatternRefId: UUID;
+  label: string;
+  sequenceNumber: number;
+}): StopInJourneyPatternRefInsertInput => ({
+  scheduled_stop_point_in_journey_pattern_ref_id: id,
+  journey_pattern_ref_id: journeyPatternRefId,
+  scheduled_stop_point_label: label,
+  scheduled_stop_point_sequence: sequenceNumber,
+});
+
+const buildStopSequence = ({
+  journeyPatternRefId,
+  labelPrefix,
+  stopsToCreate,
+}: {
+  journeyPatternRefId: UUID;
+  labelPrefix: string;
+  stopsToCreate: number;
+}): StopInJourneyPatternRefInsertInput[] => {
+  const stops: StopInJourneyPatternRefInsertInput[] = [];
+  range(1, stopsToCreate + 1).forEach((index) => {
+    const labelPostfix = padStart(index.toString(), 2, '0');
+    stops.push(
+      buildStopInJourneyPatternRef({
+        journeyPatternRefId,
+        label: `${labelPrefix}${labelPostfix}`,
+        sequenceNumber: index,
+      }),
+    );
+  });
+
+  return stops;
+};
+
 export const seedStopsInJourneyPatternRefs: StopInJourneyPatternRefInsertInput[] =
   [
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        'e3af3052-470a-4588-9cb7-053c86995690',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2201',
-      scheduled_stop_point_sequence: 1,
-    },
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        '45a540e3-bc00-4e0a-a983-0e1a1ff1738d',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2202',
-      scheduled_stop_point_sequence: 2,
-    },
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        'aa32322e-f46d-4d54-a637-69398992538a',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2203',
-      scheduled_stop_point_sequence: 3,
-    },
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        '3cfc6959-b250-46ad-9731-602a4e6230b3',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2204',
-      scheduled_stop_point_sequence: 4,
-    },
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        '7e0f9dd7-3267-4147-b17b-b2aadfab502f',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2205',
-      scheduled_stop_point_sequence: 5,
-    },
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        '2474abd1-75d0-4eb0-9a8d-95fcceb924c8',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2206',
-      scheduled_stop_point_sequence: 6,
-    },
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        '08d51269-eecd-4bba-92f7-7c7e38bf5216',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2207',
-      scheduled_stop_point_sequence: 7,
-    },
-    {
-      scheduled_stop_point_in_journey_pattern_ref_id:
-        'e50d1df6-d32e-40ff-a069-f2d67e5cd386',
-      journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-      scheduled_stop_point_label: 'H2208',
-      scheduled_stop_point_sequence: 8,
-    },
+    ...buildStopSequence({
+      journeyPatternRefId: seedJourneyPatternRefs[0].journey_pattern_ref_id,
+      labelPrefix: 'H22',
+      stopsToCreate: 8,
+    }),
   ];

--- a/test-db-manager/src/datasets/timetables/timetabledPassingTimes.ts
+++ b/test-db-manager/src/datasets/timetables/timetabledPassingTimes.ts
@@ -1,200 +1,234 @@
 import { Duration } from 'luxon';
-import { TimetabledPassingTimeInsertInput } from '../../types';
+import {
+  StopInJourneyPatternRefInsertInput,
+  TimetabledPassingTimeInsertInput,
+} from '../../types';
+import { multiplyDuration } from '../../utils';
 import { seedStopsInJourneyPatternRefs } from './stopsInJourneyPatternRefs';
 import { seedVehicleJourneys } from './vehicleJourneys';
 
-export const seedTimetabledPassingTimes: TimetabledPassingTimeInsertInput[] = [
-  // journey 1, goes from H2201->H2208
+interface TimetabledPassingTimesForJourney {
+  vehicleJourneyId: UUID;
+  scheduledStopLabels?: string[];
+  journeyStartTime: Duration; // when does journey start
+  stopInterval?: Duration; // how long it takes to drive from stop to another
+  waitTimeOnStops?: Duration; // how long vehicle stays on stop
+}
+
+const ALL_STOP_LABELS = seedStopsInJourneyPatternRefs.map(
+  (item) => item.scheduled_stop_point_label,
+);
+
+const findStopIdByLabel = (
+  label: string,
+  knownStops: StopInJourneyPatternRefInsertInput[] = seedStopsInJourneyPatternRefs,
+) => {
+  const stop = knownStops.find(
+    (item) => item.scheduled_stop_point_label === label,
+  ).scheduled_stop_point_in_journey_pattern_ref_id;
+  if (!stop) {
+    throw new Error(`Can't find stop by label "${label}"`);
+  }
+  return stop;
+};
+
+const buildTimetabledPassingTime = (params: {
+  vehicleJourneyId: UUID;
+  stopInJourneyPatternRefId: UUID;
+  arrivalTime: Duration;
+  departureTime: Duration;
+}): TimetabledPassingTimeInsertInput => ({
+  vehicle_journey_id: params.vehicleJourneyId,
+  scheduled_stop_point_in_journey_pattern_ref_id:
+    params.stopInJourneyPatternRefId,
+  arrival_time: params.arrivalTime,
+  departure_time: params.departureTime,
+});
+
+const buildTimetabledPassingTimesForJourney = ({
+  vehicleJourneyId,
+  scheduledStopLabels = ALL_STOP_LABELS,
+  journeyStartTime,
+  stopInterval = Duration.fromISO('PT5M'),
+  waitTimeOnStops = Duration.fromISO('PT0M'),
+}: TimetabledPassingTimesForJourney): TimetabledPassingTimeInsertInput[] => {
+  let arrivalTime: Duration = null;
+  let departureTime: Duration = journeyStartTime;
+  const passingTimes = [];
+  scheduledStopLabels.forEach((item, index) => {
+    passingTimes.push(
+      buildTimetabledPassingTime({
+        vehicleJourneyId,
+        stopInJourneyPatternRefId: findStopIdByLabel(item),
+        // arrival time is set to null if is it same as departure time
+        arrivalTime: arrivalTime?.equals(departureTime) ? null : arrivalTime,
+        departureTime,
+      }),
+    );
+    arrivalTime = departureTime.plus(stopInterval);
+    departureTime =
+      index === scheduledStopLabels.length - 1
+        ? null
+        : arrivalTime.plus(waitTimeOnStops);
+  });
+  return passingTimes;
+};
+
+const buildBulkJourneys = ({
+  vehicleJourneyIds,
+  blockStartTime,
+  journeyInterval = Duration.fromISO('PT5M'),
+}: {
+  vehicleJourneyIds: UUID[];
+  blockStartTime: Duration;
+  journeyInterval?: Duration;
+}): TimetabledPassingTimeInsertInput[] => {
+  return vehicleJourneyIds.flatMap((item, index) => {
+    const durationFromStart = multiplyDuration(journeyInterval, index + 1);
+    return buildTimetabledPassingTimesForJourney({
+      vehicleJourneyId: item,
+      journeyStartTime: blockStartTime.plus(durationFromStart),
+    });
+  });
+};
+
+const journey1Id = seedVehicleJourneys[0].vehicle_journey_id;
+
+const seedTimetabledPassingTimesMonFri: TimetabledPassingTimeInsertInput[] = [
+  // journey 1, goes from H2201->H2208. Defined manually to have some "random"
+  // variation in stop times etc.
   {
-    timetabled_passing_time_id: 'b0f737fb-ef12-4905-99c4-d7c93b52d5b4',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[0]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2201'),
     arrival_time: null,
     departure_time: Duration.fromISO('PT7H5M'),
   },
   {
-    timetabled_passing_time_id: 'ebc317a0-6bfd-462f-8c5d-fe01bde05fcc',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[1]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2202'),
     arrival_time: Duration.fromISO('PT7H10M'),
     departure_time: Duration.fromISO('PT7H12M'),
   },
   {
-    timetabled_passing_time_id: '841a46be-0465-4173-9d0a-565b50dbdb94',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[2]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2203'),
     arrival_time: Duration.fromISO('PT7H18M'),
     departure_time: Duration.fromISO('PT7H20M'),
   },
   {
-    timetabled_passing_time_id: '28cff770-0b4a-468d-be18-fa252e41b69f',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[3]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2204'),
     arrival_time: Duration.fromISO('PT7H28M'),
     departure_time: Duration.fromISO('PT7H30M'),
   },
   {
-    timetabled_passing_time_id: '786de875-0254-4012-8abf-468a19f1456e',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[4]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2205'),
     arrival_time: null,
     departure_time: Duration.fromISO('PT7H38M'),
   },
   {
-    timetabled_passing_time_id: '1b017b30-3e9e-4226-abd7-9aaab386cba7',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[5]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2206'),
     arrival_time: null,
     departure_time: Duration.fromISO('PT7H48M'),
   },
   {
-    timetabled_passing_time_id: '857ac79a-8e93-4e58-8022-29b4e201d1b8',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[6]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2207'),
     arrival_time: Duration.fromISO('PT7H55M'),
     departure_time: Duration.fromISO('PT7H56M'),
   },
   {
-    timetabled_passing_time_id: '94181906-f24f-418e-8929-502b3c2536dc',
-    vehicle_journey_id: seedVehicleJourneys[0].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[7]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
+    vehicle_journey_id: journey1Id,
+    scheduled_stop_point_in_journey_pattern_ref_id: findStopIdByLabel('H2208'),
     arrival_time: Duration.fromISO('PT8H12M'),
     departure_time: null,
   },
-  // journey 2, goes from H2201->H2204
-  {
-    timetabled_passing_time_id: '57fea50c-1f0f-4dfe-a070-84c7982abe90',
-    vehicle_journey_id: seedVehicleJourneys[1].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[0]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: null,
-    departure_time: Duration.fromISO('PT8H5M'),
-  },
-  {
-    timetabled_passing_time_id: '9b0f9cb7-6659-45ea-ade2-a6d40384be6a',
-    vehicle_journey_id: seedVehicleJourneys[1].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[1]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT8H10M'),
-    departure_time: Duration.fromISO('PT8H12M'),
-  },
-  {
-    timetabled_passing_time_id: '79fec60d-6e06-4765-8a7b-0177a69af185',
-    vehicle_journey_id: seedVehicleJourneys[1].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[2]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT8H18M'),
-    departure_time: Duration.fromISO('PT8H20M'),
-  },
-  {
-    timetabled_passing_time_id: '584408b5-ff1d-435a-94eb-4662e6dd4d78',
-    vehicle_journey_id: seedVehicleJourneys[1].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[3]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT8H28M'),
-    departure_time: Duration.fromISO('PT8H30M'),
-  },
-  // journey 3, goes from H2204->H2208
-  {
-    timetabled_passing_time_id: 'da306a27-8162-4a91-a427-44f7522c7ba1',
-    vehicle_journey_id: seedVehicleJourneys[2].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[4]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: null,
-    departure_time: Duration.fromISO('PT7H38M'),
-  },
-  {
-    timetabled_passing_time_id: '57982625-9797-4fec-a624-9506cea98dfb',
-    vehicle_journey_id: seedVehicleJourneys[2].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[5]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: null,
-    departure_time: Duration.fromISO('PT7H48M'),
-  },
-  {
-    timetabled_passing_time_id: 'f5e6106b-9931-4c28-8a7d-3570a9481675',
-    vehicle_journey_id: seedVehicleJourneys[2].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[6]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT7H55M'),
-    departure_time: Duration.fromISO('PT7H56M'),
-  },
-  {
-    timetabled_passing_time_id: '93289df6-f4c5-4080-89d2-970cde04eecb',
-    vehicle_journey_id: seedVehicleJourneys[2].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[7]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT8H12M'),
-    departure_time: null,
-  },
+  // journey 2, goes from H2201->H2204, waits 2 mins on each stop
+  ...buildTimetabledPassingTimesForJourney({
+    vehicleJourneyId: seedVehicleJourneys[1].vehicle_journey_id,
+    scheduledStopLabels: ['H2201', 'H2202', 'H2203', 'H2204'],
+    journeyStartTime: Duration.fromISO('PT8H5M'),
+    waitTimeOnStops: Duration.fromISO('PT2M'),
+  }),
+  // journey 3, goes from H2204->H2208, waits 2 mins on each stop
+  ...buildTimetabledPassingTimesForJourney({
+    vehicleJourneyId: seedVehicleJourneys[2].vehicle_journey_id,
+    scheduledStopLabels: ['H2204', 'H2205', 'H2206', 'H2207', 'H2208'],
+    journeyStartTime: Duration.fromISO('PT7H38M'),
+    waitTimeOnStops: Duration.fromISO('PT2M'),
+  }),
   // journey 4, goes from H2201->H2208 but misses H2202, H2204, H2206
-  {
-    timetabled_passing_time_id: '1dc62801-86d3-498b-a50e-921451f60403',
-    vehicle_journey_id: seedVehicleJourneys[3].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[0]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: null,
-    departure_time: Duration.fromISO('PT9H5M'),
-  },
-  {
-    timetabled_passing_time_id: 'c75fb50e-7728-4018-9f71-51d48bf5d996',
-    vehicle_journey_id: seedVehicleJourneys[3].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[2]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT9H18M'),
-    departure_time: Duration.fromISO('PT9H20M'),
-  },
-  {
-    timetabled_passing_time_id: '5a41fc8a-2136-42fe-a157-383ee9011a90',
-    vehicle_journey_id: seedVehicleJourneys[3].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[4]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: null,
-    departure_time: Duration.fromISO('PT9H38M'),
-  },
-  {
-    timetabled_passing_time_id: 'ffa6ed17-eaaa-432c-b24f-ed727d361cd4',
-    vehicle_journey_id: seedVehicleJourneys[3].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[6]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT9H55M'),
-    departure_time: Duration.fromISO('PT9H56M'),
-  },
-  {
-    timetabled_passing_time_id: '26e947d3-1ec9-4ae5-b57d-1c965d8b6356',
-    vehicle_journey_id: seedVehicleJourneys[3].vehicle_journey_id,
-    scheduled_stop_point_in_journey_pattern_ref_id:
-      seedStopsInJourneyPatternRefs[7]
-        .scheduled_stop_point_in_journey_pattern_ref_id,
-    arrival_time: Duration.fromISO('PT10H12M'),
-    departure_time: null,
-  },
+  ...buildTimetabledPassingTimesForJourney({
+    vehicleJourneyId: seedVehicleJourneys[3].vehicle_journey_id,
+    scheduledStopLabels: ['H2201', 'H2203', 'H2205', 'H2207', 'H2208'],
+    journeyStartTime: Duration.fromISO('PT9H5M'),
+    stopInterval: Duration.fromISO('PT10M'),
+  }),
+  // journey 5, goes through all stops, waits 1 min on each stop
+  ...buildTimetabledPassingTimesForJourney({
+    vehicleJourneyId: seedVehicleJourneys[4].vehicle_journey_id,
+    journeyStartTime: Duration.fromISO('PT7H10M'),
+    stopInterval: Duration.fromISO('PT12M'),
+    waitTimeOnStops: Duration.fromISO('PT1M'),
+  }),
+  // journey 6, waits 10 mins on each stop
+  ...buildTimetabledPassingTimesForJourney({
+    vehicleJourneyId: seedVehicleJourneys[5].vehicle_journey_id,
+    scheduledStopLabels: ['H2201', 'H2202', 'H2203', 'H2207'],
+    journeyStartTime: Duration.fromISO('PT7H12M'),
+    stopInterval: Duration.fromISO('PT10M'),
+  }),
+  // journey 7, waits 15 mins on each stop
+  ...buildTimetabledPassingTimesForJourney({
+    vehicleJourneyId: seedVehicleJourneys[6].vehicle_journey_id,
+    journeyStartTime: Duration.fromISO('PT7H15M'),
+    stopInterval: Duration.fromISO('PT15M'),
+  }),
+  ...buildBulkJourneys({
+    vehicleJourneyIds: [
+      seedVehicleJourneys[7].vehicle_journey_id,
+      seedVehicleJourneys[8].vehicle_journey_id,
+      seedVehicleJourneys[9].vehicle_journey_id,
+      seedVehicleJourneys[10].vehicle_journey_id,
+      seedVehicleJourneys[11].vehicle_journey_id,
+      seedVehicleJourneys[12].vehicle_journey_id,
+      seedVehicleJourneys[13].vehicle_journey_id,
+      seedVehicleJourneys[14].vehicle_journey_id,
+      seedVehicleJourneys[15].vehicle_journey_id,
+      seedVehicleJourneys[16].vehicle_journey_id,
+      seedVehicleJourneys[17].vehicle_journey_id,
+      seedVehicleJourneys[18].vehicle_journey_id,
+      seedVehicleJourneys[19].vehicle_journey_id,
+    ],
+    blockStartTime: Duration.fromISO('PT7H18M'),
+    journeyInterval: Duration.fromISO('PT2M'),
+  }),
+];
+
+const seedTimetabledPassingTimesSat: TimetabledPassingTimeInsertInput[] = [
+  ...buildBulkJourneys({
+    vehicleJourneyIds: [
+      seedVehicleJourneys[20].vehicle_journey_id,
+      seedVehicleJourneys[21].vehicle_journey_id,
+      seedVehicleJourneys[22].vehicle_journey_id,
+      seedVehicleJourneys[23].vehicle_journey_id,
+    ],
+    blockStartTime: Duration.fromISO('PT10H0M'),
+  }),
+];
+
+const seedTimetabledPassingTimesSun: TimetabledPassingTimeInsertInput[] = [
+  ...buildTimetabledPassingTimesForJourney({
+    vehicleJourneyId: seedVehicleJourneys[24].vehicle_journey_id,
+    journeyStartTime: Duration.fromISO('PT10H15M'),
+    stopInterval: Duration.fromISO('PT15M'),
+  }),
+];
+
+export const seedTimetabledPassingTimes: TimetabledPassingTimeInsertInput[] = [
+  ...seedTimetabledPassingTimesMonFri,
+  ...seedTimetabledPassingTimesSat,
+  ...seedTimetabledPassingTimesSun,
 ];

--- a/test-db-manager/src/datasets/timetables/vehicleJourneys.ts
+++ b/test-db-manager/src/datasets/timetables/vehicleJourneys.ts
@@ -1,31 +1,53 @@
+import { v4 as uuid } from 'uuid';
 import { VehicleJourneyInsertInput } from '../../types';
 import { seedJourneyPatternRefs } from './journeyPatternRefs';
 import { seedVehicleServiceBlocks } from './vehicleServiceBlocks';
 
-const commonJourneyProps = {
-  journey_pattern_ref_id: seedJourneyPatternRefs[0].journey_pattern_ref_id,
-  block_id: seedVehicleServiceBlocks[0].block_id,
-};
+const monFriBlockId = seedVehicleServiceBlocks[0].block_id;
+const satBlockId = seedVehicleServiceBlocks[1].block_id;
+const sunBlockId = seedVehicleServiceBlocks[2].block_id;
+
+const buildVehicleJourney = ({
+  vehicleJourneyId,
+  journeyPatternRefId = seedJourneyPatternRefs[0].journey_pattern_ref_id,
+  blockId = monFriBlockId,
+}: {
+  vehicleJourneyId: UUID;
+  journeyPatternRefId?: UUID;
+  blockId?: UUID;
+}): VehicleJourneyInsertInput => ({
+  vehicle_journey_id: vehicleJourneyId,
+  journey_pattern_ref_id: journeyPatternRefId,
+  block_id: blockId,
+});
 
 export const seedVehicleJourneys: VehicleJourneyInsertInput[] = [
-  // journey 1
-  {
-    vehicle_journey_id: '6f1a8bd0-2017-498f-9ad2-d7ff0ffb6001',
-    ...commonJourneyProps,
-  },
-  // journey 2
-  {
-    vehicle_journey_id: '40bc64e0-08aa-47ba-b50d-54e4b64f0abb',
-    ...commonJourneyProps,
-  },
-  // journey 3
-  {
-    vehicle_journey_id: '4dc5f622-afcf-41c6-9098-aa43db2f879b',
-    ...commonJourneyProps,
-  },
-  // journey 4
-  {
-    vehicle_journey_id: 'ab5212f5-4ea0-4f17-be8d-3c9e7892bb72',
-    ...commonJourneyProps,
-  },
+  // Journeys 1-20, all belong to same journey pattern and service block (Vehicle 1 Mon-Fri)
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  buildVehicleJourney({ vehicleJourneyId: uuid() }),
+  // Journeys 21-24, all belong to same journey pattern and service block (Vehicle 1 Sat)
+  buildVehicleJourney({ vehicleJourneyId: uuid(), blockId: satBlockId }),
+  buildVehicleJourney({ vehicleJourneyId: uuid(), blockId: satBlockId }),
+  buildVehicleJourney({ vehicleJourneyId: uuid(), blockId: satBlockId }),
+  buildVehicleJourney({ vehicleJourneyId: uuid(), blockId: satBlockId }),
+  // journey 25, belongs to service block (Vehicle 1 Sun)
+  buildVehicleJourney({ vehicleJourneyId: uuid(), blockId: sunBlockId }),
 ];

--- a/test-db-manager/src/datasets/timetables/vehicleServiceBlocks.ts
+++ b/test-db-manager/src/datasets/timetables/vehicleServiceBlocks.ts
@@ -1,35 +1,41 @@
+import { v4 as uuid } from 'uuid';
 import { VehicleServiceBlockInsertInput } from '../../types';
 import { seedVehicleServices } from './vehicleServices';
 
+const buildVehicleServiceBlock = ({
+  blockId = uuid(),
+  vehicleServiceId,
+}: {
+  blockId?: UUID;
+  vehicleServiceId: UUID;
+}): VehicleServiceBlockInsertInput => ({
+  vehicle_service_id: vehicleServiceId,
+  block_id: blockId,
+});
+
 export const seedVehicleServiceBlocks: VehicleServiceBlockInsertInput[] = [
   // Vehicle 1 Mon-Fri
-  {
-    vehicle_service_id: seedVehicleServices[0].vehicle_service_id,
-    block_id: '3ebce471-1ef2-4951-af34-6a9ff0660cb8',
-  },
+  buildVehicleServiceBlock({
+    vehicleServiceId: seedVehicleServices[0].vehicle_service_id,
+  }),
   // Vehicle 1 Sat
-  {
-    vehicle_service_id: seedVehicleServices[1].vehicle_service_id,
-    block_id: '1ca443fe-d6fe-4124-88a0-ed061077aeb6',
-  },
+  buildVehicleServiceBlock({
+    vehicleServiceId: seedVehicleServices[1].vehicle_service_id,
+  }),
   // Vehicle 1 Sun
-  {
-    vehicle_service_id: seedVehicleServices[2].vehicle_service_id,
-    block_id: 'd51c6443-ec88-497c-9786-114482de05a5',
-  },
+  buildVehicleServiceBlock({
+    vehicleServiceId: seedVehicleServices[2].vehicle_service_id,
+  }),
   // Vehicle 2 Mon-Fri
-  {
-    vehicle_service_id: seedVehicleServices[0].vehicle_service_id,
-    block_id: '1ad90735-7294-475e-bf06-80f5f2163377',
-  },
+  buildVehicleServiceBlock({
+    vehicleServiceId: seedVehicleServices[0].vehicle_service_id,
+  }),
   // Vehicle 2 Sat
-  {
-    vehicle_service_id: seedVehicleServices[1].vehicle_service_id,
-    block_id: '9d37fa3c-c228-41e5-99e9-6e351160a4f5',
-  },
+  buildVehicleServiceBlock({
+    vehicleServiceId: seedVehicleServices[1].vehicle_service_id,
+  }),
   // Vehicle 2 Sun
-  {
-    vehicle_service_id: seedVehicleServices[2].vehicle_service_id,
-    block_id: '19b647c7-a515-4993-bd07-abb0f2948cfe',
-  },
+  buildVehicleServiceBlock({
+    vehicleServiceId: seedVehicleServices[2].vehicle_service_id,
+  }),
 ];

--- a/test-db-manager/src/datasets/timetables/vehicleServices.ts
+++ b/test-db-manager/src/datasets/timetables/vehicleServices.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { VehicleServiceInsertInput } from '../../types';
 import { seedVehicleScheduleFrames } from './vehicleScheduleFrames';
 
@@ -24,47 +25,44 @@ const SAT_DAY_TYPE = '61374d2b-5cce-4a7d-b63a-d487f3a05e0d';
 const SUN_DAY_TYPE = '0e1855f1-dfca-4900-a118-f608aa07e939';
 /* eslint-enable @typescript-eslint/no-unused-vars */
 
+const basicVehicleScheduleFrameId =
+  seedVehicleScheduleFrames[0].vehicle_schedule_frame_id;
+
 export const seedVehicleServices: VehicleServiceInsertInput[] = [
   // vehicle 1, Mon-Fri
   {
-    vehicle_service_id: '6b8525aa-42dc-455f-8558-132ff1b8ae10',
+    vehicle_service_id: uuid(),
     day_type_id: MON_FRI_DAY_TYPE,
-    vehicle_schedule_frame_id:
-      seedVehicleScheduleFrames[0].vehicle_schedule_frame_id,
+    vehicle_schedule_frame_id: basicVehicleScheduleFrameId,
   },
   // vehicle 1, Sat
   {
-    vehicle_service_id: 'c77f0015-b30b-44f2-b837-aba7a23e1457',
+    vehicle_service_id: uuid(),
     day_type_id: SAT_DAY_TYPE,
-    vehicle_schedule_frame_id:
-      seedVehicleScheduleFrames[0].vehicle_schedule_frame_id,
+    vehicle_schedule_frame_id: basicVehicleScheduleFrameId,
   },
   // vehicle 1, Sun
   {
-    vehicle_service_id: 'e5bb5eab-4285-413d-9def-5e0852073f78',
+    vehicle_service_id: uuid(),
     day_type_id: SUN_DAY_TYPE,
-    vehicle_schedule_frame_id:
-      seedVehicleScheduleFrames[0].vehicle_schedule_frame_id,
+    vehicle_schedule_frame_id: basicVehicleScheduleFrameId,
   },
   // vehicle 2, Mon-Fri
   {
-    vehicle_service_id: '954add13-560a-472a-a556-fb8484c7efe8',
+    vehicle_service_id: uuid(),
     day_type_id: MON_FRI_DAY_TYPE,
-    vehicle_schedule_frame_id:
-      seedVehicleScheduleFrames[0].vehicle_schedule_frame_id,
+    vehicle_schedule_frame_id: basicVehicleScheduleFrameId,
   },
   // vehicle 2, Sat
   {
-    vehicle_service_id: 'aa65a84d-5dd6-4437-a758-4588f10feeb0',
+    vehicle_service_id: uuid(),
     day_type_id: SAT_DAY_TYPE,
-    vehicle_schedule_frame_id:
-      seedVehicleScheduleFrames[0].vehicle_schedule_frame_id,
+    vehicle_schedule_frame_id: basicVehicleScheduleFrameId,
   },
   // vehicle 2, Sun
   {
-    vehicle_service_id: '5dde7383-f241-46aa-ad19-5b8a883fb6f9',
+    vehicle_service_id: uuid(),
     day_type_id: SUN_DAY_TYPE,
-    vehicle_schedule_frame_id:
-      seedVehicleScheduleFrames[0].vehicle_schedule_frame_id,
+    vehicle_schedule_frame_id: basicVehicleScheduleFrameId,
   },
 ];

--- a/test-db-manager/src/seed.ts
+++ b/test-db-manager/src/seed.ts
@@ -7,11 +7,7 @@ import {
   seedVehicleServiceBlocks,
   seedVehicleServices,
 } from './datasets/timetables';
-import {
-  clearTimetablesDb,
-  populateTimetablesDb,
-  TimetablesResources,
-} from './db-helpers';
+import { populateTimetablesDb, TimetablesResources } from './db-helpers';
 
 const seedTimetablesResources: TimetablesResources = {
   journeyPatternRefs: seedJourneyPatternRefs,
@@ -24,7 +20,6 @@ const seedTimetablesResources: TimetablesResources = {
 };
 
 const seedTimetables = async (resources: TimetablesResources) => {
-  await clearTimetablesDb(resources);
   await populateTimetablesDb(resources);
 };
 

--- a/test-db-manager/src/utils/index.ts
+++ b/test-db-manager/src/utils/index.ts
@@ -1,0 +1,7 @@
+import { Duration } from 'luxon';
+
+export const multiplyDuration = (duration: Duration, multiplier: number) => {
+  const durationInMs = duration.toMillis();
+  const multiplied = durationInMs * multiplier;
+  return Duration.fromMillis(multiplied);
+};

--- a/test-db-manager/tsconfig.json
+++ b/test-db-manager/tsconfig.json
@@ -8,6 +8,8 @@
     "outDir": "ts-dist",
     "rootDir": "src",
     "moduleResolution": "node",
+    // syntheticDefaultImports seem to be needed for avoiding "This module is declared with 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag." error from imports like "import padStart from 'lodash/padStart';"
+    "allowSyntheticDefaultImports": true,
     // for some reason building this project gives errors if this is not defined
     "skipLibCheck": true /* Skip type checking of all declaration files (*.d.ts). */
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10780,6 +10780,11 @@ uuid@^8.3.0, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"


### PR DESCRIPTION
- Generate seed data with builder functions and loops
- Remove most of hardcoded uuid values as having those makes live difficult when seeding data e.g. in loop, and even if we would have those we would still have difficulties when "re-seeding" db without emptying it e.g. after seed dataset is modified.

Related to HSLdevcom/jore4#1023

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/427)
<!-- Reviewable:end -->
