### PR TITLE
Add notification about deviations

### DIFF
--- a/ui/src/components/timetables/import/ConfirmPreviewedTimetablesImportForm.tsx
+++ b/ui/src/components/timetables/import/ConfirmPreviewedTimetablesImportForm.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { Column, Row } from '../../../layoutComponents';
@@ -15,10 +15,17 @@ export type FormState = z.infer<typeof schema>;
 interface Props {
   defaultValues?: Partial<FormState>;
   onSubmit: (state: FormState) => void;
+  fetchRouteDeviations: (priority: number) => void;
+  clearRouteDeviations: () => void;
 }
 
 export const ConfirmPreviewedTimetablesImportFormComponent = (
-  { defaultValues, onSubmit }: Props,
+  {
+    clearRouteDeviations,
+    defaultValues,
+    fetchRouteDeviations,
+    onSubmit,
+  }: Props,
   externalRef: ExplicitAny,
 ): JSX.Element => {
   const methods = useForm<FormState>({
@@ -26,7 +33,22 @@ export const ConfirmPreviewedTimetablesImportFormComponent = (
     resolver: zodResolver(schema),
   });
 
-  const { handleSubmit } = methods;
+  const { handleSubmit, watch } = methods;
+
+  const { priority, timetableImportStrategy } = watch();
+
+  useEffect(() => {
+    if (timetableImportStrategy === 'replace' && priority) {
+      fetchRouteDeviations(priority);
+    } else {
+      clearRouteDeviations();
+    }
+  }, [
+    clearRouteDeviations,
+    fetchRouteDeviations,
+    priority,
+    timetableImportStrategy,
+  ]);
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/ui/src/components/timetables/import/DeviationSection.tsx
+++ b/ui/src/components/timetables/import/DeviationSection.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next';
+import { MdClose, MdWarning } from 'react-icons/md';
+import { VehicleScheduleFrameInfo } from '../../../hooks/timetables-import/deviations/useCreateVehicleScheduleFrameInfo';
+import { useDeviationSort } from '../../../hooks/timetables-import/deviations/useDeviationSort';
+import { IconButton } from '../../../uiComponents';
+import { RouteDeviationLink } from './RouteDeviationLink';
+
+export const DeviationSection = ({
+  className = '',
+  routeDeviations,
+  handleClose,
+}: {
+  className?: string;
+  routeDeviations: VehicleScheduleFrameInfo[];
+  handleClose: () => void;
+}) => {
+  const { t } = useTranslation();
+  const { sortDeviations } = useDeviationSort();
+
+  const sortedDeviations = sortDeviations(routeDeviations);
+
+  return (
+    <div className={className}>
+      <h3>
+        <MdWarning
+          className="mr-2 inline h-6 w-6 text-hsl-red"
+          role="img"
+          title={t('timetablesPreview.attention')}
+        />
+        {t('timetablesPreview.deviations', { count: routeDeviations.length })}
+      </h3>
+      <div className="relative mt-8 flex flex-row space-x-4 rounded-lg border border-hsl-highlight-yellow-dark bg-hsl-highlight-yellow-light p-6">
+        <MdWarning
+          className="mr-2 inline h-6 w-6 text-hsl-red"
+          role="img"
+          title={t('timetablesPreview.attention')}
+        />
+        <div>
+          <p>{t('timetablesPreview.deviationsWarning')}</p>
+          <div className="flex flex-row">
+            {t('timetablesPreview.missingRoutes')}
+            {sortedDeviations.map((deviation, index, { length }) => (
+              <RouteDeviationLink
+                key={deviation.routeId}
+                deviation={deviation}
+                isLast={length - 1 === index}
+                testIdPrefix={`RouteDeviationLink::${index}`}
+              />
+            ))}
+          </div>
+          <IconButton
+            className="absolute top-4 right-4 text-xl"
+            icon={<MdClose />}
+            onClick={handleClose}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
@@ -6,6 +6,12 @@ import {
   useTimetablesImport,
   useToggle,
 } from '../../../hooks';
+import {
+  useGetStagingVehicleScheduleFrameIds,
+  useReplaceDeviations,
+  useToReplaceVehicleScheduleFrames,
+  useVehicleScheduleFrameWithRouteLabelAndLineId,
+} from '../../../hooks/timetables-import/deviations';
 import { Container, Row, Visible } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { AccordionButton, SimpleButton } from '../../../uiComponents';
@@ -15,6 +21,7 @@ import {
   FormState,
 } from './ConfirmPreviewedTimetablesImportForm';
 import { ImportContentsView } from './ImportContentsView';
+import { SummarySection } from './SummarySection';
 
 const testIds = {
   toggleShowStagingTimetables:
@@ -31,11 +38,20 @@ const defaultValues: Partial<FormState> = {
 export const PreviewTimetablesPage = (): JSX.Element => {
   const { t } = useTranslation();
   const history = useHistory();
-
   const { vehicleJourneys, vehicleScheduleFrames } = useTimetablesImport();
   const [showStagingTimetables, toggleShowStagingTimetables] = useToggle(true);
   const { onConfirmTimetablesImport } = useConfirmTimetablesImportUIAction();
-
+  const { fetchToReplaceFrames } = useToReplaceVehicleScheduleFrames();
+  const { fetchVehicleFrames } =
+    useVehicleScheduleFrameWithRouteLabelAndLineId();
+  const { fetchStagingVehicleFrameIds } =
+    useGetStagingVehicleScheduleFrameIds();
+  const { clearRouteDeviations, deviations, fetchRouteDeviations } =
+    useReplaceDeviations(
+      fetchToReplaceFrames,
+      fetchVehicleFrames,
+      fetchStagingVehicleFrameIds,
+    );
   const vehicleJourneyCount = vehicleJourneys?.length || 0;
   const importedTimetablesExist = vehicleJourneyCount > 0;
 
@@ -91,6 +107,8 @@ export const PreviewTimetablesPage = (): JSX.Element => {
           <h3>{t('timetablesPreview.contentUsage')}</h3>
           <ConfirmPreviewedTimetablesImportForm
             ref={formRef}
+            fetchRouteDeviations={fetchRouteDeviations}
+            clearRouteDeviations={clearRouteDeviations}
             onSubmit={onSubmit}
             defaultValues={defaultValues}
           />
@@ -101,6 +119,7 @@ export const PreviewTimetablesPage = (): JSX.Element => {
           </div>
         </Visible>
       </div>
+      <SummarySection className="mt-10" deviations={deviations} />
       <div className="pt-10">
         <Row className="justify-end space-x-4">
           <SimpleButton

--- a/ui/src/components/timetables/import/RouteDeviationLink.spec.tsx
+++ b/ui/src/components/timetables/import/RouteDeviationLink.spec.tsx
@@ -1,0 +1,103 @@
+import { buildLocalizedString } from '@hsl/jore4-test-db-manager';
+import uniqueId from 'lodash/uniqueId';
+import { RouteDirectionEnum } from '../../../generated/graphql';
+import { render } from '../../../utils/test-utils';
+import { RouteDeviationLink } from './RouteDeviationLink';
+
+const deviationWithoutVariant = {
+  uniqueLabel: '108N',
+  lineId: '123',
+  direction: RouteDirectionEnum.Inbound,
+  routeName: buildLocalizedString('Route name that shows on title'),
+  routeId: uniqueId(),
+};
+
+describe(`<${RouteDeviationLink.name} />`, () => {
+  test('should render label text', () => {
+    const { getByTestId } = render(
+      <RouteDeviationLink
+        deviation={deviationWithoutVariant}
+        isLast
+        testIdPrefix="RouteDeviationLink::1"
+      />,
+    );
+
+    expect(getByTestId('RouteDeviationLink::1::label').textContent).toBe(
+      '108N',
+    );
+  });
+
+  test('should render direction badge text', () => {
+    const { getByTestId } = render(
+      <RouteDeviationLink
+        deviation={deviationWithoutVariant}
+        testIdPrefix="RouteDeviationLink::1"
+      />,
+    );
+
+    expect(getByTestId('DirectionBadge::value').textContent).toBe('2');
+  });
+
+  test('should render direction badge title', () => {
+    const { getByTitle } = render(
+      <RouteDeviationLink
+        deviation={deviationWithoutVariant}
+        testIdPrefix="RouteDeviationLink::1"
+      />,
+    );
+
+    expect(getByTitle('2 - Keskustaan päin')).toBeInTheDocument();
+  });
+
+  test('should render correct link', () => {
+    const { getByTestId } = render(
+      <RouteDeviationLink
+        deviation={deviationWithoutVariant}
+        testIdPrefix="RouteDeviationLink::1"
+      />,
+    );
+
+    expect(
+      getByTestId('RouteDeviationLink::1::link').getAttribute('href'),
+    ).toBe(`/timetables/lines/123?routeLabels=108N`);
+  });
+
+  test('should render correct title', () => {
+    const { getByTestId } = render(
+      <RouteDeviationLink
+        deviation={deviationWithoutVariant}
+        testIdPrefix="RouteDeviationLink::1"
+      />,
+    );
+
+    expect(
+      getByTestId('RouteDeviationLink::1::link').getAttribute('title'),
+    ).toBe('Route name that shows on title');
+  });
+
+  test('should have comma in label when it is not the last item', () => {
+    const { getByTestId } = render(
+      <RouteDeviationLink
+        deviation={deviationWithoutVariant}
+        testIdPrefix="RouteDeviationLink::3"
+      />,
+    );
+
+    expect(getByTestId('RouteDeviationLink::3::label').textContent).toBe(
+      '108N,',
+    );
+  });
+
+  test('should not render comma when last element', () => {
+    const { getByTestId } = render(
+      <RouteDeviationLink
+        deviation={deviationWithoutVariant}
+        isLast
+        testIdPrefix="RouteDeviationLink::0"
+      />,
+    );
+    expect(getByTestId('RouteDeviationLink::0::label').textContent).toBe(
+      '108N',
+    );
+  });
+});

--- a/ui/src/components/timetables/import/RouteDeviationLink.tsx
+++ b/ui/src/components/timetables/import/RouteDeviationLink.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { VehicleScheduleFrameInfo } from '../../../hooks/timetables-import/deviations/useCreateVehicleScheduleFrameInfo';
+import { parseI18nField } from '../../../i18n/utils';
+import { routeDetails } from '../../../router/routeDetails';
+import { DirectionBadge } from '../../routes-and-lines/line-details/DirectionBadge';
+
+interface Props {
+  deviation: VehicleScheduleFrameInfo;
+  isLast?: boolean;
+  testIdPrefix: string;
+}
+
+const testIds = {
+  link: (testIdPrefix: string) => `${testIdPrefix}::link`,
+  label: (testIdPrefix: string) => `${testIdPrefix}::label`,
+};
+
+export const RouteDeviationLink = ({
+  deviation,
+  isLast,
+  testIdPrefix,
+}: Props) => {
+  const { t } = useTranslation();
+  const { lineId, uniqueLabel, direction } = deviation;
+  return (
+    <Link
+      to={routeDetails['/timetables/lines/:id'].getLink(lineId, uniqueLabel)}
+      title={parseI18nField(deviation.routeName)}
+      data-testid={testIds.link(testIdPrefix)}
+    >
+      <div className="flex items-center">
+        <DirectionBadge
+          direction={direction}
+          titleName={t(`directionEnum.${direction}`)}
+          className="mx-1 !h-4 !w-4 text-sm"
+        />
+        <span
+          className="mr-1 font-bold text-black underline"
+          data-testid={testIds.label(testIdPrefix)}
+        >
+          {uniqueLabel}
+          {!isLast && ','}
+        </span>
+      </div>
+    </Link>
+  );
+};

--- a/ui/src/components/timetables/import/SummarySection.tsx
+++ b/ui/src/components/timetables/import/SummarySection.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { VehicleScheduleFrameInfo } from '../../../hooks/timetables-import/deviations/useCreateVehicleScheduleFrameInfo';
+import { Visible } from '../../../layoutComponents/Visible';
+import { DeviationSection } from './DeviationSection';
+
+interface Props {
+  deviations: VehicleScheduleFrameInfo[];
+  className?: string;
+}
+
+export const SummarySection = ({ className = '', deviations }: Props) => {
+  const [showDeviationSection, setShowDeviationSection] =
+    useState<boolean>(true);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    setShowDeviationSection(true);
+  }, [deviations]);
+
+  return (
+    <div className={className}>
+      <h2>{t('timetablesPreview.summary')}</h2>
+      <Visible visible={deviations.length > 0 && showDeviationSection}>
+        <DeviationSection
+          className="mt-8 rounded-lg border bg-white px-12 py-6"
+          routeDeviations={deviations}
+          handleClose={() => setShowDeviationSection(false)}
+        />
+      </Visible>
+    </div>
+  );
+};

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -21131,6 +21131,54 @@ export type GetSubstituteOperatingPeriodsQuery = {
   } | null;
 };
 
+export type GetToReplaceVehicleScheduleFramesQueryVariables = Exact<{
+  arg1: ToReplaceVehicleScheduleFrameIdsInput;
+}>;
+
+export type GetToReplaceVehicleScheduleFramesQuery = {
+  __typename?: 'query_root';
+  toReplaceVehicleScheduleFrameIds?: {
+    __typename?: 'ToReplaceVehicleScheduleFrameIdsOutput';
+    toReplaceVehicleScheduleFrameIds: Array<UUID | null>;
+  } | null;
+};
+
+export type GetVehicleScheduleFrameWithRouteAndLineInfoQueryVariables = Exact<{
+  vehicle_schedule_frame_ids: Array<Scalars['uuid']> | Scalars['uuid'];
+}>;
+
+export type GetVehicleScheduleFrameWithRouteAndLineInfoQuery = {
+  __typename?: 'query_root';
+  timetables?: {
+    __typename?: 'timetables_timetables_query';
+    timetables_vehicle_schedule_vehicle_schedule_frame: Array<{
+      __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
+      vehicle_schedule_frame_id: UUID;
+      vehicle_services: Array<{
+        __typename?: 'timetables_vehicle_service_vehicle_service';
+        vehicle_service_id: UUID;
+        journey_patterns_in_vehicle_service: Array<{
+          __typename?: 'timetables_vehicle_service_journey_patterns_in_vehicle_service';
+          journey_pattern_id: UUID;
+          journey_pattern_instance?: {
+            __typename?: 'journey_pattern_journey_pattern';
+            journey_pattern_id: UUID;
+            journey_pattern_route?: {
+              __typename?: 'route_route';
+              route_id: UUID;
+              unique_label: string;
+              direction: RouteDirectionEnum;
+              variant?: number | null;
+              name_i18n: LocalizedString;
+              route_line: { __typename?: 'route_line'; line_id: UUID };
+            } | null;
+          } | null;
+        }>;
+      }>;
+    }>;
+  } | null;
+};
+
 export type VehicleJourneyWithRouteInfoFragment = {
   __typename?: 'timetables_vehicle_journey_vehicle_journey';
   start_time: luxon.Duration;
@@ -26105,6 +26153,150 @@ export type GetSubstituteOperatingPeriodsQueryResult = Apollo.QueryResult<
   GetSubstituteOperatingPeriodsQuery,
   GetSubstituteOperatingPeriodsQueryVariables
 >;
+export const GetToReplaceVehicleScheduleFramesDocument = gql`
+  query GetToReplaceVehicleScheduleFrames(
+    $arg1: ToReplaceVehicleScheduleFrameIdsInput!
+  ) {
+    toReplaceVehicleScheduleFrameIds(arg1: $arg1) {
+      toReplaceVehicleScheduleFrameIds
+    }
+  }
+`;
+
+/**
+ * __useGetToReplaceVehicleScheduleFramesQuery__
+ *
+ * To run a query within a React component, call `useGetToReplaceVehicleScheduleFramesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetToReplaceVehicleScheduleFramesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetToReplaceVehicleScheduleFramesQuery({
+ *   variables: {
+ *      arg1: // value for 'arg1'
+ *   },
+ * });
+ */
+export function useGetToReplaceVehicleScheduleFramesQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetToReplaceVehicleScheduleFramesQuery,
+    GetToReplaceVehicleScheduleFramesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetToReplaceVehicleScheduleFramesQuery,
+    GetToReplaceVehicleScheduleFramesQueryVariables
+  >(GetToReplaceVehicleScheduleFramesDocument, options);
+}
+export function useGetToReplaceVehicleScheduleFramesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetToReplaceVehicleScheduleFramesQuery,
+    GetToReplaceVehicleScheduleFramesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetToReplaceVehicleScheduleFramesQuery,
+    GetToReplaceVehicleScheduleFramesQueryVariables
+  >(GetToReplaceVehicleScheduleFramesDocument, options);
+}
+export type GetToReplaceVehicleScheduleFramesQueryHookResult = ReturnType<
+  typeof useGetToReplaceVehicleScheduleFramesQuery
+>;
+export type GetToReplaceVehicleScheduleFramesLazyQueryHookResult = ReturnType<
+  typeof useGetToReplaceVehicleScheduleFramesLazyQuery
+>;
+export type GetToReplaceVehicleScheduleFramesQueryResult = Apollo.QueryResult<
+  GetToReplaceVehicleScheduleFramesQuery,
+  GetToReplaceVehicleScheduleFramesQueryVariables
+>;
+export const GetVehicleScheduleFrameWithRouteAndLineInfoDocument = gql`
+  query GetVehicleScheduleFrameWithRouteAndLineInfo(
+    $vehicle_schedule_frame_ids: [uuid!]!
+  ) {
+    timetables {
+      timetables_vehicle_schedule_vehicle_schedule_frame(
+        where: {
+          vehicle_schedule_frame_id: { _in: $vehicle_schedule_frame_ids }
+        }
+      ) {
+        vehicle_schedule_frame_id
+        vehicle_services {
+          vehicle_service_id
+          journey_patterns_in_vehicle_service {
+            journey_pattern_id
+            journey_pattern_instance {
+              journey_pattern_id
+              journey_pattern_route {
+                route_id
+                unique_label
+                direction
+                variant
+                name_i18n
+                route_line {
+                  line_id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetVehicleScheduleFrameWithRouteAndLineInfoQuery__
+ *
+ * To run a query within a React component, call `useGetVehicleScheduleFrameWithRouteAndLineInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetVehicleScheduleFrameWithRouteAndLineInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetVehicleScheduleFrameWithRouteAndLineInfoQuery({
+ *   variables: {
+ *      vehicle_schedule_frame_ids: // value for 'vehicle_schedule_frame_ids'
+ *   },
+ * });
+ */
+export function useGetVehicleScheduleFrameWithRouteAndLineInfoQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetVehicleScheduleFrameWithRouteAndLineInfoQuery,
+    GetVehicleScheduleFrameWithRouteAndLineInfoQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetVehicleScheduleFrameWithRouteAndLineInfoQuery,
+    GetVehicleScheduleFrameWithRouteAndLineInfoQueryVariables
+  >(GetVehicleScheduleFrameWithRouteAndLineInfoDocument, options);
+}
+export function useGetVehicleScheduleFrameWithRouteAndLineInfoLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetVehicleScheduleFrameWithRouteAndLineInfoQuery,
+    GetVehicleScheduleFrameWithRouteAndLineInfoQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetVehicleScheduleFrameWithRouteAndLineInfoQuery,
+    GetVehicleScheduleFrameWithRouteAndLineInfoQueryVariables
+  >(GetVehicleScheduleFrameWithRouteAndLineInfoDocument, options);
+}
+export type GetVehicleScheduleFrameWithRouteAndLineInfoQueryHookResult =
+  ReturnType<typeof useGetVehicleScheduleFrameWithRouteAndLineInfoQuery>;
+export type GetVehicleScheduleFrameWithRouteAndLineInfoLazyQueryHookResult =
+  ReturnType<typeof useGetVehicleScheduleFrameWithRouteAndLineInfoLazyQuery>;
+export type GetVehicleScheduleFrameWithRouteAndLineInfoQueryResult =
+  Apollo.QueryResult<
+    GetVehicleScheduleFrameWithRouteAndLineInfoQuery,
+    GetVehicleScheduleFrameWithRouteAndLineInfoQueryVariables
+  >;
 export const GetStagingVehicleScheduleFramesDocument = gql`
   query GetStagingVehicleScheduleFrames {
     timetables {
@@ -27558,6 +27750,23 @@ export function useGetSubstituteOperatingPeriodsAsyncQuery() {
 export type GetSubstituteOperatingPeriodsAsyncQueryHookResult = ReturnType<
   typeof useGetSubstituteOperatingPeriodsAsyncQuery
 >;
+export function useGetToReplaceVehicleScheduleFramesAsyncQuery() {
+  return useAsyncQuery<
+    GetToReplaceVehicleScheduleFramesQuery,
+    GetToReplaceVehicleScheduleFramesQueryVariables
+  >(GetToReplaceVehicleScheduleFramesDocument);
+}
+export type GetToReplaceVehicleScheduleFramesAsyncQueryHookResult = ReturnType<
+  typeof useGetToReplaceVehicleScheduleFramesAsyncQuery
+>;
+export function useGetVehicleScheduleFrameWithRouteAndLineInfoAsyncQuery() {
+  return useAsyncQuery<
+    GetVehicleScheduleFrameWithRouteAndLineInfoQuery,
+    GetVehicleScheduleFrameWithRouteAndLineInfoQueryVariables
+  >(GetVehicleScheduleFrameWithRouteAndLineInfoDocument);
+}
+export type GetVehicleScheduleFrameWithRouteAndLineInfoAsyncQueryHookResult =
+  ReturnType<typeof useGetVehicleScheduleFrameWithRouteAndLineInfoAsyncQuery>;
 export function useGetStagingVehicleScheduleFramesAsyncQuery() {
   return useAsyncQuery<
     GetStagingVehicleScheduleFramesQuery,

--- a/ui/src/hooks/timetables-import/deviations/index.ts
+++ b/ui/src/hooks/timetables-import/deviations/index.ts
@@ -1,0 +1,7 @@
+export * from './useCreateVehicleScheduleFrameInfo';
+export * from './useDeviationSort';
+export * from './useFindOrphanRoutes';
+export * from './useGetStagingVechicleScheduleFrameIds';
+export * from './useReplaceDeviations';
+export * from './useToReplaceVehicleScheduleFrames';
+export * from './useVehicleScheduleFrameWithRouteLabelAndLineId';

--- a/ui/src/hooks/timetables-import/deviations/useCreateVehicleScheduleFrameInfo.ts
+++ b/ui/src/hooks/timetables-import/deviations/useCreateVehicleScheduleFrameInfo.ts
@@ -1,0 +1,63 @@
+import compact from 'lodash/compact';
+import isEmpty from 'lodash/isEmpty';
+import { useCallback } from 'react';
+import { RouteDirectionEnum } from '../../../generated/graphql';
+import { RouteDirection } from '../../../types/RouteDirection';
+import { VehicleScheduleVehicleScheduleFrameWithRoutes } from './useVehicleScheduleFrameWithRouteLabelAndLineId';
+
+export type VehicleScheduleFrameInfo = {
+  uniqueLabel: string;
+  lineId: string;
+  direction: RouteDirectionEnum;
+  routeId: string;
+  routeName: LocalizedString;
+};
+
+export const useCreateVehicleScheduleFrameInfo = () => {
+  const createVehicleScheduleFrameInfo = useCallback(
+    (
+      vehicleScheduleFrames: VehicleScheduleVehicleScheduleFrameWithRoutes[],
+    ): VehicleScheduleFrameInfo[] => {
+      if (isEmpty(vehicleScheduleFrames)) {
+        return [];
+      }
+      const items = vehicleScheduleFrames.flatMap((item) =>
+        item.vehicle_services
+          .map((service) =>
+            service.journey_patterns_in_vehicle_service.map((journey) => {
+              const journeyPatternRoute =
+                journey.journey_pattern_instance?.journey_pattern_route;
+              if (!journeyPatternRoute) {
+                return undefined;
+              }
+              return {
+                uniqueLabel: journeyPatternRoute.unique_label,
+                lineId: journeyPatternRoute.route_line.line_id,
+                direction: journeyPatternRoute.direction,
+                routeName: journeyPatternRoute.name_i18n,
+                routeId: journeyPatternRoute.route_id,
+              };
+            }),
+          )
+          .flat(),
+      );
+
+      return compact(items)
+        .filter(
+          (item) => item.uniqueLabel !== undefined && item.lineId !== undefined,
+        )
+        .map((item) => ({
+          uniqueLabel: item.uniqueLabel,
+          lineId: item.lineId as string,
+          direction: item.direction as RouteDirection,
+          routeName: item.routeName,
+          routeId: item.routeId,
+        }));
+    },
+    [],
+  );
+
+  return {
+    createVehicleScheduleFrameInfo,
+  };
+};

--- a/ui/src/hooks/timetables-import/deviations/useDeviationSort.spec.ts
+++ b/ui/src/hooks/timetables-import/deviations/useDeviationSort.spec.ts
@@ -1,0 +1,139 @@
+import {
+  RouteDirectionEnum,
+  buildLocalizedString,
+} from '@hsl/jore4-test-db-manager';
+import { renderHook } from '@testing-library/react';
+import { VehicleScheduleFrameInfo } from './useCreateVehicleScheduleFrameInfo';
+import { useDeviationSort } from './useDeviationSort';
+
+describe('sortDeviations hook', () => {
+  const { result } = renderHook(useDeviationSort);
+
+  test('should sort by label in ascending order', () => {
+    const data: VehicleScheduleFrameInfo[] = [
+      {
+        uniqueLabel: '22',
+        lineId: '1',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: '135',
+        lineId: '2',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '2',
+        routeName: buildLocalizedString('route'),
+      },
+    ];
+
+    const sortedDeviations = result.current.sortDeviations(data);
+
+    expect(sortedDeviations).toEqual([
+      {
+        uniqueLabel: '135',
+        lineId: '2',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '2',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: '22',
+        lineId: '1',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+    ]);
+  });
+
+  test('should sort by direction when label is the same', () => {
+    const data: VehicleScheduleFrameInfo[] = [
+      {
+        uniqueLabel: '22',
+        lineId: '1',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: '22',
+        lineId: '2',
+        direction: RouteDirectionEnum.Outbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+    ];
+
+    const sortedDeviations = result.current.sortDeviations(data);
+
+    expect(sortedDeviations).toEqual([
+      {
+        uniqueLabel: '22',
+        lineId: '2',
+        direction: RouteDirectionEnum.Outbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: '22',
+        lineId: '1',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+    ]);
+  });
+
+  test('should sort labels without variant first', () => {
+    const data: VehicleScheduleFrameInfo[] = [
+      {
+        uniqueLabel: 'A_3',
+        lineId: '1',
+        direction: RouteDirectionEnum.Outbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: 'A',
+        lineId: '1',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: 'A',
+        lineId: '1',
+        direction: RouteDirectionEnum.Outbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+    ];
+
+    const sortedDeviations = result.current.sortDeviations(data);
+
+    expect(sortedDeviations).toEqual([
+      {
+        uniqueLabel: 'A',
+        lineId: '1',
+        direction: RouteDirectionEnum.Outbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: 'A',
+        lineId: '1',
+        direction: RouteDirectionEnum.Inbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+      {
+        uniqueLabel: 'A_3',
+        lineId: '1',
+        direction: RouteDirectionEnum.Outbound,
+        routeId: '1',
+        routeName: buildLocalizedString('route'),
+      },
+    ]);
+  });
+});

--- a/ui/src/hooks/timetables-import/deviations/useDeviationSort.ts
+++ b/ui/src/hooks/timetables-import/deviations/useDeviationSort.ts
@@ -1,0 +1,16 @@
+import orderBy from 'lodash/orderBy';
+import { VehicleScheduleFrameInfo } from './useCreateVehicleScheduleFrameInfo';
+
+export const useDeviationSort = () => {
+  const sortDeviations = (
+    routeDeviations: VehicleScheduleFrameInfo[],
+  ): VehicleScheduleFrameInfo[] => {
+    return orderBy(
+      routeDeviations,
+      ['uniqueLabel', 'direction'],
+      ['asc', 'desc'],
+    );
+  };
+
+  return { sortDeviations };
+};

--- a/ui/src/hooks/timetables-import/deviations/useFindOrphanRoutes.spec.ts
+++ b/ui/src/hooks/timetables-import/deviations/useFindOrphanRoutes.spec.ts
@@ -1,0 +1,134 @@
+import { buildLocalizedString } from '@hsl/jore4-test-db-manager';
+import { RouteDirectionEnum } from '../../../generated/graphql';
+import { renderHook } from '../../../utils/test-utils/renderer';
+import { useFindOrphanRoutes } from './useFindOrphanRoutes';
+
+const notUsedPartOfInfoObject = {
+  direction: RouteDirectionEnum.Inbound,
+  lineId: '0',
+  routeName: buildLocalizedString('route'),
+};
+
+const testCases = [
+  {
+    testName: 'should find correct object when uniqueLabel is unique',
+    toReplaceRoutes: [
+      {
+        uniqueLabel: 'B',
+        routeId: '1',
+        ...notUsedPartOfInfoObject,
+      },
+      {
+        uniqueLabel: 'A',
+        routeId: '2',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+    stagingRoutes: [
+      {
+        uniqueLabel: 'B',
+        routeId: '1',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+    expected: [
+      {
+        uniqueLabel: 'A',
+        routeId: '2',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+  },
+  {
+    testName:
+      'should find object with unique route id when uniqueLabel is the same',
+    toReplaceRoutes: [
+      {
+        uniqueLabel: 'B',
+        routeId: '1',
+        ...notUsedPartOfInfoObject,
+      },
+      {
+        uniqueLabel: 'B',
+        routeId: '2',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+    stagingRoutes: [
+      {
+        uniqueLabel: 'B',
+        routeId: '2',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+    expected: [
+      {
+        uniqueLabel: 'B',
+        routeId: '1',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+  },
+  {
+    testName: 'should return empty list when inputs have same content',
+    toReplaceRoutes: [
+      {
+        uniqueLabel: 'B',
+        routeId: '1',
+        ...notUsedPartOfInfoObject,
+      },
+      {
+        uniqueLabel: 'B',
+        routeId: '2',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+    stagingRoutes: [
+      {
+        uniqueLabel: 'B',
+        routeId: '1',
+        ...notUsedPartOfInfoObject,
+      },
+      {
+        uniqueLabel: 'B',
+        routeId: '2',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+    expected: [],
+  },
+  {
+    testName: 'should return empty list when toReplace is empty',
+    toReplaceRoutes: [],
+    stagingRoutes: [
+      {
+        uniqueLabel: 'B',
+        routeId: '1',
+        ...notUsedPartOfInfoObject,
+      },
+      {
+        uniqueLabel: 'B',
+        routeId: '2',
+        ...notUsedPartOfInfoObject,
+      },
+    ],
+    expected: [],
+  },
+];
+
+describe('findOrphanRoutes hook', () => {
+  testCases.forEach((testArgs) => {
+    const { testName, toReplaceRoutes, stagingRoutes, expected } = testArgs;
+
+    test(`${testName}`, () => {
+      const { result } = renderHook(() => useFindOrphanRoutes());
+
+      const orphans = result.current.findOrphanRoutes({
+        toReplaceRoutes,
+        stagingRoutes,
+      });
+
+      expect(orphans).toEqual(expected);
+    });
+  });
+});

--- a/ui/src/hooks/timetables-import/deviations/useFindOrphanRoutes.ts
+++ b/ui/src/hooks/timetables-import/deviations/useFindOrphanRoutes.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { VehicleScheduleFrameInfo } from './useCreateVehicleScheduleFrameInfo';
+
+export const useFindOrphanRoutes = () => {
+  const routesAreEqual = (
+    routeA: VehicleScheduleFrameInfo,
+    routeB: VehicleScheduleFrameInfo,
+  ) => {
+    return (
+      routeA.uniqueLabel === routeB.uniqueLabel &&
+      routeA.routeId === routeB.routeId
+    );
+  };
+
+  const findOrphanRoutes = useCallback(
+    ({
+      toReplaceRoutes,
+      stagingRoutes,
+    }: {
+      toReplaceRoutes: VehicleScheduleFrameInfo[];
+      stagingRoutes: VehicleScheduleFrameInfo[];
+    }) => {
+      const orphans = toReplaceRoutes.filter((toBeReplacedRoute) => {
+        return !stagingRoutes.some((stagingRoute) =>
+          routesAreEqual(stagingRoute, toBeReplacedRoute),
+        );
+      });
+
+      return orphans;
+    },
+    [],
+  );
+  return { findOrphanRoutes };
+};

--- a/ui/src/hooks/timetables-import/deviations/useGetStagingVechicleScheduleFrameIds.ts
+++ b/ui/src/hooks/timetables-import/deviations/useGetStagingVechicleScheduleFrameIds.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useGetStagingVehicleScheduleFramesAsyncQuery } from '../../../generated/graphql';
+
+export const useGetStagingVehicleScheduleFrameIds = () => {
+  const [getStagingVehicleScheduleFramesQuery] =
+    useGetStagingVehicleScheduleFramesAsyncQuery();
+
+  const fetchStagingVehicleFrameIds = useCallback(async () => {
+    const result = await getStagingVehicleScheduleFramesQuery({});
+
+    const vehicleScheduleFrames =
+      result.data?.timetables
+        ?.timetables_vehicle_schedule_vehicle_schedule_frame ?? [];
+
+    const stagedVehicleScheduleFrameIds = vehicleScheduleFrames.map(
+      (frame) => frame.vehicle_schedule_frame_id,
+    );
+
+    return stagedVehicleScheduleFrameIds;
+  }, [getStagingVehicleScheduleFramesQuery]);
+
+  return { fetchStagingVehicleFrameIds };
+};

--- a/ui/src/hooks/timetables-import/deviations/useReplaceDeviations.spec.ts
+++ b/ui/src/hooks/timetables-import/deviations/useReplaceDeviations.spec.ts
@@ -1,0 +1,239 @@
+import { act, renderHook } from '@testing-library/react';
+import { RouteDirectionEnum } from '../../../generated/graphql';
+import { useReplaceDeviations } from './useReplaceDeviations';
+import { VehicleScheduleVehicleScheduleFrameWithRoutes } from './useVehicleScheduleFrameWithRouteLabelAndLineId';
+
+jest.mock('../../../utils/toastService', () => ({
+  showDangerToastWithError: jest.fn(),
+}));
+const showDangerToastWithErrorMock = jest.requireMock(
+  '../../../utils/toastService',
+).showDangerToastWithError;
+
+const mockFetchReplacedFrames = jest.fn(() =>
+  Promise.resolve(['35e94feb-21d0-4418-9c9a-58345066af78']),
+);
+const mockFetchStagingVehicleFrameIds = jest.fn(() => Promise.resolve([]));
+
+const vsf1: VehicleScheduleVehicleScheduleFrameWithRoutes[] = [
+  {
+    __typename: 'timetables_vehicle_schedule_vehicle_schedule_frame',
+    vehicle_schedule_frame_id: '35e94feb-21d0-4418-9c9a-58345066af78',
+    vehicle_services: [
+      {
+        vehicle_service_id: 'e8a3d1b1-cd6a-41aa-b965-26f78b75c95e',
+        journey_patterns_in_vehicle_service: [
+          {
+            journey_pattern_id: '4b070731-700d-4c4c-8e30-cd177fa80ada',
+            journey_pattern_instance: {
+              journey_pattern_id: '4b070731-700d-4c4c-8e30-cd177fa80ada',
+              journey_pattern_route: {
+                route_id: 'c17ebc8e-3922-46b4-9aef-1e59c2ceffc9',
+                unique_label: '133',
+                direction: RouteDirectionEnum.Outbound,
+
+                name_i18n: {
+                  fi_FI: 'Friisilä-Matinkylä (M)-Henttaa',
+                },
+                route_line: {
+                  line_id: '4fdd4b18-8ad0-440b-941c-bebf920b6c63',
+                  __typename: 'route_line',
+                },
+                __typename: 'route_route',
+              },
+              __typename: 'journey_pattern_journey_pattern',
+            },
+            __typename:
+              'timetables_vehicle_service_journey_patterns_in_vehicle_service',
+          },
+          {
+            journey_pattern_id: '7eb10e90-e6fc-4914-b21a-97b3d538bf86',
+            journey_pattern_instance: {
+              journey_pattern_id: '7eb10e90-e6fc-4914-b21a-97b3d538bf86',
+              journey_pattern_route: {
+                route_id: 'f8efd2c4-487d-462d-a97d-984ba99f12aa',
+                unique_label: '108N',
+                direction: RouteDirectionEnum.Outbound,
+
+                name_i18n: {
+                  fi_FI: 'Kamppi-Teekkarikylä-Tapiola(M)-Westendinasema',
+                },
+                route_line: {
+                  line_id: '9d0a1133-8da8-468f-8214-2bdbdeade92a',
+                  __typename: 'route_line',
+                },
+                __typename: 'route_route',
+              },
+              __typename: 'journey_pattern_journey_pattern',
+            },
+            __typename:
+              'timetables_vehicle_service_journey_patterns_in_vehicle_service',
+          },
+          {
+            journey_pattern_id: 'a32d0747-4716-4d20-99b0-075e8c62cc1a',
+            journey_pattern_instance: {
+              journey_pattern_id: 'a32d0747-4716-4d20-99b0-075e8c62cc1a',
+              journey_pattern_route: {
+                route_id: '46ac4353-f968-4575-aa46-dbc2f248967b',
+                unique_label: '108N',
+                direction: RouteDirectionEnum.Inbound,
+
+                name_i18n: {
+                  fi_FI: 'Kamppi-Teekkarikylä-Tapiola(M)-Westendinasema',
+                },
+                route_line: {
+                  line_id: '9d0a1133-8da8-468f-8214-2bdbdeade92a',
+                  __typename: 'route_line',
+                },
+                __typename: 'route_route',
+              },
+              __typename: 'journey_pattern_journey_pattern',
+            },
+            __typename:
+              'timetables_vehicle_service_journey_patterns_in_vehicle_service',
+          },
+        ],
+        __typename: 'timetables_vehicle_service_vehicle_service',
+      },
+    ],
+  },
+];
+
+const vsf2: VehicleScheduleVehicleScheduleFrameWithRoutes[] = [
+  {
+    vehicle_schedule_frame_id: '77fa8187-9a8e-4ce6-9fe2-5855f438b0e2',
+    vehicle_services: [
+      {
+        vehicle_service_id: 'fb6bc3e2-b63c-47f4-8d79-5ac6e47ea76e',
+        journey_patterns_in_vehicle_service: [
+          {
+            journey_pattern_id: '0d05d12f-cf7b-47f8-961c-edb89b789e1d',
+            journey_pattern_instance: {
+              journey_pattern_id: '0d05d12f-cf7b-47f8-961c-edb89b789e1d',
+              journey_pattern_route: {
+                route_id: '0037b7c8-2875-4014-9601-640616398d8e',
+                unique_label: '133',
+                direction: RouteDirectionEnum.Inbound,
+
+                name_i18n: {
+                  fi_FI: 'Friisilä-Matinkylä (M)-Henttaa',
+                },
+                route_line: {
+                  line_id: '4fdd4b18-8ad0-440b-941c-bebf920b6c63',
+                  __typename: 'route_line',
+                },
+                __typename: 'route_route',
+              },
+              __typename: 'journey_pattern_journey_pattern',
+            },
+            __typename:
+              'timetables_vehicle_service_journey_patterns_in_vehicle_service',
+          },
+          {
+            journey_pattern_id: '4b070731-700d-4c4c-8e30-cd177fa80ada',
+            journey_pattern_instance: {
+              journey_pattern_id: '4b070731-700d-4c4c-8e30-cd177fa80ada',
+              journey_pattern_route: {
+                route_id: 'c17ebc8e-3922-46b4-9aef-1e59c2ceffc9',
+                unique_label: '133',
+                direction: RouteDirectionEnum.Outbound,
+
+                name_i18n: {
+                  fi_FI: 'Friisilä-Matinkylä (M)-Henttaa',
+                },
+                route_line: {
+                  line_id: '4fdd4b18-8ad0-440b-941c-bebf920b6c63',
+                  __typename: 'route_line',
+                },
+                __typename: 'route_route',
+              },
+              __typename: 'journey_pattern_journey_pattern',
+            },
+            __typename:
+              'timetables_vehicle_service_journey_patterns_in_vehicle_service',
+          },
+        ],
+        __typename: 'timetables_vehicle_service_vehicle_service',
+      },
+    ],
+    __typename: 'timetables_vehicle_schedule_vehicle_schedule_frame',
+  },
+];
+describe('replaceDeviations hook', () => {
+  it('should return no deviations when there is no staging vehicle frames', async () => {
+    const mockFetchVehicleFrames = jest.fn(() => Promise.resolve([]));
+    const { result } = renderHook(() =>
+      useReplaceDeviations(
+        mockFetchReplacedFrames,
+        mockFetchVehicleFrames,
+        mockFetchStagingVehicleFrameIds,
+      ),
+    );
+    await act(async () => {
+      await result.current.fetchRouteDeviations(10);
+    });
+    expect(result.current.deviations).toEqual([]);
+  });
+
+  it('should return deviation', async () => {
+    const mockFetchVehicleFrames2 = jest.fn();
+    mockFetchVehicleFrames2
+      .mockResolvedValueOnce(vsf1)
+      .mockResolvedValueOnce(vsf2);
+
+    const { result } = renderHook(() =>
+      useReplaceDeviations(
+        mockFetchReplacedFrames,
+        mockFetchVehicleFrames2,
+        mockFetchStagingVehicleFrameIds,
+      ),
+    );
+
+    await act(async () => {
+      await result.current.fetchRouteDeviations(10);
+    });
+
+    expect(result.current.deviations).toEqual([
+      {
+        direction: 'outbound',
+        uniqueLabel: '108N',
+        lineId: '9d0a1133-8da8-468f-8214-2bdbdeade92a',
+        routeId: 'f8efd2c4-487d-462d-a97d-984ba99f12aa',
+        routeName: {
+          fi_FI: 'Kamppi-Teekkarikylä-Tapiola(M)-Westendinasema',
+        },
+      },
+      {
+        direction: 'inbound',
+        uniqueLabel: '108N',
+        lineId: '9d0a1133-8da8-468f-8214-2bdbdeade92a',
+        routeId: '46ac4353-f968-4575-aa46-dbc2f248967b',
+        routeName: {
+          fi_FI: 'Kamppi-Teekkarikylä-Tapiola(M)-Westendinasema',
+        },
+      },
+    ]);
+  });
+
+  it('should call showDangerToastWithError when error is thrown', async () => {
+    const mockFetchVehicleFrames = jest.fn(() =>
+      Promise.reject(new Error('Some error message')),
+    );
+
+    const { result } = renderHook(() =>
+      useReplaceDeviations(
+        mockFetchReplacedFrames,
+        mockFetchVehicleFrames,
+        mockFetchStagingVehicleFrameIds,
+      ),
+    );
+    await act(async () => {
+      await result.current.fetchRouteDeviations(10);
+    });
+    expect(showDangerToastWithErrorMock).toHaveBeenCalledWith(
+      'Puuttuvien reittien haku epäonnistui',
+      new Error('Some error message'),
+    );
+    expect(result.current.deviations).toEqual([]);
+  });
+});

--- a/ui/src/hooks/timetables-import/deviations/useReplaceDeviations.ts
+++ b/ui/src/hooks/timetables-import/deviations/useReplaceDeviations.ts
@@ -1,0 +1,89 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TimetablePriority } from '../../../types/enums';
+import { showDangerToastWithError } from '../../../utils';
+import {
+  VehicleScheduleFrameInfo,
+  useCreateVehicleScheduleFrameInfo,
+} from './useCreateVehicleScheduleFrameInfo';
+import { useFindOrphanRoutes } from './useFindOrphanRoutes';
+import { VehicleScheduleVehicleScheduleFrameWithRoutes } from './useVehicleScheduleFrameWithRouteLabelAndLineId';
+
+export const useReplaceDeviations = (
+  fetchToReplaceFrames: (
+    ids: UUID[],
+    targetPriority: number,
+  ) => Promise<UUID[]>,
+  fetchVehicleFrames: (
+    ids: UUID[],
+  ) => Promise<VehicleScheduleVehicleScheduleFrameWithRoutes[]>,
+  fetchStagingVehicleFrameIds: () => Promise<UUID[]>,
+) => {
+  const { t } = useTranslation();
+  const { createVehicleScheduleFrameInfo } =
+    useCreateVehicleScheduleFrameInfo();
+  const { findOrphanRoutes } = useFindOrphanRoutes();
+
+  const [deviations, setDeviations] = useState<VehicleScheduleFrameInfo[]>([]);
+
+  const fetchRouteDeviations = useCallback(
+    async (targetPriority: TimetablePriority) => {
+      try {
+        const stagedVehicleScheduleFrameIds =
+          await fetchStagingVehicleFrameIds();
+
+        if (!stagedVehicleScheduleFrameIds) {
+          setDeviations([]);
+          return;
+        }
+
+        const toReplace = await fetchToReplaceFrames(
+          stagedVehicleScheduleFrameIds,
+          targetPriority,
+        );
+
+        if (!toReplace) {
+          setDeviations([]);
+          return;
+        }
+
+        const [toReplaceVehicleScheduleFrames, stagedVehicleScheduleFrames] =
+          await Promise.all([
+            fetchVehicleFrames(toReplace),
+            fetchVehicleFrames(stagedVehicleScheduleFrameIds),
+          ]);
+
+        const foundDeviations = findOrphanRoutes({
+          toReplaceRoutes: createVehicleScheduleFrameInfo(
+            toReplaceVehicleScheduleFrames,
+          ),
+          stagingRoutes: createVehicleScheduleFrameInfo(
+            stagedVehicleScheduleFrames,
+          ),
+        });
+
+        setDeviations(foundDeviations);
+      } catch (error) {
+        showDangerToastWithError(
+          t('timetablesPreview.deviationFetchFailed'),
+          error,
+        );
+        setDeviations([]);
+      }
+    },
+    [
+      createVehicleScheduleFrameInfo,
+      fetchStagingVehicleFrameIds,
+      fetchToReplaceFrames,
+      fetchVehicleFrames,
+      findOrphanRoutes,
+      t,
+    ],
+  );
+
+  const clearRouteDeviations = useCallback(() => {
+    setDeviations([]);
+  }, []);
+
+  return { deviations, fetchRouteDeviations, clearRouteDeviations };
+};

--- a/ui/src/hooks/timetables-import/deviations/useToReplaceVehicleScheduleFrames.ts
+++ b/ui/src/hooks/timetables-import/deviations/useToReplaceVehicleScheduleFrames.ts
@@ -1,0 +1,48 @@
+import { gql } from '@apollo/client';
+import compact from 'lodash/compact';
+import { useCallback } from 'react';
+import { useGetToReplaceVehicleScheduleFramesAsyncQuery } from '../../../generated/graphql';
+import { TimetablePriority } from '../../../types/enums';
+
+const GQL_GET_REPLACED_VEHICLE_SCHEDULE_FRAMES = gql`
+  query GetToReplaceVehicleScheduleFrames(
+    $arg1: ToReplaceVehicleScheduleFrameIdsInput!
+  ) {
+    toReplaceVehicleScheduleFrameIds(arg1: $arg1) {
+      toReplaceVehicleScheduleFrameIds
+    }
+  }
+`;
+export const useToReplaceVehicleScheduleFrames = () => {
+  const [getReplacedQuery] = useGetToReplaceVehicleScheduleFramesAsyncQuery();
+
+  const fetchToReplaceFrames = useCallback(
+    async (ids: UUID[], targetPriority: TimetablePriority) => {
+      try {
+        const replacedPromises = ids.map(async (id) => {
+          return getReplacedQuery({
+            arg1: {
+              targetPriority,
+              stagingVehicleScheduleFrameId: id,
+            },
+          });
+        });
+
+        const replaced = (await Promise.all(replacedPromises)).flatMap(
+          (response) =>
+            response.data.toReplaceVehicleScheduleFrameIds
+              ?.toReplaceVehicleScheduleFrameIds,
+        );
+
+        return compact(replaced);
+      } catch (error) {
+        throw new Error(
+          `Failed to fetch to replace vehicle schedule frames: ${error}`,
+        );
+      }
+    },
+    [getReplacedQuery],
+  );
+
+  return { fetchToReplaceFrames };
+};

--- a/ui/src/hooks/timetables-import/deviations/useVehicleScheduleFrameWithRouteLabelAndLineId.ts
+++ b/ui/src/hooks/timetables-import/deviations/useVehicleScheduleFrameWithRouteLabelAndLineId.ts
@@ -1,0 +1,64 @@
+import { gql } from '@apollo/client';
+import { useCallback } from 'react';
+import {
+  GetVehicleScheduleFrameWithRouteAndLineInfoQuery,
+  useGetVehicleScheduleFrameWithRouteAndLineInfoAsyncQuery,
+} from '../../../generated/graphql';
+
+const GQL_VEHICLE_SCHEDULE_FRAME_WITH_ROUTE_AND_LINE_INFO = gql`
+  query GetVehicleScheduleFrameWithRouteAndLineInfo(
+    $vehicle_schedule_frame_ids: [uuid!]!
+  ) {
+    timetables {
+      timetables_vehicle_schedule_vehicle_schedule_frame(
+        where: {
+          vehicle_schedule_frame_id: { _in: $vehicle_schedule_frame_ids }
+        }
+      ) {
+        vehicle_schedule_frame_id
+        vehicle_services {
+          vehicle_service_id
+          journey_patterns_in_vehicle_service {
+            journey_pattern_id
+            journey_pattern_instance {
+              journey_pattern_id
+              journey_pattern_route {
+                route_id
+                unique_label
+                direction
+                variant
+                name_i18n
+                route_line {
+                  line_id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+export type VehicleScheduleVehicleScheduleFrameWithRoutes = NonNullable<
+  GetVehicleScheduleFrameWithRouteAndLineInfoQuery['timetables']
+>['timetables_vehicle_schedule_vehicle_schedule_frame'][0];
+
+export const useVehicleScheduleFrameWithRouteLabelAndLineId = () => {
+  const [getVehicleScheduleFramesQuery] =
+    useGetVehicleScheduleFrameWithRouteAndLineInfoAsyncQuery();
+
+  const fetchVehicleFrames = useCallback(
+    async (ids: UUID[]) => {
+      const result = await getVehicleScheduleFramesQuery({
+        vehicle_schedule_frame_ids: ids,
+      });
+      const vehicleScheduleFrames: VehicleScheduleVehicleScheduleFrameWithRoutes[] =
+        result.data?.timetables
+          ?.timetables_vehicle_schedule_vehicle_schedule_frame ?? [];
+      return vehicleScheduleFrames;
+    },
+    [getVehicleScheduleFramesQuery],
+  );
+
+  return { fetchVehicleFrames };
+};

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -382,15 +382,21 @@
     "chooseSubstituteDay": "Select..."
   },
   "timetablesPreview": {
-    "preview": "Preview",
+    "attention": "Attention",
     "closePreview": "Close preview",
-    "save": "Save timetables",
-    "departures": "Departures: {{ count }}",
-    "showContent": "Show content",
+    "blockCount": "{{ count }} blocks",
     "closeContent": "Close content",
     "contentUsage": "Content usage",
+    "departures": "Departures: {{ count }}",
+    "deviationFetchFailed": "Failed to fetch missing routes",
+    "deviations": "Deviations ({{ count }})",
+    "deviationsWarning": "The Hastus file is missing the schedules of the routes previously imported. These expire with this recording. If you want, import them separately or add them to this file.",
     "fileContent": "File content",
-    "blockCount": "{{ count }} blocks"
+    "missingRoutes": "Missing routes:",
+    "preview": "Preview",
+    "save": "Save timetables",
+    "showContent": "Show content",
+    "summary": "Summary"
   },
   "timetableVersionsTableHeaders": {
     "status": "Status",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -382,15 +382,21 @@
     "chooseSubstituteDay": "Valitse..."
   },
   "timetablesPreview": {
-    "preview": "Esikatselu",
+    "attention": "Huomio",
     "closePreview": "Sulje esikatselu",
-    "save": "Tallenna aikataulut",
-    "departures": "Lähtöjä: {{ count }}",
-    "showContent": "Näytä sisältö",
+    "blockCount": "{{ count }} autokiertoa",
     "closeContent": "Sulje sisältö",
     "contentUsage": "Sisällön käyttö",
+    "departures": "Lähtöjä: {{ count }}",
+    "deviationFetchFailed": "Puuttuvien reittien haku epäonnistui",
+    "deviations": "Poikkeamat ({{ count }})",
+    "deviationsWarning": "Hastus-tiedostosta puuttuvat aiemmin samassa yhteydessä ladattujen reittien aikataulut. Näiden voimassaolo päättyy tällä tallennuksella. Tuo ne halutessasi erikseen tai lisää tähän tiedostoon.",
     "fileContent": "Tiedoston sisältö",
-    "blockCount": "{{ count }} autokiertoa"
+    "missingRoutes": "Puuttuvat reitit:",
+    "preview": "Esikatselu",
+    "save": "Tallenna aikataulut",
+    "showContent": "Näytä sisältö",
+    "summary": "Yhteenveto"
   },
   "timetableVersionsTableHeaders": {
     "status": "Tila",


### PR DESCRIPTION
Separated adding three hooks to own commits. There has been arguments that "dead" code should not be added before usage, but I think this can help in review etc.. 
These hooks are: `useGetStagingVehicleScheduleFrameIds`, `useVehicleScheduleFramesWithRouteLabelAndLineId` and `useToReplaceVehicleScheduleFrames`

Latest commit has a few new components and there is a few unit tests for those. There is also hook `useReplaceDeviations`. This hook uses hooks added in earlier commits. There is also few "helper" hooks and they have few unit tests to endorse wanted behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/683)
<!-- Reviewable:end -->
