### PR TITLE
Remove duplicate rows from route list

### DIFF
--- a/ui/src/components/common/RouteTableRow.tsx
+++ b/ui/src/components/common/RouteTableRow.tsx
@@ -24,6 +24,7 @@ const GQL_ROUTE_TABLE_ROW = gql`
     priority
     on_line_id
     variant
+    unique_label
     route_journey_patterns {
       journey_pattern_id
       journey_pattern_refs {

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -13931,6 +13931,7 @@ export type RouteTableRowFragment = {
   priority: number;
   on_line_id: UUID;
   variant?: number | null;
+  unique_label?: string | null;
   route_id: UUID;
   label: string;
   route_shape?: GeoJSON.LineString | null;
@@ -13972,6 +13973,7 @@ export type ListChangingRoutesQuery = {
     priority: number;
     on_line_id: UUID;
     variant?: number | null;
+    unique_label?: string | null;
     route_id: UUID;
     label: string;
     route_shape?: GeoJSON.LineString | null;
@@ -16913,6 +16915,7 @@ export type SearchLinesAndRoutesQuery = {
     priority: number;
     on_line_id: UUID;
     variant?: number | null;
+    unique_label?: string | null;
     route_id: UUID;
     label: string;
     route_shape?: GeoJSON.LineString | null;
@@ -17746,6 +17749,7 @@ export const RouteTableRowFragmentDoc = gql`
     priority
     on_line_id
     variant
+    unique_label
     route_journey_patterns {
       journey_pattern_id
       journey_pattern_refs {

--- a/ui/src/hooks/search/useSearchResults.ts
+++ b/ui/src/hooks/search/useSearchResults.ts
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client';
 import {
   LineTableRowFragment,
+  RouteDirectionEnum,
   RouteTableRowFragment,
   useSearchLinesAndRoutesQuery,
 } from '../../generated/graphql';
@@ -46,25 +47,44 @@ export const useSearchResults = (): {
   const lines = (result.data?.route_line || []) as LineTableRowFragment[];
   const routes = (result.data?.route_route || []) as RouteTableRowFragment[];
 
-  const getResultCount = () => {
-    switch (parsedSearchQueryParameters.filter.displayedType) {
-      case DisplayedSearchResultType.Lines:
-        return lines?.length;
-      case DisplayedSearchResultType.Routes:
-        return routes?.length;
-      default:
-        // eslint-disable-next-line no-console
-        console.error(
-          `Error: ${parsedSearchQueryParameters.filter.displayedType} does not exist.`,
+  // Reduce routes to only have the 'Outbound' versions of the routes if there are two
+  // versions of the route
+  const reducedRoutes = routes.reduce(
+    (acc: RouteTableRowFragment[], current) => {
+      const duplicateUniqueLabelExists = acc.some(
+        (route) => route.unique_label === current.unique_label,
+      );
+
+      if (!duplicateUniqueLabelExists) {
+        return [...acc, current];
+      }
+
+      // In case we have two directions of the same route, we want to show the details of
+      // the Outbound routes. So if the 'current' is 'Outbound', it means that the
+      // route inside 'acc' is 'Inbound' and needs to be replaced.
+      if (current.direction === RouteDirectionEnum.Outbound) {
+        const filtered = acc.filter(
+          (r) => r.unique_label !== current.unique_label,
         );
-        return 0;
-    }
+        return [...filtered, current];
+      }
+      // If the 'current' is 'Inbound', it means that 'acc' already has the 'Outbound'
+      // version of the route.
+      return acc;
+    },
+    [],
+  );
+
+  const resultCounts: Record<DisplayedSearchResultType, number> = {
+    [DisplayedSearchResultType.Lines]: lines.length,
+    [DisplayedSearchResultType.Routes]: reducedRoutes.length,
   };
+  const resultType = parsedSearchQueryParameters.filter.displayedType;
 
   return {
     lines,
-    routes,
-    resultCount: getResultCount(),
-    resultType: parsedSearchQueryParameters.filter.displayedType,
+    routes: reducedRoutes,
+    resultCount: resultCounts[resultType],
+    resultType,
   };
 };


### PR DESCRIPTION
Two directions of the same route resulted in two rows in search results. We do not want to show duplicate rows. If there are two directions, we want to show the Outbound version.

Resolves HSLdevcom/jore4#1147

Also a minor refactor of getting the resultCount. Now it uses Record data structure instead of switch case method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/519)
<!-- Reviewable:end -->
