### PR TITLE
Fix local parallel e2e execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,19 @@ We have those because sometimes there is need to do e.g. complex graphql queries
 - To disable map tile rendering (e.g. to speed up tests or improve reliability in CI), set the `CYPRESS_DISABLE_MAP_TILES=true` environment variable
 - To list existing e2e test cases run `yarn test:e2e:list`
 - Tests have tags for features and other test sets, like `@smoke`. Run tests for a specific tag with `yarn test:e2e --env grepTags=@routes`, for example. Further Cypress grep documentation: https://github.com/cypress-io/cypress/tree/develop/npm/grep
-- Cypress tests can be run in parallel with the `yarn test:e2e:parallel` command. Parallel execution is built using the [cypress-parallel](https://github.com/tnicola/cypress-parallel) library.
-- Parallel execution requires three separate instances of the `hasura` and `testdb` containers. These are started by default by the `start-dependencies.sh` script.
-- Routing of data in parallel execution is handled in `jore4-ui/test-db-manager/src/hasuraApi.ts`, `jore4-ui/test-db-manager/src/config.ts` and `jore4-ui/cypress/support/commands.ts`.
 
-Failed tests ran without browser can be investigated visually by looking at videos and screenshots at `./cypress/reports`. Videos are disabled by default, and can be enabled in `cypress.config.ts` by setting the value of the `video` property to `true`.
+Failed tests that have been run headlessly can be investigated visually by looking at videos and screenshots at `./cypress/reports`. Videos are disabled by default, and can be enabled in `cypress.config.ts` by setting the value of the `video` property to `true`.
 Anyway, debugging is generally easier when Cypress is opened with browser as then you can poke around with browsers devtools.
+
+### Local e2e test parallellization
+
+- Cypress e2e tests can be run in parallel locally with the `yarn test:e2e:parallel` command. Parallel execution is built using the [cypress-parallel](https://github.com/tnicola/cypress-parallel) library.
+- Parallel execution is not enabled in the CI currently.
+- Currently tests can be run in a maximum of three threads.
+- Parallel execution in three threads requires three separate instances of the `hasura` and `testdb` containers. These are started by default by the `start-dependencies.sh` script.
+- Routing of requests in parallel execution is handled in the following files: `jore4-ui/test-db-manager/src/hasuraApi.ts`, `jore4-ui/test-db-manager/src/config.ts`, `jore4-ui/cypress/support/commands.ts`, `nginx.conf`
+
+During parallel test execution Cypress assigns a value to `x-Environment` header value based on the current Cypress thread. Possible values are `e2e1`, `e2e2` and `e2e3`, and default value `e2e4` that is used when tests are not run in parallel, which also applies to using the environment manually. `e2e4` routes requests to `hasura` and `testdb` containers. In `docker-compose.custom.yml` the `HASURA_URL` environment value is set to point to the Hasura URL that the locally running UI is using to enable routing of the requests based on the `x-Environment` header value.
 
 ### CI
 

--- a/cypress/e2e/hastusExport.cy.ts
+++ b/cypress/e2e/hastusExport.cy.ts
@@ -141,7 +141,6 @@ const stopsInJourneyPattern = buildStopsInJourneyPattern(
   journeyPatterns[0].journey_pattern_id!,
 );
 
-// NOTE: Hastus export tests do not work currently when running e2e tests in parallel
 describe('Hastus export', () => {
   let routesAndLinesPage: RoutesAndLinesPage;
 

--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -147,7 +147,6 @@ const stopsInJourneyPattern = buildStopsInJourneyPattern(
   journeyPatterns[0].journey_pattern_id!,
 );
 
-// NOTE: Timetable import tests do not work currently when running e2e tests in parallel
 describe('Timetable import and export', () => {
   let timetablesMainPage: TimetablesMainpage;
   let importTimetablesPage: ImportTimetablesPage;

--- a/cypress/parallel-weights.json
+++ b/cypress/parallel-weights.json
@@ -1,13 +1,15 @@
 {
-  "e2e/changeLanguage.cy.ts": { "time": 4580, "weight": 1 },
-  "e2e/createLine.cy.ts": { "time": 9421, "weight": 3 },
-  "e2e/createRoute.cy.ts": { "time": 73492, "weight": 27 },
-  "e2e/createStop.cy.ts": { "time": 48684, "weight": 18 },
-  "e2e/editLineInfo.cy.ts": { "time": 6811, "weight": 2 },
-  "e2e/editRoute.cy.ts": { "time": 33991, "weight": 12 },
-  "e2e/editRouteShape.cy.ts": { "time": 23231, "weight": 8 },
-  "e2e/editStop.cy.ts": { "time": 43789, "weight": 16 },
-  "e2e/login.cy.ts": { "time": 2415, "weight": 0 },
-  "e2e/routeStops.cy.ts": { "time": 39910, "weight": 15 },
-  "e2e/searchRoutesAndLines.cy.ts": { "time": 3872, "weight": 1 }
+  "e2e/changeLanguage.cy.ts": { "time": 3884, "weight": 1 },
+  "e2e/createLine.cy.ts": { "time": 6888, "weight": 3 },
+  "e2e/createRoute.cy.ts": { "time": 68542, "weight": 31 },
+  "e2e/createStop.cy.ts": { "time": 45514, "weight": 20 },
+  "e2e/editLineInfo.cy.ts": { "time": 6810, "weight": 3 },
+  "e2e/editRoute.cy.ts": { "time": 29301, "weight": 13 },
+  "e2e/editRouteShape.cy.ts": { "time": 22512, "weight": 10 },
+  "e2e/editStop.cy.ts": { "time": 39468, "weight": 18 },
+  "e2e/hastusExport.cy.ts": { "time": 12418, "weight": 5 },
+  "e2e/login.cy.ts": { "time": 2384, "weight": 1 },
+  "e2e/routeStops.cy.ts": { "time": 33400, "weight": 15 },
+  "e2e/searchRoutesAndLines.cy.ts": { "time": 3722, "weight": 1 },
+  "e2e/timetableImport.cy.ts": { "time": 9131, "weight": 4 }
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -92,9 +92,33 @@ Cypress.Commands.add('setupTests', () => {
     }
   });
 
-  cy.intercept('/api/hastus/import').as('hastusImport');
+  cy.intercept('POST', '/api/hastus/import', (req) => {
+    // eslint-disable-next-line no-param-reassign
+    req.alias = 'hastusImport';
+    // default instance = thread4, e2e1 = thread1, etc
+    const currentExecutorIndex =
+      Cypress.env('CYPRESS_THREAD') || CurrentExecutorIndex.default;
+    Cypress.log({
+      message: `Hastus executor index, ${currentExecutorIndex}`,
+    });
+    // eslint-disable-next-line no-param-reassign
+    req.headers['x-Environment'] = `e2e${currentExecutorIndex}`;
+    req.continue();
+  });
 
-  cy.intercept('/api/hastus/export/**').as('hastusExport');
+  cy.intercept('POST', '/api/hastus/export/**', (req) => {
+    // eslint-disable-next-line no-param-reassign
+    req.alias = 'hastusExport';
+    // default instance = thread4, e2e1 = thread1, etc
+    const currentExecutorIndex =
+      Cypress.env('CYPRESS_THREAD') || CurrentExecutorIndex.default;
+    Cypress.log({
+      message: `Hastus executor index, ${currentExecutorIndex}`,
+    });
+    // eslint-disable-next-line no-param-reassign
+    req.headers['x-Environment'] = `e2e${currentExecutorIndex}`;
+    req.continue();
+  });
 
   cy.intercept('/api/mapmatching/api/route/v1/**').as('mapMatching');
 });

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -18,6 +18,12 @@ services:
   jore4-hastus:
     # pinning hastus import-export-microservice version
     image: "hsldevcom/jore4-hastus:main--20230524-bfc077adcfbaedcee68bf986f19b807e6ac0562c"
+    environment:
+      # use the same Hasura URL that the UI uses to enable routing requests to correct Hasura instances
+      # when running e2e tests in parallel
+      HASURA_URL: "http://host.docker.internal:3300/api/graphql/v1/graphql"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   jore4-hasura-e2e1:
     image: *hasura-image


### PR DESCRIPTION
Running e2e tests in parallel locally should work now WHEN `host.docker.internal` points to the host machine. This should work automatically when using Docker Desktop.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/619)
<!-- Reviewable:end -->
