### PR TITLE
Add new timetable page logic

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -4,7 +4,7 @@ services:
     # Link to available jore4-hasura images in Docker Hub:
     # https://hub.docker.com/r/hsldevcom/jore4-hasura/tags?page=1&ordering=last_updated
     # The :hsl-tag contains the desired version of hsl specific hasura.
-    image: &hasura-image 'hsldevcom/jore4-hasura:hsl-main--20230524-15a564f76a75f82bf5c789491387cdce4394932b'
+    image: &hasura-image 'hsldevcom/jore4-hasura:hsl-main--20230711-f0391a96258129a48308711536ec733fa12fefd0'
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -10068,6 +10068,249 @@ export type TimetablesReturnValueTimetableVersionVarianceFields = {
   priority?: Maybe<Scalars['Float']>;
 };
 
+/**
+ * This return value table is used in function vehicle_journey.get_vehicle_schedules_on_date. It consists of vehicle_journey_id, vehicle_schedule_frame_id or
+ * substitute_operating_day_by_line_type_id and also enriched with data, which are used in the UI side.
+ */
+export type TimetablesReturnValueVehicleSchedule = {
+  __typename?: 'timetables_return_value_vehicle_schedule';
+  created_at?: Maybe<Scalars['timestamptz']>;
+  /** An object relationship */
+  day_type?: Maybe<TimetablesServiceCalendarDayType>;
+  day_type_id: Scalars['uuid'];
+  priority: Scalars['Int'];
+  substitute_operating_day_by_line_type_id?: Maybe<Scalars['uuid']>;
+  validity_end: Scalars['date'];
+  validity_start: Scalars['date'];
+  /** An object relationship */
+  vehicle_journey?: Maybe<TimetablesVehicleJourneyVehicleJourney>;
+  vehicle_journey_id?: Maybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: Maybe<Scalars['uuid']>;
+};
+
+/** aggregated selection of "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleAggregate = {
+  __typename?: 'timetables_return_value_vehicle_schedule_aggregate';
+  aggregate?: Maybe<TimetablesReturnValueVehicleScheduleAggregateFields>;
+  nodes: Array<TimetablesReturnValueVehicleSchedule>;
+};
+
+/** aggregate fields of "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleAggregateFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_aggregate_fields';
+  avg?: Maybe<TimetablesReturnValueVehicleScheduleAvgFields>;
+  count: Scalars['Int'];
+  max?: Maybe<TimetablesReturnValueVehicleScheduleMaxFields>;
+  min?: Maybe<TimetablesReturnValueVehicleScheduleMinFields>;
+  stddev?: Maybe<TimetablesReturnValueVehicleScheduleStddevFields>;
+  stddev_pop?: Maybe<TimetablesReturnValueVehicleScheduleStddevPopFields>;
+  stddev_samp?: Maybe<TimetablesReturnValueVehicleScheduleStddevSampFields>;
+  sum?: Maybe<TimetablesReturnValueVehicleScheduleSumFields>;
+  var_pop?: Maybe<TimetablesReturnValueVehicleScheduleVarPopFields>;
+  var_samp?: Maybe<TimetablesReturnValueVehicleScheduleVarSampFields>;
+  variance?: Maybe<TimetablesReturnValueVehicleScheduleVarianceFields>;
+};
+
+/** aggregate fields of "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleAggregateFieldsCountArgs = {
+  columns?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleSelectColumn>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** aggregate avg on columns */
+export type TimetablesReturnValueVehicleScheduleAvgFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_avg_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** Boolean expression to filter rows from the table "return_value.vehicle_schedule". All fields are combined with a logical 'AND'. */
+export type TimetablesReturnValueVehicleScheduleBoolExp = {
+  _and?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleBoolExp>>;
+  _not?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  _or?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleBoolExp>>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
+  day_type?: InputMaybe<TimetablesServiceCalendarDayTypeBoolExp>;
+  day_type_id?: InputMaybe<UuidComparisonExp>;
+  priority?: InputMaybe<IntComparisonExp>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<UuidComparisonExp>;
+  validity_end?: InputMaybe<DateComparisonExp>;
+  validity_start?: InputMaybe<DateComparisonExp>;
+  vehicle_journey?: InputMaybe<TimetablesVehicleJourneyVehicleJourneyBoolExp>;
+  vehicle_journey_id?: InputMaybe<UuidComparisonExp>;
+  vehicle_schedule_frame_id?: InputMaybe<UuidComparisonExp>;
+};
+
+/** input type for incrementing numeric columns in table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleIncInput = {
+  priority?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleInsertInput = {
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  day_type?: InputMaybe<TimetablesServiceCalendarDayTypeObjRelInsertInput>;
+  day_type_id?: InputMaybe<Scalars['uuid']>;
+  priority?: InputMaybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<Scalars['uuid']>;
+  validity_end?: InputMaybe<Scalars['date']>;
+  validity_start?: InputMaybe<Scalars['date']>;
+  vehicle_journey?: InputMaybe<TimetablesVehicleJourneyVehicleJourneyObjRelInsertInput>;
+  vehicle_journey_id?: InputMaybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** aggregate max on columns */
+export type TimetablesReturnValueVehicleScheduleMaxFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_max_fields';
+  created_at?: Maybe<Scalars['timestamptz']>;
+  day_type_id?: Maybe<Scalars['uuid']>;
+  priority?: Maybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: Maybe<Scalars['uuid']>;
+  validity_end?: Maybe<Scalars['date']>;
+  validity_start?: Maybe<Scalars['date']>;
+  vehicle_journey_id?: Maybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: Maybe<Scalars['uuid']>;
+};
+
+/** aggregate min on columns */
+export type TimetablesReturnValueVehicleScheduleMinFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_min_fields';
+  created_at?: Maybe<Scalars['timestamptz']>;
+  day_type_id?: Maybe<Scalars['uuid']>;
+  priority?: Maybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: Maybe<Scalars['uuid']>;
+  validity_end?: Maybe<Scalars['date']>;
+  validity_start?: Maybe<Scalars['date']>;
+  vehicle_journey_id?: Maybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: Maybe<Scalars['uuid']>;
+};
+
+/** response of any mutation on the table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleMutationResponse = {
+  __typename?: 'timetables_return_value_vehicle_schedule_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data from the rows affected by the mutation */
+  returning: Array<TimetablesReturnValueVehicleSchedule>;
+};
+
+/** Ordering options when selecting data from "return_value.vehicle_schedule". */
+export type TimetablesReturnValueVehicleScheduleOrderBy = {
+  created_at?: InputMaybe<OrderBy>;
+  day_type?: InputMaybe<TimetablesServiceCalendarDayTypeOrderBy>;
+  day_type_id?: InputMaybe<OrderBy>;
+  priority?: InputMaybe<OrderBy>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<OrderBy>;
+  validity_end?: InputMaybe<OrderBy>;
+  validity_start?: InputMaybe<OrderBy>;
+  vehicle_journey?: InputMaybe<TimetablesVehicleJourneyVehicleJourneyOrderBy>;
+  vehicle_journey_id?: InputMaybe<OrderBy>;
+  vehicle_schedule_frame_id?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "return_value.vehicle_schedule" */
+export enum TimetablesReturnValueVehicleScheduleSelectColumn {
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  DayTypeId = 'day_type_id',
+  /** column name */
+  Priority = 'priority',
+  /** column name */
+  SubstituteOperatingDayByLineTypeId = 'substitute_operating_day_by_line_type_id',
+  /** column name */
+  ValidityEnd = 'validity_end',
+  /** column name */
+  ValidityStart = 'validity_start',
+  /** column name */
+  VehicleJourneyId = 'vehicle_journey_id',
+  /** column name */
+  VehicleScheduleFrameId = 'vehicle_schedule_frame_id',
+}
+
+/** input type for updating data in table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleSetInput = {
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  day_type_id?: InputMaybe<Scalars['uuid']>;
+  priority?: InputMaybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<Scalars['uuid']>;
+  validity_end?: InputMaybe<Scalars['date']>;
+  validity_start?: InputMaybe<Scalars['date']>;
+  vehicle_journey_id?: InputMaybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** aggregate stddev on columns */
+export type TimetablesReturnValueVehicleScheduleStddevFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_stddev_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type TimetablesReturnValueVehicleScheduleStddevPopFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_stddev_pop_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type TimetablesReturnValueVehicleScheduleStddevSampFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_stddev_samp_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** Streaming cursor of the table "return_value_vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleStreamCursorInput = {
+  /** Stream column input with initial value */
+  initial_value: TimetablesReturnValueVehicleScheduleStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<TimetablesCursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type TimetablesReturnValueVehicleScheduleStreamCursorValueInput = {
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  day_type_id?: InputMaybe<Scalars['uuid']>;
+  priority?: InputMaybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<Scalars['uuid']>;
+  validity_end?: InputMaybe<Scalars['date']>;
+  validity_start?: InputMaybe<Scalars['date']>;
+  vehicle_journey_id?: InputMaybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** aggregate sum on columns */
+export type TimetablesReturnValueVehicleScheduleSumFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_sum_fields';
+  priority?: Maybe<Scalars['Int']>;
+};
+
+export type TimetablesReturnValueVehicleScheduleUpdates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<TimetablesReturnValueVehicleScheduleIncInput>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<TimetablesReturnValueVehicleScheduleSetInput>;
+  /** filter the rows which have to be updated */
+  where: TimetablesReturnValueVehicleScheduleBoolExp;
+};
+
+/** aggregate var_pop on columns */
+export type TimetablesReturnValueVehicleScheduleVarPopFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_var_pop_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate var_samp on columns */
+export type TimetablesReturnValueVehicleScheduleVarSampFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_var_samp_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate variance on columns */
+export type TimetablesReturnValueVehicleScheduleVarianceFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_variance_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
 /** A type of day characterised by one or more properties which affect public transport operation. For example: weekday in school holidays. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=1:6:3:299  */
 export type TimetablesServiceCalendarDayType = {
   __typename?: 'timetables_service_calendar_day_type';
@@ -10676,6 +10919,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineType = {
   begin_datetime: Scalars['timestamptz'];
   /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
   begin_time?: Maybe<Scalars['interval']>;
+  created_at: Scalars['timestamptz'];
   /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
   end_datetime: Scalars['timestamptz'];
   /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
@@ -10743,6 +10987,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeBoolExp = {
   >;
   begin_datetime?: InputMaybe<TimestamptzComparisonExp>;
   begin_time?: InputMaybe<IntervalComparisonExp>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
   end_datetime?: InputMaybe<TimestamptzComparisonExp>;
   end_time?: InputMaybe<IntervalComparisonExp>;
   substitute_day_of_week?: InputMaybe<IntComparisonExp>;
@@ -10770,6 +11015,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeInsertInput
   {
     /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
     begin_time?: InputMaybe<Scalars['interval']>;
+    created_at?: InputMaybe<Scalars['timestamptz']>;
     /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
     end_time?: InputMaybe<Scalars['interval']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10788,6 +11034,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeMaxFields =
     __typename?: 'timetables_service_calendar_substitute_operating_day_by_line_type_max_fields';
     /** Calculated timestamp for the instant from which the substituting public transit comes into effect. */
     begin_datetime?: Maybe<Scalars['timestamptz']>;
+    created_at?: Maybe<Scalars['timestamptz']>;
     /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
     end_datetime?: Maybe<Scalars['timestamptz']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10806,6 +11053,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeMinFields =
     __typename?: 'timetables_service_calendar_substitute_operating_day_by_line_type_min_fields';
     /** Calculated timestamp for the instant from which the substituting public transit comes into effect. */
     begin_datetime?: Maybe<Scalars['timestamptz']>;
+    created_at?: Maybe<Scalars['timestamptz']>;
     /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
     end_datetime?: Maybe<Scalars['timestamptz']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10848,6 +11096,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeOnConflict 
 export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeOrderBy = {
   begin_datetime?: InputMaybe<OrderBy>;
   begin_time?: InputMaybe<OrderBy>;
+  created_at?: InputMaybe<OrderBy>;
   end_datetime?: InputMaybe<OrderBy>;
   end_time?: InputMaybe<OrderBy>;
   substitute_day_of_week?: InputMaybe<OrderBy>;
@@ -10870,6 +11119,8 @@ export enum TimetablesServiceCalendarSubstituteOperatingDayByLineTypeSelectColum
   /** column name */
   BeginTime = 'begin_time',
   /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
   EndDatetime = 'end_datetime',
   /** column name */
   EndTime = 'end_time',
@@ -10890,6 +11141,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeSetInput =
   {
     /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
     begin_time?: InputMaybe<Scalars['interval']>;
+    created_at?: InputMaybe<Scalars['timestamptz']>;
     /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
     end_time?: InputMaybe<Scalars['interval']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10942,6 +11194,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeStreamCurso
     begin_datetime?: InputMaybe<Scalars['timestamptz']>;
     /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
     begin_time?: InputMaybe<Scalars['interval']>;
+    created_at?: InputMaybe<Scalars['timestamptz']>;
     /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
     end_datetime?: InputMaybe<Scalars['timestamptz']>;
     /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
@@ -10968,6 +11221,8 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeSumFields =
 export enum TimetablesServiceCalendarSubstituteOperatingDayByLineTypeUpdateColumn {
   /** column name */
   BeginTime = 'begin_time',
+  /** column name */
+  CreatedAt = 'created_at',
   /** column name */
   EndTime = 'end_time',
   /** column name */
@@ -11491,6 +11746,8 @@ export type TimetablesTimetablesMutationFrontend = {
   timetables_delete_passing_times_timetabled_passing_time_by_pk?: Maybe<TimetablesPassingTimesTimetabledPassingTime>;
   /** delete data from the table: "return_value.timetable_version" */
   timetables_delete_return_value_timetable_version?: Maybe<TimetablesReturnValueTimetableVersionMutationResponse>;
+  /** delete data from the table: "return_value.vehicle_schedule" */
+  timetables_delete_return_value_vehicle_schedule?: Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>;
   /** delete data from the table: "service_calendar.day_type" */
   timetables_delete_service_calendar_day_type?: Maybe<TimetablesServiceCalendarDayTypeMutationResponse>;
   /** delete data from the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -11543,6 +11800,10 @@ export type TimetablesTimetablesMutationFrontend = {
   timetables_insert_return_value_timetable_version?: Maybe<TimetablesReturnValueTimetableVersionMutationResponse>;
   /** insert a single row into the table: "return_value.timetable_version" */
   timetables_insert_return_value_timetable_version_one?: Maybe<TimetablesReturnValueTimetableVersion>;
+  /** insert data into the table: "return_value.vehicle_schedule" */
+  timetables_insert_return_value_vehicle_schedule?: Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>;
+  /** insert a single row into the table: "return_value.vehicle_schedule" */
+  timetables_insert_return_value_vehicle_schedule_one?: Maybe<TimetablesReturnValueVehicleSchedule>;
   /** insert data into the table: "service_calendar.day_type" */
   timetables_insert_service_calendar_day_type?: Maybe<TimetablesServiceCalendarDayTypeMutationResponse>;
   /** insert data into the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -11604,6 +11865,12 @@ export type TimetablesTimetablesMutationFrontend = {
   /** update multiples rows of table: "return_value.timetable_version" */
   timetables_update_return_value_timetable_version_many?: Maybe<
     Array<Maybe<TimetablesReturnValueTimetableVersionMutationResponse>>
+  >;
+  /** update data of the table: "return_value.vehicle_schedule" */
+  timetables_update_return_value_vehicle_schedule?: Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>;
+  /** update multiples rows of table: "return_value.vehicle_schedule" */
+  timetables_update_return_value_vehicle_schedule_many?: Maybe<
+    Array<Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>>
   >;
   /** update data of the table: "service_calendar.day_type" */
   timetables_update_service_calendar_day_type?: Maybe<TimetablesServiceCalendarDayTypeMutationResponse>;
@@ -11718,6 +11985,11 @@ export type TimetablesTimetablesMutationFrontendTimetablesDeletePassingTimesTime
 export type TimetablesTimetablesMutationFrontendTimetablesDeleteReturnValueTimetableVersionArgs =
   {
     where: TimetablesReturnValueTimetableVersionBoolExp;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesDeleteReturnValueVehicleScheduleArgs =
+  {
+    where: TimetablesReturnValueVehicleScheduleBoolExp;
   };
 
 export type TimetablesTimetablesMutationFrontendTimetablesDeleteServiceCalendarDayTypeArgs =
@@ -11854,6 +12126,16 @@ export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueTimet
 export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueTimetableVersionOneArgs =
   {
     object: TimetablesReturnValueTimetableVersionInsertInput;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueVehicleScheduleArgs =
+  {
+    objects: Array<TimetablesReturnValueVehicleScheduleInsertInput>;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueVehicleScheduleOneArgs =
+  {
+    object: TimetablesReturnValueVehicleScheduleInsertInput;
   };
 
 export type TimetablesTimetablesMutationFrontendTimetablesInsertServiceCalendarDayTypeArgs =
@@ -12020,6 +12302,18 @@ export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueTimet
 export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueTimetableVersionManyArgs =
   {
     updates: Array<TimetablesReturnValueTimetableVersionUpdates>;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueVehicleScheduleArgs =
+  {
+    _inc?: InputMaybe<TimetablesReturnValueVehicleScheduleIncInput>;
+    _set?: InputMaybe<TimetablesReturnValueVehicleScheduleSetInput>;
+    where: TimetablesReturnValueVehicleScheduleBoolExp;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueVehicleScheduleManyArgs =
+  {
+    updates: Array<TimetablesReturnValueVehicleScheduleUpdates>;
   };
 
 export type TimetablesTimetablesMutationFrontendTimetablesUpdateServiceCalendarDayTypeArgs =
@@ -12272,6 +12566,10 @@ export type TimetablesTimetablesQuery = {
   timetables_return_value_timetable_version: Array<TimetablesReturnValueTimetableVersion>;
   /** fetch aggregated fields from the table: "return_value.timetable_version" */
   timetables_return_value_timetable_version_aggregate: TimetablesReturnValueTimetableVersionAggregate;
+  /** fetch data from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule: Array<TimetablesReturnValueVehicleSchedule>;
+  /** fetch aggregated fields from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
   /** fetch data from the table: "service_calendar.day_type" */
   timetables_service_calendar_day_type: Array<TimetablesServiceCalendarDayType>;
   /** fetch data from the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -12300,6 +12598,10 @@ export type TimetablesTimetablesQuery = {
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_aggregate: TimetablesServicePatternScheduledStopPointInJourneyPatternRefAggregate;
   /** fetch data from the table: "service_pattern.scheduled_stop_point_in_journey_pattern_ref" using primary key columns */
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_by_pk?: Maybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRef>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" which returns "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date: Array<TimetablesReturnValueVehicleSchedule>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" and query aggregates on result of table type "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
   /** fetch data from the table: "vehicle_journey.vehicle_journey" */
   timetables_vehicle_journey_vehicle_journey: Array<TimetablesVehicleJourneyVehicleJourney>;
   /** fetch aggregated fields from the table: "vehicle_journey.vehicle_journey" */
@@ -12432,6 +12734,28 @@ export type TimetablesTimetablesQueryTimetablesReturnValueTimetableVersionAggreg
     offset?: InputMaybe<Scalars['Int']>;
     order_by?: InputMaybe<Array<TimetablesReturnValueTimetableVersionOrderBy>>;
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
+  };
+
+export type TimetablesTimetablesQueryTimetablesReturnValueVehicleScheduleArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesQueryTimetablesReturnValueVehicleScheduleAggregateArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesQueryTimetablesServiceCalendarDayTypeArgs = {
@@ -12574,6 +12898,30 @@ export type TimetablesTimetablesQueryTimetablesServicePatternScheduledStopPointI
 export type TimetablesTimetablesQueryTimetablesServicePatternScheduledStopPointInJourneyPatternRefByPkArgs =
   {
     scheduled_stop_point_in_journey_pattern_ref_id: Scalars['uuid'];
+  };
+
+export type TimetablesTimetablesQueryTimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesQueryTimetablesVehicleJourneyGetVehicleSchedulesOnDateAggregateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesQueryTimetablesVehicleJourneyVehicleJourneyArgs =
@@ -12834,6 +13182,12 @@ export type TimetablesTimetablesSubscription = {
   timetables_return_value_timetable_version_aggregate: TimetablesReturnValueTimetableVersionAggregate;
   /** fetch data from the table in a streaming manner: "return_value.timetable_version" */
   timetables_return_value_timetable_version_stream: Array<TimetablesReturnValueTimetableVersion>;
+  /** fetch data from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule: Array<TimetablesReturnValueVehicleSchedule>;
+  /** fetch aggregated fields from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
+  /** fetch data from the table in a streaming manner: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule_stream: Array<TimetablesReturnValueVehicleSchedule>;
   /** fetch data from the table: "service_calendar.day_type" */
   timetables_service_calendar_day_type: Array<TimetablesServiceCalendarDayType>;
   /** fetch data from the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -12870,6 +13224,10 @@ export type TimetablesTimetablesSubscription = {
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_by_pk?: Maybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRef>;
   /** fetch data from the table in a streaming manner: "service_pattern.scheduled_stop_point_in_journey_pattern_ref" */
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_stream: Array<TimetablesServicePatternScheduledStopPointInJourneyPatternRef>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" which returns "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date: Array<TimetablesReturnValueVehicleSchedule>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" and query aggregates on result of table type "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
   /** fetch data from the table: "vehicle_journey.vehicle_journey" */
   timetables_vehicle_journey_vehicle_journey: Array<TimetablesVehicleJourneyVehicleJourney>;
   /** fetch aggregated fields from the table: "vehicle_journey.vehicle_journey" */
@@ -13041,6 +13399,37 @@ export type TimetablesTimetablesSubscriptionTimetablesReturnValueTimetableVersio
       InputMaybe<TimetablesReturnValueTimetableVersionStreamCursorInput>
     >;
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesReturnValueVehicleScheduleArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesReturnValueVehicleScheduleAggregateArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesReturnValueVehicleScheduleStreamArgs =
+  {
+    batch_size: Scalars['Int'];
+    cursor: Array<
+      InputMaybe<TimetablesReturnValueVehicleScheduleStreamCursorInput>
+    >;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesSubscriptionTimetablesServiceCalendarDayTypeArgs =
@@ -13222,6 +13611,30 @@ export type TimetablesTimetablesSubscriptionTimetablesServicePatternScheduledSto
       InputMaybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRefStreamCursorInput>
     >;
     where?: InputMaybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRefBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesVehicleJourneyGetVehicleSchedulesOnDateAggregateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesSubscriptionTimetablesVehicleJourneyVehicleJourneyArgs =
@@ -13514,6 +13927,11 @@ export type TimetablesTimetablesSubscriptionTimetablesVehicleTypeVehicleTypeStre
     >;
     where?: InputMaybe<TimetablesVehicleTypeVehicleTypeBoolExp>;
   };
+
+export type TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs = {
+  journey_pattern_uuid?: InputMaybe<Scalars['uuid']>;
+  observation_date?: InputMaybe<Scalars['date']>;
+};
 
 /** The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:1:1:831  */
 export type TimetablesVehicleJourneyVehicleJourney = {

--- a/ui/graphql.schema.json
+++ b/ui/graphql.schema.json
@@ -63013,6 +63013,1660 @@
       },
       {
         "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule",
+        "description": "This return value table is used in function vehicle_journey.get_vehicle_schedules_on_date. It consists of vehicle_journey_id, vehicle_schedule_frame_id or\nsubstitute_operating_day_by_line_type_id and also enriched with data, which are used in the UI side.",
+        "fields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_service_calendar_day_type",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "date",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "date",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_vehicle_journey_vehicle_journey",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_aggregate",
+        "description": "aggregated selection of \"return_value.vehicle_schedule\"",
+        "fields": [
+          {
+            "name": "aggregate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_aggregate_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_aggregate_fields",
+        "description": "aggregate fields of \"return_value.vehicle_schedule\"",
+        "fields": [
+          {
+            "name": "avg",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_avg_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "args": [
+              {
+                "name": "columns",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_max_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_stddev_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_stddev_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_stddev_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_sum_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_var_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_var_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_variance_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_avg_fields",
+        "description": "aggregate avg on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"return_value.vehicle_schedule\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_service_calendar_day_type_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "date_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "date_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_vehicle_journey_vehicle_journey_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_inc_input",
+        "description": "input type for incrementing numeric columns in table \"return_value.vehicle_schedule\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "priority",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_insert_input",
+        "description": "input type for inserting data into table \"return_value.vehicle_schedule\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_service_calendar_day_type_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_vehicle_journey_vehicle_journey_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_max_fields",
+        "description": "aggregate max on columns",
+        "fields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_min_fields",
+        "description": "aggregate min on columns",
+        "fields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_mutation_response",
+        "description": "response of any mutation on the table \"return_value.vehicle_schedule\"",
+        "fields": [
+          {
+            "name": "affected_rows",
+            "description": "number of rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "returning",
+            "description": "data from the rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_order_by",
+        "description": "Ordering options when selecting data from \"return_value.vehicle_schedule\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_service_calendar_day_type_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_vehicle_journey_vehicle_journey_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "timetables_return_value_vehicle_schedule_select_column",
+        "description": "select columns of table \"return_value.vehicle_schedule\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_set_input",
+        "description": "input type for updating data in table \"return_value.vehicle_schedule\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_stddev_fields",
+        "description": "aggregate stddev on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_stddev_pop_fields",
+        "description": "aggregate stddev_pop on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_stddev_samp_fields",
+        "description": "aggregate stddev_samp on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_stream_cursor_input",
+        "description": "Streaming cursor of the table \"return_value_vehicle_schedule\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initial_value",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "timetables_return_value_vehicle_schedule_stream_cursor_value_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "timetables_cursor_ordering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_stream_cursor_value_input",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "day_type_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "substitute_operating_day_by_line_type_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_end",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "validity_start",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_journey_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vehicle_schedule_frame_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_sum_fields",
+        "description": "aggregate sum on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_updates",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_inc",
+            "description": "increments the numeric columns with given value of the filtered values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_inc_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_set",
+            "description": "sets the columns of the filtered rows to the given values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_set_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": "filter the rows which have to be updated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_var_pop_fields",
+        "description": "aggregate var_pop on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_var_samp_fields",
+        "description": "aggregate var_samp on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "timetables_return_value_vehicle_schedule_variance_fields",
+        "description": "aggregate variance on columns",
+        "fields": [
+          {
+            "name": "priority",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "timetables_service_calendar_day_type",
         "description": "A type of day characterised by one or more properties which affect public transport operation. For example: weekday in school holidays. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=1:6:3:299 ",
         "fields": [
@@ -66214,6 +67868,22 @@
             "deprecationReason": null
           },
           {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "end_datetime",
             "description": "Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect.",
             "args": [],
@@ -66656,6 +68326,18 @@
             "deprecationReason": null
           },
           {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "end_datetime",
             "description": null,
             "type": {
@@ -66803,6 +68485,18 @@
             "deprecationReason": null
           },
           {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "end_time",
             "description": "The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual.",
             "type": {
@@ -66887,6 +68581,18 @@
           {
             "name": "begin_datetime",
             "description": "Calculated timestamp for the instant from which the substituting public transit comes into effect.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -66982,6 +68688,18 @@
           {
             "name": "begin_datetime",
             "description": "Calculated timestamp for the instant from which the substituting public transit comes into effect.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -67253,6 +68971,18 @@
             "deprecationReason": null
           },
           {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "end_datetime",
             "description": null,
             "type": {
@@ -67389,6 +69119,12 @@
             "deprecationReason": null
           },
           {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "end_datetime",
             "description": "column name",
             "isDeprecated": false,
@@ -67445,6 +69181,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "interval",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
               "ofType": null
             },
             "defaultValue": null,
@@ -67667,6 +69415,18 @@
             "deprecationReason": null
           },
           {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "end_datetime",
             "description": "Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect.",
             "type": {
@@ -67788,6 +69548,12 @@
         "enumValues": [
           {
             "name": "begin_time",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -70419,6 +72185,35 @@
             "deprecationReason": null
           },
           {
+            "name": "timetables_delete_return_value_vehicle_schedule",
+            "description": "delete data from the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "where",
+                "description": "filter the rows which have to be deleted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "timetables_delete_service_calendar_day_type",
             "description": "delete data from the table: \"service_calendar.day_type\"",
             "args": [
@@ -71271,6 +73066,72 @@
             "type": {
               "kind": "OBJECT",
               "name": "timetables_return_value_timetable_version",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_insert_return_value_vehicle_schedule",
+            "description": "insert data into the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "objects",
+                "description": "the rows to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "timetables_return_value_vehicle_schedule_insert_input",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_insert_return_value_vehicle_schedule_one",
+            "description": "insert a single row into the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "object",
+                "description": "the row to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule_insert_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule",
               "ofType": null
             },
             "isDeprecated": false,
@@ -72510,6 +74371,100 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "timetables_return_value_timetable_version_mutation_response",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_update_return_value_vehicle_schedule",
+            "description": "update data of the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "_inc",
+                "description": "increments the numeric columns with given value of the filtered values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_inc_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows which have to be updated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "timetables_return_value_vehicle_schedule_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_update_return_value_vehicle_schedule_many",
+            "description": "update multiples rows of table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "updates",
+                "description": "updates to execute, in order",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "timetables_return_value_vehicle_schedule_updates",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "timetables_return_value_vehicle_schedule_mutation_response",
                 "ofType": null
               }
             },
@@ -75142,6 +77097,200 @@
             "deprecationReason": null
           },
           {
+            "name": "timetables_return_value_vehicle_schedule",
+            "description": "fetch data from the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_return_value_vehicle_schedule_aggregate",
+            "description": "fetch aggregated fields from the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "timetables_return_value_vehicle_schedule_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "timetables_service_calendar_day_type",
             "description": "fetch data from the table: \"service_calendar.day_type\"",
             "args": [
@@ -76271,6 +78420,232 @@
               "kind": "OBJECT",
               "name": "timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date",
+            "description": "execute function \"vehicle_journey.get_vehicle_schedules_on_date\" which returns \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "args",
+                "description": "input parameters for function \"vehicle_journey_get_vehicle_schedules_on_date\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date_args",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date_aggregate",
+            "description": "execute function \"vehicle_journey.get_vehicle_schedules_on_date\" and query aggregates on result of table type \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "args",
+                "description": "input parameters for function \"vehicle_journey_get_vehicle_schedules_on_date_aggregate\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date_args",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "timetables_return_value_vehicle_schedule_aggregate",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -79178,6 +81553,273 @@
             "deprecationReason": null
           },
           {
+            "name": "timetables_return_value_vehicle_schedule",
+            "description": "fetch data from the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_return_value_vehicle_schedule_aggregate",
+            "description": "fetch aggregated fields from the table: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "timetables_return_value_vehicle_schedule_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_return_value_vehicle_schedule_stream",
+            "description": "fetch data from the table in a streaming manner: \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "batch_size",
+                "description": "maximum number of rows returned in a single batch",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "cursor",
+                "description": "cursor to stream the results returned by the query",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_stream_cursor_input",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "timetables_service_calendar_day_type",
             "description": "fetch data from the table: \"service_calendar.day_type\"",
             "args": [
@@ -80598,6 +83240,232 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date",
+            "description": "execute function \"vehicle_journey.get_vehicle_schedules_on_date\" which returns \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "args",
+                "description": "input parameters for function \"vehicle_journey_get_vehicle_schedules_on_date\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date_args",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "timetables_return_value_vehicle_schedule",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date_aggregate",
+            "description": "execute function \"vehicle_journey.get_vehicle_schedules_on_date\" and query aggregates on result of table type \"return_value.vehicle_schedule\"",
+            "args": [
+              {
+                "name": "args",
+                "description": "input parameters for function \"vehicle_journey_get_vehicle_schedules_on_date_aggregate\"",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date_args",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "timetables_return_value_vehicle_schedule_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "timetables_return_value_vehicle_schedule_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "timetables_return_value_vehicle_schedule_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "timetables_return_value_vehicle_schedule_aggregate",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -83076,6 +85944,41 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timetables_vehicle_journey_get_vehicle_schedules_on_date_args",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "journey_pattern_uuid",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "observation_date",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
       <button
         aria-checked="false"
         aria-labelledby="headlessui-label-:r0:"
-        class=" border-grey relative inline-flex h-6 w-11 items-center rounded-full border transition-colors"
+        class=" border-grey relative inline-flex h-6 w-11 items-center rounded-full border transition-colors focus-visible:ring"
         data-headlessui-state=""
         data-testid="show-unused-stops-switch"
         id="headlessui-switch-:r1:"
@@ -234,7 +234,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
       <button
         aria-checked="false"
         aria-labelledby="headlessui-label-:r0:"
-        class=" border-grey relative inline-flex h-6 w-11 items-center rounded-full border transition-colors"
+        class=" border-grey relative inline-flex h-6 w-11 items-center rounded-full border transition-colors focus-visible:ring"
         data-headlessui-state=""
         data-testid="show-unused-stops-switch"
         id="headlessui-switch-:r1:"
@@ -657,7 +657,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
       <button
         aria-checked="true"
         aria-labelledby="headlessui-label-:r0:"
-        class=" border-brand bg-brand relative inline-flex h-6 w-11 items-center rounded-full border transition-colors"
+        class=" border-brand bg-brand relative inline-flex h-6 w-11 items-center rounded-full border transition-colors focus-visible:ring"
         data-headlessui-state="checked"
         data-testid="show-unused-stops-switch"
         id="headlessui-switch-:r1:"

--- a/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
+++ b/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
@@ -27,27 +27,39 @@ export const VehicleJourneyGroupInfo = ({
   const dispatch = useAppDispatch();
 
   const changeVehicleScheduleFrameValidity = () => {
-    dispatch(
-      openChangeTimetableValidityModalAction(
-        vehicleJourneyGroup.vehicleScheduleFrameId,
-      ),
-    );
+    if (vehicleJourneyGroup.vehicleScheduleFrameId) {
+      dispatch(
+        openChangeTimetableValidityModalAction(
+          vehicleJourneyGroup.vehicleScheduleFrameId,
+        ),
+      );
+    }
   };
 
   const { vehicleJourneys } = vehicleJourneyGroup;
 
-  const tripCount = vehicleJourneys.length;
+  const hasTimetables = !!vehicleJourneys;
+  const tripCount = vehicleJourneys?.length;
   const orderedVehicleJourneys = orderBy(vehicleJourneys, 'start_time');
 
   const firstTrip = orderedVehicleJourneys[0];
   const lastTrip = orderedVehicleJourneys[orderedVehicleJourneys.length - 1];
+
+  // disable the button in case of substitute operating day
+  // TODO: in the future there might be a need for using this button to
+  // link to the substitute operating day's page
+  const isDisabled = !vehicleJourneyGroup.vehicleScheduleFrameId;
+  const hoverStyle = `${commonHoverStyle} hover:bg-light-grey`;
 
   return (
     <Row
       className={`items-center space-x-4 text-center text-sm text-hsl-dark-80 ${className}`}
     >
       <IconButton
-        className={`mr-2 h-8 w-16 rounded-sm border border-light-grey bg-white text-base ${commonHoverStyle} hover:bg-light-grey`}
+        className={`mr-2 h-8 w-16 rounded-sm border border-light-grey bg-white text-base  ${
+          isDisabled ? 'text-light-grey' : hoverStyle
+        }`}
+        disabled={isDisabled}
         onClick={changeVehicleScheduleFrameValidity}
         icon={<i className="icon-calendar" />}
         testId={testIds.changeValidityButton}
@@ -57,14 +69,19 @@ export const VehicleJourneyGroupInfo = ({
           vehicleJourneyGroup.validity.validityStart,
         )} - ${mapToShortDate(vehicleJourneyGroup.validity.validityEnd)}`}
       </span>
-      <span>|</span>
-      <span className="font-bold">
-        {t('timetables.tripCount', { count: tripCount })}
-      </span>
-      <span>|</span>
-      <span>{`${mapDurationToShortTime(
-        firstTrip.start_time,
-      )}  ...  ${mapDurationToShortTime(lastTrip.start_time)}`}</span>
+      {hasTimetables && (
+        <>
+          <span>|</span>
+          <span className="font-bold">
+            {t('timetables.tripCount', { count: tripCount })}
+          </span>
+          <span>|</span>
+          <span>
+            {`${mapDurationToShortTime(firstTrip.start_time)} ...
+            ${mapDurationToShortTime(lastTrip.start_time)}`}
+          </span>
+        </>
+      )}
     </Row>
   );
 };

--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopSection.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { pipe, uniq } from 'remeda';
 import { RouteWithJourneyPatternStopsFragment } from '../../../generated/graphql';
 import { VehicleJourneyGroup, useTimetablesViewState } from '../../../hooks';
@@ -22,6 +23,7 @@ export const PassingTimesByStopSection = ({
   route,
 }: Props): JSX.Element => {
   const { dayType, setDayType } = useTimetablesViewState();
+  const { t } = useTranslation();
 
   const vehicleJourneyGroupsToDisplay =
     vehicleJourneyGroups?.filter(
@@ -70,10 +72,16 @@ export const PassingTimesByStopSection = ({
               vehicleJourneyGroup={vehicleJourneyGroup}
             />
           </Row>
-          <PassingTimesByStopTable
-            vehicleJourneys={vehicleJourneyGroup.vehicleJourneys}
-            route={route}
-          />
+          {vehicleJourneyGroup.vehicleJourneys ? (
+            <PassingTimesByStopTable
+              vehicleJourneys={vehicleJourneyGroup.vehicleJourneys}
+              route={route}
+            />
+          ) : (
+            <span className="flex justify-center">
+              {t('timetables.noTraffic')}
+            </span>
+          )}
         </div>
       ))}
     </div>

--- a/ui/src/components/timetables/vehicle-schedule-details/VehicleScheduleDetailsPage.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/VehicleScheduleDetailsPage.tsx
@@ -15,7 +15,10 @@ import {
   selectChangeTimetableValidityModal,
   selectTimetable,
 } from '../../../redux';
-import { setShowArrivalTimesAction } from '../../../redux/slices/timetable';
+import {
+  setShowAllValidAction,
+  setShowArrivalTimesAction,
+} from '../../../redux/slices/timetable';
 import { SimpleButton, Switch, SwitchLabel } from '../../../uiComponents';
 import { ObservationDateControl } from '../../common/ObservationDateControl';
 import { FormColumn, FormRow } from '../../forms/common';
@@ -24,6 +27,11 @@ import { LineTitle } from '../../routes-and-lines/line-details/LineTitle';
 import { ChangeTimetablesValidityModal } from '../common/ChangeTimetablesValidityModal';
 import { RouteTimetableList } from './RouteTimetableList';
 import { TimetableNavigation } from './TimetableNavigation';
+
+const testIds = {
+  showArrivalTimesSwitch: 'VehicleScheduleDetailsPage::showArrivalTimesSwitch',
+  showAllValidSwitch: 'VehicleScheduleDetailsPage::showAllValidSwitch',
+};
 
 export const VehicleScheduleDetailsPage = (): JSX.Element => {
   const { t } = useTranslation();
@@ -36,13 +44,17 @@ export const VehicleScheduleDetailsPage = (): JSX.Element => {
   const { routeLabel, setShowDefaultView, activeView } =
     useTimetablesViewState();
   const { displayedRouteLabels } = useGetRoutesDisplayedInList(line);
-  const { showArrivalTimes } = useAppSelector(selectTimetable);
+  const { showArrivalTimes, showAllValid } = useAppSelector(selectTimetable);
   const changeTimetableValidityModalState = useAppSelector(
     selectChangeTimetableValidityModal,
   );
 
   const onShowArrivalTimesChanged = (enabled: boolean) => {
     dispatch(setShowArrivalTimesAction(enabled));
+  };
+
+  const onShowAllValidChanged = (enabled: boolean) => {
+    dispatch(setShowAllValidAction(enabled));
   };
 
   const onCloseTimetableValidityModal = () => {
@@ -59,11 +71,6 @@ export const VehicleScheduleDetailsPage = (): JSX.Element => {
           displayedRouteLabels?.includes(route.label),
         ) || []
       : line?.line_routes.filter((route) => route.label === routeLabel) || [];
-
-  const testIds = {
-    showArrivalTimesSwitch:
-      'VehicleScheduleDetailsPage::showArrivalTimesSwitch',
-  };
 
   return (
     <div>
@@ -86,6 +93,19 @@ export const VehicleScheduleDetailsPage = (): JSX.Element => {
       <Container className="py-10">
         <FormRow mdColumns={6} className="mb-8">
           <ObservationDateControl className="max-w-max" />
+          <Visible visible={activeView === TimetablesView.DEFAULT}>
+            <div className="justify-normal col-span-2 mb-1 flex items-center space-x-4 self-end">
+              <HuiSwitch.Group>
+                <SwitchLabel>{t('timetables.showAllValid')}</SwitchLabel>
+                <Switch
+                  checked={showAllValid}
+                  testId={testIds.showAllValidSwitch}
+                  className="mb-1"
+                  onChange={onShowAllValidChanged}
+                />
+              </HuiSwitch.Group>
+            </div>
+          </Visible>
           <Visible
             visible={activeView === TimetablesView.PASSING_TIMES_BY_STOP}
           >

--- a/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
@@ -51,15 +51,17 @@ export const VehicleServiceTable = ({
 
   const { vehicleJourneys, priority, dayType, createdAt } = vehicleJourneyGroup;
 
-  const departureTimesByHour = pipe(
-    vehicleJourneys,
-    (services) => services.flatMap((item) => item.start_time),
-    (journeyStartTimes) =>
-      journeyStartTimes.sort(
-        (time1, time2) => time1.as('millisecond') - time2.as('millisecond'),
-      ),
-    (journeyStartTimes) => groupBy(journeyStartTimes, (item) => item.hours),
-  );
+  const departureTimesByHour = vehicleJourneys
+    ? pipe(
+        vehicleJourneys,
+        (services) => services.flatMap((item) => item.start_time),
+        (journeyStartTimes) =>
+          journeyStartTimes.sort(
+            (time1, time2) => time1.as('millisecond') - time2.as('millisecond'),
+          ),
+        (journeyStartTimes) => groupBy(journeyStartTimes, (item) => item.hours),
+      )
+    : [];
 
   const rowData: VehicleServiceRowData[] = Object.entries(
     departureTimesByHour,
@@ -122,7 +124,7 @@ export const VehicleServiceTable = ({
         </div>
       </Visible>
       <Visible visible={!hasVehicleJourneys}>
-        <p>{t('timetables.noSchedules')}</p>
+        <p className="text-center">{t('timetables.noTraffic')}</p>
       </Visible>
     </div>
   );

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -10072,6 +10072,249 @@ export type TimetablesReturnValueTimetableVersionVarianceFields = {
   priority?: Maybe<Scalars['Float']>;
 };
 
+/**
+ * This return value table is used in function vehicle_journey.get_vehicle_schedules_on_date. It consists of vehicle_journey_id, vehicle_schedule_frame_id or
+ * substitute_operating_day_by_line_type_id and also enriched with data, which are used in the UI side.
+ */
+export type TimetablesReturnValueVehicleSchedule = {
+  __typename?: 'timetables_return_value_vehicle_schedule';
+  created_at?: Maybe<Scalars['timestamptz']>;
+  /** An object relationship */
+  day_type?: Maybe<TimetablesServiceCalendarDayType>;
+  day_type_id: Scalars['uuid'];
+  priority: Scalars['Int'];
+  substitute_operating_day_by_line_type_id?: Maybe<Scalars['uuid']>;
+  validity_end: Scalars['date'];
+  validity_start: Scalars['date'];
+  /** An object relationship */
+  vehicle_journey?: Maybe<TimetablesVehicleJourneyVehicleJourney>;
+  vehicle_journey_id?: Maybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: Maybe<Scalars['uuid']>;
+};
+
+/** aggregated selection of "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleAggregate = {
+  __typename?: 'timetables_return_value_vehicle_schedule_aggregate';
+  aggregate?: Maybe<TimetablesReturnValueVehicleScheduleAggregateFields>;
+  nodes: Array<TimetablesReturnValueVehicleSchedule>;
+};
+
+/** aggregate fields of "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleAggregateFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_aggregate_fields';
+  avg?: Maybe<TimetablesReturnValueVehicleScheduleAvgFields>;
+  count: Scalars['Int'];
+  max?: Maybe<TimetablesReturnValueVehicleScheduleMaxFields>;
+  min?: Maybe<TimetablesReturnValueVehicleScheduleMinFields>;
+  stddev?: Maybe<TimetablesReturnValueVehicleScheduleStddevFields>;
+  stddev_pop?: Maybe<TimetablesReturnValueVehicleScheduleStddevPopFields>;
+  stddev_samp?: Maybe<TimetablesReturnValueVehicleScheduleStddevSampFields>;
+  sum?: Maybe<TimetablesReturnValueVehicleScheduleSumFields>;
+  var_pop?: Maybe<TimetablesReturnValueVehicleScheduleVarPopFields>;
+  var_samp?: Maybe<TimetablesReturnValueVehicleScheduleVarSampFields>;
+  variance?: Maybe<TimetablesReturnValueVehicleScheduleVarianceFields>;
+};
+
+/** aggregate fields of "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleAggregateFieldsCountArgs = {
+  columns?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleSelectColumn>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** aggregate avg on columns */
+export type TimetablesReturnValueVehicleScheduleAvgFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_avg_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** Boolean expression to filter rows from the table "return_value.vehicle_schedule". All fields are combined with a logical 'AND'. */
+export type TimetablesReturnValueVehicleScheduleBoolExp = {
+  _and?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleBoolExp>>;
+  _not?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  _or?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleBoolExp>>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
+  day_type?: InputMaybe<TimetablesServiceCalendarDayTypeBoolExp>;
+  day_type_id?: InputMaybe<UuidComparisonExp>;
+  priority?: InputMaybe<IntComparisonExp>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<UuidComparisonExp>;
+  validity_end?: InputMaybe<DateComparisonExp>;
+  validity_start?: InputMaybe<DateComparisonExp>;
+  vehicle_journey?: InputMaybe<TimetablesVehicleJourneyVehicleJourneyBoolExp>;
+  vehicle_journey_id?: InputMaybe<UuidComparisonExp>;
+  vehicle_schedule_frame_id?: InputMaybe<UuidComparisonExp>;
+};
+
+/** input type for incrementing numeric columns in table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleIncInput = {
+  priority?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleInsertInput = {
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  day_type?: InputMaybe<TimetablesServiceCalendarDayTypeObjRelInsertInput>;
+  day_type_id?: InputMaybe<Scalars['uuid']>;
+  priority?: InputMaybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<Scalars['uuid']>;
+  validity_end?: InputMaybe<Scalars['date']>;
+  validity_start?: InputMaybe<Scalars['date']>;
+  vehicle_journey?: InputMaybe<TimetablesVehicleJourneyVehicleJourneyObjRelInsertInput>;
+  vehicle_journey_id?: InputMaybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** aggregate max on columns */
+export type TimetablesReturnValueVehicleScheduleMaxFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_max_fields';
+  created_at?: Maybe<Scalars['timestamptz']>;
+  day_type_id?: Maybe<Scalars['uuid']>;
+  priority?: Maybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: Maybe<Scalars['uuid']>;
+  validity_end?: Maybe<Scalars['date']>;
+  validity_start?: Maybe<Scalars['date']>;
+  vehicle_journey_id?: Maybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: Maybe<Scalars['uuid']>;
+};
+
+/** aggregate min on columns */
+export type TimetablesReturnValueVehicleScheduleMinFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_min_fields';
+  created_at?: Maybe<Scalars['timestamptz']>;
+  day_type_id?: Maybe<Scalars['uuid']>;
+  priority?: Maybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: Maybe<Scalars['uuid']>;
+  validity_end?: Maybe<Scalars['date']>;
+  validity_start?: Maybe<Scalars['date']>;
+  vehicle_journey_id?: Maybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: Maybe<Scalars['uuid']>;
+};
+
+/** response of any mutation on the table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleMutationResponse = {
+  __typename?: 'timetables_return_value_vehicle_schedule_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data from the rows affected by the mutation */
+  returning: Array<TimetablesReturnValueVehicleSchedule>;
+};
+
+/** Ordering options when selecting data from "return_value.vehicle_schedule". */
+export type TimetablesReturnValueVehicleScheduleOrderBy = {
+  created_at?: InputMaybe<OrderBy>;
+  day_type?: InputMaybe<TimetablesServiceCalendarDayTypeOrderBy>;
+  day_type_id?: InputMaybe<OrderBy>;
+  priority?: InputMaybe<OrderBy>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<OrderBy>;
+  validity_end?: InputMaybe<OrderBy>;
+  validity_start?: InputMaybe<OrderBy>;
+  vehicle_journey?: InputMaybe<TimetablesVehicleJourneyVehicleJourneyOrderBy>;
+  vehicle_journey_id?: InputMaybe<OrderBy>;
+  vehicle_schedule_frame_id?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "return_value.vehicle_schedule" */
+export enum TimetablesReturnValueVehicleScheduleSelectColumn {
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  DayTypeId = 'day_type_id',
+  /** column name */
+  Priority = 'priority',
+  /** column name */
+  SubstituteOperatingDayByLineTypeId = 'substitute_operating_day_by_line_type_id',
+  /** column name */
+  ValidityEnd = 'validity_end',
+  /** column name */
+  ValidityStart = 'validity_start',
+  /** column name */
+  VehicleJourneyId = 'vehicle_journey_id',
+  /** column name */
+  VehicleScheduleFrameId = 'vehicle_schedule_frame_id',
+}
+
+/** input type for updating data in table "return_value.vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleSetInput = {
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  day_type_id?: InputMaybe<Scalars['uuid']>;
+  priority?: InputMaybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<Scalars['uuid']>;
+  validity_end?: InputMaybe<Scalars['date']>;
+  validity_start?: InputMaybe<Scalars['date']>;
+  vehicle_journey_id?: InputMaybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** aggregate stddev on columns */
+export type TimetablesReturnValueVehicleScheduleStddevFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_stddev_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type TimetablesReturnValueVehicleScheduleStddevPopFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_stddev_pop_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type TimetablesReturnValueVehicleScheduleStddevSampFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_stddev_samp_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** Streaming cursor of the table "return_value_vehicle_schedule" */
+export type TimetablesReturnValueVehicleScheduleStreamCursorInput = {
+  /** Stream column input with initial value */
+  initial_value: TimetablesReturnValueVehicleScheduleStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<TimetablesCursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type TimetablesReturnValueVehicleScheduleStreamCursorValueInput = {
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  day_type_id?: InputMaybe<Scalars['uuid']>;
+  priority?: InputMaybe<Scalars['Int']>;
+  substitute_operating_day_by_line_type_id?: InputMaybe<Scalars['uuid']>;
+  validity_end?: InputMaybe<Scalars['date']>;
+  validity_start?: InputMaybe<Scalars['date']>;
+  vehicle_journey_id?: InputMaybe<Scalars['uuid']>;
+  vehicle_schedule_frame_id?: InputMaybe<Scalars['uuid']>;
+};
+
+/** aggregate sum on columns */
+export type TimetablesReturnValueVehicleScheduleSumFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_sum_fields';
+  priority?: Maybe<Scalars['Int']>;
+};
+
+export type TimetablesReturnValueVehicleScheduleUpdates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<TimetablesReturnValueVehicleScheduleIncInput>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<TimetablesReturnValueVehicleScheduleSetInput>;
+  /** filter the rows which have to be updated */
+  where: TimetablesReturnValueVehicleScheduleBoolExp;
+};
+
+/** aggregate var_pop on columns */
+export type TimetablesReturnValueVehicleScheduleVarPopFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_var_pop_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate var_samp on columns */
+export type TimetablesReturnValueVehicleScheduleVarSampFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_var_samp_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate variance on columns */
+export type TimetablesReturnValueVehicleScheduleVarianceFields = {
+  __typename?: 'timetables_return_value_vehicle_schedule_variance_fields';
+  priority?: Maybe<Scalars['Float']>;
+};
+
 /** A type of day characterised by one or more properties which affect public transport operation. For example: weekday in school holidays. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=1:6:3:299  */
 export type TimetablesServiceCalendarDayType = {
   __typename?: 'timetables_service_calendar_day_type';
@@ -10680,6 +10923,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineType = {
   begin_datetime: Scalars['timestamptz'];
   /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
   begin_time?: Maybe<Scalars['interval']>;
+  created_at: Scalars['timestamptz'];
   /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
   end_datetime: Scalars['timestamptz'];
   /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
@@ -10747,6 +10991,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeBoolExp = {
   >;
   begin_datetime?: InputMaybe<TimestamptzComparisonExp>;
   begin_time?: InputMaybe<IntervalComparisonExp>;
+  created_at?: InputMaybe<TimestamptzComparisonExp>;
   end_datetime?: InputMaybe<TimestamptzComparisonExp>;
   end_time?: InputMaybe<IntervalComparisonExp>;
   substitute_day_of_week?: InputMaybe<IntComparisonExp>;
@@ -10774,6 +11019,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeInsertInput
   {
     /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
     begin_time?: InputMaybe<Scalars['interval']>;
+    created_at?: InputMaybe<Scalars['timestamptz']>;
     /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
     end_time?: InputMaybe<Scalars['interval']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10792,6 +11038,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeMaxFields =
     __typename?: 'timetables_service_calendar_substitute_operating_day_by_line_type_max_fields';
     /** Calculated timestamp for the instant from which the substituting public transit comes into effect. */
     begin_datetime?: Maybe<Scalars['timestamptz']>;
+    created_at?: Maybe<Scalars['timestamptz']>;
     /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
     end_datetime?: Maybe<Scalars['timestamptz']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10810,6 +11057,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeMinFields =
     __typename?: 'timetables_service_calendar_substitute_operating_day_by_line_type_min_fields';
     /** Calculated timestamp for the instant from which the substituting public transit comes into effect. */
     begin_datetime?: Maybe<Scalars['timestamptz']>;
+    created_at?: Maybe<Scalars['timestamptz']>;
     /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
     end_datetime?: Maybe<Scalars['timestamptz']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10852,6 +11100,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeOnConflict 
 export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeOrderBy = {
   begin_datetime?: InputMaybe<OrderBy>;
   begin_time?: InputMaybe<OrderBy>;
+  created_at?: InputMaybe<OrderBy>;
   end_datetime?: InputMaybe<OrderBy>;
   end_time?: InputMaybe<OrderBy>;
   substitute_day_of_week?: InputMaybe<OrderBy>;
@@ -10874,6 +11123,8 @@ export enum TimetablesServiceCalendarSubstituteOperatingDayByLineTypeSelectColum
   /** column name */
   BeginTime = 'begin_time',
   /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
   EndDatetime = 'end_datetime',
   /** column name */
   EndTime = 'end_time',
@@ -10894,6 +11145,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeSetInput =
   {
     /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
     begin_time?: InputMaybe<Scalars['interval']>;
+    created_at?: InputMaybe<Scalars['timestamptz']>;
     /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
     end_time?: InputMaybe<Scalars['interval']>;
     /** The ISO day of week (1=Monday, ... , 7=Sunday) of the day type used as the basis for operating day substitution. A NULL value indicates that there is no public transit at all, i.e. no vehicle journeys are operated within the given time period. */
@@ -10946,6 +11198,7 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeStreamCurso
     begin_datetime?: InputMaybe<Scalars['timestamptz']>;
     /** The time from which the substituting public transit comes into effect. If NULL, the substitution is in effect from the start of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys prior to this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys before this time are operated as usual. */
     begin_time?: InputMaybe<Scalars['interval']>;
+    created_at?: InputMaybe<Scalars['timestamptz']>;
     /** Calculated timestamp for the instant (exclusive) until which the substituting public transit is in effect. */
     end_datetime?: InputMaybe<Scalars['timestamptz']>;
     /** The time (exclusive) until which the substituting public transit is valid. If NULL, the substitution is in effect until the end of the operating day. When substitute_day_of_week is not NULL (reference day case), vehicle journeys starting from this time are not operated. When substitute_day_of_week is NULL (no traffic case), the vehicle journeys starting from this time are operated as usual. */
@@ -10972,6 +11225,8 @@ export type TimetablesServiceCalendarSubstituteOperatingDayByLineTypeSumFields =
 export enum TimetablesServiceCalendarSubstituteOperatingDayByLineTypeUpdateColumn {
   /** column name */
   BeginTime = 'begin_time',
+  /** column name */
+  CreatedAt = 'created_at',
   /** column name */
   EndTime = 'end_time',
   /** column name */
@@ -11495,6 +11750,8 @@ export type TimetablesTimetablesMutationFrontend = {
   timetables_delete_passing_times_timetabled_passing_time_by_pk?: Maybe<TimetablesPassingTimesTimetabledPassingTime>;
   /** delete data from the table: "return_value.timetable_version" */
   timetables_delete_return_value_timetable_version?: Maybe<TimetablesReturnValueTimetableVersionMutationResponse>;
+  /** delete data from the table: "return_value.vehicle_schedule" */
+  timetables_delete_return_value_vehicle_schedule?: Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>;
   /** delete data from the table: "service_calendar.day_type" */
   timetables_delete_service_calendar_day_type?: Maybe<TimetablesServiceCalendarDayTypeMutationResponse>;
   /** delete data from the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -11547,6 +11804,10 @@ export type TimetablesTimetablesMutationFrontend = {
   timetables_insert_return_value_timetable_version?: Maybe<TimetablesReturnValueTimetableVersionMutationResponse>;
   /** insert a single row into the table: "return_value.timetable_version" */
   timetables_insert_return_value_timetable_version_one?: Maybe<TimetablesReturnValueTimetableVersion>;
+  /** insert data into the table: "return_value.vehicle_schedule" */
+  timetables_insert_return_value_vehicle_schedule?: Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>;
+  /** insert a single row into the table: "return_value.vehicle_schedule" */
+  timetables_insert_return_value_vehicle_schedule_one?: Maybe<TimetablesReturnValueVehicleSchedule>;
   /** insert data into the table: "service_calendar.day_type" */
   timetables_insert_service_calendar_day_type?: Maybe<TimetablesServiceCalendarDayTypeMutationResponse>;
   /** insert data into the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -11608,6 +11869,12 @@ export type TimetablesTimetablesMutationFrontend = {
   /** update multiples rows of table: "return_value.timetable_version" */
   timetables_update_return_value_timetable_version_many?: Maybe<
     Array<Maybe<TimetablesReturnValueTimetableVersionMutationResponse>>
+  >;
+  /** update data of the table: "return_value.vehicle_schedule" */
+  timetables_update_return_value_vehicle_schedule?: Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>;
+  /** update multiples rows of table: "return_value.vehicle_schedule" */
+  timetables_update_return_value_vehicle_schedule_many?: Maybe<
+    Array<Maybe<TimetablesReturnValueVehicleScheduleMutationResponse>>
   >;
   /** update data of the table: "service_calendar.day_type" */
   timetables_update_service_calendar_day_type?: Maybe<TimetablesServiceCalendarDayTypeMutationResponse>;
@@ -11722,6 +11989,11 @@ export type TimetablesTimetablesMutationFrontendTimetablesDeletePassingTimesTime
 export type TimetablesTimetablesMutationFrontendTimetablesDeleteReturnValueTimetableVersionArgs =
   {
     where: TimetablesReturnValueTimetableVersionBoolExp;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesDeleteReturnValueVehicleScheduleArgs =
+  {
+    where: TimetablesReturnValueVehicleScheduleBoolExp;
   };
 
 export type TimetablesTimetablesMutationFrontendTimetablesDeleteServiceCalendarDayTypeArgs =
@@ -11858,6 +12130,16 @@ export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueTimet
 export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueTimetableVersionOneArgs =
   {
     object: TimetablesReturnValueTimetableVersionInsertInput;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueVehicleScheduleArgs =
+  {
+    objects: Array<TimetablesReturnValueVehicleScheduleInsertInput>;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesInsertReturnValueVehicleScheduleOneArgs =
+  {
+    object: TimetablesReturnValueVehicleScheduleInsertInput;
   };
 
 export type TimetablesTimetablesMutationFrontendTimetablesInsertServiceCalendarDayTypeArgs =
@@ -12024,6 +12306,18 @@ export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueTimet
 export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueTimetableVersionManyArgs =
   {
     updates: Array<TimetablesReturnValueTimetableVersionUpdates>;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueVehicleScheduleArgs =
+  {
+    _inc?: InputMaybe<TimetablesReturnValueVehicleScheduleIncInput>;
+    _set?: InputMaybe<TimetablesReturnValueVehicleScheduleSetInput>;
+    where: TimetablesReturnValueVehicleScheduleBoolExp;
+  };
+
+export type TimetablesTimetablesMutationFrontendTimetablesUpdateReturnValueVehicleScheduleManyArgs =
+  {
+    updates: Array<TimetablesReturnValueVehicleScheduleUpdates>;
   };
 
 export type TimetablesTimetablesMutationFrontendTimetablesUpdateServiceCalendarDayTypeArgs =
@@ -12276,6 +12570,10 @@ export type TimetablesTimetablesQuery = {
   timetables_return_value_timetable_version: Array<TimetablesReturnValueTimetableVersion>;
   /** fetch aggregated fields from the table: "return_value.timetable_version" */
   timetables_return_value_timetable_version_aggregate: TimetablesReturnValueTimetableVersionAggregate;
+  /** fetch data from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule: Array<TimetablesReturnValueVehicleSchedule>;
+  /** fetch aggregated fields from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
   /** fetch data from the table: "service_calendar.day_type" */
   timetables_service_calendar_day_type: Array<TimetablesServiceCalendarDayType>;
   /** fetch data from the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -12304,6 +12602,10 @@ export type TimetablesTimetablesQuery = {
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_aggregate: TimetablesServicePatternScheduledStopPointInJourneyPatternRefAggregate;
   /** fetch data from the table: "service_pattern.scheduled_stop_point_in_journey_pattern_ref" using primary key columns */
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_by_pk?: Maybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRef>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" which returns "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date: Array<TimetablesReturnValueVehicleSchedule>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" and query aggregates on result of table type "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
   /** fetch data from the table: "vehicle_journey.vehicle_journey" */
   timetables_vehicle_journey_vehicle_journey: Array<TimetablesVehicleJourneyVehicleJourney>;
   /** fetch aggregated fields from the table: "vehicle_journey.vehicle_journey" */
@@ -12436,6 +12738,28 @@ export type TimetablesTimetablesQueryTimetablesReturnValueTimetableVersionAggreg
     offset?: InputMaybe<Scalars['Int']>;
     order_by?: InputMaybe<Array<TimetablesReturnValueTimetableVersionOrderBy>>;
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
+  };
+
+export type TimetablesTimetablesQueryTimetablesReturnValueVehicleScheduleArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesQueryTimetablesReturnValueVehicleScheduleAggregateArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesQueryTimetablesServiceCalendarDayTypeArgs = {
@@ -12578,6 +12902,30 @@ export type TimetablesTimetablesQueryTimetablesServicePatternScheduledStopPointI
 export type TimetablesTimetablesQueryTimetablesServicePatternScheduledStopPointInJourneyPatternRefByPkArgs =
   {
     scheduled_stop_point_in_journey_pattern_ref_id: Scalars['uuid'];
+  };
+
+export type TimetablesTimetablesQueryTimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesQueryTimetablesVehicleJourneyGetVehicleSchedulesOnDateAggregateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesQueryTimetablesVehicleJourneyVehicleJourneyArgs =
@@ -12838,6 +13186,12 @@ export type TimetablesTimetablesSubscription = {
   timetables_return_value_timetable_version_aggregate: TimetablesReturnValueTimetableVersionAggregate;
   /** fetch data from the table in a streaming manner: "return_value.timetable_version" */
   timetables_return_value_timetable_version_stream: Array<TimetablesReturnValueTimetableVersion>;
+  /** fetch data from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule: Array<TimetablesReturnValueVehicleSchedule>;
+  /** fetch aggregated fields from the table: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
+  /** fetch data from the table in a streaming manner: "return_value.vehicle_schedule" */
+  timetables_return_value_vehicle_schedule_stream: Array<TimetablesReturnValueVehicleSchedule>;
   /** fetch data from the table: "service_calendar.day_type" */
   timetables_service_calendar_day_type: Array<TimetablesServiceCalendarDayType>;
   /** fetch data from the table: "service_calendar.day_type_active_on_day_of_week" */
@@ -12874,6 +13228,10 @@ export type TimetablesTimetablesSubscription = {
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_by_pk?: Maybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRef>;
   /** fetch data from the table in a streaming manner: "service_pattern.scheduled_stop_point_in_journey_pattern_ref" */
   timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref_stream: Array<TimetablesServicePatternScheduledStopPointInJourneyPatternRef>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" which returns "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date: Array<TimetablesReturnValueVehicleSchedule>;
+  /** execute function "vehicle_journey.get_vehicle_schedules_on_date" and query aggregates on result of table type "return_value.vehicle_schedule" */
+  timetables_vehicle_journey_get_vehicle_schedules_on_date_aggregate: TimetablesReturnValueVehicleScheduleAggregate;
   /** fetch data from the table: "vehicle_journey.vehicle_journey" */
   timetables_vehicle_journey_vehicle_journey: Array<TimetablesVehicleJourneyVehicleJourney>;
   /** fetch aggregated fields from the table: "vehicle_journey.vehicle_journey" */
@@ -13045,6 +13403,37 @@ export type TimetablesTimetablesSubscriptionTimetablesReturnValueTimetableVersio
       InputMaybe<TimetablesReturnValueTimetableVersionStreamCursorInput>
     >;
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesReturnValueVehicleScheduleArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesReturnValueVehicleScheduleAggregateArgs =
+  {
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesReturnValueVehicleScheduleStreamArgs =
+  {
+    batch_size: Scalars['Int'];
+    cursor: Array<
+      InputMaybe<TimetablesReturnValueVehicleScheduleStreamCursorInput>
+    >;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesSubscriptionTimetablesServiceCalendarDayTypeArgs =
@@ -13226,6 +13615,30 @@ export type TimetablesTimetablesSubscriptionTimetablesServicePatternScheduledSto
       InputMaybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRefStreamCursorInput>
     >;
     where?: InputMaybe<TimetablesServicePatternScheduledStopPointInJourneyPatternRefBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
+  };
+
+export type TimetablesTimetablesSubscriptionTimetablesVehicleJourneyGetVehicleSchedulesOnDateAggregateArgs =
+  {
+    args: TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs;
+    distinct_on?: InputMaybe<
+      Array<TimetablesReturnValueVehicleScheduleSelectColumn>
+    >;
+    limit?: InputMaybe<Scalars['Int']>;
+    offset?: InputMaybe<Scalars['Int']>;
+    order_by?: InputMaybe<Array<TimetablesReturnValueVehicleScheduleOrderBy>>;
+    where?: InputMaybe<TimetablesReturnValueVehicleScheduleBoolExp>;
   };
 
 export type TimetablesTimetablesSubscriptionTimetablesVehicleJourneyVehicleJourneyArgs =
@@ -13518,6 +13931,11 @@ export type TimetablesTimetablesSubscriptionTimetablesVehicleTypeVehicleTypeStre
     >;
     where?: InputMaybe<TimetablesVehicleTypeVehicleTypeBoolExp>;
   };
+
+export type TimetablesVehicleJourneyGetVehicleSchedulesOnDateArgs = {
+  journey_pattern_uuid?: InputMaybe<Scalars['uuid']>;
+  observation_date?: InputMaybe<Scalars['date']>;
+};
 
 /** The planned movement of a public transport vehicle on a DAY TYPE from the start point to the end point of a JOURNEY PATTERN on a specified ROUTE. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:1:1:831  */
 export type TimetablesVehicleJourneyVehicleJourney = {

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -20360,102 +20360,215 @@ export type VehicleJourneyWithServiceFragment = {
   }>;
 };
 
-export type GetTimetablesForOperationDayQueryVariables = Exact<{
+export type VehicleScheduleFragment = {
+  __typename?: 'timetables_return_value_vehicle_schedule';
+  priority: number;
+  validity_start: luxon.DateTime;
+  validity_end: luxon.DateTime;
+  created_at?: luxon.DateTime | null;
+  vehicle_schedule_frame_id?: UUID | null;
+  vehicle_journey?: {
+    __typename?: 'timetables_vehicle_journey_vehicle_journey';
+    vehicle_journey_id: UUID;
+    start_time: luxon.Duration;
+    end_time: luxon.Duration;
+    journey_pattern_ref_id: UUID;
+    journey_pattern_ref: {
+      __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+      journey_pattern_ref_id: UUID;
+      journey_pattern_id: UUID;
+    };
+    block: {
+      __typename?: 'timetables_vehicle_service_block';
+      block_id: UUID;
+      vehicle_service_id: UUID;
+      vehicle_service: {
+        __typename?: 'timetables_vehicle_service_vehicle_service';
+        vehicle_service_id: UUID;
+        day_type_id: UUID;
+        vehicle_schedule_frame: {
+          __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
+          vehicle_schedule_frame_id: UUID;
+          validity_end: luxon.DateTime;
+          validity_start: luxon.DateTime;
+          priority: number;
+          name_i18n?: any | null;
+          created_at: luxon.DateTime;
+        };
+        day_type: {
+          __typename?: 'timetables_service_calendar_day_type';
+          day_type_id: UUID;
+          label: string;
+          name_i18n: any;
+        };
+      };
+    };
+    timetabled_passing_times: Array<{
+      __typename?: 'timetables_passing_times_timetabled_passing_time';
+      arrival_time?: luxon.Duration | null;
+      departure_time?: luxon.Duration | null;
+      passing_time: luxon.Duration;
+      scheduled_stop_point_in_journey_pattern_ref_id: UUID;
+      timetabled_passing_time_id: UUID;
+      vehicle_journey_id: UUID;
+      scheduled_stop_point_in_journey_pattern_ref: {
+        __typename?: 'timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref';
+        scheduled_stop_point_in_journey_pattern_ref_id: UUID;
+        scheduled_stop_point_label: string;
+        journey_pattern_ref: {
+          __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+          journey_pattern_ref_id: UUID;
+          observation_timestamp: luxon.DateTime;
+        };
+        scheduled_stop_point_instances: Array<{
+          __typename?: 'service_pattern_scheduled_stop_point';
+          priority: number;
+          direction: InfrastructureNetworkDirectionEnum;
+          scheduled_stop_point_id: UUID;
+          label: string;
+          validity_start?: luxon.DateTime | null;
+          validity_end?: luxon.DateTime | null;
+          located_on_infrastructure_link_id: UUID;
+          timing_place?: {
+            __typename?: 'timing_pattern_timing_place';
+            label: string;
+            timing_place_id: UUID;
+          } | null;
+        }>;
+      };
+      vehicle_journey: {
+        __typename?: 'timetables_vehicle_journey_vehicle_journey';
+        vehicle_journey_id: UUID;
+        block: {
+          __typename?: 'timetables_vehicle_service_block';
+          block_id: UUID;
+          vehicle_type?: {
+            __typename?: 'timetables_vehicle_type_vehicle_type';
+            description_i18n?: any | null;
+            vehicle_type_id: UUID;
+          } | null;
+        };
+      };
+    }>;
+  } | null;
+  day_type?: {
+    __typename?: 'timetables_service_calendar_day_type';
+    day_type_id: UUID;
+    label: string;
+    name_i18n: any;
+  } | null;
+};
+
+export type GetVehicleSchedulesForDateQueryVariables = Exact<{
   journey_pattern_id: Scalars['uuid'];
   observation_date: Scalars['date'];
 }>;
 
-export type GetTimetablesForOperationDayQuery = {
+export type GetVehicleSchedulesForDateQuery = {
   __typename?: 'query_root';
   timetables?: {
     __typename?: 'timetables_timetables_query';
-    timetables_vehicle_journey_vehicle_journey: Array<{
-      __typename?: 'timetables_vehicle_journey_vehicle_journey';
-      vehicle_journey_id: UUID;
-      start_time: luxon.Duration;
-      end_time: luxon.Duration;
-      journey_pattern_ref_id: UUID;
-      journey_pattern_ref: {
-        __typename?: 'timetables_journey_pattern_journey_pattern_ref';
-        journey_pattern_ref_id: UUID;
-        journey_pattern_id: UUID;
-      };
-      block: {
-        __typename?: 'timetables_vehicle_service_block';
-        block_id: UUID;
-        vehicle_service_id: UUID;
-        vehicle_service: {
-          __typename?: 'timetables_vehicle_service_vehicle_service';
-          vehicle_service_id: UUID;
-          day_type_id: UUID;
-          vehicle_schedule_frame: {
-            __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
-            vehicle_schedule_frame_id: UUID;
-            validity_end: luxon.DateTime;
-            validity_start: luxon.DateTime;
-            priority: number;
-            name_i18n?: any | null;
-            created_at: luxon.DateTime;
-          };
-          day_type: {
-            __typename?: 'timetables_service_calendar_day_type';
-            day_type_id: UUID;
-            label: string;
-            name_i18n: any;
-          };
-        };
-      };
-      timetabled_passing_times: Array<{
-        __typename?: 'timetables_passing_times_timetabled_passing_time';
-        arrival_time?: luxon.Duration | null;
-        departure_time?: luxon.Duration | null;
-        passing_time: luxon.Duration;
-        scheduled_stop_point_in_journey_pattern_ref_id: UUID;
-        timetabled_passing_time_id: UUID;
+    timetables_vehicle_journey_get_vehicle_schedules_on_date: Array<{
+      __typename?: 'timetables_return_value_vehicle_schedule';
+      priority: number;
+      validity_start: luxon.DateTime;
+      validity_end: luxon.DateTime;
+      created_at?: luxon.DateTime | null;
+      vehicle_schedule_frame_id?: UUID | null;
+      vehicle_journey?: {
+        __typename?: 'timetables_vehicle_journey_vehicle_journey';
         vehicle_journey_id: UUID;
-        scheduled_stop_point_in_journey_pattern_ref: {
-          __typename?: 'timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref';
-          scheduled_stop_point_in_journey_pattern_ref_id: UUID;
-          scheduled_stop_point_label: string;
-          journey_pattern_ref: {
-            __typename?: 'timetables_journey_pattern_journey_pattern_ref';
-            journey_pattern_ref_id: UUID;
-            observation_timestamp: luxon.DateTime;
-          };
-          scheduled_stop_point_instances: Array<{
-            __typename?: 'service_pattern_scheduled_stop_point';
-            priority: number;
-            direction: InfrastructureNetworkDirectionEnum;
-            scheduled_stop_point_id: UUID;
-            label: string;
-            validity_start?: luxon.DateTime | null;
-            validity_end?: luxon.DateTime | null;
-            located_on_infrastructure_link_id: UUID;
-            timing_place?: {
-              __typename?: 'timing_pattern_timing_place';
+        start_time: luxon.Duration;
+        end_time: luxon.Duration;
+        journey_pattern_ref_id: UUID;
+        journey_pattern_ref: {
+          __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+          journey_pattern_ref_id: UUID;
+          journey_pattern_id: UUID;
+        };
+        block: {
+          __typename?: 'timetables_vehicle_service_block';
+          block_id: UUID;
+          vehicle_service_id: UUID;
+          vehicle_service: {
+            __typename?: 'timetables_vehicle_service_vehicle_service';
+            vehicle_service_id: UUID;
+            day_type_id: UUID;
+            vehicle_schedule_frame: {
+              __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
+              vehicle_schedule_frame_id: UUID;
+              validity_end: luxon.DateTime;
+              validity_start: luxon.DateTime;
+              priority: number;
+              name_i18n?: any | null;
+              created_at: luxon.DateTime;
+            };
+            day_type: {
+              __typename?: 'timetables_service_calendar_day_type';
+              day_type_id: UUID;
               label: string;
-              timing_place_id: UUID;
-            } | null;
-          }>;
-        };
-        vehicle_journey: {
-          __typename?: 'timetables_vehicle_journey_vehicle_journey';
-          vehicle_journey_id: UUID;
-          block: {
-            __typename?: 'timetables_vehicle_service_block';
-            block_id: UUID;
-            vehicle_type?: {
-              __typename?: 'timetables_vehicle_type_vehicle_type';
-              description_i18n?: any | null;
-              vehicle_type_id: UUID;
-            } | null;
+              name_i18n: any;
+            };
           };
         };
-      }>;
+        timetabled_passing_times: Array<{
+          __typename?: 'timetables_passing_times_timetabled_passing_time';
+          arrival_time?: luxon.Duration | null;
+          departure_time?: luxon.Duration | null;
+          passing_time: luxon.Duration;
+          scheduled_stop_point_in_journey_pattern_ref_id: UUID;
+          timetabled_passing_time_id: UUID;
+          vehicle_journey_id: UUID;
+          scheduled_stop_point_in_journey_pattern_ref: {
+            __typename?: 'timetables_service_pattern_scheduled_stop_point_in_journey_pattern_ref';
+            scheduled_stop_point_in_journey_pattern_ref_id: UUID;
+            scheduled_stop_point_label: string;
+            journey_pattern_ref: {
+              __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+              journey_pattern_ref_id: UUID;
+              observation_timestamp: luxon.DateTime;
+            };
+            scheduled_stop_point_instances: Array<{
+              __typename?: 'service_pattern_scheduled_stop_point';
+              priority: number;
+              direction: InfrastructureNetworkDirectionEnum;
+              scheduled_stop_point_id: UUID;
+              label: string;
+              validity_start?: luxon.DateTime | null;
+              validity_end?: luxon.DateTime | null;
+              located_on_infrastructure_link_id: UUID;
+              timing_place?: {
+                __typename?: 'timing_pattern_timing_place';
+                label: string;
+                timing_place_id: UUID;
+              } | null;
+            }>;
+          };
+          vehicle_journey: {
+            __typename?: 'timetables_vehicle_journey_vehicle_journey';
+            vehicle_journey_id: UUID;
+            block: {
+              __typename?: 'timetables_vehicle_service_block';
+              block_id: UUID;
+              vehicle_type?: {
+                __typename?: 'timetables_vehicle_type_vehicle_type';
+                description_i18n?: any | null;
+                vehicle_type_id: UUID;
+              } | null;
+            };
+          };
+        }>;
+      } | null;
+      day_type?: {
+        __typename?: 'timetables_service_calendar_day_type';
+        day_type_id: UUID;
+        label: string;
+        name_i18n: any;
+      } | null;
     }>;
-    timetables_vehicle_service_get_vehicle_services_for_date: Array<{
-      __typename?: 'timetables_vehicle_service_vehicle_service';
-      vehicle_service_id: UUID;
+    timetables_service_calendar_get_active_day_types_for_date: Array<{
+      __typename?: 'timetables_service_calendar_day_type';
+      day_type_id: UUID;
     }>;
   } | null;
 };
@@ -21116,6 +21229,23 @@ export const VehicleJourneyWithServiceFragmentDoc = gql`
   }
   ${DayTypeAllFieldsFragmentDoc}
   ${VehicleJourneyByStopFragmentDoc}
+`;
+export const VehicleScheduleFragmentDoc = gql`
+  fragment vehicle_schedule on timetables_return_value_vehicle_schedule {
+    vehicle_journey {
+      ...vehicle_journey_with_service
+    }
+    day_type {
+      ...day_type_all_fields
+    }
+    priority
+    validity_start
+    validity_end
+    created_at
+    vehicle_schedule_frame_id
+  }
+  ${VehicleJourneyWithServiceFragmentDoc}
+  ${DayTypeAllFieldsFragmentDoc}
 `;
 export const JourneyPatternStopFragmentDoc = gql`
   fragment journey_pattern_stop on journey_pattern_scheduled_stop_point_in_journey_pattern {
@@ -24997,81 +25127,80 @@ export type UpdateVehicleScheduleFrameValidityMutationOptions =
     UpdateVehicleScheduleFrameValidityMutation,
     UpdateVehicleScheduleFrameValidityMutationVariables
   >;
-export const GetTimetablesForOperationDayDocument = gql`
-  query GetTimetablesForOperationDay(
+export const GetVehicleSchedulesForDateDocument = gql`
+  query GetVehicleSchedulesForDate(
     $journey_pattern_id: uuid!
     $observation_date: date!
   ) {
     timetables {
-      timetables_vehicle_journey_vehicle_journey(
-        where: {
-          journey_pattern_ref: {
-            journey_pattern_id: { _eq: $journey_pattern_id }
-          }
+      timetables_vehicle_journey_get_vehicle_schedules_on_date(
+        args: {
+          journey_pattern_uuid: $journey_pattern_id
+          observation_date: $observation_date
         }
       ) {
-        ...vehicle_journey_with_service
+        ...vehicle_schedule
       }
-      timetables_vehicle_service_get_vehicle_services_for_date(
+      timetables_service_calendar_get_active_day_types_for_date(
         args: { observation_date: $observation_date }
       ) {
-        vehicle_service_id
+        day_type_id
       }
     }
   }
-  ${VehicleJourneyWithServiceFragmentDoc}
+  ${VehicleScheduleFragmentDoc}
 `;
 
 /**
- * __useGetTimetablesForOperationDayQuery__
+ * __useGetVehicleSchedulesForDateQuery__
  *
- * To run a query within a React component, call `useGetTimetablesForOperationDayQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTimetablesForOperationDayQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetVehicleSchedulesForDateQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetVehicleSchedulesForDateQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetTimetablesForOperationDayQuery({
+ * const { data, loading, error } = useGetVehicleSchedulesForDateQuery({
  *   variables: {
  *      journey_pattern_id: // value for 'journey_pattern_id'
  *      observation_date: // value for 'observation_date'
  *   },
  * });
  */
-export function useGetTimetablesForOperationDayQuery(
+export function useGetVehicleSchedulesForDateQuery(
   baseOptions: Apollo.QueryHookOptions<
-    GetTimetablesForOperationDayQuery,
-    GetTimetablesForOperationDayQueryVariables
+    GetVehicleSchedulesForDateQuery,
+    GetVehicleSchedulesForDateQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
-    GetTimetablesForOperationDayQuery,
-    GetTimetablesForOperationDayQueryVariables
-  >(GetTimetablesForOperationDayDocument, options);
+    GetVehicleSchedulesForDateQuery,
+    GetVehicleSchedulesForDateQueryVariables
+  >(GetVehicleSchedulesForDateDocument, options);
 }
-export function useGetTimetablesForOperationDayLazyQuery(
+export function useGetVehicleSchedulesForDateLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetTimetablesForOperationDayQuery,
-    GetTimetablesForOperationDayQueryVariables
+    GetVehicleSchedulesForDateQuery,
+    GetVehicleSchedulesForDateQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetTimetablesForOperationDayQuery,
-    GetTimetablesForOperationDayQueryVariables
-  >(GetTimetablesForOperationDayDocument, options);
+    GetVehicleSchedulesForDateQuery,
+    GetVehicleSchedulesForDateQueryVariables
+  >(GetVehicleSchedulesForDateDocument, options);
 }
-export type GetTimetablesForOperationDayQueryHookResult = ReturnType<
-  typeof useGetTimetablesForOperationDayQuery
+export type GetVehicleSchedulesForDateQueryHookResult = ReturnType<
+  typeof useGetVehicleSchedulesForDateQuery
 >;
-export type GetTimetablesForOperationDayLazyQueryHookResult = ReturnType<
-  typeof useGetTimetablesForOperationDayLazyQuery
+export type GetVehicleSchedulesForDateLazyQueryHookResult = ReturnType<
+  typeof useGetVehicleSchedulesForDateLazyQuery
 >;
-export type GetTimetablesForOperationDayQueryResult = Apollo.QueryResult<
-  GetTimetablesForOperationDayQuery,
-  GetTimetablesForOperationDayQueryVariables
+export type GetVehicleSchedulesForDateQueryResult = Apollo.QueryResult<
+  GetVehicleSchedulesForDateQuery,
+  GetVehicleSchedulesForDateQueryVariables
 >;
 
 export function useListChangingRoutesAsyncQuery() {
@@ -25470,12 +25599,12 @@ export type GetVehicleScheduleFrameWithRoutesAsyncQueryHookResult = ReturnType<
   typeof useGetVehicleScheduleFrameWithRoutesAsyncQuery
 >;
 
-export function useGetTimetablesForOperationDayAsyncQuery() {
+export function useGetVehicleSchedulesForDateAsyncQuery() {
   return useAsyncQuery<
-    GetTimetablesForOperationDayQuery,
-    GetTimetablesForOperationDayQueryVariables
-  >(GetTimetablesForOperationDayDocument);
+    GetVehicleSchedulesForDateQuery,
+    GetVehicleSchedulesForDateQueryVariables
+  >(GetVehicleSchedulesForDateDocument);
 }
-export type GetTimetablesForOperationDayAsyncQueryHookResult = ReturnType<
-  typeof useGetTimetablesForOperationDayAsyncQuery
+export type GetVehicleSchedulesForDateAsyncQueryHookResult = ReturnType<
+  typeof useGetVehicleSchedulesForDateAsyncQuery
 >;

--- a/ui/src/hooks/vehicle-service/useGetRouteTimetables.ts
+++ b/ui/src/hooks/vehicle-service/useGetRouteTimetables.ts
@@ -1,13 +1,11 @@
-import { ApolloQueryResult, gql } from '@apollo/client';
+import { gql } from '@apollo/client';
 import { DateTime } from 'luxon';
 import { useCallback, useEffect, useState } from 'react';
-import { pipe } from 'remeda';
 import {
   DayTypeAllFieldsFragment,
-  GetTimetablesForOperationDayQuery,
-  Maybe,
   VehicleJourneyWithServiceFragment,
-  useGetTimetablesForOperationDayAsyncQuery,
+  VehicleScheduleFragment,
+  useGetVehicleSchedulesForDateAsyncQuery,
 } from '../../generated/graphql';
 import { selectChangeTimetableValidityModal } from '../../redux';
 import { findEarliestTime, findLatestTime } from '../../time';
@@ -55,48 +53,44 @@ const GQL_VEHICLE_JOURNEY_WITH_SERVICE_FRAGMENT = gql`
   }
 `;
 
-const GQL_GET_TIMETABLES_FOR_OPERATION_DAY = gql`
-  query GetTimetablesForOperationDay(
+const GQL_VEHICLE_SCHEDULES_FRAGMENT = gql`
+  fragment vehicle_schedule on timetables_return_value_vehicle_schedule {
+    vehicle_journey {
+      ...vehicle_journey_with_service
+    }
+    day_type {
+      ...day_type_all_fields
+    }
+    priority
+    validity_start
+    validity_end
+    created_at
+    vehicle_schedule_frame_id
+  }
+`;
+
+const GQL_GET_VEHICLE_SCHEDULES_FOR_DATE = gql`
+  query GetVehicleSchedulesForDate(
     $journey_pattern_id: uuid!
     $observation_date: date!
   ) {
     timetables {
-      timetables_vehicle_journey_vehicle_journey(
-        where: {
-          journey_pattern_ref: {
-            journey_pattern_id: { _eq: $journey_pattern_id }
-          }
+      timetables_vehicle_journey_get_vehicle_schedules_on_date(
+        args: {
+          journey_pattern_uuid: $journey_pattern_id
+          observation_date: $observation_date
         }
       ) {
-        ...vehicle_journey_with_service
+        ...vehicle_schedule
       }
-      timetables_vehicle_service_get_vehicle_services_for_date(
+      timetables_service_calendar_get_active_day_types_for_date(
         args: { observation_date: $observation_date }
       ) {
-        vehicle_service_id
+        day_type_id
       }
     }
   }
 `;
-
-// TODO: we probably should have better type for Timetables response, but
-// seems like it is not generated for some reason
-type Timetables =
-  ApolloQueryResult<GetTimetablesForOperationDayQuery>['data']['timetables'];
-
-const getVehicleJourneys = (timetables: Timetables) => {
-  return timetables?.timetables_vehicle_journey_vehicle_journey.length
-    ? timetables?.timetables_vehicle_journey_vehicle_journey
-    : [];
-};
-
-const getVehicleServiceIdsOnObservationDate = (timetables: Timetables) => {
-  const vehicleServiceIdsOnObservationDate =
-    timetables?.timetables_vehicle_service_get_vehicle_services_for_date.map(
-      (item) => item.vehicle_service_id,
-    );
-  return vehicleServiceIdsOnObservationDate;
-};
 
 /**
  * Interface that groups together all vehicle journeys that are valid for
@@ -108,105 +102,18 @@ const getVehicleServiceIdsOnObservationDate = (timetables: Timetables) => {
  * @property vehicleJourneys: Array of vehicle journeys
  */
 export interface VehicleJourneyGroup {
-  priority: TimetablePriority;
   dayType: DayTypeAllFieldsFragment;
+  vehicleJourneys: VehicleJourneyWithServiceFragment[] | null;
+  priority: TimetablePriority;
   validity: Validity;
-  vehicleJourneys: VehicleJourneyWithServiceFragment[];
-  createdAt: DateTime;
-  vehicleScheduleFrameId: UUID;
+  vehicleScheduleFrameId?: UUID | null;
+  createdAt?: DateTime | null | undefined;
+  inEffect?: boolean;
 }
 
-const groupVehicleJourneys = (
-  journeys: VehicleJourneyWithServiceFragment[],
-  vehicleServiceIdsOnObservationDate?: UUID[],
-) => {
-  // Vehicle journeys parsed & groupd from timetables response so that
-  // they can be shown in UI more easily.
-  return pipe(
-    journeys,
-    (input) =>
-      // filter out journeys that are not active on selected observation date
-      input.filter((item) =>
-        vehicleServiceIdsOnObservationDate?.includes(
-          item.block.vehicle_service.vehicle_service_id,
-        ),
-      ),
-    (vehicleJourneys) =>
-      vehicleJourneys.reduce<VehicleJourneyGroup[]>((groups, item) => {
-        const { vehicle_service: vehicleService } = item.block;
-        const { vehicle_schedule_frame: vehicleScheduleFrame } = vehicleService;
-
-        const foundGroup = groups.find(
-          (group) =>
-            group.dayType === vehicleService.day_type &&
-            group.priority === vehicleScheduleFrame.priority,
-        );
-        if (foundGroup) {
-          foundGroup.vehicleJourneys.push(item);
-          return groups;
-        }
-
-        return [
-          ...groups,
-          {
-            dayType: vehicleService.day_type,
-            priority: vehicleScheduleFrame.priority,
-            validity: {
-              validityStart: vehicleScheduleFrame.validity_start,
-              validityEnd: vehicleScheduleFrame.validity_end,
-            },
-            createdAt: vehicleScheduleFrame.created_at,
-            vehicleJourneys: [item],
-            vehicleScheduleFrameId:
-              vehicleScheduleFrame.vehicle_schedule_frame_id,
-          },
-        ];
-      }, []),
-  );
-};
-
-const getGroupedVehicleJourneys = (timetables: Timetables) => {
-  const vehicleServiceIds = getVehicleServiceIdsOnObservationDate(timetables);
-  const vehicleJourneys = getVehicleJourneys(timetables);
-
-  return groupVehicleJourneys(vehicleJourneys, vehicleServiceIds);
-};
-
 type Validity = {
-  validityStart?: Maybe<DateTime>;
-  validityEnd?: Maybe<DateTime>;
-};
-
-const getTimetableValidity = (timetables: Timetables): Validity => {
-  const removeNonDateValues = (times?: (DateTime | null | undefined)[]) => {
-    // we have to use unsafe `as` casting here as TS doesn't realise that we
-    // are filtering out non-date values from the input
-    return times ? times.filter((item) => !!item) : ([] as DateTime[]);
-  };
-
-  const validityStart = pipe(
-    timetables,
-    (input) =>
-      input?.timetables_vehicle_journey_vehicle_journey.map(
-        (item) =>
-          item.block.vehicle_service.vehicle_schedule_frame.validity_start,
-      ),
-    removeNonDateValues,
-    (startTimes) => findLatestTime(startTimes as DateTime[]),
-    (startTime) => (startTime.isValid ? startTime : undefined),
-  );
-  const validityEnd = pipe(
-    timetables,
-    (input) =>
-      input?.timetables_vehicle_journey_vehicle_journey.map(
-        (item) =>
-          item.block.vehicle_service.vehicle_schedule_frame.validity_end,
-      ),
-    removeNonDateValues,
-    (endTimes) => findEarliestTime(endTimes as DateTime[]),
-    (endTime) => (endTime.isValid ? endTime : undefined),
-  );
-  return { validityStart, validityEnd };
+  validityStart: DateTime;
+  validityEnd: DateTime;
 };
 
 /**
@@ -219,16 +126,116 @@ const getTimetableValidity = (timetables: Timetables): Validity => {
  * @property vehicleJourneyGroups: Array of vehicle journey groups
  */
 export interface TimetableWithMetadata {
-  timetable: Timetables;
-  validity: Validity;
+  validity?: Validity;
   journeyPatternId: UUID;
   vehicleJourneyGroups: VehicleJourneyGroup[];
 }
 
-export const useGetRouteTimetables = (journeyPatternId?: UUID) => {
-  const [getRouteTimetablesForOperationDay] =
-    useGetTimetablesForOperationDayAsyncQuery();
+const getTimetableNarrowestValidityPeriod = (
+  vehicleJourneyGroups: VehicleJourneyGroup[],
+) => {
+  const startTimes = vehicleJourneyGroups.map(
+    (item) => item.validity.validityStart,
+  );
 
+  const endTimes = vehicleJourneyGroups.map(
+    (item) => item.validity.validityEnd,
+  );
+
+  return {
+    validityStart: findLatestTime(startTimes),
+    validityEnd: findEarliestTime(endTimes),
+  };
+};
+
+/**
+ * Enriches the vehicleJourneyGroups with inEffect value calculated by checking
+ * the active day type ids, and then getting the highest priority of that type.
+ * So for example, if the observation date is a 11.7.2023 (Tuesday) and we have
+ * a Mon-Fri, Sat, Sun (Standard) and Tuesday (substitute), this function calculates
+ * that eligible day types are Mon-Fri and Tuesday, but Tuesday is highest priority, so
+ * that one will get the inEffect: true.
+ */
+const enrichWithInEffectValue = (
+  vehicleJourneyGroups: VehicleJourneyGroup[],
+  activeDayTypeIds?: UUID[],
+) => {
+  return vehicleJourneyGroups.map((group) => {
+    const dayTypeIsActive = activeDayTypeIds?.includes(
+      group.dayType.day_type_id,
+    );
+    if (!dayTypeIsActive) {
+      return { ...group, inEffect: false };
+    }
+
+    const isHighestPriorityOnActiveDayType =
+      group.priority ===
+      Math.max(
+        ...vehicleJourneyGroups
+          .filter((g) => activeDayTypeIds?.includes(g.dayType.day_type_id))
+          .map((g) => g.priority),
+      );
+
+    if (!isHighestPriorityOnActiveDayType) {
+      return { ...group, inEffect: false };
+    }
+    return { ...group, inEffect: true };
+  });
+};
+
+/**
+ * In this function we combine the vehicle schedules that we get from the
+ * SQL function, and combine them in to vehicleJourneyGroups, which represent
+ * the timetable information for a day type.
+ *
+ * In this function we group up the vehicle schedule rows by their dayTypeId and
+ * combine all the same day type's vehicleJourneys to vehicleJourneys attribute
+ * in this object. After this we can drop the grouping by dayTypeId and use
+ * Object.values to get the result as an array.
+ */
+const combineVehicleSchedulesToVehicleJourneyGroups = (
+  vehicleSchedulesOnDate?: VehicleScheduleFragment[],
+) => {
+  return Object.values(
+    vehicleSchedulesOnDate?.reduce(
+      (acc: { [key: string]: VehicleJourneyGroup }, obj) => {
+        // NOTE: Not sure why the type codegen-generator thinks this can be null. It shouldnt be.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const dayTypeId = obj.day_type!.day_type_id;
+        const vehicleJourney = obj.vehicle_journey || null;
+
+        // If there is no entry already in acc[dayTypeId], we create one with
+        // empty vehicleJourney array
+        const vehicleJourneyGroup = acc[dayTypeId] || {
+          vehicleJourneys: [],
+        };
+
+        const updatedVehicleJourneyGroup: VehicleJourneyGroup = {
+          priority: obj.priority,
+          validity: {
+            validityStart: obj.validity_start,
+            validityEnd: obj.validity_end,
+          },
+          dayType: obj.day_type as DayTypeAllFieldsFragment,
+          vehicleScheduleFrameId: obj.vehicle_schedule_frame_id,
+          createdAt: obj.created_at,
+          // if we have a vehicle journey, we can combine it, if the vehicle
+          // journey is null, it means that this day type is a 'no traffic' and the vehicleJourneys
+          // can be set to null
+          vehicleJourneys:
+            vehicleJourney && vehicleJourneyGroup.vehicleJourneys
+              ? [...vehicleJourneyGroup.vehicleJourneys, vehicleJourney]
+              : null,
+        };
+
+        return { ...acc, [dayTypeId]: updatedVehicleJourneyGroup };
+      },
+      {} as { [key: string]: VehicleJourneyGroup },
+    ) || {},
+  );
+};
+
+export const useGetRouteTimetables = (journeyPatternId?: UUID) => {
   const { observationDate } = useObservationDateQueryParam();
   const changeTimetableValidityModalState = useAppSelector(
     selectChangeTimetableValidityModal,
@@ -236,26 +243,48 @@ export const useGetRouteTimetables = (journeyPatternId?: UUID) => {
 
   const [timetables, setTimetables] = useState<TimetableWithMetadata>();
 
+  const [getVehicleSchedulesForDate] =
+    useGetVehicleSchedulesForDateAsyncQuery();
+
   const getTimetablesForRoute = useCallback(async () => {
     if (!journeyPatternId) {
       return;
     }
 
-    const res = await getRouteTimetablesForOperationDay({
+    const response = await getVehicleSchedulesForDate({
       journey_pattern_id: journeyPatternId,
       observation_date: observationDate,
     });
+    const vehicleSchedulesOnDate =
+      response.data.timetables
+        ?.timetables_vehicle_journey_get_vehicle_schedules_on_date;
 
-    const rawTimetables = res.data?.timetables;
+    const activeDayTypeIds =
+      response.data.timetables?.timetables_service_calendar_get_active_day_types_for_date.map(
+        (dayType) => dayType.day_type_id,
+      );
+
+    const vehicleJourneyGroups = combineVehicleSchedulesToVehicleJourneyGroups(
+      vehicleSchedulesOnDate,
+    );
+
+    const enrichedVehicleJourneyGroups = enrichWithInEffectValue(
+      vehicleJourneyGroups,
+      activeDayTypeIds,
+    );
+
+    const validity = vehicleJourneyGroups.length
+      ? getTimetableNarrowestValidityPeriod(vehicleJourneyGroups)
+      : undefined;
 
     const timetableWithMetadata: TimetableWithMetadata = {
-      timetable: rawTimetables,
-      validity: getTimetableValidity(rawTimetables),
-      vehicleJourneyGroups: getGroupedVehicleJourneys(rawTimetables),
+      validity,
+      vehicleJourneyGroups: enrichedVehicleJourneyGroups,
       journeyPatternId,
     };
+
     setTimetables(timetableWithMetadata);
-  }, [journeyPatternId, observationDate, getRouteTimetablesForOperationDay]);
+  }, [journeyPatternId, getVehicleSchedulesForDate, observationDate]);
 
   useEffect(() => {
     getTimetablesForRoute();

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -293,6 +293,7 @@
     "timetableValidity": "Valid {{ validityStart }} - {{ validityEnd }}",
     "departures": "Departures",
     "noSchedules": "No schedules",
+    "noTraffic": "No traffic",
     "at": "at {{ time }}",
     "showVersions": "Show versions",
     "versionsTitle": "Timetable versions",
@@ -304,6 +305,7 @@
     "tripCount": "{{ count }} trips",
     "interpolated": "Interpolated",
     "showArrivalTimes": "Show arrival times",
+    "showAllValid": "Show all valid",
     "operatedLike": "Operated like {{ dayOfWeek }}",
     "noService": "No service",
     "timeline": "Timeline"

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -293,6 +293,7 @@
     "timetableValidity": "Voimassa {{ validityStart }} - {{ validityEnd }}",
     "departures": "Lähdöt",
     "noSchedules": "Ei vuoroja",
+    "noTraffic": "Ei liikennöintiä",
     "at": "klo {{ time }}",
     "showVersions": "Näytä versiot",
     "versionsTitle": "Aikatauluversiot",
@@ -304,6 +305,7 @@
     "tripCount": "{{ count }} lähtöä",
     "interpolated": "Interpoloitu",
     "showArrivalTimes": "Näytä saapumisajat",
+    "showAllValid": "Näytä kaikki voimassaolevat",
     "operatedLike": "Ajetaan kuten {{ dayOfWeek }}",
     "noService": "Ei liikennöintiä",
     "timeline": "Aikajana"

--- a/ui/src/redux/slices/timetable.ts
+++ b/ui/src/redux/slices/timetable.ts
@@ -3,12 +3,14 @@ import { StoreType } from '../mappers';
 
 export interface TimetableState {
   showArrivalTimes: boolean;
+  showAllValid: boolean;
 }
 
 type IState = StoreType<TimetableState>;
 
 const initialState: IState = {
   showArrivalTimes: false,
+  showAllValid: false,
 };
 
 const slice = createSlice({
@@ -18,9 +20,15 @@ const slice = createSlice({
     setShowArrivalTimes: (state, action: PayloadAction<boolean>) => {
       state.showArrivalTimes = action.payload;
     },
+    setShowAllValid: (state, action: PayloadAction<boolean>) => {
+      state.showAllValid = action.payload;
+    },
   },
 });
 
-export const { setShowArrivalTimes: setShowArrivalTimesAction } = slice.actions;
+export const {
+  setShowArrivalTimes: setShowArrivalTimesAction,
+  setShowAllValid: setShowAllValidAction,
+} = slice.actions;
 
 export const timetableReducer = slice.reducer;

--- a/ui/src/uiComponents/Switch.tsx
+++ b/ui/src/uiComponents/Switch.tsx
@@ -21,7 +21,7 @@ export const Switch: React.FC<Props> = ({
       onChange={onChange}
       className={`${className} ${
         checked ? 'border-brand bg-brand' : 'border-grey'
-      } relative inline-flex h-6 w-11 items-center rounded-full border transition-colors`}
+      } relative inline-flex h-6 w-11 items-center rounded-full border transition-colors focus-visible:ring`}
       data-testid={testId}
     >
       <span


### PR DESCRIPTION
Three commits:
* Add focus-visible to Switch component
* Update hasura image and generated resources (this function adds the SQL function which is used in the new fetching logic)
* Add new fetching logic to timetable page
  * This commit is pretty massive, but the roots of the refactoring and the new logic were deep. So this
commit replaces the old way of fetching vehicle schedules for vehicleScheduleDetails and also adds support
for substitute operating days by line type. Earlier we had this a bit awkward logic of 'fetch all data in two separate
requests and then combine the information to compile wanted end result and this resulted in only the in effect schedule even though this style fetched a lot of redundant data. So with this new logic we get all the necessary information from database function and then we play with it in different
views. Now we get all vehicle schedules for day types on the observation date, we combine them in to vehicleJourneyGroups and calculate which is the one in effect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/632)
<!-- Reviewable:end -->
