### PR TITLE
Fix CYPRESS_THREAD usage

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -31,5 +31,6 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       on('task', tasks);
     },
+    env: process.env,
   },
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -82,7 +82,7 @@ Cypress.Commands.add('setupTests', () => {
       req.alias = `gql${req.body.operationName}`;
       // default instance = thread4, e2e1 = thread1, etc
       const currentExecutorIndex =
-        Cypress.env('THREAD') || CurrentExecutorIndex.default;
+        Cypress.env('CYPRESS_THREAD') || CurrentExecutorIndex.default;
       Cypress.log({
         message: `UI Hasura executor index, ${currentExecutorIndex}`,
       });


### PR DESCRIPTION
Resolves HSLdevcom/jore4#1271
Insert Node env variables in Cypress config so that 'CYPRESS_THREAD' is accessible in Cypress

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/596)
<!-- Reviewable:end -->
