### PR TITLE
Fix show drafts button layout

### DIFF
--- a/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ActionsRow.tsx
@@ -2,10 +2,11 @@ import qs from 'qs';
 import { useTranslation } from 'react-i18next';
 import { RouteLine } from '../../../generated/graphql';
 import { useGetLineDetails } from '../../../hooks';
-import { Column, Container, Row } from '../../../layoutComponents';
+import { Column, Container } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { SimpleButton } from '../../../uiComponents';
 import { ObservationDateControl } from '../../common/ObservationDateControl';
+import { FormRow } from '../../forms/common';
 
 const getDraftsUrlWithReturnToQueryString = (line: RouteLine) => {
   const draftUrl = routeDetails[Path.lineDrafts].getLink(line.label);
@@ -25,21 +26,21 @@ export const ActionsRow = ({
 
   return (
     <Container className={className}>
-      <Row>
+      <FormRow mdColumns={2}>
         <Column className="w-1/4">
           <ObservationDateControl className="flex-1" />
         </Column>
-
         {line && (
-          <SimpleButton
-            containerClassName="ml-auto"
-            inverted
-            href={getDraftsUrlWithReturnToQueryString(line)}
-          >
-            {t('lines.showDrafts')}
-          </SimpleButton>
+          <Column className="items-end justify-end">
+            <SimpleButton
+              inverted
+              href={getDraftsUrlWithReturnToQueryString(line)}
+            >
+              {t('lines.showDrafts')}
+            </SimpleButton>
+          </Column>
         )}
-      </Row>
+      </FormRow>
     </Container>
   );
 };


### PR DESCRIPTION
The button used 'ml-auto' property to place it "corretly", but that is not the right way. The button is now placed correctly with parent "items-end" and "justify-end". also the Row is now "FormRow" using mdColumns=2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/516)
<!-- Reviewable:end -->
