### PR TITLE
Implement importing timetables without preview

### DIFF
--- a/ui/src/components/timetables/import/ConfirmTimetablesImportForm.tsx
+++ b/ui/src/components/timetables/import/ConfirmTimetablesImportForm.tsx
@@ -1,0 +1,73 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRef } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Row } from '../../../layoutComponents';
+import { SimpleButton } from '../../../uiComponents';
+import { submitFormByRef } from '../../../utils';
+import {
+  PriorityForm,
+  PriorityFormState,
+  priorityFormSchema,
+} from '../../forms/common';
+
+const schema = priorityFormSchema;
+
+export type FormState = PriorityFormState;
+
+interface Props {
+  defaultValues?: Partial<FormState>;
+  className?: string;
+  onSubmit: (state: FormState) => void;
+  onCancel: () => void;
+}
+
+const testIds = {
+  saveButton: 'ConfirmTimetablesImportForm::saveButton',
+};
+
+export const ConfirmTimetablesImportForm = ({
+  defaultValues,
+  className = '',
+  onSubmit,
+  onCancel,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+  const formRef = useRef<ExplicitAny>(null);
+
+  const methods = useForm<FormState>({
+    defaultValues,
+    resolver: zodResolver(schema),
+  });
+
+  const { handleSubmit } = methods;
+
+  const onSave = () => {
+    submitFormByRef(formRef);
+  };
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <FormProvider {...methods}>
+      <form
+        id="confirm-timetables-import-form"
+        className={className}
+        onSubmit={handleSubmit(onSubmit)}
+        ref={formRef}
+      >
+        <h3 className="mb-6">{t('confirmTimetablesImportModal.priority')}</h3>
+        <PriorityForm />
+        <div className="pt-10">
+          <Row className="justify-end space-x-4">
+            <SimpleButton onClick={onCancel} inverted>
+              {t('cancel')}
+            </SimpleButton>
+            <SimpleButton testId={testIds.saveButton} onClick={onSave}>
+              {t('save')}
+            </SimpleButton>
+          </Row>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};

--- a/ui/src/components/timetables/import/ConfirmTimetablesImportModal.tsx
+++ b/ui/src/components/timetables/import/ConfirmTimetablesImportModal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useConfirmTimetablesImport } from '../../../hooks/timetables-import/useConfirmTimetablesImport';
+import { TimetablePriority } from '../../../types/Priority';
+import { Modal, ModalBody, ModalHeader } from '../../../uiComponents';
+import {
+  ConfirmTimetablesImportForm,
+  FormState,
+} from './ConfirmTimetablesImportForm';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  className?: string;
+}
+
+export const ConfirmTimetablesImportModal: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  className = '',
+}) => {
+  const { t } = useTranslation();
+  const { confirmTimetablesImport } = useConfirmTimetablesImport();
+
+  const onSave = async (state: FormState) => {
+    await confirmTimetablesImport(
+      state.priority as unknown as TimetablePriority,
+    );
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className={className}>
+      <ModalHeader
+        onClose={onClose}
+        heading={t('confirmTimetablesImportModal.title')}
+      />
+      <ModalBody>
+        <ConfirmTimetablesImportForm onSubmit={onSave} onCancel={onClose} />
+      </ModalBody>
+    </Modal>
+  );
+};

--- a/ui/src/components/timetables/import/ImportTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/ImportTimetablesPage.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useConfirmTimetablesImport } from '../../../hooks/timetables-import/useConfirmTimetablesImport';
+import { Container } from '../../../layoutComponents';
+import { SimpleButton } from '../../../uiComponents';
+import { ConfirmTimetablesImportModal } from './ConfirmTimetablesImportModal';
+
+const testIds = {
+  saveButton: 'ImportTimetablesPage::saveButton',
+};
+
+export const ImportTimetablesPage = (): JSX.Element => {
+  const { t } = useTranslation();
+  const { vehicleServiceCount } = useConfirmTimetablesImport();
+  const [isSavingImport, setIsSavingImport] = useState(false);
+
+  const importedTimetablesExist = vehicleServiceCount > 0;
+
+  return (
+    <Container>
+      <h1>{t('timetables.importTimetablesFromHastus')}</h1>
+      <SimpleButton
+        testId={testIds.saveButton}
+        onClick={() => setIsSavingImport(true)}
+        disabled={!importedTimetablesExist}
+      >
+        {t('save')}
+      </SimpleButton>
+      <ConfirmTimetablesImportModal
+        isOpen={isSavingImport}
+        onClose={() => setIsSavingImport(false)}
+      />
+    </Container>
+  );
+};

--- a/ui/src/components/timetables/main/TimetablesMainPage.tsx
+++ b/ui/src/components/timetables/main/TimetablesMainPage.tsx
@@ -1,13 +1,30 @@
 import { useTranslation } from 'react-i18next';
-import { Container } from '../../../layoutComponents';
+import { Container, Row } from '../../../layoutComponents';
+import { Path, routeDetails } from '../../../router/routeDetails';
+import { SimpleButton } from '../../../uiComponents';
 import { SearchContainer } from '../../routes-and-lines/search/SearchContainer';
+
+const testIds = {
+  importButton: 'TimetablesMainPage::importButton',
+};
 
 export const TimetablesMainPage = (): JSX.Element => {
   const { t } = useTranslation();
 
+  const importTimetablesRoute = routeDetails[Path.timetablesImport];
+
   return (
     <Container>
-      <h1>{t('timetables.timetables')}</h1>
+      <Row className="justify-between">
+        <h1>{t('timetables.timetables')}</h1>
+        <SimpleButton
+          id="import-timetables-button"
+          data-testid={testIds.importButton}
+          href={importTimetablesRoute.getLink()}
+        >
+          {t('timetables.importFromHastus')}
+        </SimpleButton>
+      </Row>
       <SearchContainer />
     </Container>
   );

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -15030,6 +15030,80 @@ export type GetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsQuery = {
   }>;
 };
 
+export type GetStagingVehicleScheduleFramesQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GetStagingVehicleScheduleFramesQuery = {
+  __typename?: 'query_root';
+  timetables?:
+    | {
+        __typename?: 'timetables_timetables_query';
+        timetables_vehicle_schedule_vehicle_schedule_frame: Array<{
+          __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
+          validity_end?: luxon.DateTime | null | undefined;
+          validity_start?: luxon.DateTime | null | undefined;
+          name_i18n: any;
+          vehicle_schedule_frame_id: UUID;
+          priority: number;
+          vehicle_services: Array<{
+            __typename?: 'timetables_vehicle_service_vehicle_service';
+            vehicle_service_id: UUID;
+            vehicle_schedule_frame: {
+              __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
+              vehicle_schedule_frame_id: UUID;
+              priority: number;
+            };
+            day_type: {
+              __typename?: 'timetables_service_calendar_day_type';
+              day_type_id: UUID;
+              label: string;
+              name_i18n: any;
+            };
+            blocks: Array<{
+              __typename?: 'timetables_vehicle_service_block';
+              block_id: UUID;
+              vehicle_journeys: Array<{
+                __typename?: 'timetables_vehicle_journey_vehicle_journey';
+                start_time: luxon.Duration;
+                vehicle_journey_id: UUID;
+              }>;
+            }>;
+          }>;
+        }>;
+      }
+    | null
+    | undefined;
+};
+
+export type ChangeStagingVehicleScheduleFramePriorityMutationVariables = Exact<{
+  newPriority: Scalars['Int'];
+}>;
+
+export type ChangeStagingVehicleScheduleFramePriorityMutation = {
+  __typename?: 'mutation_root';
+  timetables?:
+    | {
+        __typename?: 'timetables_timetables_mutation_frontend';
+        timetables_update_vehicle_schedule_vehicle_schedule_frame?:
+          | {
+              __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame_mutation_response';
+              returning: Array<{
+                __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
+                priority: number;
+                validity_end?: luxon.DateTime | null | undefined;
+                validity_start?: luxon.DateTime | null | undefined;
+                name_i18n: any;
+                vehicle_schedule_frame_id: UUID;
+              }>;
+            }
+          | null
+          | undefined;
+      }
+    | null
+    | undefined;
+};
+
 export type NewTimingPlaceFragment = {
   __typename?: 'timing_pattern_timing_place';
   label: string;
@@ -18897,6 +18971,137 @@ export type GetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsQueryResult
     GetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsQuery,
     GetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsQueryVariables
   >;
+export const GetStagingVehicleScheduleFramesDocument = gql`
+  query GetStagingVehicleScheduleFrames {
+    timetables {
+      timetables_vehicle_schedule_vehicle_schedule_frame(
+        where: { priority: { _eq: 40 } }
+      ) {
+        validity_end
+        validity_start
+        name_i18n
+        vehicle_schedule_frame_id
+        priority
+        vehicle_services {
+          ...vehicle_service_with_journeys
+        }
+      }
+    }
+  }
+  ${VehicleServiceWithJourneysFragmentDoc}
+`;
+
+/**
+ * __useGetStagingVehicleScheduleFramesQuery__
+ *
+ * To run a query within a React component, call `useGetStagingVehicleScheduleFramesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStagingVehicleScheduleFramesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetStagingVehicleScheduleFramesQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetStagingVehicleScheduleFramesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetStagingVehicleScheduleFramesQuery,
+    GetStagingVehicleScheduleFramesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetStagingVehicleScheduleFramesQuery,
+    GetStagingVehicleScheduleFramesQueryVariables
+  >(GetStagingVehicleScheduleFramesDocument, options);
+}
+export function useGetStagingVehicleScheduleFramesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetStagingVehicleScheduleFramesQuery,
+    GetStagingVehicleScheduleFramesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetStagingVehicleScheduleFramesQuery,
+    GetStagingVehicleScheduleFramesQueryVariables
+  >(GetStagingVehicleScheduleFramesDocument, options);
+}
+export type GetStagingVehicleScheduleFramesQueryHookResult = ReturnType<
+  typeof useGetStagingVehicleScheduleFramesQuery
+>;
+export type GetStagingVehicleScheduleFramesLazyQueryHookResult = ReturnType<
+  typeof useGetStagingVehicleScheduleFramesLazyQuery
+>;
+export type GetStagingVehicleScheduleFramesQueryResult = Apollo.QueryResult<
+  GetStagingVehicleScheduleFramesQuery,
+  GetStagingVehicleScheduleFramesQueryVariables
+>;
+export const ChangeStagingVehicleScheduleFramePriorityDocument = gql`
+  mutation ChangeStagingVehicleScheduleFramePriority($newPriority: Int!) {
+    timetables {
+      timetables_update_vehicle_schedule_vehicle_schedule_frame(
+        where: { priority: { _eq: 40 } }
+        _set: { priority: $newPriority }
+      ) {
+        returning {
+          priority
+          validity_end
+          validity_start
+          name_i18n
+          vehicle_schedule_frame_id
+        }
+      }
+    }
+  }
+`;
+export type ChangeStagingVehicleScheduleFramePriorityMutationFn =
+  Apollo.MutationFunction<
+    ChangeStagingVehicleScheduleFramePriorityMutation,
+    ChangeStagingVehicleScheduleFramePriorityMutationVariables
+  >;
+
+/**
+ * __useChangeStagingVehicleScheduleFramePriorityMutation__
+ *
+ * To run a mutation, you first call `useChangeStagingVehicleScheduleFramePriorityMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useChangeStagingVehicleScheduleFramePriorityMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [changeStagingVehicleScheduleFramePriorityMutation, { data, loading, error }] = useChangeStagingVehicleScheduleFramePriorityMutation({
+ *   variables: {
+ *      newPriority: // value for 'newPriority'
+ *   },
+ * });
+ */
+export function useChangeStagingVehicleScheduleFramePriorityMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    ChangeStagingVehicleScheduleFramePriorityMutation,
+    ChangeStagingVehicleScheduleFramePriorityMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    ChangeStagingVehicleScheduleFramePriorityMutation,
+    ChangeStagingVehicleScheduleFramePriorityMutationVariables
+  >(ChangeStagingVehicleScheduleFramePriorityDocument, options);
+}
+export type ChangeStagingVehicleScheduleFramePriorityMutationHookResult =
+  ReturnType<typeof useChangeStagingVehicleScheduleFramePriorityMutation>;
+export type ChangeStagingVehicleScheduleFramePriorityMutationResult =
+  Apollo.MutationResult<ChangeStagingVehicleScheduleFramePriorityMutation>;
+export type ChangeStagingVehicleScheduleFramePriorityMutationOptions =
+  Apollo.BaseMutationOptions<
+    ChangeStagingVehicleScheduleFramePriorityMutation,
+    ChangeStagingVehicleScheduleFramePriorityMutationVariables
+  >;
 export const InsertTimingPlaceDocument = gql`
   mutation InsertTimingPlace(
     $object: timing_pattern_timing_place_insert_input!
@@ -19780,6 +19985,15 @@ export type GetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsAsyncQueryH
   ReturnType<
     typeof useGetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsAsyncQuery
   >;
+export function useGetStagingVehicleScheduleFramesAsyncQuery() {
+  return useAsyncQuery<
+    GetStagingVehicleScheduleFramesQuery,
+    GetStagingVehicleScheduleFramesQueryVariables
+  >(GetStagingVehicleScheduleFramesDocument);
+}
+export type GetStagingVehicleScheduleFramesAsyncQueryHookResult = ReturnType<
+  typeof useGetStagingVehicleScheduleFramesAsyncQuery
+>;
 
 export function useGetTimingPlacesByLabelAsyncQuery() {
   return useAsyncQuery<

--- a/ui/src/hooks/timetables-import/useConfirmTimetablesImport.ts
+++ b/ui/src/hooks/timetables-import/useConfirmTimetablesImport.ts
@@ -1,0 +1,70 @@
+import { gql } from '@apollo/client';
+import { pipe } from 'remeda';
+import {
+  useChangeStagingVehicleScheduleFramePriorityMutation,
+  useGetStagingVehicleScheduleFramesQuery,
+} from '../../generated/graphql';
+import { TimetablePriority } from '../../types/Priority';
+import { mapToVariables } from '../../utils';
+
+const GQL_GET_STAGING_VEHICLE_SCHEDULE_FRAMES = gql`
+  query GetStagingVehicleScheduleFrames {
+    timetables {
+      timetables_vehicle_schedule_vehicle_schedule_frame(
+        where: { priority: { _eq: 40 } }
+      ) {
+        validity_end
+        validity_start
+        name_i18n
+        vehicle_schedule_frame_id
+        priority
+        vehicle_services {
+          ...vehicle_service_with_journeys
+        }
+      }
+    }
+  }
+`;
+
+const GQL_CHANGE_STAGING_VEHICLE_SCHEDULE_FRAME_PRIORITY = gql`
+  mutation ChangeStagingVehicleScheduleFramePriority($newPriority: Int!) {
+    timetables {
+      timetables_update_vehicle_schedule_vehicle_schedule_frame(
+        where: { priority: { _eq: 40 } }
+        _set: { priority: $newPriority }
+      ) {
+        returning {
+          priority
+          validity_end
+          validity_start
+          name_i18n
+          vehicle_schedule_frame_id
+        }
+      }
+    }
+  }
+`;
+
+export const useConfirmTimetablesImport = () => {
+  const [changeTimetablesPriority] =
+    useChangeStagingVehicleScheduleFramePriorityMutation();
+
+  const importedScheduleFrames = useGetStagingVehicleScheduleFramesQuery();
+
+  const confirmTimetablesImport = async (priority: TimetablePriority) => {
+    await changeTimetablesPriority(mapToVariables({ newPriority: priority }));
+  };
+
+  const vehicleServiceCount =
+    pipe(
+      importedScheduleFrames.data?.timetables?.timetables_vehicle_schedule_vehicle_schedule_frame.flatMap(
+        (frame) =>
+          frame.vehicle_services.flatMap((service) =>
+            service.blocks.flatMap((block) => block.vehicle_journeys),
+          ),
+      ),
+      (vehicleServices) => vehicleServices?.length,
+    ) || 0;
+
+  return { confirmTimetablesImport, vehicleServiceCount };
+};

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -289,7 +289,13 @@
     "validityPeriodLabel": "Timetables valid",
     "departures": "Departures",
     "noService": "No service",
-    "at": "at {{ time }}"
+    "at": "at {{ time }}",
+    "importFromHastus": "Import from Hastus",
+    "importTimetablesFromHastus": "Import timetables from Hastus"
+  },
+  "confirmTimetablesImportModal": {
+    "title": "Save changes",
+    "priority": "Timetables' priority"
   },
   "export": {
     "startSelecting": "Select",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -289,7 +289,13 @@
     "validityPeriodLabel": "Aikataulut voimassa",
     "departures": "Lähdöt",
     "noService": "Ei vuoroja",
-    "at": "klo {{ time }}"
+    "at": "klo {{ time }}",
+    "importFromHastus": "Tuo Hastuksesta",
+    "importTimetablesFromHastus": "Tuo aikataulut Hastuksesta"
+  },
+  "confirmTimetablesImportModal": {
+    "title": "Tallenna muutos",
+    "priority": "Aikataulujen prioriteetti"
   },
   "export": {
     "startSelecting": "Valitse",

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -14,6 +14,7 @@ import {
   TimetablesMainPage,
   VehicleScheduleDetailsPage,
 } from '../components/timetables';
+import { ImportTimetablesPage } from '../components/timetables/import/ImportTimetablesPage';
 import { Main } from '../pages/Main';
 import { Path } from './routeDetails';
 
@@ -83,6 +84,11 @@ export const Router: FunctionComponent = () => {
       _routerRoute: Path.lineTimetables,
       _exact: true,
       component: VehicleScheduleDetailsPage,
+    },
+    [Path.timetablesImport]: {
+      _routerRoute: Path.timetablesImport,
+      _exact: true,
+      component: ImportTimetablesPage,
     },
     [Path.fallback]: {
       _routerRoute: Path.fallback,

--- a/ui/src/router/routeDetails.ts
+++ b/ui/src/router/routeDetails.ts
@@ -13,6 +13,7 @@ export enum Path {
   lineDrafts = '/lines/:label/drafts',
   editLine = '/lines/:id/edit',
   lineTimetables = '/timetables/lines/:id',
+  timetablesImport = '/timetables/import',
   fallback = '*',
 }
 
@@ -94,6 +95,11 @@ export const routeDetails: Record<Path, RouteDetail> = {
   [Path.lineTimetables]: {
     getLink: (id: string, routeLabel?: string) =>
       getLineIdRouteLabelLink(Path.lineTimetables, id, routeLabel),
+    includeInNav: false,
+  },
+  [Path.timetablesImport]: {
+    getLink: () => Path.timetablesImport,
+    translationKey: 'timetables.import',
     includeInNav: false,
   },
   [Path.fallback]: {


### PR DESCRIPTION
In this PR we import routes with very MVP implementation:
- Imported routes are first saved to same database with production data with staging (40) priority after uploading csv file. This step is not done in this PR, but this change is in progress.
- After uploading timetables, "save" button will be enabled which opens a modal where we can set a priority which we want to set for the imported timetables.
- After saving that modal, imported timetables' priorities are changed to selected priority.
- This will never fail at this point as timetables lack constraints, they will be implemented later.

Resolves HSLdevcom/jore4#947

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/462)
<!-- Reviewable:end -->
