### PR TITLE
Fix minor map bugs

### DIFF
--- a/ui/src/components/map/Modal.tsx
+++ b/ui/src/components/map/Modal.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Row } from '../../layoutComponents';
 import { SimpleButton } from '../../uiComponents';
@@ -53,6 +53,18 @@ export const Modal: FunctionComponent<Props> = ({
   onSave,
   children,
 }) => {
+  const closeOnEscape = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', closeOnEscape, true);
+    return () => document.removeEventListener('keydown', closeOnEscape, true);
+  });
+
   return (
     <div data-testid={testId} className="overflow-auto bg-white">
       <ModalHeader onClose={onClose} heading={heading} />

--- a/ui/src/components/map/stops/CreateStopMarker.tsx
+++ b/ui/src/components/map/stops/CreateStopMarker.tsx
@@ -36,6 +36,7 @@ export const CreateStopMarker = ({ onCursorMove }: Props): JSX.Element => {
 
   const detectKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
+      e.preventDefault();
       dispatch(resetEnabledModesAction());
     }
   };

--- a/ui/src/hooks/stops/useEditStop.ts
+++ b/ui/src/hooks/stops/useEditStop.ts
@@ -2,6 +2,7 @@ import flow from 'lodash/flow';
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import {
   EditStopMutationVariables,
   InfrastructureNetworkDirectionEnum,
@@ -18,6 +19,7 @@ import {
   mapGetRoutesBrokenByStopChangeResult,
   mapStopResultToStop,
 } from '../../graphql';
+import { setIsMoveStopModeEnabledAction } from '../../redux';
 import {
   DirectionNotResolvedError,
   EditRouteTerminalStopsError,
@@ -72,6 +74,7 @@ export const useEditStop = () => {
   const { getConflictingStops } = useCheckValidityAndPriorityConflicts();
   const [getBrokenRoutes] = useGetRoutesBrokenByStopChangeAsyncQuery();
   const [validateTimingSettings] = useValidateTimingSettings();
+  const dispatch = useDispatch();
 
   const getRoutesBrokenByStopChange = async ({
     newLink,
@@ -281,6 +284,7 @@ export const useEditStop = () => {
       return;
     }
     if (err instanceof TimingPlaceRequiredError) {
+      dispatch(setIsMoveStopModeEnabledAction(false));
       showDangerToast(
         t('stops.timingPlaceRequired', { routeLabels: err.message }),
       );


### PR DESCRIPTION
* If stop has hastus options set for some route, the move action is now canceled instead of getting stuck.
* Pressing esc during stop move now correctly cancels the move action instead of closing the whole map.
* Added pressing 'Escape' functionality to modals. (preventDefault and call onClose)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/634)
<!-- Reviewable:end -->
