### PR TITLE
Upgrade Cypress Docker image

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node18.12.0-chrome107
+FROM cypress/browsers:node-18.16.0-chrome-113.0.5672.92-1-ff-113.0-edge-113.0.1774.35-1
 WORKDIR /e2e
 
 # for dependent modules, copy and build them


### PR DESCRIPTION
There seem to be no new images available with only Chrome installed anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/606)
<!-- Reviewable:end -->
