### PR TITLE
Fix Apollo dev tools extension

### DIFF
--- a/ui/src/graphql/ApolloProvider.tsx
+++ b/ui/src/graphql/ApolloProvider.tsx
@@ -2,7 +2,13 @@ import { ApolloProvider as Provider } from '@apollo/client';
 import { FC } from 'react';
 import { createGraphqlClient } from './client';
 
+let graphqlClient: ReturnType<typeof createGraphqlClient> | null = null;
+
 export const ApolloProvider: FC = ({ children }) => {
-  const graphqlClient = createGraphqlClient();
+  // Initialize client only once, so we get only one cache instance.
+  if (!graphqlClient) {
+    graphqlClient = createGraphqlClient();
+  }
+
   return <Provider client={graphqlClient}>{children}</Provider>;
 };


### PR DESCRIPTION
Was happening because next.js renders our app (ui/_app.tsx) twice, and the cache is initialized during that process.
This seems to be because of next.js rewrites, and is normal behavior: https://github.com/vercel/next.js/issues/33028#issuecomment-1006179699

However, the Apollo dev tools extension doesn't work properly (shows nothing) when multiple apollo clients are created. See:
https://github.com/apollographql/apollo-client-devtools/issues/822#issuecomment-1059166308

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/601)
<!-- Reviewable:end -->
