### PR TITLE
Fix route row alternative button action behaviour

### DIFF
--- a/ui/src/components/common/LineDetailsButton.tsx
+++ b/ui/src/components/common/LineDetailsButton.tsx
@@ -21,10 +21,9 @@ export const LineDetailsButton = ({
   className = '',
 }: Props): JSX.Element => {
   const history = useHistory();
+
   const onClick = () => {
-    history.push({
-      pathname: routeDetails[Path.lineDetails].getLink(lineId, routeLabel),
-    });
+    history.push(routeDetails[Path.lineDetails].getLink(lineId, routeLabel));
   };
   return (
     <IconButton

--- a/ui/src/components/common/LineTimetablesButton.tsx
+++ b/ui/src/components/common/LineTimetablesButton.tsx
@@ -23,10 +23,9 @@ export const LineTimetablesButton = ({
 }: Props): JSX.Element => {
   const disabledStyle = '!bg-background opacity-70 pointer-events-none';
   const history = useHistory();
+
   const onClick = () => {
-    history.push({
-      pathname: routeDetails[Path.lineTimetables].getLink(lineId, routeLabel),
-    });
+    history.push(routeDetails[Path.lineTimetables].getLink(lineId, routeLabel));
   };
   return (
     <IconButton


### PR DESCRIPTION
This button used the getLink() method from routeDetails, which included the queryParams in the result, which was then passed to history,push()'s attribute 'pathname'. The resulting page thought that the queryParams was part of the lineId and did not work correctly resulting in blank page.

Resolves #HSLdevcom/jore4#1148

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/518)
<!-- Reviewable:end -->
