### PR TITLE
Add waits to timingplace dropdown search

### DIFF
--- a/cypress/e2e/editStop.cy.ts
+++ b/cypress/e2e/editStop.cy.ts
@@ -260,9 +260,15 @@ describe('Stop editing tests', () => {
         .click();
       map.stopPopUp.getEditButton().click();
 
+      stopForm.getTimingPlaceDropdown().type(testTimingPlaceLabels.label1);
+
+      // Wait for the search results before trying to find the result list item
+      cy.wait('@gqlGetTimingPlacesForCombobox')
+        .its('response.statusCode')
+        .should('equal', 200);
+
       stopForm
         .getTimingPlaceDropdown()
-        .click()
         .find('ul')
         .should('contain', testTimingPlaceLabels.label1);
     },

--- a/cypress/pageObjects/StopForm.ts
+++ b/cypress/pageObjects/StopForm.ts
@@ -42,6 +42,10 @@ export class StopForm {
   selectTimingPlace(timingPlaceName: string) {
     // type to form to make sure that desired timing place is visible
     this.getTimingPlaceDropdown().type(timingPlaceName);
+    // Wait for the search results before trying to find the result list item
+    cy.wait('@gqlGetTimingPlacesForCombobox')
+      .its('response.statusCode')
+      .should('equal', 200);
     this.getTimingPlaceDropdown().find('li').contains(timingPlaceName).click();
   }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.4.11",
-    "@headlessui/react": "1.6.5",
+    "@headlessui/react": "^1.7.10",
     "@nebula.gl/edit-modes": "0.23.8",
     "@reduxjs/toolkit": "^1.8.0",
     "@graphql-typed-document-node/core": "^3.2.0",

--- a/ui/src/components/forms/route/ChooseLineDropdown.tsx
+++ b/ui/src/components/forms/route/ChooseLineDropdown.tsx
@@ -57,6 +57,7 @@ export const ChooseLineDropdown = ({
     <SearchableDropdown
       id="choose-line-combobox"
       testId={testId}
+      query={query}
       mapToButtonContent={mapToButtonContent}
       options={options}
       value={value}

--- a/ui/src/components/forms/route/ChooseRouteDropdown.tsx
+++ b/ui/src/components/forms/route/ChooseRouteDropdown.tsx
@@ -71,6 +71,7 @@ export const ChooseRouteDropdown = ({
     <SearchableDropdown
       id="choose-route-combobox"
       testId={testId}
+      query={query}
       mapToButtonContent={mapToButtonContent}
       options={options}
       value={value}

--- a/ui/src/components/forms/route/__snapshots__/ChooseLineDropdown.spec.tsx.snap
+++ b/ui/src/components/forms/route/__snapshots__/ChooseLineDropdown.spec.tsx.snap
@@ -4,24 +4,29 @@ exports[`<ChooseLineDropdown /> Opens dropdown when clicked and shows all lines 
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state="open"
     data-testid="ChooseLineDropdown1"
     id="choose-line-combobox"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r8:"
-      aria-controls="headlessui-combobox-options-:r7:"
+      aria-activedescendant="headlessui-combobox-option-:r7:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r6:"
       aria-expanded="true"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state="open"
       data-testid="ChooseLineDropdown1::input"
       id="headlessui-combobox-input-:r4:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
-      aria-controls="headlessui-combobox-options-:r7:"
+      aria-controls="headlessui-combobox-options-:r6:"
       aria-expanded="true"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state="open"
       data-testid="ChooseLineDropdown1::button"
       id="headlessui-combobox-button-:r5:"
       tabindex="-1"
@@ -56,15 +61,16 @@ exports[`<ChooseLineDropdown /> Opens dropdown when clicked and shows all lines 
       />
     </button>
     <ul
-      aria-activedescendant="headlessui-combobox-option-:r8:"
       aria-labelledby="headlessui-combobox-button-:r5:"
       class="absolute left-0 z-10 w-full rounded-b-md border border-black border-opacity-20 bg-white shadow-md focus:outline-none transition ease-out duration-100 opacity-0 scale-95"
-      id="headlessui-combobox-options-:r7:"
+      data-headlessui-state="open"
+      id="headlessui-combobox-options-:r6:"
       role="listbox"
     >
       <li
         aria-selected="true"
-        id="headlessui-combobox-option-:r8:"
+        data-headlessui-state="active selected"
+        id="headlessui-combobox-option-:r7:"
         role="option"
         tabindex="-1"
       >
@@ -102,7 +108,9 @@ exports[`<ChooseLineDropdown /> Opens dropdown when clicked and shows all lines 
         </span>
       </li>
       <li
-        id="headlessui-combobox-option-:r9:"
+        aria-selected="false"
+        data-headlessui-state=""
+        id="headlessui-combobox-option-:r8:"
         role="option"
         tabindex="-1"
       >
@@ -148,21 +156,26 @@ exports[`<ChooseLineDropdown /> Shows correct texts when loading with preselecte
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseLineDropdown1"
     id="choose-line-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::input"
       id="headlessui-combobox-input-:r0:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::button"
       id="headlessui-combobox-button-:r1:"
       tabindex="-1"
@@ -204,21 +217,26 @@ exports[`<ChooseLineDropdown /> Shows correct texts when loading with preselecte
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseLineDropdown1"
     id="choose-line-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::input"
       id="headlessui-combobox-input-:r0:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::button"
       id="headlessui-combobox-button-:r1:"
       tabindex="-1"
@@ -260,21 +278,26 @@ exports[`<ChooseLineDropdown /> Shows correct texts when loading without pre-sel
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseLineDropdown1"
     id="choose-line-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::input"
       id="headlessui-combobox-input-:r2:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::button"
       id="headlessui-combobox-button-:r3:"
       tabindex="-1"
@@ -316,21 +339,26 @@ exports[`<ChooseLineDropdown /> Shows correct texts when loading without pre-sel
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseLineDropdown1"
     id="choose-line-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::input"
       id="headlessui-combobox-input-:r2:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseLineDropdown1::button"
       id="headlessui-combobox-button-:r3:"
       tabindex="-1"

--- a/ui/src/components/forms/route/__snapshots__/ChooseRouteDropdown.spec.tsx.snap
+++ b/ui/src/components/forms/route/__snapshots__/ChooseRouteDropdown.spec.tsx.snap
@@ -4,23 +4,28 @@ exports[`<ChooseRouteDropdown /> Filters shown routes when query is set 1`] = `
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseRouteDropdown1"
     id="choose-route-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::input"
-      id="headlessui-combobox-input-:r6:"
+      id="headlessui-combobox-input-:r5:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::button"
-      id="headlessui-combobox-button-:r7:"
+      id="headlessui-combobox-button-:r6:"
       tabindex="-1"
       type="button"
     >
@@ -60,23 +65,28 @@ exports[`<ChooseRouteDropdown /> Filters shown routes when query is set 2`] = `
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseRouteDropdown1"
     id="choose-route-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::input"
-      id="headlessui-combobox-input-:r6:"
+      id="headlessui-combobox-input-:r5:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::button"
-      id="headlessui-combobox-button-:r7:"
+      id="headlessui-combobox-button-:r6:"
       tabindex="-1"
       type="button"
     >
@@ -116,26 +126,31 @@ exports[`<ChooseRouteDropdown /> Filters shown routes when query is set 3`] = `
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state="open"
     data-testid="ChooseRouteDropdown1"
     id="choose-route-combobox"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:ra:"
-      aria-controls="headlessui-combobox-options-:r9:"
+      aria-activedescendant="headlessui-combobox-option-:r8:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r7:"
       aria-expanded="true"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state="open"
       data-testid="ChooseRouteDropdown1::input"
-      id="headlessui-combobox-input-:r6:"
+      id="headlessui-combobox-input-:r5:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
-      aria-controls="headlessui-combobox-options-:r9:"
+      aria-controls="headlessui-combobox-options-:r7:"
       aria-expanded="true"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state="open"
       data-testid="ChooseRouteDropdown1::button"
-      id="headlessui-combobox-button-:r7:"
+      id="headlessui-combobox-button-:r6:"
       tabindex="-1"
       type="button"
     >
@@ -163,14 +178,16 @@ exports[`<ChooseRouteDropdown /> Filters shown routes when query is set 3`] = `
       />
     </button>
     <ul
-      aria-activedescendant="headlessui-combobox-option-:ra:"
-      aria-labelledby="headlessui-combobox-button-:r7:"
+      aria-labelledby="headlessui-combobox-button-:r6:"
       class="absolute left-0 z-10 w-full rounded-b-md border border-black border-opacity-20 bg-white shadow-md focus:outline-none transition ease-out duration-100 opacity-0 scale-95"
-      id="headlessui-combobox-options-:r9:"
+      data-headlessui-state="open"
+      id="headlessui-combobox-options-:r7:"
       role="listbox"
     >
       <li
-        id="headlessui-combobox-option-:ra:"
+        aria-selected="false"
+        data-headlessui-state="active"
+        id="headlessui-combobox-option-:r8:"
         role="option"
         tabindex="-1"
       >
@@ -223,21 +240,26 @@ exports[`<ChooseRouteDropdown /> Opens dropdown when clicked and shows all route
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseRouteDropdown1"
     id="choose-route-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::input"
       id="headlessui-combobox-input-:r0:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::button"
       id="headlessui-combobox-button-:r1:"
       tabindex="-1"
@@ -279,21 +301,26 @@ exports[`<ChooseRouteDropdown /> Opens dropdown when clicked and shows all route
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state=""
     data-testid="ChooseRouteDropdown1"
     id="choose-route-combobox"
   >
     <input
+      aria-autocomplete="list"
       aria-expanded="false"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::input"
       id="headlessui-combobox-input-:r0:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
       aria-expanded="false"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state=""
       data-testid="ChooseRouteDropdown1::button"
       id="headlessui-combobox-button-:r1:"
       tabindex="-1"
@@ -335,24 +362,29 @@ exports[`<ChooseRouteDropdown /> Opens dropdown when clicked and shows all route
 <DocumentFragment>
   <div
     class="relative w-full"
+    data-headlessui-state="open"
     data-testid="ChooseRouteDropdown1"
     id="choose-route-combobox"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r4:"
-      aria-controls="headlessui-combobox-options-:r3:"
+      aria-activedescendant="headlessui-combobox-option-:r3:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r2:"
       aria-expanded="true"
       class="relative h-full w-full rounded-md border border-grey bg-white py-3 px-2"
+      data-headlessui-state="open"
       data-testid="ChooseRouteDropdown1::input"
       id="headlessui-combobox-input-:r0:"
       role="combobox"
       type="text"
+      value=""
     />
     <button
-      aria-controls="headlessui-combobox-options-:r3:"
+      aria-controls="headlessui-combobox-options-:r2:"
       aria-expanded="true"
-      aria-haspopup="true"
+      aria-haspopup="listbox"
       class="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+      data-headlessui-state="open"
       data-testid="ChooseRouteDropdown1::button"
       id="headlessui-combobox-button-:r1:"
       tabindex="-1"
@@ -387,14 +419,16 @@ exports[`<ChooseRouteDropdown /> Opens dropdown when clicked and shows all route
       />
     </button>
     <ul
-      aria-activedescendant="headlessui-combobox-option-:r4:"
       aria-labelledby="headlessui-combobox-button-:r1:"
       class="absolute left-0 z-10 w-full rounded-b-md border border-black border-opacity-20 bg-white shadow-md focus:outline-none transition ease-out duration-100 opacity-0 scale-95"
-      id="headlessui-combobox-options-:r3:"
+      data-headlessui-state="open"
+      id="headlessui-combobox-options-:r2:"
       role="listbox"
     >
       <li
-        id="headlessui-combobox-option-:r4:"
+        aria-selected="false"
+        data-headlessui-state="active"
+        id="headlessui-combobox-option-:r3:"
         role="option"
         tabindex="-1"
       >
@@ -439,7 +473,9 @@ exports[`<ChooseRouteDropdown /> Opens dropdown when clicked and shows all route
         </span>
       </li>
       <li
-        id="headlessui-combobox-option-:r5:"
+        aria-selected="false"
+        data-headlessui-state=""
+        id="headlessui-combobox-option-:r4:"
         role="option"
         tabindex="-1"
       >

--- a/ui/src/components/forms/stop/ChooseTimingPlaceDropdown.tsx
+++ b/ui/src/components/forms/stop/ChooseTimingPlaceDropdown.tsx
@@ -60,6 +60,7 @@ export const ChooseTimingPlaceDropdown = ({
   return (
     <SearchableDropdown
       id="choose-timing-place-combobox"
+      query={query}
       testId={testId}
       mapToButtonContent={mapToButtonContent}
       nullOptionRender={nullOptionRender}

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
         aria-checked="false"
         aria-labelledby="headlessui-label-:r0:"
         class=" border-grey relative inline-flex h-6 w-11 items-center rounded-full border transition-colors"
+        data-headlessui-state=""
         data-testid="show-unused-stops-switch"
         id="headlessui-switch-:r1:"
         role="switch"
@@ -234,6 +235,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
         aria-checked="false"
         aria-labelledby="headlessui-label-:r0:"
         class=" border-grey relative inline-flex h-6 w-11 items-center rounded-full border transition-colors"
+        data-headlessui-state=""
         data-testid="show-unused-stops-switch"
         id="headlessui-switch-:r1:"
         role="switch"
@@ -499,11 +501,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           <td>
             <div
               class="relative"
+              data-headlessui-state=""
             >
               <button
                 aria-expanded="false"
-                aria-haspopup="true"
+                aria-haspopup="menu"
                 class="mx-auto flex items-center px-3 focus:outline-none"
+                data-headlessui-state=""
                 data-testid="StopActionsDrowdown::menu"
                 id="headlessui-menu-button-:r2:"
                 type="button"
@@ -599,11 +603,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           <td>
             <div
               class="relative"
+              data-headlessui-state=""
             >
               <button
                 aria-expanded="false"
-                aria-haspopup="true"
+                aria-haspopup="menu"
                 class="mx-auto flex items-center px-3 focus:outline-none"
+                data-headlessui-state=""
                 data-testid="StopActionsDrowdown::menu"
                 id="headlessui-menu-button-:r3:"
                 type="button"
@@ -652,6 +658,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
         aria-checked="true"
         aria-labelledby="headlessui-label-:r0:"
         class=" border-brand bg-brand relative inline-flex h-6 w-11 items-center rounded-full border transition-colors"
+        data-headlessui-state="checked"
         data-testid="show-unused-stops-switch"
         id="headlessui-switch-:r1:"
         role="switch"
@@ -917,11 +924,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           <td>
             <div
               class="relative"
+              data-headlessui-state=""
             >
               <button
                 aria-expanded="false"
-                aria-haspopup="true"
+                aria-haspopup="menu"
                 class="mx-auto flex items-center px-3 focus:outline-none"
+                data-headlessui-state=""
                 data-testid="StopActionsDrowdown::menu"
                 id="headlessui-menu-button-:r2:"
                 type="button"
@@ -1017,11 +1026,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           <td>
             <div
               class="relative"
+              data-headlessui-state=""
             >
               <button
                 aria-expanded="false"
-                aria-haspopup="true"
+                aria-haspopup="menu"
                 class="mx-auto flex items-center px-3 focus:outline-none"
+                data-headlessui-state=""
                 data-testid="StopActionsDrowdown::menu"
                 id="headlessui-menu-button-:r4:"
                 type="button"
@@ -1117,11 +1128,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           <td>
             <div
               class="relative"
+              data-headlessui-state=""
             >
               <button
                 aria-expanded="false"
-                aria-haspopup="true"
+                aria-haspopup="menu"
                 class="mx-auto flex items-center px-3 focus:outline-none"
+                data-headlessui-state=""
                 data-testid="StopActionsDrowdown::menu"
                 id="headlessui-menu-button-:r5:"
                 type="button"

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -12,6 +12,7 @@ export * from './ui';
 export * from './urlQuery';
 export * from './useAsyncQuery';
 export * from './useCheckValidityAndPriorityConflicts';
+export * from './useDebouncedString';
 export * from './useGetLineTimetableVersions';
 export * from './usePagination';
 export * from './useShowRoutesOnModal';

--- a/ui/src/hooks/ui/useChooseRouteDropdown.ts
+++ b/ui/src/hooks/ui/useChooseRouteDropdown.ts
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client';
 import { DateTime } from 'luxon';
+import { useState } from 'react';
 import {
   RouteAllFieldsFragment,
   useGetRouteDetailsByLabelWildcardQuery,
@@ -7,6 +8,7 @@ import {
 } from '../../generated/graphql';
 import { Priority } from '../../types/enums';
 import { mapToSqlLikeValue, mapToVariables } from '../../utils';
+import { useDebouncedString } from '../useDebouncedString';
 
 const GQL_GET_ROUTE_DETAILS_BY_LABEL_WILDCARD = gql`
   query GetRouteDetailsByLabelWildcard(
@@ -53,9 +55,12 @@ export const useChooseRouteDropdown = ({
   priorities,
   routeId,
 }: Props) => {
+  const [debouncedQuery] = useDebouncedString(query, 300);
+
+  const [routes, setRoutes] = useState<RouteAllFieldsFragment[]>(Array);
   const routesResult = useGetRouteDetailsByLabelWildcardQuery(
     mapToVariables({
-      labelPattern: `${mapToSqlLikeValue(query)}%`,
+      labelPattern: `${mapToSqlLikeValue(debouncedQuery)}%`,
       date: observationDate.toISO(),
       priorities,
     }),
@@ -69,12 +74,22 @@ export const useChooseRouteDropdown = ({
     variables: { routeId: routeId! },
   });
 
+  if (
+    !routesResult.loading &&
+    routesResult.data &&
+    routesResult.data?.route_route !== routes
+  ) {
+    setRoutes(routesResult.data.route_route);
+  }
+
   const selectedRoute = selectedRouteResult.data?.route_route_by_pk as
     | RouteAllFieldsFragment
     | undefined;
 
-  const routes = (routesResult.data?.route_route ||
-    []) as RouteAllFieldsFragment[];
+  // While fetching the selected route, we can use the data from routes
+  const displayedSelectedRoute = selectedRouteResult.loading
+    ? routes.find((route) => route.route_id === routeId)
+    : selectedRoute;
 
-  return { routes, selectedRoute };
+  return { routes, selectedRoute: displayedSelectedRoute };
 };

--- a/ui/src/hooks/ui/useChooseTimingPlaceDropdown.ts
+++ b/ui/src/hooks/ui/useChooseTimingPlaceDropdown.ts
@@ -1,4 +1,6 @@
 import { gql } from '@apollo/client';
+import { useState } from 'react';
+import { useDebouncedString } from '..';
 import {
   TimingPlaceForComboboxFragment,
   useGetSelectedTimingPlaceDetailsByIdQuery,
@@ -41,9 +43,13 @@ export const useChooseTimingPlaceDropdown = (
   timingPlaces: TimingPlaceForComboboxFragment[];
   selectedTimingPlace?: TimingPlaceForComboboxFragment;
 } => {
+  const [debouncedQuery] = useDebouncedString(query, 300);
+
+  const [timingPlaces, setTimingPlaces] =
+    useState<TimingPlaceForComboboxFragment[]>(Array);
   const timingPlacesResult = useGetTimingPlacesForComboboxQuery(
     mapToVariables({
-      labelPattern: `${mapToSqlLikeValue(query)}%`,
+      labelPattern: `${mapToSqlLikeValue(debouncedQuery)}%`,
     }),
   );
 
@@ -55,16 +61,26 @@ export const useChooseTimingPlaceDropdown = (
     variables: { timing_place_id: timingPlaceId! },
   });
 
+  if (
+    !timingPlacesResult.loading &&
+    timingPlacesResult.data &&
+    timingPlacesResult.data.timing_pattern_timing_place !== timingPlaces
+  ) {
+    setTimingPlaces(timingPlacesResult.data?.timing_pattern_timing_place);
+  }
+
   const selectedTimingPlace = selectedTimingPlaceResults.data
     ?.timing_pattern_timing_place_by_pk as
     | TimingPlaceForComboboxFragment
     | undefined;
 
-  const timingPlaces = (timingPlacesResult.data?.timing_pattern_timing_place ||
-    []) as TimingPlaceForComboboxFragment[];
+  // While fetching the selected timingplace, we can use the data from timingPlaces
+  const displayedSelectedTimingPlace = selectedTimingPlaceResults.loading
+    ? timingPlaces.find((tp) => tp.timing_place_id === timingPlaceId)
+    : selectedTimingPlace;
 
   return {
     timingPlaces,
-    selectedTimingPlace,
+    selectedTimingPlace: displayedSelectedTimingPlace,
   };
 };

--- a/ui/src/hooks/useDebouncedString.ts
+++ b/ui/src/hooks/useDebouncedString.ts
@@ -1,0 +1,19 @@
+import debounce from 'lodash/debounce';
+import { useEffect, useMemo, useState } from 'react';
+
+/**
+ * Takes string as input, debounces and returns it after given delay
+ */
+export const useDebouncedString = (string: string, delay: number) => {
+  const [debouncedString, setDebouncedString] = useState('');
+  const debouncedSetString = useMemo(
+    () => debounce(setDebouncedString, delay),
+    [delay],
+  );
+
+  useEffect(() => {
+    debouncedSetString(string);
+  }, [debouncedSetString, string]);
+
+  return [debouncedString];
+};

--- a/ui/src/uiComponents/Combobox.tsx
+++ b/ui/src/uiComponents/Combobox.tsx
@@ -2,7 +2,7 @@ import { Combobox as HUICombobox, Transition } from '@headlessui/react';
 import { Fragment, ReactNode } from 'react';
 import { Noop } from 'react-hook-form';
 import { MdCheck, MdSearch } from 'react-icons/md';
-import { OptionRenderPropArg, dropdownTransition } from './Listbox';
+import { dropdownTransition, OptionRenderPropArg } from './Listbox';
 
 export const testIds = {
   input: (testId: string) => `${testId}::input`,
@@ -43,13 +43,28 @@ export const Combobox = ({
   options,
   value,
   onChange,
-  onBlur,
+  onBlur: onBlurParent,
   onQueryChange,
-  nullable = false,
 }: Props): JSX.Element => {
   const onItemSelected = (val: string) => {
     const event: ComboboxEvent = { target: { value: val } };
     onChange(event);
+  };
+
+  /**
+   * HUI Combobox is somewhat weirdly implemented and clicking an option inside the combobox
+   * will trigger onBlur event which will cause a flickering inside the texts that are shown
+   * in the combobox. This is why we want to prevent the default when selecting item from the
+   * options. Only if we really focus out (click outside the combobox) we want to trigger
+   * onBlur event.
+   */
+  const onBlur = (e: React.FocusEvent) => {
+    const relatedTarget = e.relatedTarget as HTMLElement;
+    if (relatedTarget?.role === 'option') {
+      e.preventDefault();
+    } else if (onBlurParent) {
+      onBlurParent();
+    }
   };
 
   return (
@@ -61,7 +76,6 @@ export const Combobox = ({
       onChange={onItemSelected}
       onBlur={onBlur}
       data-testid={testId}
-      nullable={nullable}
     >
       {({ open }) => (
         <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,10 +1626,12 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@headlessui/react@1.6.5":
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.6.5.tgz#5587c537de809cf3146eb2ff263e5e940b1bf69c"
-  integrity sha512-3VkKteDxlxf3fE0KbfO9t60KC1lM7YNpZggLpwzVNg1J/zwL+h+4N7MBlFDVpInZI3rKlZGpNx0PWsG/9c2vQg==
+"@headlessui/react@^1.7.10":
+  version "1.7.10"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.10.tgz#0971a33843a76f2bf4b801a43f76e3730fe15884"
+  integrity sha512-1m66h/5eayTEZVT2PI13/2PG3EVC7a9XalmUtVSC8X76pcyKYMuyX1XAL2RUtCr8WhoMa/KrDEyoeU5v+kSQOw==
+  dependencies:
+    client-only "^0.0.1"
 
 "@hookform/resolvers@^3.0.0":
   version "3.0.0"
@@ -4209,7 +4211,7 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==


### PR DESCRIPTION
We need to type in the timing place name to be sure to find it in the test, but without the wait cypress picks up a "deprecating" html element where it does not find the result. When we add the wait, we should have the correct element with the result before the `.find('li').contains(timingplace)` is ran. Same for the assert in the last test.

This also enchances the ChooseTimingPlaceDrowdown behaviour. No more flickering between searches and clear query when a timing place is selected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/498)
<!-- Reviewable:end -->
