### PR TITLE
Update pinned hasura image

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -9,7 +9,7 @@ services:
     # https://hub.docker.com/r/hsldevcom/jore4-hasura/tags?page=1&ordering=last_updated
     # The :hsl-tag contains the desired version of hsl specific hasura.
     # Waiting for merging feature-branch to main in hasura-repo
-    image: &hasura-image 'hsldevcom/jore4-hasura:hsl-main--20230810-f2cffa5fecb8bf3e6f2107a8c13fa73738bc85c9'
+    image: &hasura-image 'hsldevcom/jore4-hasura:hsl-main--20230916-cd171ca374479398ceea744cc0287f71458dd036'
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -1309,7 +1309,7 @@ export type InfrastructureNetworkInfrastructureLinkBoolExp = {
 
 /** unique or primary key constraints on table "infrastructure_network.infrastructure_link" */
 export enum InfrastructureNetworkInfrastructureLinkConstraint {
-  /** unique or primary key constraint on columns "external_link_source", "external_link_id" */
+  /** unique or primary key constraint on columns "external_link_id", "external_link_source" */
   InfrastructureLinkExternalLinkIdExternalLinkSourceIdx = 'infrastructure_link_external_link_id_external_link_source_idx',
   /** unique or primary key constraint on columns "infrastructure_link_id" */
   InfrastructureLinkPkey = 'infrastructure_link_pkey',
@@ -5425,7 +5425,7 @@ export type RouteInfrastructureLinkAlongRouteBoolExp = {
 
 /** unique or primary key constraints on table "route.infrastructure_link_along_route" */
 export enum RouteInfrastructureLinkAlongRouteConstraint {
-  /** unique or primary key constraint on columns "route_id", "infrastructure_link_sequence" */
+  /** unique or primary key constraint on columns "infrastructure_link_sequence", "route_id" */
   InfrastructureLinkAlongRoutePkey = 'infrastructure_link_along_route_pkey',
 }
 
@@ -7340,7 +7340,7 @@ export type ServicePatternDistanceBetweenStopsCalculationBoolExp = {
 
 /** unique or primary key constraints on table "service_pattern.distance_between_stops_calculation" */
 export enum ServicePatternDistanceBetweenStopsCalculationConstraint {
-  /** unique or primary key constraint on columns "route_priority", "stop_interval_sequence", "observation_date", "journey_pattern_id" */
+  /** unique or primary key constraint on columns "observation_date", "stop_interval_sequence", "journey_pattern_id", "route_priority" */
   DistanceBetweenStopsCalculationPkey = 'distance_between_stops_calculation_pkey',
 }
 
@@ -7824,6 +7824,8 @@ export type ServicePatternScheduledStopPointArrRelInsertInput = {
 export type ServicePatternScheduledStopPointAvgFields = {
   __typename?: 'service_pattern_scheduled_stop_point_avg_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by avg() on columns of table "service_pattern.scheduled_stop_point" */
@@ -7917,6 +7919,8 @@ export type ServicePatternScheduledStopPointMaxFields = {
   /** The infrastructure link on which the stop is located. */
   located_on_infrastructure_link_id?: Maybe<Scalars['uuid']>;
   priority?: Maybe<Scalars['Int']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
   /** The ID of the scheduled stop point. */
   scheduled_stop_point_id?: Maybe<Scalars['uuid']>;
   /** Optional reference to a TIMING PLACE. If NULL, the SCHEDULED STOP POINT is not used for timing. */
@@ -7952,6 +7956,8 @@ export type ServicePatternScheduledStopPointMinFields = {
   /** The infrastructure link on which the stop is located. */
   located_on_infrastructure_link_id?: Maybe<Scalars['uuid']>;
   priority?: Maybe<Scalars['Int']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
   /** The ID of the scheduled stop point. */
   scheduled_stop_point_id?: Maybe<Scalars['uuid']>;
   /** Optional reference to a TIMING PLACE. If NULL, the SCHEDULED STOP POINT is not used for timing. */
@@ -8068,6 +8074,8 @@ export type ServicePatternScheduledStopPointSetInput = {
 export type ServicePatternScheduledStopPointStddevFields = {
   __typename?: 'service_pattern_scheduled_stop_point_stddev_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by stddev() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8079,6 +8087,8 @@ export type ServicePatternScheduledStopPointStddevOrderBy = {
 export type ServicePatternScheduledStopPointStddevPopFields = {
   __typename?: 'service_pattern_scheduled_stop_point_stddev_pop_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by stddev_pop() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8090,6 +8100,8 @@ export type ServicePatternScheduledStopPointStddevPopOrderBy = {
 export type ServicePatternScheduledStopPointStddevSampFields = {
   __typename?: 'service_pattern_scheduled_stop_point_stddev_samp_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by stddev_samp() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8130,6 +8142,8 @@ export type ServicePatternScheduledStopPointStreamCursorValueInput = {
 export type ServicePatternScheduledStopPointSumFields = {
   __typename?: 'service_pattern_scheduled_stop_point_sum_fields';
   priority?: Maybe<Scalars['Int']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by sum() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8172,6 +8186,8 @@ export type ServicePatternScheduledStopPointUpdates = {
 export type ServicePatternScheduledStopPointVarPopFields = {
   __typename?: 'service_pattern_scheduled_stop_point_var_pop_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by var_pop() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8183,6 +8199,8 @@ export type ServicePatternScheduledStopPointVarPopOrderBy = {
 export type ServicePatternScheduledStopPointVarSampFields = {
   __typename?: 'service_pattern_scheduled_stop_point_var_samp_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by var_samp() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8194,6 +8212,8 @@ export type ServicePatternScheduledStopPointVarSampOrderBy = {
 export type ServicePatternScheduledStopPointVarianceFields = {
   __typename?: 'service_pattern_scheduled_stop_point_variance_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by variance() on columns of table "service_pattern.scheduled_stop_point" */
@@ -9666,7 +9686,7 @@ export type TimetablesPassingTimesTimetabledPassingTimeBoolExp = {
 export enum TimetablesPassingTimesTimetabledPassingTimeConstraint {
   /** unique or primary key constraint on columns "timetabled_passing_time_id" */
   TimetabledPassingTimePkey = 'timetabled_passing_time_pkey',
-  /** unique or primary key constraint on columns "vehicle_journey_id", "scheduled_stop_point_in_journey_pattern_ref_id" */
+  /** unique or primary key constraint on columns "scheduled_stop_point_in_journey_pattern_ref_id", "vehicle_journey_id" */
   TimetabledPassingTimeStopPointUniqueIdx = 'timetabled_passing_time_stop_point_unique_idx',
 }
 
@@ -9851,7 +9871,7 @@ export type TimetablesPassingTimesTimetabledPassingTimeUpdates = {
 export type TimetablesReturnValueTimetableVersion = {
   __typename?: 'timetables_return_value_timetable_version';
   /** An object relationship */
-  day_type: TimetablesServiceCalendarDayType;
+  day_type?: Maybe<TimetablesServiceCalendarDayType>;
   day_type_id: Scalars['uuid'];
   in_effect: Scalars['Boolean'];
   priority: Scalars['Int'];
@@ -10492,7 +10512,7 @@ export type TimetablesServiceCalendarDayTypeActiveOnDayOfWeekBoolExp = {
 
 /** unique or primary key constraints on table "service_calendar.day_type_active_on_day_of_week" */
 export enum TimetablesServiceCalendarDayTypeActiveOnDayOfWeekConstraint {
-  /** unique or primary key constraint on columns "day_type_id", "day_of_week" */
+  /** unique or primary key constraint on columns "day_of_week", "day_type_id" */
   DayTypeActiveOnDayOfWeekPkey = 'day_type_active_on_day_of_week_pkey',
 }
 
@@ -13045,10 +13065,6 @@ export type TimetablesTimetablesQuery = {
   timetables_vehicle_service_get_timetables_and_substitute_operating_days: Array<TimetablesReturnValueTimetableVersion>;
   /** execute function "vehicle_service.get_timetables_and_substitute_operating_days" and query aggregates on result of table type "return_value.timetable_version" */
   timetables_vehicle_service_get_timetables_and_substitute_operating_days_aggregate: TimetablesReturnValueTimetableVersionAggregate;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" which returns "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date: Array<TimetablesVehicleServiceVehicleService>;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" and query aggregates on result of table type "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date_aggregate: TimetablesVehicleServiceVehicleServiceAggregate;
   /** fetch data from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
   timetables_vehicle_service_journey_patterns_in_vehicle_service: Array<TimetablesVehicleServiceJourneyPatternsInVehicleService>;
   /** fetch aggregated fields from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
@@ -13499,30 +13515,6 @@ export type TimetablesTimetablesQueryTimetablesVehicleServiceGetTimetablesAndSub
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
   };
 
-export type TimetablesTimetablesQueryTimetablesVehicleServiceGetVehicleServicesForDateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
-export type TimetablesTimetablesQueryTimetablesVehicleServiceGetVehicleServicesForDateAggregateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
 export type TimetablesTimetablesQueryTimetablesVehicleServiceJourneyPatternsInVehicleServiceArgs =
   {
     distinct_on?: InputMaybe<
@@ -13716,10 +13708,6 @@ export type TimetablesTimetablesSubscription = {
   timetables_vehicle_service_get_timetables_and_substitute_operating_days: Array<TimetablesReturnValueTimetableVersion>;
   /** execute function "vehicle_service.get_timetables_and_substitute_operating_days" and query aggregates on result of table type "return_value.timetable_version" */
   timetables_vehicle_service_get_timetables_and_substitute_operating_days_aggregate: TimetablesReturnValueTimetableVersionAggregate;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" which returns "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date: Array<TimetablesVehicleServiceVehicleService>;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" and query aggregates on result of table type "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date_aggregate: TimetablesVehicleServiceVehicleServiceAggregate;
   /** fetch data from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
   timetables_vehicle_service_journey_patterns_in_vehicle_service: Array<TimetablesVehicleServiceJourneyPatternsInVehicleService>;
   /** fetch aggregated fields from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
@@ -14287,30 +14275,6 @@ export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceGetTimetable
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
   };
 
-export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceGetVehicleServicesForDateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
-export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceGetVehicleServicesForDateAggregateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
 export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceJourneyPatternsInVehicleServiceArgs =
   {
     distinct_on?: InputMaybe<
@@ -14625,10 +14589,14 @@ export type TimetablesVehicleJourneyVehicleJourneyMaxFields = {
   block_id?: Maybe<Scalars['uuid']>;
   /** Displayed name of the journey. */
   displayed_name?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_end_time" */
+  end_time?: Maybe<Scalars['String']>;
   /** The JOURNEY PATTERN on which the VEHICLE JOURNEY travels */
   journey_pattern_ref_id?: Maybe<Scalars['uuid']>;
   /** STANDARD | DRY_RUN | SERVICE_JOURNEY */
   journey_type?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_start_time" */
+  start_time?: Maybe<Scalars['String']>;
   vehicle_journey_id?: Maybe<Scalars['uuid']>;
 };
 
@@ -14652,10 +14620,14 @@ export type TimetablesVehicleJourneyVehicleJourneyMinFields = {
   block_id?: Maybe<Scalars['uuid']>;
   /** Displayed name of the journey. */
   displayed_name?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_end_time" */
+  end_time?: Maybe<Scalars['String']>;
   /** The JOURNEY PATTERN on which the VEHICLE JOURNEY travels */
   journey_pattern_ref_id?: Maybe<Scalars['uuid']>;
   /** STANDARD | DRY_RUN | SERVICE_JOURNEY */
   journey_type?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_start_time" */
+  start_time?: Maybe<Scalars['String']>;
   vehicle_journey_id?: Maybe<Scalars['uuid']>;
 };
 
@@ -15600,10 +15572,6 @@ export type TimetablesVehicleServiceGetTimetablesAndSubstituteOperatingDaysArgs 
     start_date?: InputMaybe<Scalars['date']>;
   };
 
-export type TimetablesVehicleServiceGetVehicleServicesForDateArgs = {
-  observation_date?: InputMaybe<Scalars['date']>;
-};
-
 /**
  * A denormalized table containing relationships between vehicle_services and journey_patterns (via journey_pattern_ref.journey_pattern_id).
  *  Without this table this relationship could be found via vehicle_service -> block -> vehicle_journey -> journey_pattern_ref.
@@ -15721,7 +15689,7 @@ export type TimetablesVehicleServiceJourneyPatternsInVehicleServiceBoolExp = {
 
 /** unique or primary key constraints on table "vehicle_service.journey_patterns_in_vehicle_service" */
 export enum TimetablesVehicleServiceJourneyPatternsInVehicleServiceConstraint {
-  /** unique or primary key constraint on columns "vehicle_service_id", "journey_pattern_id" */
+  /** unique or primary key constraint on columns "journey_pattern_id", "vehicle_service_id" */
   JourneyPatternsInVehicleServicePkey = 'journey_patterns_in_vehicle_service_pkey',
 }
 

--- a/ui/graphql.schema.json
+++ b/ui/graphql.schema.json
@@ -9743,7 +9743,7 @@
         "enumValues": [
           {
             "name": "infrastructure_link_external_link_id_external_link_source_idx",
-            "description": "unique or primary key constraint on columns \"external_link_source\", \"external_link_id\"",
+            "description": "unique or primary key constraint on columns \"external_link_id\", \"external_link_source\"",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -34152,7 +34152,7 @@
         "enumValues": [
           {
             "name": "infrastructure_link_along_route_pkey",
-            "description": "unique or primary key constraint on columns \"route_id\", \"infrastructure_link_sequence\"",
+            "description": "unique or primary key constraint on columns \"infrastructure_link_sequence\", \"route_id\"",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -45259,7 +45259,7 @@
         "enumValues": [
           {
             "name": "distance_between_stops_calculation_pkey",
-            "description": "unique or primary key constraint on columns \"route_priority\", \"stop_interval_sequence\", \"observation_date\", \"journey_pattern_id\"",
+            "description": "unique or primary key constraint on columns \"observation_date\", \"stop_interval_sequence\", \"journey_pattern_id\", \"route_priority\"",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -48071,6 +48071,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -48767,6 +48779,18 @@
             "deprecationReason": null
           },
           {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "scheduled_stop_point_id",
             "description": "The ID of the scheduled stop point.",
             "args": [],
@@ -48951,6 +48975,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
               "ofType": null
             },
             "isDeprecated": false,
@@ -49649,6 +49685,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -49695,6 +49743,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -49737,6 +49797,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
               "ofType": null
             },
             "isDeprecated": false,
@@ -49945,6 +50017,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -50107,6 +50191,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -50153,6 +50249,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -50195,6 +50303,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "relative_distance_from_infrastructure_link_start",
+            "description": "The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
               "ofType": null
             },
             "isDeprecated": false,
@@ -60663,7 +60783,7 @@
           },
           {
             "name": "timetabled_passing_time_stop_point_unique_idx",
-            "description": "unique or primary key constraint on columns \"vehicle_journey_id\", \"scheduled_stop_point_in_journey_pattern_ref_id\"",
+            "description": "unique or primary key constraint on columns \"scheduled_stop_point_in_journey_pattern_ref_id\", \"vehicle_journey_id\"",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -61531,13 +61651,9 @@
             "description": "An object relationship",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "timetables_service_calendar_day_type",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "timetables_service_calendar_day_type",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -65850,7 +65966,7 @@
         "enumValues": [
           {
             "name": "day_type_active_on_day_of_week_pkey",
-            "description": "unique or primary key constraint on columns \"day_type_id\", \"day_of_week\"",
+            "description": "unique or primary key constraint on columns \"day_of_week\", \"day_type_id\"",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -82173,232 +82289,6 @@
             "deprecationReason": null
           },
           {
-            "name": "timetables_vehicle_service_get_vehicle_services_for_date",
-            "description": "execute function \"vehicle_service.get_vehicle_services_for_date\" which returns \"vehicle_service.vehicle_service\"",
-            "args": [
-              {
-                "name": "args",
-                "description": "input parameters for function \"vehicle_service_get_vehicle_services_for_date\"",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "timetables_vehicle_service_get_vehicle_services_for_date_args",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "timetables_vehicle_service_vehicle_service_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "timetables_vehicle_service_vehicle_service_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "timetables_vehicle_service_vehicle_service_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "timetables_vehicle_service_vehicle_service",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timetables_vehicle_service_get_vehicle_services_for_date_aggregate",
-            "description": "execute function \"vehicle_service.get_vehicle_services_for_date\" and query aggregates on result of table type \"vehicle_service.vehicle_service\"",
-            "args": [
-              {
-                "name": "args",
-                "description": "input parameters for function \"vehicle_service_get_vehicle_services_for_date_aggregate\"",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "timetables_vehicle_service_get_vehicle_services_for_date_args",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "timetables_vehicle_service_vehicle_service_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "timetables_vehicle_service_vehicle_service_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "timetables_vehicle_service_vehicle_service_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "timetables_vehicle_service_vehicle_service_aggregate",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "timetables_vehicle_service_journey_patterns_in_vehicle_service",
             "description": "fetch data from the table: \"vehicle_service.journey_patterns_in_vehicle_service\"",
             "args": [
@@ -87509,232 +87399,6 @@
             "deprecationReason": null
           },
           {
-            "name": "timetables_vehicle_service_get_vehicle_services_for_date",
-            "description": "execute function \"vehicle_service.get_vehicle_services_for_date\" which returns \"vehicle_service.vehicle_service\"",
-            "args": [
-              {
-                "name": "args",
-                "description": "input parameters for function \"vehicle_service_get_vehicle_services_for_date\"",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "timetables_vehicle_service_get_vehicle_services_for_date_args",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "timetables_vehicle_service_vehicle_service_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "timetables_vehicle_service_vehicle_service_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "timetables_vehicle_service_vehicle_service_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "timetables_vehicle_service_vehicle_service",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timetables_vehicle_service_get_vehicle_services_for_date_aggregate",
-            "description": "execute function \"vehicle_service.get_vehicle_services_for_date\" and query aggregates on result of table type \"vehicle_service.vehicle_service\"",
-            "args": [
-              {
-                "name": "args",
-                "description": "input parameters for function \"vehicle_service_get_vehicle_services_for_date_aggregate\"",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "timetables_vehicle_service_get_vehicle_services_for_date_args",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "distinct_on",
-                "description": "distinct select on columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "timetables_vehicle_service_vehicle_service_select_column",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "limit",
-                "description": "limit the number of rows returned",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "skip the first n rows. Use only with order_by",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "order_by",
-                "description": "sort the rows by one or more columns",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "timetables_vehicle_service_vehicle_service_order_by",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": "filter the rows returned",
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "timetables_vehicle_service_vehicle_service_bool_exp",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "timetables_vehicle_service_vehicle_service_aggregate",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "timetables_vehicle_service_journey_patterns_in_vehicle_service",
             "description": "fetch data from the table: \"vehicle_service.journey_patterns_in_vehicle_service\"",
             "args": [
@@ -89939,6 +89603,18 @@
             "deprecationReason": null
           },
           {
+            "name": "end_time",
+            "description": "A computed field, executes function \"vehicle_journey.vehicle_journey_end_time\"",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "journey_pattern_ref_id",
             "description": "The JOURNEY PATTERN on which the VEHICLE JOURNEY travels",
             "args": [],
@@ -89953,6 +89629,18 @@
           {
             "name": "journey_type",
             "description": "STANDARD | DRY_RUN | SERVICE_JOURNEY",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start_time",
+            "description": "A computed field, executes function \"vehicle_journey.vehicle_journey_start_time\"",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -90081,6 +89769,18 @@
             "deprecationReason": null
           },
           {
+            "name": "end_time",
+            "description": "A computed field, executes function \"vehicle_journey.vehicle_journey_end_time\"",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "journey_pattern_ref_id",
             "description": "The JOURNEY PATTERN on which the VEHICLE JOURNEY travels",
             "args": [],
@@ -90095,6 +89795,18 @@
           {
             "name": "journey_type",
             "description": "STANDARD | DRY_RUN | SERVICE_JOURNEY",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start_time",
+            "description": "A computed field, executes function \"vehicle_journey.vehicle_journey_start_time\"",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -95352,29 +95064,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "timetables_vehicle_service_get_vehicle_services_for_date_args",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "observation_date",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "date",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
         "name": "timetables_vehicle_service_journey_patterns_in_vehicle_service",
         "description": "A denormalized table containing relationships between vehicle_services and journey_patterns (via journey_pattern_ref.journey_pattern_id).\n Without this table this relationship could be found via vehicle_service -> block -> vehicle_journey -> journey_pattern_ref.\n Kept up to date with triggers, should not be updated manually.",
@@ -96045,7 +95734,7 @@
         "enumValues": [
           {
             "name": "journey_patterns_in_vehicle_service_pkey",
-            "description": "unique or primary key constraint on columns \"vehicle_service_id\", \"journey_pattern_id\"",
+            "description": "unique or primary key constraint on columns \"journey_pattern_id\", \"vehicle_service_id\"",
             "isDeprecated": false,
             "deprecationReason": null
           }

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -1313,7 +1313,7 @@ export type InfrastructureNetworkInfrastructureLinkBoolExp = {
 
 /** unique or primary key constraints on table "infrastructure_network.infrastructure_link" */
 export enum InfrastructureNetworkInfrastructureLinkConstraint {
-  /** unique or primary key constraint on columns "external_link_source", "external_link_id" */
+  /** unique or primary key constraint on columns "external_link_id", "external_link_source" */
   InfrastructureLinkExternalLinkIdExternalLinkSourceIdx = 'infrastructure_link_external_link_id_external_link_source_idx',
   /** unique or primary key constraint on columns "infrastructure_link_id" */
   InfrastructureLinkPkey = 'infrastructure_link_pkey',
@@ -5429,7 +5429,7 @@ export type RouteInfrastructureLinkAlongRouteBoolExp = {
 
 /** unique or primary key constraints on table "route.infrastructure_link_along_route" */
 export enum RouteInfrastructureLinkAlongRouteConstraint {
-  /** unique or primary key constraint on columns "route_id", "infrastructure_link_sequence" */
+  /** unique or primary key constraint on columns "infrastructure_link_sequence", "route_id" */
   InfrastructureLinkAlongRoutePkey = 'infrastructure_link_along_route_pkey',
 }
 
@@ -7344,7 +7344,7 @@ export type ServicePatternDistanceBetweenStopsCalculationBoolExp = {
 
 /** unique or primary key constraints on table "service_pattern.distance_between_stops_calculation" */
 export enum ServicePatternDistanceBetweenStopsCalculationConstraint {
-  /** unique or primary key constraint on columns "route_priority", "stop_interval_sequence", "observation_date", "journey_pattern_id" */
+  /** unique or primary key constraint on columns "observation_date", "stop_interval_sequence", "journey_pattern_id", "route_priority" */
   DistanceBetweenStopsCalculationPkey = 'distance_between_stops_calculation_pkey',
 }
 
@@ -7828,6 +7828,8 @@ export type ServicePatternScheduledStopPointArrRelInsertInput = {
 export type ServicePatternScheduledStopPointAvgFields = {
   __typename?: 'service_pattern_scheduled_stop_point_avg_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by avg() on columns of table "service_pattern.scheduled_stop_point" */
@@ -7921,6 +7923,8 @@ export type ServicePatternScheduledStopPointMaxFields = {
   /** The infrastructure link on which the stop is located. */
   located_on_infrastructure_link_id?: Maybe<Scalars['uuid']>;
   priority?: Maybe<Scalars['Int']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
   /** The ID of the scheduled stop point. */
   scheduled_stop_point_id?: Maybe<Scalars['uuid']>;
   /** Optional reference to a TIMING PLACE. If NULL, the SCHEDULED STOP POINT is not used for timing. */
@@ -7956,6 +7960,8 @@ export type ServicePatternScheduledStopPointMinFields = {
   /** The infrastructure link on which the stop is located. */
   located_on_infrastructure_link_id?: Maybe<Scalars['uuid']>;
   priority?: Maybe<Scalars['Int']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
   /** The ID of the scheduled stop point. */
   scheduled_stop_point_id?: Maybe<Scalars['uuid']>;
   /** Optional reference to a TIMING PLACE. If NULL, the SCHEDULED STOP POINT is not used for timing. */
@@ -8072,6 +8078,8 @@ export type ServicePatternScheduledStopPointSetInput = {
 export type ServicePatternScheduledStopPointStddevFields = {
   __typename?: 'service_pattern_scheduled_stop_point_stddev_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by stddev() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8083,6 +8091,8 @@ export type ServicePatternScheduledStopPointStddevOrderBy = {
 export type ServicePatternScheduledStopPointStddevPopFields = {
   __typename?: 'service_pattern_scheduled_stop_point_stddev_pop_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by stddev_pop() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8094,6 +8104,8 @@ export type ServicePatternScheduledStopPointStddevPopOrderBy = {
 export type ServicePatternScheduledStopPointStddevSampFields = {
   __typename?: 'service_pattern_scheduled_stop_point_stddev_samp_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by stddev_samp() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8134,6 +8146,8 @@ export type ServicePatternScheduledStopPointStreamCursorValueInput = {
 export type ServicePatternScheduledStopPointSumFields = {
   __typename?: 'service_pattern_scheduled_stop_point_sum_fields';
   priority?: Maybe<Scalars['Int']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by sum() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8176,6 +8190,8 @@ export type ServicePatternScheduledStopPointUpdates = {
 export type ServicePatternScheduledStopPointVarPopFields = {
   __typename?: 'service_pattern_scheduled_stop_point_var_pop_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by var_pop() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8187,6 +8203,8 @@ export type ServicePatternScheduledStopPointVarPopOrderBy = {
 export type ServicePatternScheduledStopPointVarSampFields = {
   __typename?: 'service_pattern_scheduled_stop_point_var_samp_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by var_samp() on columns of table "service_pattern.scheduled_stop_point" */
@@ -8198,6 +8216,8 @@ export type ServicePatternScheduledStopPointVarSampOrderBy = {
 export type ServicePatternScheduledStopPointVarianceFields = {
   __typename?: 'service_pattern_scheduled_stop_point_variance_fields';
   priority?: Maybe<Scalars['Float']>;
+  /** The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1]. */
+  relative_distance_from_infrastructure_link_start?: Maybe<Scalars['float8']>;
 };
 
 /** order by variance() on columns of table "service_pattern.scheduled_stop_point" */
@@ -9670,7 +9690,7 @@ export type TimetablesPassingTimesTimetabledPassingTimeBoolExp = {
 export enum TimetablesPassingTimesTimetabledPassingTimeConstraint {
   /** unique or primary key constraint on columns "timetabled_passing_time_id" */
   TimetabledPassingTimePkey = 'timetabled_passing_time_pkey',
-  /** unique or primary key constraint on columns "vehicle_journey_id", "scheduled_stop_point_in_journey_pattern_ref_id" */
+  /** unique or primary key constraint on columns "scheduled_stop_point_in_journey_pattern_ref_id", "vehicle_journey_id" */
   TimetabledPassingTimeStopPointUniqueIdx = 'timetabled_passing_time_stop_point_unique_idx',
 }
 
@@ -9855,7 +9875,7 @@ export type TimetablesPassingTimesTimetabledPassingTimeUpdates = {
 export type TimetablesReturnValueTimetableVersion = {
   __typename?: 'timetables_return_value_timetable_version';
   /** An object relationship */
-  day_type: TimetablesServiceCalendarDayType;
+  day_type?: Maybe<TimetablesServiceCalendarDayType>;
   day_type_id: Scalars['uuid'];
   in_effect: Scalars['Boolean'];
   priority: Scalars['Int'];
@@ -10496,7 +10516,7 @@ export type TimetablesServiceCalendarDayTypeActiveOnDayOfWeekBoolExp = {
 
 /** unique or primary key constraints on table "service_calendar.day_type_active_on_day_of_week" */
 export enum TimetablesServiceCalendarDayTypeActiveOnDayOfWeekConstraint {
-  /** unique or primary key constraint on columns "day_type_id", "day_of_week" */
+  /** unique or primary key constraint on columns "day_of_week", "day_type_id" */
   DayTypeActiveOnDayOfWeekPkey = 'day_type_active_on_day_of_week_pkey',
 }
 
@@ -13049,10 +13069,6 @@ export type TimetablesTimetablesQuery = {
   timetables_vehicle_service_get_timetables_and_substitute_operating_days: Array<TimetablesReturnValueTimetableVersion>;
   /** execute function "vehicle_service.get_timetables_and_substitute_operating_days" and query aggregates on result of table type "return_value.timetable_version" */
   timetables_vehicle_service_get_timetables_and_substitute_operating_days_aggregate: TimetablesReturnValueTimetableVersionAggregate;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" which returns "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date: Array<TimetablesVehicleServiceVehicleService>;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" and query aggregates on result of table type "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date_aggregate: TimetablesVehicleServiceVehicleServiceAggregate;
   /** fetch data from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
   timetables_vehicle_service_journey_patterns_in_vehicle_service: Array<TimetablesVehicleServiceJourneyPatternsInVehicleService>;
   /** fetch aggregated fields from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
@@ -13503,30 +13519,6 @@ export type TimetablesTimetablesQueryTimetablesVehicleServiceGetTimetablesAndSub
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
   };
 
-export type TimetablesTimetablesQueryTimetablesVehicleServiceGetVehicleServicesForDateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
-export type TimetablesTimetablesQueryTimetablesVehicleServiceGetVehicleServicesForDateAggregateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
 export type TimetablesTimetablesQueryTimetablesVehicleServiceJourneyPatternsInVehicleServiceArgs =
   {
     distinct_on?: InputMaybe<
@@ -13720,10 +13712,6 @@ export type TimetablesTimetablesSubscription = {
   timetables_vehicle_service_get_timetables_and_substitute_operating_days: Array<TimetablesReturnValueTimetableVersion>;
   /** execute function "vehicle_service.get_timetables_and_substitute_operating_days" and query aggregates on result of table type "return_value.timetable_version" */
   timetables_vehicle_service_get_timetables_and_substitute_operating_days_aggregate: TimetablesReturnValueTimetableVersionAggregate;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" which returns "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date: Array<TimetablesVehicleServiceVehicleService>;
-  /** execute function "vehicle_service.get_vehicle_services_for_date" and query aggregates on result of table type "vehicle_service.vehicle_service" */
-  timetables_vehicle_service_get_vehicle_services_for_date_aggregate: TimetablesVehicleServiceVehicleServiceAggregate;
   /** fetch data from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
   timetables_vehicle_service_journey_patterns_in_vehicle_service: Array<TimetablesVehicleServiceJourneyPatternsInVehicleService>;
   /** fetch aggregated fields from the table: "vehicle_service.journey_patterns_in_vehicle_service" */
@@ -14291,30 +14279,6 @@ export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceGetTimetable
     where?: InputMaybe<TimetablesReturnValueTimetableVersionBoolExp>;
   };
 
-export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceGetVehicleServicesForDateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
-export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceGetVehicleServicesForDateAggregateArgs =
-  {
-    args: TimetablesVehicleServiceGetVehicleServicesForDateArgs;
-    distinct_on?: InputMaybe<
-      Array<TimetablesVehicleServiceVehicleServiceSelectColumn>
-    >;
-    limit?: InputMaybe<Scalars['Int']>;
-    offset?: InputMaybe<Scalars['Int']>;
-    order_by?: InputMaybe<Array<TimetablesVehicleServiceVehicleServiceOrderBy>>;
-    where?: InputMaybe<TimetablesVehicleServiceVehicleServiceBoolExp>;
-  };
-
 export type TimetablesTimetablesSubscriptionTimetablesVehicleServiceJourneyPatternsInVehicleServiceArgs =
   {
     distinct_on?: InputMaybe<
@@ -14629,10 +14593,14 @@ export type TimetablesVehicleJourneyVehicleJourneyMaxFields = {
   block_id?: Maybe<Scalars['uuid']>;
   /** Displayed name of the journey. */
   displayed_name?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_end_time" */
+  end_time?: Maybe<Scalars['String']>;
   /** The JOURNEY PATTERN on which the VEHICLE JOURNEY travels */
   journey_pattern_ref_id?: Maybe<Scalars['uuid']>;
   /** STANDARD | DRY_RUN | SERVICE_JOURNEY */
   journey_type?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_start_time" */
+  start_time?: Maybe<Scalars['String']>;
   vehicle_journey_id?: Maybe<Scalars['uuid']>;
 };
 
@@ -14656,10 +14624,14 @@ export type TimetablesVehicleJourneyVehicleJourneyMinFields = {
   block_id?: Maybe<Scalars['uuid']>;
   /** Displayed name of the journey. */
   displayed_name?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_end_time" */
+  end_time?: Maybe<Scalars['String']>;
   /** The JOURNEY PATTERN on which the VEHICLE JOURNEY travels */
   journey_pattern_ref_id?: Maybe<Scalars['uuid']>;
   /** STANDARD | DRY_RUN | SERVICE_JOURNEY */
   journey_type?: Maybe<Scalars['String']>;
+  /** A computed field, executes function "vehicle_journey.vehicle_journey_start_time" */
+  start_time?: Maybe<Scalars['String']>;
   vehicle_journey_id?: Maybe<Scalars['uuid']>;
 };
 
@@ -15604,10 +15576,6 @@ export type TimetablesVehicleServiceGetTimetablesAndSubstituteOperatingDaysArgs 
     start_date?: InputMaybe<Scalars['date']>;
   };
 
-export type TimetablesVehicleServiceGetVehicleServicesForDateArgs = {
-  observation_date?: InputMaybe<Scalars['date']>;
-};
-
 /**
  * A denormalized table containing relationships between vehicle_services and journey_patterns (via journey_pattern_ref.journey_pattern_id).
  *  Without this table this relationship could be found via vehicle_service -> block -> vehicle_journey -> journey_pattern_ref.
@@ -15725,7 +15693,7 @@ export type TimetablesVehicleServiceJourneyPatternsInVehicleServiceBoolExp = {
 
 /** unique or primary key constraints on table "vehicle_service.journey_patterns_in_vehicle_service" */
 export enum TimetablesVehicleServiceJourneyPatternsInVehicleServiceConstraint {
-  /** unique or primary key constraint on columns "vehicle_service_id", "journey_pattern_id" */
+  /** unique or primary key constraint on columns "journey_pattern_id", "vehicle_service_id" */
   JourneyPatternsInVehicleServicePkey = 'journey_patterns_in_vehicle_service_pkey',
 }
 
@@ -21009,12 +20977,12 @@ export type TimetableVersionFragment = {
   validity_end: luxon.DateTime;
   priority: number;
   in_effect: boolean;
-  day_type: {
+  day_type?: {
     __typename?: 'timetables_service_calendar_day_type';
     day_type_id: UUID;
     name_i18n: any;
     label: string;
-  };
+  } | null;
   substitute_operating_day_by_line_type?: {
     __typename?: 'timetables_service_calendar_substitute_operating_day_by_line_type';
     substitute_operating_day_by_line_type_id: UUID;
@@ -21045,12 +21013,12 @@ export type GetTimetableVersionsByJourneyPatternIdsQuery = {
       validity_end: luxon.DateTime;
       priority: number;
       in_effect: boolean;
-      day_type: {
+      day_type?: {
         __typename?: 'timetables_service_calendar_day_type';
         day_type_id: UUID;
         name_i18n: any;
         label: string;
-      };
+      } | null;
       substitute_operating_day_by_line_type?: {
         __typename?: 'timetables_service_calendar_substitute_operating_day_by_line_type';
         substitute_operating_day_by_line_type_id: UUID;

--- a/ui/src/hooks/useGetTimetableVersions.ts
+++ b/ui/src/hooks/useGetTimetableVersions.ts
@@ -112,6 +112,17 @@ const mapVehicleScheduleFrameData = (
 };
 
 const mapDayTypeData = (timetableVersionData: TimetableVersionFragment) => {
+  // When using the SQL functions, we had to create a return_value dummy table in the database
+  // but we do not want to include it in the data model, since we never save anything to the tables.
+  // Because there are no FK constraints, this day_type object relationship from hasura can theoratically
+  // be null, and that is why our graphql-codegen types it as nullable. In our case though, it can never
+  // be null since it is evaluated at the same time as the day_type_id is found.
+  // As this should never happen, we can throw an error, because it would require investigation if it would happen.
+  if (!timetableVersionData.day_type) {
+    throw new Error(
+      'Day type is missing. Requires investigation as this should never happen.',
+    );
+  }
   return {
     dayType: {
       id: timetableVersionData.day_type.day_type_id,


### PR DESCRIPTION
As explained in the committed comment, we removed the FK constraints from return_value.timetable_version because we do not want to make it part of the data model, since it is only a dummy table for function return value. But because of this, the graphql-codegen now types it as nullable, even though it can't ever be null in our case. To fix this, added an if-statement with an explanatory comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/671)
<!-- Reviewable:end -->
