### PR TITLE
Add default sorting for versions and daytype colours

### DIFF
--- a/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
@@ -21,12 +21,24 @@ const getStatusClassName = ({
   const statusClassNames: Record<TimetablePriority, string> = {
     [TimetablePriority.Standard]: 'bg-brand text-white',
     [TimetablePriority.Temporary]: 'bg-city-bicycle-yellow',
-    [TimetablePriority.Special]: 'bg-hsl-light-purple',
+    [TimetablePriority.Special]: 'bg-hsl-purple',
     [TimetablePriority.SubstituteByLineType]: 'bg-hsl-orange',
     [TimetablePriority.Draft]: 'bg-background',
     [TimetablePriority.Staging]: 'bg-hsl-red',
   };
   return statusClassNames[priority];
+};
+
+const getDayTypeClassName = (priority: TimetablePriority) => {
+  const dayTypeClassNames: Record<TimetablePriority, string> = {
+    [TimetablePriority.Standard]: 'bg-hsl-dark-green',
+    [TimetablePriority.Temporary]: 'bg-city-bicycle-yellow',
+    [TimetablePriority.Special]: 'bg-hsl-purple',
+    [TimetablePriority.SubstituteByLineType]: 'bg-hsl-orange',
+    [TimetablePriority.Draft]: 'bg-background',
+    [TimetablePriority.Staging]: 'bg-hsl-red',
+  };
+  return dayTypeClassNames[priority];
 };
 
 interface Props {
@@ -35,7 +47,6 @@ interface Props {
 
 export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
   const { t } = useTranslation();
-
   const statusClassName = ` ${getStatusClassName({
     priority: data.vehicleScheduleFrame.priority,
     inEffect: data.inEffect,
@@ -45,16 +56,14 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
     ? t('timetables.inEffect')
     : mapTimetablePriorityToUiName(data.vehicleScheduleFrame.priority);
 
-  // TODO: After we get special days implemented, we need to determine this className
-  // depending on wheter the row is from vehicleService or from special day.
-  // The className for special days is: 'bg-city-bicycle-yellow bg-opacity-25'
-  const dayTypeClassName = `bg-hsl-dark-green bg-opacity-25`;
-
   const substituteDayOperatingText = data.substituteDay?.substituteDayOfWeek
     ? t('timetables.operatedLike', {
         dayOfWeek: mapDayOfWeekToUiName(data.substituteDay.substituteDayOfWeek),
       })
     : t('timetables.noService');
+  const dayTypeClassName = `${getDayTypeClassName(
+    data.vehicleScheduleFrame.priority,
+  )} bg-opacity-25`;
 
   return (
     <tr className="h-14 text-center [&>td]:border [&>td]:border-light-grey">

--- a/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
@@ -1,8 +1,10 @@
+import orderBy from 'lodash/orderBy';
 import { DateTime } from 'luxon';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import {
+  TimetableVersionRowData,
   useGetJourneyPatternIdsByLineLabel,
   useGetTimetableVersions,
   useTimetableVersionsReturnToQueryParam,
@@ -54,6 +56,18 @@ export const TimetableVersionsPage = (): JSX.Element => {
     ) || [];
   const { onClose } = useTimetableVersionsReturnToQueryParam();
 
+  const sortTimetables = (timetables: TimetableVersionRowData[]) => {
+    return orderBy(
+      timetables,
+      [
+        (version) => version.inEffect,
+        (version) => version.routeLabelAndVariant,
+        (version) => version.vehicleScheduleFrame.validityStart,
+      ],
+      ['desc', 'asc', 'asc'],
+    );
+  };
+
   return (
     <Container>
       <FormRow mdColumns={2}>
@@ -73,7 +87,7 @@ export const TimetableVersionsPage = (): JSX.Element => {
         <h3>{t('timetables.operatingCalendar')}</h3>
         <TimetableVersionTable
           className="mb-8 w-full"
-          data={timetablesExcludingDrafts}
+          data={sortTimetables(timetablesExcludingDrafts)}
         />
         <h3>{t('timetables.drafts')}</h3>
         <TimetableVersionTable

--- a/ui/src/generated/theme.ts
+++ b/ui/src/generated/theme.ts
@@ -18,6 +18,7 @@ export const theme = {
     hslHighlightYellowDark: "#C89515",
     hslHighlightYellowLight: "#FFD771",
     hslLightPurple: "#DDC8E0",
+    hslPurple: "#C5A3CC",
     hslOrange: "#FFA87E",
     routes: {
       bus: "#0074BF",

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -28,6 +28,7 @@ module.exports = {
         'hsl-warning-yellow': colors.hslWarningYellow,
         'hsl-highlight-yellow-dark': colors.hslHighlightYellowDark,
         'hsl-highlight-yellow-light': colors.hslHighlightYellowLight,
+        'hsl-purple': colors.hslPurple,
         'hsl-light-purple': colors.hslLightPurple,
         'hsl-orange': colors.hslOrange,
       },

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -18,6 +18,7 @@ const theme = {
     hslHighlightYellowDark: '#C89515',
     hslHighlightYellowLight: '#FFD771',
     hslLightPurple: '#DDC8E0',
+    hslPurple: '#C5A3CC',
     hslOrange: '#FFA87E',
     routes: {
       bus: '#0074BF',


### PR DESCRIPTION
These colours will help indicate what priority is in effect. Also add default sorting of the list. Later one can sort the list how one wants, but for now the default sorting is enough.

Resolves HSLdevcom/jore4#1152

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/610)
<!-- Reviewable:end -->
