### PR TITLE
Force clear and type into terminus inputs

### DIFF
--- a/cypress/pageObjects/TerminusNameInputs.ts
+++ b/cypress/pageObjects/TerminusNameInputs.ts
@@ -46,27 +46,31 @@ export class TerminusNameInputs {
     origin: TerminusValues,
     destination: TerminusValues,
   ) {
-    this.getTerminusOriginFinnishNameInput().clear().type(origin.finnishName);
+    this.getTerminusOriginFinnishNameInput()
+      .clear({ force: true })
+      .type(origin.finnishName, { force: true });
     this.getTerminusOriginFinnishShortNameInput()
-      .clear()
-      .type(origin.finnishShortName);
-    this.getTerminusOriginSwedishNameInput().clear().type(origin.swedishName);
+      .clear({ force: true })
+      .type(origin.finnishShortName, { force: true });
+    this.getTerminusOriginSwedishNameInput()
+      .clear({ force: true })
+      .type(origin.swedishName, { force: true });
     this.getTerminusOriginSwedishShortNameInput()
-      .clear()
-      .type(origin.swedishShortName);
+      .clear({ force: true })
+      .type(origin.swedishShortName, { force: true });
 
     this.getTerminusDestinationFinnishNameInput()
-      .clear()
-      .type(destination.finnishName);
+      .clear({ force: true })
+      .type(destination.finnishName, { force: true });
     this.getTerminusDestinationFinnishShortNameInput()
-      .clear()
-      .type(destination.finnishShortName);
+      .clear({ force: true })
+      .type(destination.finnishShortName, { force: true });
     this.getTerminusDestinationSwedishNameInput()
-      .clear()
-      .type(destination.swedishName);
+      .clear({ force: true })
+      .type(destination.swedishName, { force: true });
     this.getTerminusDestinationSwedishShortNameInput()
-      .clear()
-      .type(destination.swedishShortName);
+      .clear({ force: true })
+      .type(destination.swedishShortName, { force: true });
   }
 
   verifyOriginValues(originValues: TerminusValues) {


### PR DESCRIPTION
Use force:true in clearing route form inputs and in typing into them to see if it makes tests more stable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/674)
<!-- Reviewable:end -->
