### PR TITLE
Revert to using run-cypress-tests-v1

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -57,8 +57,6 @@ jobs:
         env:
           CYPRESS_TESTS_KEPT_IN_MEMORY: 0
         timeout-minutes: 15
-        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v2
+        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v1
         with:
           test-tags: ''
-          video: 'false'
-          threads: '2'


### PR DESCRIPTION
Try running e2e tests in one thread to see if it is any more stable