### PR TITLE
Define StoppingBusService as the line type in test data

### DIFF
--- a/cypress/e2e/createRoute.cy.ts
+++ b/cypress/e2e/createRoute.cy.ts
@@ -7,6 +7,7 @@ import {
   ReusableComponentsVehicleModeEnum,
   RouteDirectionEnum,
   RouteInsertInput,
+  RouteTypeOfLineEnum,
   StopInsertInput,
   StopInJourneyPatternInsertInput,
   buildLine,
@@ -63,18 +64,22 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1 Test line 1' }),
     line_id: '88f8f9fe-058b-49a2-ac8d-42d13488c7fb',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
   {
     ...buildLine({ label: '1 Test line 2' }),
     line_id: 'c0e4e702-60b6-4b90-9313-e463814a9422',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
   {
     ...buildLine({ label: '1 Test line 3' }),
     line_id: '71e19f0a-6eb3-40f2-9818-fb8ea5be135e',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
   {
     ...buildLine({ label: '1 Line with indefinite end time' }),
     line_id: 'ecbd895b-a720-4211-849f-ca380465c838',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/editLineInfo.cy.ts
+++ b/cypress/e2e/editLineInfo.cy.ts
@@ -2,6 +2,7 @@ import {
   buildLine,
   LineInsertInput,
   Priority,
+  RouteTypeOfLineEnum,
 } from '@hsl/jore4-test-db-manager';
 import { Tag } from '../enums';
 import { LineDetailsPage, LineForm } from '../pageObjects';
@@ -18,6 +19,7 @@ const lines: LineInsertInput[] = [
     ...buildLine({ label: '1999' }),
     line_id: '9e800038-3fbb-11ed-b878-0242ac120002',
     priority: Priority.Standard,
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/editRoute.cy.ts
+++ b/cypress/e2e/editRoute.cy.ts
@@ -6,6 +6,7 @@ import {
   Priority,
   RouteDirectionEnum,
   RouteInsertInput,
+  RouteTypeOfLineEnum,
   StopInJourneyPatternInsertInput,
   StopInsertInput,
   buildLine,
@@ -58,10 +59,12 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1 Test line 1' }),
     line_id: '88f8f9fe-058b-49a2-ac8d-42d13488c7fb',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
   {
     ...buildLine({ label: '2 Test line 2' }),
     line_id: 'a7107e50-7c9b-4788-b874-906d9f637eb9',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/editRouteShape.cy.ts
+++ b/cypress/e2e/editRouteShape.cy.ts
@@ -6,6 +6,7 @@ import {
   Priority,
   RouteDirectionEnum,
   RouteInsertInput,
+  RouteTypeOfLineEnum,
   StopInsertInput,
   StopInJourneyPatternInsertInput,
   buildLine,
@@ -74,6 +75,7 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: 'Test line 1' }),
     line_id: '08d1fa6b-440c-421e-ad4d-0778d65afe60',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/hastusExport.cy.ts
+++ b/cypress/e2e/hastusExport.cy.ts
@@ -11,6 +11,7 @@ import {
   LineInsertInput,
   mapToGetInfrastructureLinksByExternalIdsQuery,
   RouteInsertInput,
+  RouteTypeOfLineEnum,
   StopInsertInput,
   StopInJourneyPatternInsertInput,
 } from '@hsl/jore4-test-db-manager';
@@ -49,6 +50,7 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1234' }),
     line_id: '08d1fa6b-440c-421e-ad4d-0778d65afe60',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/routeStops.cy.ts
+++ b/cypress/e2e/routeStops.cy.ts
@@ -5,6 +5,7 @@ import {
   LineInsertInput,
   RouteInsertInput,
   StopInJourneyPatternInsertInput,
+  RouteTypeOfLineEnum,
   StopInsertInput,
   buildLine,
   buildRoute,
@@ -32,6 +33,7 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1' }),
     line_id: '5dfa82f1-b3f7-4e26-b31d-0d7bd78da0bf',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/searchRoutesAndLines.cy.ts
+++ b/cypress/e2e/searchRoutesAndLines.cy.ts
@@ -3,6 +3,7 @@ import {
   buildRoute,
   LineInsertInput,
   RouteInsertInput,
+  RouteTypeOfLineEnum,
 } from '@hsl/jore4-test-db-manager';
 import { Tag } from '../enums';
 import { RoutesAndLinesPage, SearchResultsPage } from '../pageObjects';
@@ -12,14 +13,17 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1666' }),
     line_id: '5dfa82f1-b3f7-4e26-b31d-0d7bd78da0be',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
   {
     ...buildLine({ label: '2666' }),
     line_id: '61e4d95e-34e5-11ed-a261-0242ac120002',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
   {
     ...buildLine({ label: '1777' }),
     line_id: '47c5fe92-e630-430b-a2da-2c6739acbb2b',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -12,6 +12,7 @@ import {
   mapToGetInfrastructureLinksByExternalIdsQuery,
   RouteInsertInput,
   StopInJourneyPatternInsertInput,
+  RouteTypeOfLineEnum,
   StopInsertInput,
   TimetablePriority,
 } from '@hsl/jore4-test-db-manager';
@@ -58,6 +59,7 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1234' }),
     line_id: '08d1fa6b-440c-421e-ad4d-0778d65afe60',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/timetablePassingTimes.cy.ts
+++ b/cypress/e2e/timetablePassingTimes.cy.ts
@@ -11,6 +11,7 @@ import {
   LineInsertInput,
   mapToGetInfrastructureLinksByExternalIdsQuery,
   RouteInsertInput,
+  RouteTypeOfLineEnum,
   StopInsertInput,
   TimetablePriority,
   StopInJourneyPatternInsertInput,
@@ -59,6 +60,7 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1234' }),
     line_id: 'f148d51b-36ff-4321-8cf1-049946f75f73',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 

--- a/cypress/e2e/timetableValidityPeriod.cy.ts
+++ b/cypress/e2e/timetableValidityPeriod.cy.ts
@@ -5,6 +5,7 @@ import {
   LineInsertInput,
   RouteInsertInput,
   StopInJourneyPatternInsertInput,
+  RouteTypeOfLineEnum,
   StopInsertInput,
   TimetablePriority,
   buildLine,
@@ -58,6 +59,7 @@ const lines: LineInsertInput[] = [
   {
     ...buildLine({ label: '1234' }),
     line_id: '4b8c8f84-12bc-4716-b15e-476f0efaa645',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
 ];
 


### PR DESCRIPTION
Make test data more realistic by creating StoppingBusService type of lines. By default the line type seems to be RegionalBusService.

Resolves HSLdevcom/jore4#1436

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/663)
<!-- Reviewable:end -->
