### PR TITLE
Refactor pageobject responsibilities

### DIFF
--- a/cypress/e2e/createRoute.cy.ts
+++ b/cypress/e2e/createRoute.cy.ts
@@ -189,8 +189,6 @@ describe('Route creation', () => {
           label: testRouteLabels.label1,
           direction: RouteDirectionEnum.Outbound,
           line: String(lines[0].label),
-        },
-        changeValidityFormInfo: {
           validityStartISODate: '2022-01-01',
           validityEndISODate: '2025-12-01',
           priority: Priority.Standard,
@@ -229,8 +227,6 @@ describe('Route creation', () => {
           label: testRouteLabels.label2,
           direction: RouteDirectionEnum.Inbound,
           line: String(lines[1].label),
-        },
-        changeValidityFormInfo: {
           validityStartISODate: '2022-01-01',
           validityEndISODate: '2025-12-01',
           priority: Priority.Standard,
@@ -272,8 +268,6 @@ describe('Route creation', () => {
           label: testRouteLabels.label3,
           direction: RouteDirectionEnum.Outbound,
           line: String(lines[2].label),
-        },
-        changeValidityFormInfo: {
           validityStartISODate: '2022-01-01',
           validityEndISODate: '2025-12-01',
           priority: Priority.Standard,
@@ -309,8 +303,6 @@ describe('Route creation', () => {
           label: testRouteLabels.label4,
           direction: RouteDirectionEnum.Outbound,
           line: String(lines[3].label),
-        },
-        changeValidityFormInfo: {
           validityStartISODate: '2022-01-01',
           priority: Priority.Standard,
         },

--- a/cypress/e2e/createStop.cy.ts
+++ b/cypress/e2e/createStop.cy.ts
@@ -83,8 +83,8 @@ describe('Stop creation tests', () => {
     { scrollBehavior: 'bottom', defaultCommandTimeout: 10000 },
     () => {
       modalMap.createStopAtLocation({
-        stopFormInfo: { label: testStopLabels.testLabel1 },
-        changeValidityFormInfo: {
+        stopFormInfo: {
+          label: testStopLabels.testLabel1,
           validityStartISODate: '2022-01-01',
           priority: Priority.Standard,
         },
@@ -117,8 +117,6 @@ describe('Stop creation tests', () => {
           // Actual coordinates will be on Topeliuksenkatu
           latitude: '60.18083637150667',
           longitude: '24.9215054260969',
-        },
-        changeValidityFormInfo: {
           validityStartISODate: '2022-01-01',
           priority: Priority.Standard,
         },
@@ -153,8 +151,8 @@ describe('Stop creation tests', () => {
     { scrollBehavior: 'bottom', defaultCommandTimeout: 10000 },
     () => {
       modalMap.createStopAtLocation({
-        stopFormInfo: { label: testStopLabels.endDateLabel },
-        changeValidityFormInfo: {
+        stopFormInfo: {
+          label: testStopLabels.endDateLabel,
           validityStartISODate: '2022-01-01',
           validityEndISODate: '2040-12-31',
           priority: Priority.Standard,

--- a/cypress/pageObjects/ChangeValidityForm.ts
+++ b/cypress/pageObjects/ChangeValidityForm.ts
@@ -1,8 +1,8 @@
 import { Priority } from '@hsl/jore4-test-db-manager';
 
 export interface ChangeValidityFormInfo {
-  priority: Priority;
-  validityStartISODate: string;
+  priority?: Priority;
+  validityStartISODate?: string;
   validityEndISODate?: string;
 }
 
@@ -72,8 +72,12 @@ export class ChangeValidityForm {
   };
 
   fillForm(values: ChangeValidityFormInfo) {
-    this.setPriority(values.priority);
-    this.setStartDate(values.validityStartISODate);
+    if (values.priority) {
+      this.setPriority(values.priority);
+    }
+    if (values.validityStartISODate) {
+      this.setStartDate(values.validityStartISODate);
+    }
     this.setEndDate(values.validityEndISODate);
   }
 }

--- a/cypress/pageObjects/ModalMap.ts
+++ b/cypress/pageObjects/ModalMap.ts
@@ -1,14 +1,9 @@
-import {
-  ChangeValidityForm,
-  ChangeValidityFormInfo,
-} from './ChangeValidityForm';
 import { EditRouteModal } from './EditRouteModal';
 import { ClickPointNearMapMarker, Map } from './Map';
 import { MapFooter } from './MapFooter';
 import { RouteFormInfo, RoutePropertiesForm } from './RoutePropertiesForm';
 import { RouteStopsOverlay } from './RouteStopsOverlay';
 import { StopForm, StopFormInfo } from './StopForm';
-import { TerminusNameInputs } from './TerminusNameInputs';
 import { Toast } from './Toast';
 
 export class ModalMap {
@@ -17,10 +12,6 @@ export class ModalMap {
   mapFooter = new MapFooter();
 
   routePropertiesForm = new RoutePropertiesForm();
-
-  terminusNameInputs = new TerminusNameInputs();
-
-  changeValidityForm = new ChangeValidityForm();
 
   stopForm = new StopForm();
 
@@ -38,11 +29,9 @@ export class ModalMap {
    */
   createStopNextToAnotherStop = ({
     stopFormInfo,
-    changeValidityFormInfo,
     stopPoint,
   }: {
     stopFormInfo: StopFormInfo;
-    changeValidityFormInfo: ChangeValidityFormInfo;
     stopPoint: ClickPointNearMapMarker;
   }) => {
     this.mapFooter.addStop();
@@ -50,7 +39,6 @@ export class ModalMap {
     this.map.clickAtPositionFromMapMarkerByTestId(stopPoint);
 
     this.stopForm.fillForm(stopFormInfo);
-    this.changeValidityForm.fillForm(changeValidityFormInfo);
 
     this.stopForm.save();
   };
@@ -60,12 +48,10 @@ export class ModalMap {
    */
   createStopAtLocation = ({
     stopFormInfo,
-    changeValidityFormInfo,
     clickRelativePoint,
   }: {
     stopFormInfo: StopFormInfo;
     clickRelativePoint: { xPercentage: number; yPercentage: number };
-    changeValidityFormInfo: ChangeValidityFormInfo;
   }) => {
     this.mapFooter.addStop();
 
@@ -75,7 +61,6 @@ export class ModalMap {
     );
 
     this.stopForm.fillForm(stopFormInfo);
-    this.changeValidityForm.fillForm(changeValidityFormInfo);
 
     this.stopForm.save();
   };
@@ -88,12 +73,10 @@ export class ModalMap {
    */
   createRoute = ({
     routeFormInfo,
-    changeValidityFormInfo,
     routePoints,
     omittedStops,
   }: {
     routeFormInfo: RouteFormInfo;
-    changeValidityFormInfo: ChangeValidityFormInfo;
     routePoints: ClickPointNearMapMarker[];
     omittedStops?: string[];
   }) => {
@@ -101,22 +84,6 @@ export class ModalMap {
 
     this.routePropertiesForm.fillRouteProperties(routeFormInfo);
 
-    this.terminusNameInputs.fillTerminusNameInputsForm(
-      {
-        finnishName: 'Lähtöpaikka',
-        swedishName: 'Ursprung',
-        finnishShortName: 'LP',
-        swedishShortName: 'UP',
-      },
-      {
-        finnishName: 'Määränpää',
-        swedishName: 'Ändstation',
-        finnishShortName: 'MP',
-        swedishShortName: 'ÄS',
-      },
-    );
-
-    this.changeValidityForm.fillForm(changeValidityFormInfo);
     this.editRouteModal.save();
 
     routePoints.forEach((routePoint) => {

--- a/cypress/pageObjects/RoutePropertiesForm.ts
+++ b/cypress/pageObjects/RoutePropertiesForm.ts
@@ -1,13 +1,22 @@
 import { RouteDirectionEnum } from '@hsl/jore4-test-db-manager';
+import {
+  ChangeValidityForm,
+  ChangeValidityFormInfo,
+} from './ChangeValidityForm';
+import { TerminusNameInputs } from './TerminusNameInputs';
 
-export interface RouteFormInfo {
-  finnishName: string;
-  label: string;
-  direction: RouteDirectionEnum;
+export interface RouteFormInfo extends ChangeValidityFormInfo {
+  finnishName?: string;
+  label?: string;
+  direction?: RouteDirectionEnum;
   line?: string;
 }
 
 export class RoutePropertiesForm {
+  terminusNameInputs = new TerminusNameInputs();
+
+  changeValidityForm = new ChangeValidityForm();
+
   getForm() {
     return cy.get('#route-properties-form');
   }
@@ -41,11 +50,34 @@ export class RoutePropertiesForm {
   }
 
   fillRouteProperties(values: RouteFormInfo) {
-    this.getFinnishNameInput().clear().type(values.finnishName);
-    this.getLabelInput().clear().type(values.label);
-    this.selectDirection(values.direction);
+    if (values.finnishName) {
+      this.getFinnishNameInput().clear().type(values.finnishName);
+    }
+    if (values.label) {
+      this.getLabelInput().clear().type(values.label);
+    }
+    if (values.direction) {
+      this.selectDirection(values.direction);
+    }
     if (values.line) {
       this.selectLine(values.line);
     }
+
+    this.terminusNameInputs.fillTerminusNameInputsForm(
+      {
+        finnishName: 'Lähtöpaikka',
+        swedishName: 'Ursprung',
+        finnishShortName: 'LP',
+        swedishShortName: 'UP',
+      },
+      {
+        finnishName: 'Määränpää',
+        swedishName: 'Ändstation',
+        finnishShortName: 'MP',
+        swedishShortName: 'ÄS',
+      },
+    );
+
+    this.changeValidityForm.fillForm(values);
   }
 }

--- a/cypress/pageObjects/StopForm.ts
+++ b/cypress/pageObjects/StopForm.ts
@@ -1,10 +1,17 @@
-export interface StopFormInfo {
+import {
+  ChangeValidityForm,
+  ChangeValidityFormInfo,
+} from './ChangeValidityForm';
+
+export interface StopFormInfo extends ChangeValidityFormInfo {
   label: string;
   longitude?: string;
   latitude?: string;
 }
 
 export class StopForm {
+  changeValidityForm = new ChangeValidityForm();
+
   getLabelInput() {
     return cy.getByTestId('StopFormComponent::label');
   }
@@ -25,6 +32,7 @@ export class StopForm {
     if (values.longitude) {
       this.getLongitudeInput().clear().type(values.longitude);
     }
+    this.changeValidityForm.fillForm(values);
   }
 
   /** Clicks the Edit stop modal's save button. Can be given forceAction = true


### PR DESCRIPTION
We now extend StopFormInfo and RouteFormInfo from ChangeValidityFormInfo so that we do not have to give multiple different objects to the test functions. These are logically also nested like this.

Resolves HSLdevcom/jore4#1068

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-ui/429)
<!-- Reviewable:end -->
