### PR TITLE
Fix hastus microservice proxy port

### DIFF
--- a/ui/server.js
+++ b/ui/server.js
@@ -49,7 +49,7 @@ const devProxy = {
     pathRewrite: {
       '^/api/hastus': '', // remove path.
     },
-    target: 'http://127.0.0.1:3008',
+    target: 'http://127.0.0.1:3201',
   },
 };
 


### PR DESCRIPTION
- Port used in docker compose is different to the port that was configured to the microservice app itself when the proxy was added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/549)
<!-- Reviewable:end -->
