### PR TITLE
Add hastus check on export

### DIFF
--- a/ui/src/components/common/LineTableRow.tsx
+++ b/ui/src/components/common/LineTableRow.tsx
@@ -23,11 +23,14 @@ const GQL_LINE_TABLE_ROW = gql`
   fragment line_table_row on route_line {
     name_i18n
     short_name_i18n
+    validity_start
+    validity_end
     priority
     ...line_map_params
     line_routes {
       ...route_map_params
       unique_label
+      direction
       route_journey_patterns {
         journey_pattern_id
         journey_pattern_refs {
@@ -35,6 +38,11 @@ const GQL_LINE_TABLE_ROW = gql`
           vehicle_journeys {
             vehicle_journey_id
           }
+        }
+        scheduled_stop_point_in_journey_patterns {
+          journey_pattern_id
+          scheduled_stop_point_sequence
+          is_used_as_timing_point
         }
       }
     }

--- a/ui/src/components/common/LineTableRow.tsx
+++ b/ui/src/components/common/LineTableRow.tsx
@@ -5,11 +5,7 @@ import {
   useAppSelector,
   useShowRoutesOnModal,
 } from '../../hooks';
-import {
-  deselectRouteUniqueLabelsAction,
-  selectExport,
-  selectRouteUniqueLabelsAction,
-} from '../../redux';
+import { deselectRowAction, selectExport, selectRowAction } from '../../redux';
 import { routeHasTimetables } from '../../utils/route';
 import {
   RouteLineTableRow,
@@ -58,7 +54,7 @@ export const LineTableRow = ({
 }: Props): JSX.Element => {
   const { showRoutesOnMapByLineLabel } = useShowRoutesOnModal();
   const dispatch = useAppDispatch();
-  const { selectedRouteUniqueLabels } = useAppSelector(selectExport);
+  const { selectedRows } = useAppSelector(selectExport);
 
   const showLineRoutes = () => {
     showRoutesOnMapByLineLabel(line);
@@ -66,11 +62,10 @@ export const LineTableRow = ({
 
   const onSelectChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     const selected = event.target.checked;
-    const selectAction = selected
-      ? selectRouteUniqueLabelsAction
-      : deselectRouteUniqueLabelsAction;
 
-    dispatch(selectAction(line.line_routes.map((route) => route.label)));
+    const selectAction = selected ? selectRowAction : deselectRowAction;
+
+    dispatch(selectAction(line.label));
   };
 
   const hasRoutes = line.line_routes?.length > 0;
@@ -78,11 +73,8 @@ export const LineTableRow = ({
   // Entire line is selected for export if it has routes and each of those is selected.
   // Selecting only subset of routes shouldn't be possible, as user can select routes
   // from line list or from route list, not from both simultaneously.
-  const isSelected =
-    hasRoutes &&
-    line.line_routes.every((route) =>
-      selectedRouteUniqueLabels.includes(route.label),
-    );
+
+  const isSelected = selectedRows.includes(line.label);
 
   // Check if any of the line's route has timetables existing
   const hasTimetables = line.line_routes.some(routeHasTimetables);

--- a/ui/src/components/common/RouteTableRow.tsx
+++ b/ui/src/components/common/RouteTableRow.tsx
@@ -29,6 +29,11 @@ const GQL_ROUTE_TABLE_ROW = gql`
           vehicle_journey_id
         }
       }
+      scheduled_stop_point_in_journey_patterns {
+        journey_pattern_id
+        scheduled_stop_point_sequence
+        is_used_as_timing_point
+      }
     }
   }
 `;

--- a/ui/src/components/common/RouteTableRow.tsx
+++ b/ui/src/components/common/RouteTableRow.tsx
@@ -5,11 +5,7 @@ import {
   useAppSelector,
   useShowRoutesOnModal,
 } from '../../hooks';
-import {
-  deselectRouteUniqueLabelAction,
-  selectExport,
-  selectRouteUniqueLabelAction,
-} from '../../redux';
+import { deselectRowAction, selectExport, selectRowAction } from '../../redux';
 import { routeHasTimetables } from '../../utils/route';
 import {
   RouteLineTableRow,
@@ -57,7 +53,7 @@ export const RouteTableRow = ({
 }: Props): JSX.Element => {
   const { showRouteOnMap } = useShowRoutesOnModal();
   const dispatch = useAppDispatch();
-  const { selectedRouteUniqueLabels } = useAppSelector(selectExport);
+  const { selectedRows } = useAppSelector(selectExport);
 
   const onClickShowRouteOnMap = () => {
     showRouteOnMap(route);
@@ -65,16 +61,13 @@ export const RouteTableRow = ({
 
   const onSelectChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     const selected = event.target.checked;
-    const selectAction = selected
-      ? selectRouteUniqueLabelAction
-      : deselectRouteUniqueLabelAction;
-
+    const selectAction = selected ? selectRowAction : deselectRowAction;
     dispatch(selectAction(route.unique_label));
   };
 
   const hasTimetables = routeHasTimetables(route);
+  const isSelected = selectedRows.includes(route.unique_label);
 
-  const isSelected = selectedRouteUniqueLabels.includes(route.unique_label);
   return (
     <RouteLineTableRow
       rowItem={route}

--- a/ui/src/components/common/search/ResultSelector.tsx
+++ b/ui/src/components/common/search/ResultSelector.tsx
@@ -4,7 +4,7 @@ import {
   useAppDispatch,
   useSearch,
 } from '../../../hooks';
-import { resetSelectedRoutesAction } from '../../../redux';
+import { resetSelectedRowsAction } from '../../../redux';
 import { SimpleSmallButton } from '../../../uiComponents';
 import { DisplayedSearchResultType } from '../../../utils';
 
@@ -20,14 +20,14 @@ export const ResultSelector = (): JSX.Element => {
   const { displayedType } = queryParameters.filter;
 
   const displayRoutes = () => {
-    dispatch(resetSelectedRoutesAction());
+    dispatch(resetSelectedRowsAction());
     setFilter(
       SearchQueryParameterNames.DisplayedType,
       DisplayedSearchResultType.Routes,
     );
   };
   const displayLines = () => {
-    dispatch(resetSelectedRoutesAction());
+    dispatch(resetSelectedRowsAction());
     setFilter(
       SearchQueryParameterNames.DisplayedType,
       DisplayedSearchResultType.Lines,

--- a/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
+++ b/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
@@ -17,6 +17,7 @@ import { SimpleSmallButton } from '../../../uiComponents';
 import {
   DisplayedSearchResultType,
   isRouteActiveOnObservationDate,
+  showDangerToast,
 } from '../../../utils';
 
 const testIds = {
@@ -33,7 +34,8 @@ export const ExportToolbar = (): JSX.Element => {
     useSearchResults();
   const { isSelectingRoutesForExport, selectedRows } =
     useAppSelector(selectExport);
-  const { canExport, exportRoutesToHastus } = useExportRoutes();
+  const { canExport, exportRoutesToHastus, findNotEligibleRoutesForExport } =
+    useExportRoutes();
 
   const linesWithRoutes = lines.filter((line) => !!line.line_routes.length);
 
@@ -78,9 +80,20 @@ export const ExportToolbar = (): JSX.Element => {
   };
 
   const exportRoutes = () => {
-    exportRoutesToHastus(
-      exportData.toBeExportedRoutes.map((route) => route.unique_label),
+    const notEligibleRoutes = findNotEligibleRoutesForExport(
+      exportData.toBeExportedRoutes,
     );
+    if (!notEligibleRoutes.length) {
+      exportRoutesToHastus(
+        exportData.toBeExportedRoutes.map((route) => route.unique_label),
+      );
+    } else {
+      showDangerToast(
+        t('export.notEligibleRoutesForExport', {
+          routes: notEligibleRoutes.join(', '),
+        }),
+      );
+    }
   };
 
   return (

--- a/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
+++ b/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
@@ -1,22 +1,23 @@
-import isEqual from 'lodash/isEqual';
-import uniq from 'lodash/uniq';
 import { useTranslation } from 'react-i18next';
-import { pipe } from 'remeda';
 import {
   useAppDispatch,
   useAppSelector,
   useExportRoutes,
+  useObservationDateQueryParam,
   useSearchResults,
 } from '../../../hooks';
 import { Row, Visible } from '../../../layoutComponents';
 import {
-  resetSelectedRoutesAction,
+  resetSelectedRowsAction,
   selectExport,
-  selectRouteUniqueLabelsAction,
+  selectRowsAction,
   setIsSelectingRoutesForExportAction,
 } from '../../../redux';
 import { SimpleSmallButton } from '../../../uiComponents';
-import { DisplayedSearchResultType } from '../../../utils';
+import {
+  DisplayedSearchResultType,
+  isRouteActiveOnObservationDate,
+} from '../../../utils';
 
 const testIds = {
   toggleSelectingButton: 'ExportToolBar::toggleSelectingButton',
@@ -26,54 +27,59 @@ const testIds = {
 export const ExportToolbar = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
+  const { observationDate } = useObservationDateQueryParam();
 
-  const {
-    resultCount,
-    resultType,
-    reducedRoutes,
-    lines,
-  } = useSearchResults();
-  const { isSelectingRoutesForExport, selectedRouteUniqueLabels } =
+  const { resultCount, resultType, routes, reducedRoutes, lines } =
+    useSearchResults();
+  const { isSelectingRoutesForExport, selectedRows } =
     useAppSelector(selectExport);
   const { canExport, exportRoutesToHastus } = useExportRoutes();
 
-  const searchResultRouteUniqueLabels = pipe(
-    resultType === DisplayedSearchResultType.Routes
-      ? reducedRoutes.map((route) => route.unique_label)
-      : lines.flatMap((line) =>
-          line.line_routes.map((route) => route.unique_label),
-        ),
-    uniq,
-  );
+  const linesWithRoutes = lines.filter((line) => !!line.line_routes.length);
 
-  const isAllResultsSelected = isEqual(
-    [...selectedRouteUniqueLabels].sort(),
-    [...searchResultRouteUniqueLabels].sort(),
-  );
+  const exportData =
+    resultType === DisplayedSearchResultType.Routes
+      ? {
+          resultsByType: reducedRoutes,
+          searchResultLabels: reducedRoutes.map((route) => route.unique_label),
+          toBeExportedRoutes: routes.filter((route) =>
+            selectedRows.includes(route.unique_label),
+          ),
+        }
+      : {
+          // Lines without routes are filtered out, since they are not selectable (nothing to export)
+          // They are also ignored when determining 'isAllResultsSelected'
+          resultsByType: linesWithRoutes,
+          searchResultLabels: linesWithRoutes.map((line) => line.label),
+          toBeExportedRoutes: lines
+            .filter((line) => selectedRows.includes(line.label))
+            .flatMap((line) =>
+              line.line_routes.filter((route) =>
+                isRouteActiveOnObservationDate(route, observationDate),
+              ),
+            ),
+        };
+
+  const isAllResultsSelected =
+    selectedRows.length === exportData.resultsByType.length;
 
   const onSelectAll = () => {
     if (isAllResultsSelected) {
-      dispatch(resetSelectedRoutesAction());
+      dispatch(resetSelectedRowsAction());
     } else {
-      dispatch(selectRouteUniqueLabelsAction(searchResultRouteUniqueLabels));
+      dispatch(selectRowsAction(exportData.searchResultLabels));
     }
   };
 
   const toggleIsSelecting = () => {
     dispatch(setIsSelectingRoutesForExportAction(!isSelectingRoutesForExport));
     // We always want to start selection from scratch
-    dispatch(resetSelectedRoutesAction());
+    dispatch(resetSelectedRowsAction());
   };
-
-  // If no route is selected, export all routes in search results by default
-  const isExportingAllSearchResults = selectedRouteUniqueLabels.length === 0;
 
   const exportRoutes = () => {
     exportRoutesToHastus(
-      // If we are "exporting all", export all routes in search results
-      isExportingAllSearchResults
-        ? searchResultRouteUniqueLabels
-        : selectedRouteUniqueLabels,
+      exportData.toBeExportedRoutes.map((route) => route.unique_label),
     );
   };
 
@@ -106,13 +112,9 @@ export const ExportToolbar = (): JSX.Element => {
       <Visible visible={isSelectingRoutesForExport}>
         <SimpleSmallButton
           inverted
-          disabled={!canExport}
+          disabled={!canExport || !selectedRows.length}
           onClick={exportRoutes}
-          label={t(
-            isExportingAllSearchResults
-              ? 'export.exportAll'
-              : 'export.exportSelected',
-          )}
+          label={t('export.exportSelected')}
           className="!rounded-full"
           testId={testIds.exportSelectedButton}
         />

--- a/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
+++ b/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
@@ -27,14 +27,19 @@ export const ExportToolbar = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
-  const { resultCount, resultType, routes, lines } = useSearchResults();
+  const {
+    resultCount,
+    resultType,
+    reducedRoutes,
+    lines,
+  } = useSearchResults();
   const { isSelectingRoutesForExport, selectedRouteUniqueLabels } =
     useAppSelector(selectExport);
   const { canExport, exportRoutesToHastus } = useExportRoutes();
 
   const searchResultRouteUniqueLabels = pipe(
     resultType === DisplayedSearchResultType.Routes
-      ? routes.map((route) => route.unique_label)
+      ? reducedRoutes.map((route) => route.unique_label)
       : lines.flatMap((line) =>
           line.line_routes.map((route) => route.unique_label),
         ),

--- a/ui/src/components/routes-and-lines/search/SearchContainer.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchContainer.tsx
@@ -1,11 +1,13 @@
 import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import {
   SearchQueryParameterNames,
   useSearch,
   useToggle,
 } from '../../../hooks';
 import { Column, Container, Row, Visible } from '../../../layoutComponents';
+import { resetSelectedRowsAction } from '../../../redux';
 import { ChevronToggle, SimpleButton } from '../../../uiComponents';
 import { AllOptionEnum } from '../../../utils';
 import { SearchInput } from '../../common/search';
@@ -17,6 +19,7 @@ import { PriorityCondition } from './conditions/PriorityCondition';
 export const SearchContainer = (): JSX.Element => {
   const { searchConditions, setSearchCondition, handleSearch } = useSearch();
   const { t } = useTranslation();
+  const dispatch = useDispatch();
 
   const [isExpanded, toggleIsExpanded] = useToggle();
   const testIds = {
@@ -44,6 +47,11 @@ export const SearchContainer = (): JSX.Element => {
     setSearchCondition(SearchQueryParameterNames.ObservationDate, dateTime);
   };
 
+  const onSearch = () => {
+    dispatch(resetSelectedRowsAction());
+    handleSearch();
+  };
+
   const vehicleModeDropdownId = 'search.primaryVehicleMode';
   const typeOfLineDropdownId = 'search.typeOfLine';
 
@@ -58,7 +66,7 @@ export const SearchContainer = (): JSX.Element => {
             <SearchInput
               testId={testIds.searchInput}
               value={searchConditions.label}
-              onSearch={handleSearch}
+              onSearch={onSearch}
               onChange={onChangeLabel}
             />
             <ChevronToggle
@@ -121,7 +129,7 @@ export const SearchContainer = (): JSX.Element => {
           >
             {t('hide')}
           </SimpleButton>
-          <SimpleButton containerClassName="mr-6" onClick={handleSearch}>
+          <SimpleButton containerClassName="mr-6" onClick={onSearch}>
             {t('search.search')}
           </SimpleButton>
         </Row>

--- a/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
@@ -16,12 +16,12 @@ export const SearchResultPage = (): JSX.Element => {
   const { resultCount } = useSearchResults();
   const { t } = useTranslation();
   const { getPaginatedData } = usePagination();
-  const { lines, routes } = useSearchResults();
+  const { lines, reducedRoutes } = useSearchResults();
   const { basePath } = useBasePath();
   const itemsPerPage = 10;
 
   const displayedLines = getPaginatedData(lines, itemsPerPage);
-  const displayedRoutes = getPaginatedData(routes, itemsPerPage);
+  const displayedRoutes = getPaginatedData(reducedRoutes, itemsPerPage);
 
   const testIds = {
     container: 'SearchResultsPage::Container',

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -16510,14 +16510,15 @@ export type LineTableRowFragment = {
   __typename?: 'route_line';
   name_i18n: LocalizedString;
   short_name_i18n: LocalizedString;
+  validity_start?: luxon.DateTime | null;
+  validity_end?: luxon.DateTime | null;
   priority: number;
   line_id: UUID;
   label: string;
-  validity_start?: luxon.DateTime | null;
-  validity_end?: luxon.DateTime | null;
   line_routes: Array<{
     __typename?: 'route_route';
     unique_label: string;
+    direction: RouteDirectionEnum;
     route_id: UUID;
     route_shape?: GeoJSON.LineString | null;
     label: string;
@@ -16533,6 +16534,12 @@ export type LineTableRowFragment = {
           __typename?: 'timetables_vehicle_journey_vehicle_journey';
           vehicle_journey_id: UUID;
         }>;
+      }>;
+      scheduled_stop_point_in_journey_patterns: Array<{
+        __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern';
+        journey_pattern_id: UUID;
+        scheduled_stop_point_sequence: number;
+        is_used_as_timing_point: boolean;
       }>;
     }>;
   }>;
@@ -16561,6 +16568,12 @@ export type RouteTableRowFragment = {
         __typename?: 'timetables_vehicle_journey_vehicle_journey';
         vehicle_journey_id: UUID;
       }>;
+    }>;
+    scheduled_stop_point_in_journey_patterns: Array<{
+      __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern';
+      journey_pattern_id: UUID;
+      scheduled_stop_point_sequence: number;
+      is_used_as_timing_point: boolean;
     }>;
   }>;
 };
@@ -16628,6 +16641,12 @@ export type ListChangingRoutesQuery = {
           vehicle_journey_id: UUID;
         }>;
       }>;
+      scheduled_stop_point_in_journey_patterns: Array<{
+        __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern';
+        journey_pattern_id: UUID;
+        scheduled_stop_point_sequence: number;
+        is_used_as_timing_point: boolean;
+      }>;
     }>;
   }>;
 };
@@ -16642,14 +16661,15 @@ export type ListOwnLinesQuery = {
     __typename?: 'route_line';
     name_i18n: LocalizedString;
     short_name_i18n: LocalizedString;
+    validity_start?: luxon.DateTime | null;
+    validity_end?: luxon.DateTime | null;
     priority: number;
     line_id: UUID;
     label: string;
-    validity_start?: luxon.DateTime | null;
-    validity_end?: luxon.DateTime | null;
     line_routes: Array<{
       __typename?: 'route_route';
       unique_label: string;
+      direction: RouteDirectionEnum;
       route_id: UUID;
       route_shape?: GeoJSON.LineString | null;
       label: string;
@@ -16665,6 +16685,12 @@ export type ListOwnLinesQuery = {
             __typename?: 'timetables_vehicle_journey_vehicle_journey';
             vehicle_journey_id: UUID;
           }>;
+        }>;
+        scheduled_stop_point_in_journey_patterns: Array<{
+          __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern';
+          journey_pattern_id: UUID;
+          scheduled_stop_point_sequence: number;
+          is_used_as_timing_point: boolean;
         }>;
       }>;
     }>;
@@ -19492,14 +19518,15 @@ export type SearchLinesAndRoutesQuery = {
     __typename?: 'route_line';
     name_i18n: LocalizedString;
     short_name_i18n: LocalizedString;
+    validity_start?: luxon.DateTime | null;
+    validity_end?: luxon.DateTime | null;
     priority: number;
     line_id: UUID;
     label: string;
-    validity_start?: luxon.DateTime | null;
-    validity_end?: luxon.DateTime | null;
     line_routes: Array<{
       __typename?: 'route_route';
       unique_label: string;
+      direction: RouteDirectionEnum;
       route_id: UUID;
       route_shape?: GeoJSON.LineString | null;
       label: string;
@@ -19515,6 +19542,12 @@ export type SearchLinesAndRoutesQuery = {
             __typename?: 'timetables_vehicle_journey_vehicle_journey';
             vehicle_journey_id: UUID;
           }>;
+        }>;
+        scheduled_stop_point_in_journey_patterns: Array<{
+          __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern';
+          journey_pattern_id: UUID;
+          scheduled_stop_point_sequence: number;
+          is_used_as_timing_point: boolean;
         }>;
       }>;
     }>;
@@ -19542,6 +19575,12 @@ export type SearchLinesAndRoutesQuery = {
           __typename?: 'timetables_vehicle_journey_vehicle_journey';
           vehicle_journey_id: UUID;
         }>;
+      }>;
+      scheduled_stop_point_in_journey_patterns: Array<{
+        __typename?: 'journey_pattern_scheduled_stop_point_in_journey_pattern';
+        journey_pattern_id: UUID;
+        scheduled_stop_point_sequence: number;
+        is_used_as_timing_point: boolean;
       }>;
     }>;
   }>;
@@ -20608,11 +20647,14 @@ export const LineTableRowFragmentDoc = gql`
   fragment line_table_row on route_line {
     name_i18n
     short_name_i18n
+    validity_start
+    validity_end
     priority
     ...line_map_params
     line_routes {
       ...route_map_params
       unique_label
+      direction
       route_journey_patterns {
         journey_pattern_id
         journey_pattern_refs {
@@ -20620,6 +20662,11 @@ export const LineTableRowFragmentDoc = gql`
           vehicle_journeys {
             vehicle_journey_id
           }
+        }
+        scheduled_stop_point_in_journey_patterns {
+          journey_pattern_id
+          scheduled_stop_point_sequence
+          is_used_as_timing_point
         }
       }
     }
@@ -20643,6 +20690,11 @@ export const RouteTableRowFragmentDoc = gql`
         vehicle_journeys {
           vehicle_journey_id
         }
+      }
+      scheduled_stop_point_in_journey_patterns {
+        journey_pattern_id
+        scheduled_stop_point_sequence
+        is_used_as_timing_point
       }
     }
   }

--- a/ui/src/hooks/line-drafts/useGetLineDraftDetails.ts
+++ b/ui/src/hooks/line-drafts/useGetLineDraftDetails.ts
@@ -1,22 +1,13 @@
-import { DateTime } from 'luxon';
 import { useParams } from 'react-router-dom';
 import { useObservationDateQueryParam } from '..';
-import {
-  RouteValidityFragment,
-  useGetRoutesWithStopsQuery,
-} from '../../generated/graphql';
-import { isDateInRange } from '../../time';
+import { useGetRoutesWithStopsQuery } from '../../generated/graphql';
 import { Priority } from '../../types/enums';
 import {
   buildPriorityEqualGqlFilter,
   buildRouteLineLabelGqlFilter,
+  isRouteActiveOnObservationDate,
   mapToVariables,
 } from '../../utils';
-
-const isRouteActiveOnObservationDate = (
-  route: RouteValidityFragment,
-  observationDate: DateTime,
-) => isDateInRange(observationDate, route.validity_start, route.validity_end);
 
 export const useGetLineDraftDetails = () => {
   const { label } = useParams<{ label: string }>();

--- a/ui/src/hooks/routes/useExportRoutes.ts
+++ b/ui/src/hooks/routes/useExportRoutes.ts
@@ -1,5 +1,10 @@
 import { exportRoutesToHastus as exportToHastus } from '../../api/hastus';
-import { downloadFile } from '../../utils';
+import { RouteTableRowFragment } from '../../generated/graphql';
+import {
+  downloadFile,
+  extractJourneyPatternFirstStop,
+  extractJourneyPatternLastStop,
+} from '../../utils';
 import { useSearchQueryParser } from '../search';
 import { useObservationDateQueryParam } from '../urlQuery';
 
@@ -10,7 +15,48 @@ export const useExportRoutes = () => {
   const { priorities } = search;
 
   // Routes can be exported to Hastus only when there is only 1 priority selected
+  // TODO: this will be reworked to not be dependant on search criteria
   const canExport = priorities?.length === 1;
+
+  const hasFirstAndLastStopSetAsTimingPoint = (
+    route: Pick<RouteTableRowFragment, 'route_journey_patterns'>,
+  ): boolean => {
+    const isEligibleJourneyPatterns = route.route_journey_patterns.map((jp) => {
+      const firstStop = extractJourneyPatternFirstStop<{
+        is_used_as_timing_point: boolean;
+      }>(jp);
+      const lastStop = extractJourneyPatternLastStop<{
+        is_used_as_timing_point: boolean;
+      }>(jp);
+      return (
+        firstStop.is_used_as_timing_point && lastStop.is_used_as_timing_point
+      );
+    });
+
+    return isEligibleJourneyPatterns.some((eligible) => eligible);
+  };
+
+  /**
+   * Checks if routes are eligible for export. All routes should have their first
+   * and last stop set as timing point for it to be eligible for export. Returns
+   * all routes uniqueLabel and direction which are not eligible.
+   */
+  const findNotEligibleRoutesForExport = (
+    routesToExport: Pick<
+      RouteTableRowFragment,
+      'unique_label' | 'direction' | 'route_journey_patterns'
+    >[],
+  ): string[] => {
+    const notEligibleRoutes: string[] = [];
+    routesToExport.forEach((route) => {
+      if (!hasFirstAndLastStopSetAsTimingPoint(route)) {
+        const uniqueLabelAndDirection = `${route.unique_label} (${route.direction})`;
+        notEligibleRoutes.push(uniqueLabelAndDirection);
+      }
+    });
+
+    return notEligibleRoutes;
+  };
 
   const exportRoutesToHastus = async (routeLabels: string[]) => {
     if (!canExport) {
@@ -31,5 +77,9 @@ export const useExportRoutes = () => {
     );
   };
 
-  return { canExport, exportRoutesToHastus };
+  return {
+    canExport,
+    exportRoutesToHastus,
+    findNotEligibleRoutesForExport,
+  };
 };

--- a/ui/src/hooks/search/useSearchResults.ts
+++ b/ui/src/hooks/search/useSearchResults.ts
@@ -32,6 +32,7 @@ export const useSearchResults = (): {
   lines: LineTableRowFragment[];
   /** Routes reduced to only have 1 direction per label */
   reducedRoutes: RouteTableRowFragment[];
+  routes: RouteTableRowFragment[];
   resultCount: number;
   resultType: DisplayedSearchResultType;
 } => {
@@ -85,6 +86,7 @@ export const useSearchResults = (): {
   return {
     lines,
     reducedRoutes,
+    routes,
     resultCount: resultCounts[resultType],
     resultType,
   };

--- a/ui/src/hooks/search/useSearchResults.ts
+++ b/ui/src/hooks/search/useSearchResults.ts
@@ -6,8 +6,8 @@ import {
   useSearchLinesAndRoutesQuery,
 } from '../../generated/graphql';
 import {
-  buildSearchLinesAndRoutesGqlQueryVariables,
   DisplayedSearchResultType,
+  buildSearchLinesAndRoutesGqlQueryVariables,
   mapToVariables,
 } from '../../utils';
 import { useSearchQueryParser } from './useSearchQueryParser';
@@ -30,7 +30,8 @@ const GQL_SEARCH_LINES_AND_ROUTES = gql`
 
 export const useSearchResults = (): {
   lines: LineTableRowFragment[];
-  routes: RouteTableRowFragment[];
+  /** Routes reduced to only have 1 direction per label */
+  reducedRoutes: RouteTableRowFragment[];
   resultCount: number;
   resultType: DisplayedSearchResultType;
 } => {
@@ -83,7 +84,7 @@ export const useSearchResults = (): {
 
   return {
     lines,
-    routes: reducedRoutes,
+    reducedRoutes,
     resultCount: resultCounts[resultType],
     resultType,
   };

--- a/ui/src/hooks/search/useSearchResults.ts
+++ b/ui/src/hooks/search/useSearchResults.ts
@@ -45,8 +45,8 @@ export const useSearchResults = (): {
     mapToVariables(searchQueryVariables),
   );
 
-  const lines = (result.data?.route_line || []) as LineTableRowFragment[];
-  const routes = (result.data?.route_route || []) as RouteTableRowFragment[];
+  const lines = result.data?.route_line || [];
+  const routes = result.data?.route_route || [];
 
   // Reduce routes to only have the 'Outbound' versions of the routes if there are two
   // versions of the route

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -356,8 +356,7 @@
   "export": {
     "startSelecting": "Select",
     "quitSelecting": "Quit selecting",
-    "exportSelected": "Export selected to Hastus",
-    "exportAll": "Export all to Hastus"
+    "exportSelected": "Export selected to Hastus"
   },
   "save": "Save",
   "edit": "Edit",

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -356,7 +356,8 @@
   "export": {
     "startSelecting": "Select",
     "quitSelecting": "Quit selecting",
-    "exportSelected": "Export selected to Hastus"
+    "exportSelected": "Export selected to Hastus",
+    "notEligibleRoutesForExport": "Following routes are not eligible for export: {{ routes }}. First and last stop has to be used as Hastus-place."
   },
   "save": "Save",
   "edit": "Edit",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -356,7 +356,8 @@
   "export": {
     "startSelecting": "Valitse",
     "quitSelecting": "Sulje valinnat",
-    "exportSelected": "Vie valitut Hastukseen"
+    "exportSelected": "Vie valitut Hastukseen",
+    "notEligibleRoutesForExport": "Seuraavia reittejä ei voida viedä: {{ routes }}. Ensimmäisen ja viimeisen pysäkin täytyy olla asetettuna käyttämään Hastus-paikkaa."
   },
   "save": "Tallenna",
   "edit": "Muokkaa",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -356,8 +356,7 @@
   "export": {
     "startSelecting": "Valitse",
     "quitSelecting": "Sulje valinnat",
-    "exportSelected": "Vie valitut Hastukseen",
-    "exportAll": "Vie kaikki Hastukseen"
+    "exportSelected": "Vie valitut Hastukseen"
   },
   "save": "Tallenna",
   "edit": "Muokkaa",

--- a/ui/src/redux/slices/export.ts
+++ b/ui/src/redux/slices/export.ts
@@ -3,12 +3,12 @@ import uniq from 'lodash/uniq';
 
 interface IState {
   isSelectingRoutesForExport: boolean;
-  selectedRouteUniqueLabels: string[];
+  selectedRows: string[];
 }
 
 const initialState: IState = {
   isSelectingRoutesForExport: false,
-  selectedRouteUniqueLabels: [],
+  selectedRows: [],
 };
 
 const slice = createSlice({
@@ -18,58 +18,32 @@ const slice = createSlice({
     setIsSelectingRoutesForExport: (state, action: PayloadAction<boolean>) => {
       state.isSelectingRoutesForExport = action.payload;
     },
-    selectRouteUniqueLabel: (state: IState, action: PayloadAction<string>) => {
-      const { selectedRouteUniqueLabels } = state;
-
-      state.selectedRouteUniqueLabels = uniq([
-        ...selectedRouteUniqueLabels,
-        action.payload,
-      ]);
+    selectRow: (state: IState, action: PayloadAction<string>) => {
+      const { selectedRows: selectedRoutes } = state;
+      state.selectedRows = [...selectedRoutes, action.payload];
     },
-    deselectRouteUniqueLabel: (
-      state: IState,
-      action: PayloadAction<string>,
-    ) => {
-      const { selectedRouteUniqueLabels } = state;
-
-      state.selectedRouteUniqueLabels = selectedRouteUniqueLabels.filter(
-        (label) => label !== action.payload,
-      );
+    deselectRow: (state: IState, action: PayloadAction<string>) => {
+      const { selectedRows } = state;
+      state.selectedRows = selectedRows.filter((id) => id !== action.payload);
     },
-    selectRouteUniqueLabels: (
-      state: IState,
-      action: PayloadAction<string[]>,
-    ) => {
-      const { selectedRouteUniqueLabels } = state;
-
-      state.selectedRouteUniqueLabels = uniq([
-        ...selectedRouteUniqueLabels,
-        ...action.payload,
-      ]);
+    selectRows: (state: IState, action: PayloadAction<string[]>) => {
+      const { selectedRows } = state;
+      // If we are selecting rows with "Select all", we need to take uniq
+      // to avoid adding the already checked rows again
+      state.selectedRows = uniq([...selectedRows, ...action.payload]);
     },
-    deselectRouteUniqueLabels: (
-      state: IState,
-      action: PayloadAction<string[]>,
-    ) => {
-      const { selectedRouteUniqueLabels } = state;
-
-      state.selectedRouteUniqueLabels = selectedRouteUniqueLabels.filter(
-        (uniqueLabel) => !action.payload.includes(uniqueLabel),
-      );
-    },
-    resetSelectedRoutes: (state) => {
-      state.selectedRouteUniqueLabels = initialState.selectedRouteUniqueLabels;
+    resetSelectedRows: (state) => {
+      state.selectedRows = initialState.selectedRows;
     },
   },
 });
 
 export const {
   setIsSelectingRoutesForExport: setIsSelectingRoutesForExportAction,
-  selectRouteUniqueLabel: selectRouteUniqueLabelAction,
-  deselectRouteUniqueLabel: deselectRouteUniqueLabelAction,
-  selectRouteUniqueLabels: selectRouteUniqueLabelsAction,
-  deselectRouteUniqueLabels: deselectRouteUniqueLabelsAction,
-  resetSelectedRoutes: resetSelectedRoutesAction,
+  selectRow: selectRowAction,
+  deselectRow: deselectRowAction,
+  selectRows: selectRowsAction,
+  resetSelectedRows: resetSelectedRowsAction,
 } = slice.actions;
 
 export const exportReducer = slice.reducer;

--- a/ui/src/utils/journeyPattern.ts
+++ b/ui/src/utils/journeyPattern.ts
@@ -90,3 +90,47 @@ export const mapRouteStopsToJourneyPatternStops = (
       : [];
   });
 };
+
+type JourneyPatternWithGenericReturnType<TType> = {
+  scheduled_stop_point_in_journey_patterns: (TType & {
+    scheduled_stop_point_sequence: number;
+  })[];
+};
+
+/**
+ * Extracts the first stop of journey pattern with the given TType typing
+ */
+export const extractJourneyPatternFirstStop = <TType>(
+  journeyPattern: JourneyPatternWithGenericReturnType<TType>,
+) => {
+  return journeyPattern.scheduled_stop_point_in_journey_patterns.reduce(
+    (minObj, currentObj) => {
+      if (
+        currentObj.scheduled_stop_point_sequence <
+        minObj.scheduled_stop_point_sequence
+      ) {
+        return currentObj;
+      }
+      return minObj;
+    },
+  );
+};
+
+/**
+ * Extracts the last stop of journey pattern with the given TType typing
+ */
+export const extractJourneyPatternLastStop = <TType>(
+  journeyPattern: JourneyPatternWithGenericReturnType<TType>,
+) => {
+  return journeyPattern.scheduled_stop_point_in_journey_patterns.reduce(
+    (minObj, currentObj) => {
+      if (
+        currentObj.scheduled_stop_point_sequence <
+        minObj.scheduled_stop_point_sequence
+      ) {
+        return currentObj;
+      }
+      return minObj;
+    },
+  );
+};

--- a/ui/src/utils/route.ts
+++ b/ui/src/utils/route.ts
@@ -1,7 +1,10 @@
+import { DateTime } from 'luxon';
 import {
   RouteAllFieldsFragment,
   RouteTableRowFragment,
+  RouteValidityFragment,
 } from '../generated/graphql';
+import { isDateInRange } from '../time';
 
 /**
  * Type that includes route_journey_patterns with journey pattern refs. This is used
@@ -39,3 +42,8 @@ export const hasRouteVariant = (route: RouteWithLabel) =>
 
 export const getRouteLabelVariantText = (route: RouteWithLabel) =>
   `${route.label}${hasRouteVariant(route) ? ` ${route.variant}` : ''}`;
+
+export const isRouteActiveOnObservationDate = (
+  route: Pick<RouteValidityFragment, 'validity_start' | 'validity_end'>,
+  observationDate: DateTime,
+) => isDateInRange(observationDate, route.validity_start, route.validity_end);

--- a/ui/src/utils/route.ts
+++ b/ui/src/utils/route.ts
@@ -4,11 +4,27 @@ import {
 } from '../generated/graphql';
 
 /**
+ * Type that includes route_journey_patterns with journey pattern refs. This is used
+ * for checking if route has timetables, and this is used for type checking that the
+ * object has only the necessary information. So the routeHasTimetables() can be called
+ * with any route object, as long as it has
+ * route_journey_patterns: {
+ *   journey_pattern_refs
+ * }
+ */
+type RouteJourneyPatternsWithJourneyPatternRefs = {
+  route_journey_patterns: Pick<
+    RouteTableRowFragment['route_journey_patterns'][0],
+    'journey_pattern_refs'
+  >[];
+};
+
+/**
  * Checks if the route has any vehicle_journey's existing. If there is
  * that means that the route has timetables.
  */
 export const routeHasTimetables = (
-  route: Pick<RouteTableRowFragment, 'route_journey_patterns'>,
+  route: RouteJourneyPatternsWithJourneyPatternRefs,
 ) =>
   route.route_journey_patterns.some((routeJourneyPattern) =>
     routeJourneyPattern.journey_pattern_refs.some(


### PR DESCRIPTION
Commit messages should have everything explained, but to sum up:
* Refactored route export selecting
* Reset selections on search
* Remove unintuitive behaviour when nothing was selected
* When exporting a line, only the routes that are valid on observation date are now exported
* Some other minor refactoring and clean up in code
* Add validation before export that all the exported routes have their hastus place set for first and last stop

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/636)
<!-- Reviewable:end -->
