### PR TITLE
Set number of tests kept in memory to 0 in the CI

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -54,6 +54,8 @@ jobs:
           psql postgresql://dbadmin:adminpassword@localhost:6432/jore4e2e < ${{ env.DUMP_PATH }}
 
       - name: Run e2e tests from github action
+        env:
+          CYPRESS_TESTS_KEPT_IN_MEMORY: 0
         timeout-minutes: 15
         uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v2
         with:

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     viewportWidth: 1920,
     viewportHeight: 1080,
     requestTimeout: 20000,
-    numTestsKeptInMemory: 5,
+    numTestsKeptInMemory: Number(process.env.CYPRESS_TESTS_KEPT_IN_MEMORY) || 5,
     retries: {
       // Configure retry attempts for `cypress run`
       // Default is 0


### PR DESCRIPTION
We don't need to keep test snapshots in memory in the CI, since they are needed only for inspecting steps in the Cypress runner

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/661)
<!-- Reviewable:end -->
