### PR TITLE
Run e2e tests in two threds

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -59,4 +59,4 @@ jobs:
         with:
           test-tags: ''
           video: 'false'
-          threads: '3'
+          threads: '2'


### PR DESCRIPTION
Run e2e tests in two threads instead of three to see if it affects test stability

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/659)
<!-- Reviewable:end -->
