### PR TITLE
Disable next.js compression to stop error spam

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  compress: false, // We have server rendering disabled so can't use compression.
   async rewrites() {
     return [
       {


### PR DESCRIPTION
Specifically this spam:
  TypeError: Cannot read properties of undefined (reading 'end')

Root cause was revealed by stack trace:
compression is not available without server target. See https://nextjs.org/docs/pages/api-reference/next-config-js/compress

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/598)
<!-- Reviewable:end -->
