### PR TITLE
Add Hasura role header to websocket connections

### DIFF
--- a/ui/src/graphql/auth.ts
+++ b/ui/src/graphql/auth.ts
@@ -4,7 +4,7 @@ import { QueryHookOptions } from '@apollo/client/react/types/types';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode } from 'graphql';
 
-const REQUESTED_HASURA_ROLE_HEADER = 'x-hasura-role';
+export const REQUESTED_HASURA_ROLE_HEADER = 'x-hasura-role';
 
 export type Role = string;
 

--- a/ui/src/graphql/client.ts
+++ b/ui/src/graphql/client.ts
@@ -14,7 +14,7 @@ import { DateTime, Duration } from 'luxon';
 import introspectionResult from '../../graphql.schema.json';
 import { isDateLike, parseDate } from '../time';
 import { mapHttpToWs } from '../utils/url';
-import { authRoleMiddleware } from './auth';
+import { authRoleMiddleware, REQUESTED_HASURA_ROLE_HEADER } from './auth';
 
 const buildScalarMappingLink = () => {
   const typesMap = {
@@ -82,6 +82,12 @@ const buildWebSocketLink = () => {
     uri: getGraphqlUrl(false, true),
     options: {
       reconnect: true,
+      // TODO: deal with authentication properly. Some possibly useful info here: https://github.com/apollographql/apollo-client/issues/3967
+      connectionParams: {
+        headers: {
+          [REQUESTED_HASURA_ROLE_HEADER]: 'admin',
+        },
+      },
     },
   });
 };


### PR DESCRIPTION
Used at least in auth hook, which gets spammed about every second. This was previously causing the auth backend to throw an error on each call because the required header was missing.

This does raise a question though, does the auth hook even work correctly, because even it failing all the time didn't seem to affect UI behavior at all.

Also tried adding "lazy: true" to the websocket parameters, as suggested by couple of separate issues:
  https://github.com/apollographql/subscriptions-transport-ws/issues/381#issuecomment-375905514
  https://github.com/apollographql/apollo-client/issues/3967#issuecomment-450255702
This stopped the hook being called completely (no more errors, right?), but also Apollo cache didn't work properly anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/600)
<!-- Reviewable:end -->
