### PR TITLE
Add eslint rule for no cy.pause()

### DIFF
--- a/cypress/.eslintrc.js
+++ b/cypress/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
         // cypress runs tests with mocha instead of jest, so jest-specific rules make no sense.
         // TODO: rather disable whole 'plugin:jest/recommended' at once (but how?)
         'jest/expect-expect': 'off',
+        'cypress/no-pause': 'error',
       },
     },
   ],


### PR DESCRIPTION
`cy.pause()` is useful when developing tests, but we don't want it in pull requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/624)
<!-- Reviewable:end -->
