### PR TITLE
Fix seed2 generating intervals with seconds / milliseconds

### DIFF
--- a/test-db-manager/src/builders/common.ts
+++ b/test-db-manager/src/builders/common.ts
@@ -6,8 +6,19 @@ import { randomInt } from '../utils';
 export const buildLabelArray = (labelPrefix: string, labelCount: number) =>
   range(1, labelCount + 1).map((no) => `${labelPrefix}${no}`);
 
-export const buildRandomDuration = (min: Duration, max: Duration) =>
-  Duration.fromMillis(randomInt(min.toMillis(), max.toMillis()));
+export const buildRandomDuration = (min: Duration, max: Duration) => {
+  const unroundedDuration = Duration.fromMillis(
+    randomInt(min.toMillis(), max.toMillis()),
+  );
+
+  // We only want to handle durations in minute precision, currently.
+  const durationParts = unroundedDuration.rescale().toObject();
+  delete durationParts.seconds;
+  delete durationParts.milliseconds;
+  const durationInMinutes = Duration.fromObject(durationParts);
+
+  return durationInMinutes;
+};
 
 type ConstantCount = number;
 type RandomCount = { min: number; max: number };


### PR DESCRIPTION
Not typically what we want.
Might be possible to prevent this in DB level, if it seems important.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/620)
<!-- Reviewable:end -->
