### PR TITLE
Fix route shapes

### DIFF
--- a/cypress/e2e/createRoute.cy.ts
+++ b/cypress/e2e/createRoute.cy.ts
@@ -132,8 +132,8 @@ const buildInfraLinksAlongRoute = (
 ): InfraLinkAlongRouteInsertInput[] => [
   {
     route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[0],
-    infrastructure_link_sequence: 0,
+    infrastructure_link_id: infrastructureLinkIds[2],
+    infrastructure_link_sequence: 2,
     is_traversal_forwards: true,
   },
   {
@@ -144,8 +144,8 @@ const buildInfraLinksAlongRoute = (
   },
   {
     route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[2],
-    infrastructure_link_sequence: 2,
+    infrastructure_link_id: infrastructureLinkIds[0],
+    infrastructure_link_sequence: 0,
     is_traversal_forwards: true,
   },
 ];

--- a/cypress/e2e/editRouteShape.cy.ts
+++ b/cypress/e2e/editRouteShape.cy.ts
@@ -42,7 +42,7 @@ const testCreatedRouteLabels = {
   templateRoute: 'T-reitti 2',
 };
 
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
+// These external infralink IDs exist in the seed data.
 // These form a straight line on Eerikinkatu in Helsinki.
 // Coordinates are partial since they are needed only for the stop creation.
 
@@ -123,8 +123,8 @@ const buildInfraLinksAlongRoute = (
 ): InfraLinkAlongRouteInsertInput[] => [
   {
     route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[0],
-    infrastructure_link_sequence: 0,
+    infrastructure_link_id: infrastructureLinkIds[2],
+    infrastructure_link_sequence: 2,
     is_traversal_forwards: true,
   },
   {
@@ -135,8 +135,8 @@ const buildInfraLinksAlongRoute = (
   },
   {
     route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[2],
-    infrastructure_link_sequence: 2,
+    infrastructure_link_id: infrastructureLinkIds[0],
+    infrastructure_link_sequence: 0,
     is_traversal_forwards: true,
   },
 ];


### PR DESCRIPTION
Route shapes were a bit unrealistic after the infralink dump was updated.

Resolves HSLdevcom/jore4#1274

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/599)
<!-- Reviewable:end -->
