### PR TITLE
Remove timetable validity range and overall fixes to Timetables view

### DIFF
--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../hooks';
 import { Row, Visible } from '../../../layoutComponents';
 import { selectTimetable } from '../../../redux';
-import { mapToShortDate } from '../../../time';
 import { AccordionButton } from '../../../uiComponents';
 import { RouteLabel } from '../../common/RouteLabel';
 import { DirectionBadge } from '../../routes-and-lines/line-details/DirectionBadge';
@@ -55,9 +54,6 @@ export const RouteTimetablesSection = ({
     route?.route_journey_patterns[0].journey_pattern_id,
   );
 
-  const { validityStart, validityEnd } = timetables?.validity || {};
-  const hasValidityPeriod = !!validityStart && !!validityEnd;
-
   if (!route) {
     return <></>;
   }
@@ -84,14 +80,6 @@ export const RouteTimetablesSection = ({
           <h3 className="ml-3.5">
             <RouteLabel label={route.label} variant={route.variant} />
           </h3>
-          <Visible visible={hasValidityPeriod}>
-            <p className="ml-auto mr-8">
-              {t('timetables.timetableValidity', {
-                validityStart: mapToShortDate(validityStart),
-                validityEnd: mapToShortDate(validityEnd),
-              })}
-            </p>
-          </Visible>
         </div>
         <div className="ml-1 bg-background p-3">
           <AccordionButton

--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -77,9 +77,10 @@ export const RouteTimetablesSection = ({
             className="my-5 ml-12"
             titleName={t(`directionEnum.${route.direction}`)}
           />
-          <h3 className="ml-3.5">
+          <h3 className="m-3.5">
             <RouteLabel label={route.label} variant={route.variant} />
           </h3>
+          <span className="text-xl">{route.name_i18n?.fi_FI}</span>
         </div>
         <div className="ml-1 bg-background p-3">
           <AccordionButton

--- a/ui/src/components/timetables/vehicle-schedule-details/VehicleScheduleDetailsPage.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/VehicleScheduleDetailsPage.tsx
@@ -9,7 +9,7 @@ import {
   useTimetableVersionsReturnToQueryParam,
   useTimetablesViewState,
 } from '../../../hooks';
-import { Container, Visible } from '../../../layoutComponents';
+import { Container, Row, Visible } from '../../../layoutComponents';
 import {
   closeChangeTimetableValidityModalAction,
   selectChangeTimetableValidityModal,
@@ -75,17 +75,20 @@ export const VehicleScheduleDetailsPage = (): JSX.Element => {
   return (
     <div>
       <PageHeader>
-        {line && (
-          <LineTitle
-            line={line}
-            showValidityPeriod={false}
-            allowSelectingMultipleRoutes={
-              // If passing times by stop view is active, only allow selecting
-              // one route at the time
-              activeView !== TimetablesView.PASSING_TIMES_BY_STOP
-            }
-          />
-        )}
+        <Row>
+          <i className="icon-bus-alt text-6xl text-tweaked-brand" />
+          {line && (
+            <LineTitle
+              line={line}
+              showValidityPeriod={false}
+              allowSelectingMultipleRoutes={
+                // If passing times by stop view is active, only allow selecting
+                // one route at the time
+                activeView !== TimetablesView.PASSING_TIMES_BY_STOP
+              }
+            />
+          )}
+        </Row>
       </PageHeader>
       <Visible visible={line && activeView !== TimetablesView.DEFAULT}>
         <TimetableNavigation onClose={setShowDefaultView} />

--- a/ui/src/components/timetables/vehicle-schedule-details/VehicleScheduleDetailsPage.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/VehicleScheduleDetailsPage.tsx
@@ -93,7 +93,7 @@ export const VehicleScheduleDetailsPage = (): JSX.Element => {
       <Visible visible={line && activeView !== TimetablesView.DEFAULT}>
         <TimetableNavigation onClose={setShowDefaultView} />
       </Visible>
-      <Container className="py-10">
+      <Container>
         <FormRow mdColumns={6} className="mb-8">
           <ObservationDateControl className="max-w-max" />
           <Visible visible={activeView === TimetablesView.DEFAULT}>

--- a/ui/src/layoutComponents/Container.tsx
+++ b/ui/src/layoutComponents/Container.tsx
@@ -12,7 +12,7 @@ export const Container: React.FC<Props> = ({
 }) => {
   return (
     <div
-      className={`container mx-auto py-20 ${className}`}
+      className={`container mx-auto py-10 ${className}`}
       data-testid={testId}
     >
       {children}


### PR DESCRIPTION
The validity range in the Timetables view was deemed unnecessary, so I removed it. 
While looking at that the proper ticket I found a few small things to fix: 

- The timetables "header" was missing the vehicle icon, so I added it similarly as in Lines & Routes
- Juha noticed over-sized padding above the "Tarkasteluhetki", which was caused by a huge y-axis padding in the 'Container' component. Checked that all references looked OK. Had a different solution to define them in each one separately, but reverted to just halfing it, without touching all of the references separately.
- Talked with Juha and we noticed that the Timetable Route row should have the route's name, so I added that as well.

Resolves HSLdevcom/jore4#1391