### PR TITLE
Make scripts runnable even if bash is not the default shell

### DIFF
--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -37,7 +37,7 @@ function import_dump {
   # Add a row to sql dump disabling triggers
   echo -e "SET session_replication_role = replica;\n$(cat dump.sql)" > dump.sql
 
-  sh ./scripts/seed-from-dump.sh
+  ./scripts/seed-from-dump.sh
 }
 
 function usage {

--- a/scripts/seed-infrastructure-links.sh
+++ b/scripts/seed-infrastructure-links.sh
@@ -4,13 +4,13 @@ cd $(dirname "$0")/..
 
 DB_CONNECTION_STRING=postgresql://dbadmin:adminpassword@localhost:5432/jore4e2e
 
-echo "Seeding infrastructure links for db $1..."
+echo "$1: Seeding infrastructure links..."
 
 SUCCESS=false
 while ! $SUCCESS; do
-  echo "Checking if infrastructure link schema exists..."
+  echo "$1: Checking if infrastructure link schema exists..."
   if [[ $(docker exec $1 psql $DB_CONNECTION_STRING -AXqtc "SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname = 'infrastructure_network' AND tablename = 'infrastructure_link');") = "t" ]]; then
-    echo "Schema found! Seeding infrastructure links..."
+    echo "$1: Schema found! Seeding infrastructure links..."
       docker exec -i $1 psql $DB_CONNECTION_STRING < test-db-manager/src/dumps/infraLinks/infraLinks.sql;
       SUCCESS=true
   fi

--- a/scripts/setup-dependencies-and-seed.sh
+++ b/scripts/setup-dependencies-and-seed.sh
@@ -10,7 +10,7 @@ then
 fi
 
 # Start dependencies
-sh ./scripts/start-dependencies.sh
+./scripts/start-dependencies.sh
 
 # Download routes and lines dump if it does not exist
 if [ ! -e jore4dump.pgdump ]

--- a/scripts/start-dependencies.sh
+++ b/scripts/start-dependencies.sh
@@ -63,7 +63,8 @@ function start_docker_bundle {
 download_docker_bundle
 check_pinned_hasura
 start_docker_bundle "${1:-x}"
-./scripts/seed-infrastructure-links.sh testdb
-./scripts/seed-infrastructure-links.sh testdb-e2e1
-./scripts/seed-infrastructure-links.sh testdb-e2e2
-./scripts/seed-infrastructure-links.sh testdb-e2e3
+./scripts/seed-infrastructure-links.sh testdb &
+./scripts/seed-infrastructure-links.sh testdb-e2e1 &
+./scripts/seed-infrastructure-links.sh testdb-e2e2 &
+./scripts/seed-infrastructure-links.sh testdb-e2e3 &
+wait

--- a/scripts/start-dependencies.sh
+++ b/scripts/start-dependencies.sh
@@ -63,7 +63,7 @@ function start_docker_bundle {
 download_docker_bundle
 check_pinned_hasura
 start_docker_bundle "${1:-x}"
-sh ./scripts/seed-infrastructure-links.sh testdb
-sh ./scripts/seed-infrastructure-links.sh testdb-e2e1
-sh ./scripts/seed-infrastructure-links.sh testdb-e2e2
-sh ./scripts/seed-infrastructure-links.sh testdb-e2e3
+./scripts/seed-infrastructure-links.sh testdb
+./scripts/seed-infrastructure-links.sh testdb-e2e1
+./scripts/seed-infrastructure-links.sh testdb-e2e2
+./scripts/seed-infrastructure-links.sh testdb-e2e3


### PR DESCRIPTION
For example on PopOS sh uses dash by default,
and the scripts don't work on that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/597)
<!-- Reviewable:end -->
