### PR TITLE
Try experimentalModifyObstructiveThirdPartyCode in Cypress config

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     viewportHeight: 1080,
     requestTimeout: 20000,
     numTestsKeptInMemory: 5,
+    experimentalModifyObstructiveThirdPartyCode: true,
     retries: {
       // Configure retry attempts for `cypress run`
       // Default is 0


### PR DESCRIPTION
Test if this setting affects test stability. Details for the setting: https://docs.cypress.io/guides/guides/web-security#Modifying-Obstructive-Third-Party-Code

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/662)
<!-- Reviewable:end -->
