### PR TITLE
Update journey pattern ids when seeding database

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To update used dumps (`./test-db-manager/src/dumps/infraLinks/infraLinks.sql` du
 
 ### Fixing timetables seed data
 
-- After that you will need to fix some foreign key references to keep timetables seed functional. In `./test-db-manager/src/seed2.ts` there are journey pattern ids (UUID), that you will need to replace to keep references from timetables to routes and lines timetables functional. To do this, search for the routes mentioned in the `seed2.ts` comments from `dump.sql`. Make sure validity period and direction match to the one mentioned in the `seed2.ts` file. Then take the found route's id and search for the route's journey pattern in the same file. Take the journey pattern id and replace the old journey pattern id in the `seed2.ts` file with the new one. This step can also be done without using the dump file, e.g. using an SQL client or even the UI, as long as the db is seeded with the new dump.
+- After that you will need to fix some foreign key references to keep timetables seed functional. In `./test-db-manager/src/seed2-ids.ts` there are journey pattern ids (UUID), that you will need to replace to keep references from timetables to routes and lines timetables functional. To do this, run './scripts/extract-seed-route-ids.sh' with the parameters of the label of the line to use, dump file sql and the `.ts` file to replace, which is `./test-db-manager/src/seed2-ids.ts`. Default line to use is `641`. This step is also automatically done when running dev env setup.
 
 ## Docker reference
 

--- a/scripts/extract-seed-route-ids.sh
+++ b/scripts/extract-seed-route-ids.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+function usage {
+
+  SCRIPT_NAME=$(basename "$0")
+  echo "
+  Usage $SCRIPT_NAME <route-label> <dump-file> <target-json-file>
+
+  <route-label> is the label of the route to search the ids for
+
+  <dump-file> is the .sql dump from where to search the route definition
+
+  <target-json-file> is the target file where to write the result
+  "
+}
+
+if [[ -z "$3" ]]; then
+  usage
+  exit
+fi
+
+cd $(dirname "$0")/..
+
+INBOUND_ROUTE_ID=$(grep -E "[[:space:]]$1[[:space:]]" $2 | grep -E "[[:space:]]2050-" | grep -E "[[:space:]]inbound[[:space:]]" | cut -f1)
+INBOUND_JP_ID=$(grep -E "[[:space:]]$INBOUND_ROUTE_ID" $2 | cut -f1)
+OUTBOUND_ROUTE_ID=$(grep -E "[[:space:]]$1[[:space:]]" $2 | grep -E "[[:space:]]2050-" | grep -E "[[:space:]]outbound[[:space:]]" | cut -f1)
+OUTBOUND_JP_ID=$(grep -E "[[:space:]]$OUTBOUND_ROUTE_ID" $2 | cut -f1)
+
+if [[ -z "$INBOUND_JP_ID" ]]; then
+  echo "Aborting: inbound journey pattern id not found!"
+  exit
+fi
+
+if [[ -z "$OUTBOUND_JP_ID" ]]; then
+  echo "Aborting: outbound journey pattern id not found!"
+  exit
+fi
+
+echo "// Auto-generated from dump ids when running the extract-seed-route-ids.sh or setup-dependencies-and-seed.sh
+export const JOURNEY_PATTERN_IDS = {
+  jp1: '$OUTBOUND_JP_ID',
+  jp2: '$INBOUND_JP_ID',
+};" > $3
+

--- a/scripts/setup-dependencies-and-seed.sh
+++ b/scripts/setup-dependencies-and-seed.sh
@@ -22,7 +22,9 @@ fi
 echo "y" | ./scripts/development.sh dump:import
 
 # Seed timetables
+./scripts/extract-seed-route-ids.sh 641 dump.sql test-db-manager/src/seed2-ids.ts
 cd ./test-db-manager
+yarn build
 yarn seed2
 
 echo "All done! Happy coding! :)"

--- a/test-db-manager/src/seed2-ids.ts
+++ b/test-db-manager/src/seed2-ids.ts
@@ -1,0 +1,5 @@
+// Auto-generated from dump ids when running the extract-seed-route-ids.sh or setup-dependencies-and-seed.sh
+export const JOURNEY_PATTERN_IDS = {
+  jp1: 'ff040a66-1675-4664-910d-95e7fa1a0b85',
+  jp2: '2f2a51c9-d73a-4d8c-8a75-f0ed2b5a9dcb',
+};

--- a/test-db-manager/src/seed2.ts
+++ b/test-db-manager/src/seed2.ts
@@ -19,6 +19,7 @@ import {
   populateTimetablesDb,
 } from './db-helpers';
 import { getVehicleTypes } from './queries/timetables';
+import { JOURNEY_PATTERN_IDS } from './seed2-ids';
 import { Priority } from './types';
 
 const seedTimetables = async (resources: TimetablesResources) => {
@@ -34,7 +35,7 @@ const seedDb = async () => {
     vehicleTypesResult.data.timetables.timetables_vehicle_type_vehicle_type;
 
   // route 641, direction 1
-  const jp1 = 'ff040a66-1675-4664-910d-95e7fa1a0b85';
+  const { jp1 } = JOURNEY_PATTERN_IDS;
   const jpRef1 = buildJourneyPatternRefDeep(jp1, {
     journeyPatternRefBase: { type_of_line: 'stopping_bus_service' },
     stopBase: {},
@@ -42,7 +43,7 @@ const seedDb = async () => {
   });
 
   // route 641, direction 2
-  const jp2 = '2f2a51c9-d73a-4d8c-8a75-f0ed2b5a9dcb';
+  const { jp2 } = JOURNEY_PATTERN_IDS;
   const jpRef2 = buildJourneyPatternRefDeep(jp2, {
     journeyPatternRefBase: { type_of_line: 'stopping_bus_service' },
     stopBase: {},


### PR DESCRIPTION
Fetch the jourey pattern ids of the two routes used when running dump update script.
Update seed2.ts to read the journey pattern ids from an external file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/589)
<!-- Reviewable:end -->
