### PR TITLE
Fix Timetables minute hover bug

### DIFF
--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTable.spec.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTable.spec.tsx
@@ -269,9 +269,9 @@ describe(`<${PassingTimesByStopTable.name} />`, () => {
     const arrivalTimes = timeContainersH221[1].querySelectorAll(
       selectors.arrivalTime,
     );
-    expect(arrivalTimes[0]).toHaveClass('invisible');
+    expect(arrivalTimes[0]).toHaveClass('hidden');
 
-    expect(arrivalTimes[1]).not.toHaveClass('invisible');
+    expect(arrivalTimes[1]).not.toHaveClass('hidden');
     expect(arrivalTimes[1]).toHaveTextContent('58');
   });
 

--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingMinute.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingMinute.tsx
@@ -64,22 +64,22 @@ export const PassingTimesByStopTableRowPassingMinute = ({
     : '';
 
   return (
-    <span>
+    <span className="inline-flex">
       <button
         className={twMerge(
           'inline-flex flex-col items-end rounded-sm border border-transparent px-0.5 align-text-bottom text-xs',
-          'hover:border-hsl-highlight-yellow-dark hover:bg-city-bicycle-yellow',
+          'px-1 hover:border-hsl-highlight-yellow-dark hover:bg-city-bicycle-yellow',
           highlightClassName,
         )}
         onClick={() => setSelectedPassingTime(passingTime)}
         type="button"
         data-testid={testIds.selectPassingTimeButton}
       >
-        <span className="flex flex-col">
+        <span className="flex h-full flex-col justify-center">
           <span
             data-testid={testIds.arrivalTime}
             className={`text-2xs leading-tight ${
-              displayArrival ? '' : 'invisible'
+              displayArrival ? '' : 'hidden'
             }`}
           >
             {displayedArrival}

--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingTime.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingTime.tsx
@@ -28,7 +28,7 @@ export const PassingTimesByStopTableRowPassingTime = ({
 
   return (
     <span
-      className="my-2 mr-6 inline-block space-x-2 whitespace-nowrap border-b border-dashed border-grey"
+      className="my-2 mr-5 inline-flex h-8 space-x-2 whitespace-nowrap border-b border-dashed border-grey"
       data-testid={testIds.timeContainer}
     >
       <span


### PR DESCRIPTION
The minute data fields looked wrong with a tall box with an empty top. 

Fixed by balancing the departure and arrival minute button's size and vertically centered it.

Resolves HSLdevcom/jore4#1243

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/665)
<!-- Reviewable:end -->
