### PR TITLE
Run UI jest tests sequentially instead of in parallel

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
     "prebuild": "yarn generate-theme",
     "build": "next build && next export",
     "ts:check": "yarn tsc --noEmit",
-    "test": "jest --ci",
+    "test": "jest --ci --runInBand",
     "test:unit": "yarn test --testRegex='^(?!.*\\.integration\\.spec\\.tsx?$).*\\.spec\\.tsx?$'",
     "test:integration": "yarn test --testRegex='\\.integration\\.spec\\.tsx?$'",
     "generate-theme": "./convert-theme-to-ts.js",


### PR DESCRIPTION
When running in parallel,
the tests run in about 30s and need over 10 gigs of memory. When running sequentially,
they run in about 20s and need about 2 gigs of memory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/685)
<!-- Reviewable:end -->
