### PR TITLE
Don't crash UI if timing place description is missing

### DIFF
--- a/ui/src/components/forms/stop/ChooseTimingPlaceDropdown.tsx
+++ b/ui/src/components/forms/stop/ChooseTimingPlaceDropdown.tsx
@@ -13,7 +13,7 @@ interface Props extends ListboxInputProps {
 
 const mapToOptionContent = (item: TimingPlaceForComboboxFragment) => (
   <div>
-    <span>{`${item.label} (${item.description.fi_FI})`}</span>
+    <span>{`${item.label} (${item.description?.fi_FI})`}</span>
   </div>
 );
 
@@ -47,7 +47,7 @@ export const ChooseTimingPlaceDropdown = ({
     return (
       <div className="w-full">
         {displayedTimingPlace
-          ? `${displayedTimingPlace?.label} (${displayedTimingPlace?.description.fi_FI})`
+          ? `${displayedTimingPlace?.label} (${displayedTimingPlace?.description?.fi_FI})`
           : t('stops.chooseTimingPlace')}
       </div>
     );


### PR DESCRIPTION
Temporary fix for now as timing places are missing descriptions

Resolves HSLdevcom/jore4#1256

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/593)
<!-- Reviewable:end -->
