### PR TITLE
Upgrade react-router-dom to v6

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "react-map-gl": "^6.1.16",
     "react-map-gl-draw": "^1.0.3",
     "react-redux": "^7.2.6",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.18.0",
     "react-spinners": "^0.13.8",
     "redux-logger": "^3.0.6",
     "remeda": "^1.9.1",

--- a/ui/src/components/common/LineDetailsButton.tsx
+++ b/ui/src/components/common/LineDetailsButton.tsx
@@ -1,4 +1,4 @@
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Path, routeDetails } from '../../router/routeDetails';
 import { IconButton } from '../../uiComponents/IconButton';
 import { commonHoverStyle } from '../../uiComponents/SimpleButton';
@@ -20,10 +20,10 @@ export const LineDetailsButton = ({
   routeLabel,
   className = '',
 }: Props): JSX.Element => {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const onClick = () => {
-    history.push(routeDetails[Path.lineDetails].getLink(lineId, routeLabel));
+    navigate(routeDetails[Path.lineDetails].getLink(lineId, routeLabel));
   };
   return (
     <IconButton

--- a/ui/src/components/common/LineTimetablesButton.tsx
+++ b/ui/src/components/common/LineTimetablesButton.tsx
@@ -1,6 +1,6 @@
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Path, routeDetails } from '../../router/routeDetails';
-import { commonHoverStyle, IconButton } from '../../uiComponents';
+import { IconButton, commonHoverStyle } from '../../uiComponents';
 
 const testIds = {
   button: 'LocatorButton::button',
@@ -22,10 +22,10 @@ export const LineTimetablesButton = ({
   className = '',
 }: Props): JSX.Element => {
   const disabledStyle = '!bg-background opacity-70 pointer-events-none';
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const onClick = () => {
-    history.push(routeDetails[Path.lineTimetables].getLink(lineId, routeLabel));
+    navigate(routeDetails[Path.lineTimetables].getLink(lineId, routeLabel));
   };
   return (
     <IconButton

--- a/ui/src/components/common/RedirectWithQuery.tsx
+++ b/ui/src/components/common/RedirectWithQuery.tsx
@@ -1,12 +1,12 @@
 import qs from 'qs';
-import { Redirect, RedirectProps } from 'react-router-dom';
+import { Navigate, NavigateProps } from 'react-router-dom';
 import { useUrlQuery } from '../../hooks';
 
-export const RedirectWithQuery = (props: RedirectProps): JSX.Element => {
+export const RedirectWithQuery = (props: NavigateProps): JSX.Element => {
   const { queryParams } = useUrlQuery();
   const { to, ...propsWithoutTo } = props;
   return (
-    <Redirect
+    <Navigate
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...propsWithoutTo}
       to={{

--- a/ui/src/components/forms/line/LineForm.tsx
+++ b/ui/src/components/forms/line/LineForm.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { Row } from '../../../layoutComponents';
 import { Priority } from '../../../types/enums';
 import { FormContainer, SimpleButton } from '../../../uiComponents';
@@ -13,8 +13,8 @@ import {
   schema as changeValidityFormSaveFormSchema,
 } from '../common/ChangeValidityForm';
 import {
-  FormState as LinePropertiesFormState,
   LinePropertiesForm,
+  FormState as LinePropertiesFormState,
   schema as linePropertiesFormSchema,
 } from './LinePropertiesForm';
 
@@ -31,7 +31,7 @@ interface Props {
 }
 
 export const LineForm = ({ defaultValues, onSubmit }: Props): JSX.Element => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const formRef = useRef<ExplicitAny>(null);
 
   const { t } = useTranslation();
@@ -50,7 +50,7 @@ export const LineForm = ({ defaultValues, onSubmit }: Props): JSX.Element => {
   };
 
   const onCancel = () => {
-    history.goBack();
+    navigate(-1);
   };
 
   return (

--- a/ui/src/components/navbar/NavLinks.tsx
+++ b/ui/src/components/navbar/NavLinks.tsx
@@ -17,10 +17,13 @@ export const NavLinks: FunctionComponent = () => {
           <div key={translationKey} className="flex hover:bg-brand-darker">
             <NavLink
               to={getLink()}
-              className="mx-5 border-b-4 border-transparent py-5 text-white hover:border-white"
-              activeClassName="!border-white"
+              className={({ isActive }) =>
+                `mx-5 border-b-4 border-transparent py-5 text-white hover:border-white ${
+                  isActive ? '!border-white' : ''
+                }`
+              }
               data-testid={testIds.navLink(translationKey)}
-              exact
+              end
             >
               {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
               {t(translationKey!)}

--- a/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
+++ b/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Redirect } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import {
   LineDefaultFieldsFragment,
   ReusableComponentsVehicleModeEnum,
@@ -53,7 +53,7 @@ export const CreateNewLinePage = (): JSX.Element => {
   if (createdLineId) {
     // if line was successfully created, redirect to its page
     return (
-      <Redirect
+      <Navigate
         to={{ pathname: routeDetails[Path.lineDetails].getLink(createdLineId) }}
       />
     );

--- a/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Redirect, useParams } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import {
   LineAllFieldsFragment,
   useGetLineDetailsByIdQuery,
 } from '../../../generated/graphql';
 import { mapLineDetailsResult } from '../../../graphql';
-import { useEditLine } from '../../../hooks';
+import { useEditLine, useRequiredParams } from '../../../hooks';
 import { Container } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { mapToISODate } from '../../../time';
@@ -45,7 +45,7 @@ export const EditLinePage = (): JSX.Element => {
     defaultErrorHandler,
   } = useEditLine();
 
-  const { id } = useParams<{ id: string }>();
+  const { id } = useRequiredParams<{ id: string }>();
   const lineDetailsResult = useGetLineDetailsByIdQuery(
     mapToVariables({ line_id: id }),
   );
@@ -71,7 +71,7 @@ export const EditLinePage = (): JSX.Element => {
   if (hasFinishedEditing) {
     // if line was successfully edited, redirect to its page
     return (
-      <Redirect to={{ pathname: routeDetails[Path.lineDetails].getLink(id) }} />
+      <Navigate to={{ pathname: routeDetails[Path.lineDetails].getLink(id) }} />
     );
   }
 

--- a/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 import {
   RouteDefaultFieldsFragment,
   ServicePatternScheduledStopPoint,
@@ -11,6 +10,7 @@ import {
   useDeleteRoute,
   useEditRouteJourneyPattern,
   useEditRouteMetadata,
+  useRequiredParams,
 } from '../../../hooks';
 import { Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
@@ -66,7 +66,7 @@ export const EditRoutePage = (): JSX.Element => {
   } = useEditRouteJourneyPattern();
   const [conflicts, setConflicts] = useState<RouteDefaultFieldsFragment[]>([]);
   const formRef = useRef<ExplicitAny>(null);
-  const { id } = useParams<{ id: string }>();
+  const { id } = useRequiredParams<{ id: string }>();
 
   const routeDetailsResult = useGetRouteDetailsByIdsQuery({
     ...mapToVariables({ route_ids: [id] }),

--- a/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router';
-import { useRoutesAndLinesDraftReturnToQueryParam } from '../../../hooks';
+import {
+  useRequiredParams,
+  useRoutesAndLinesDraftReturnToQueryParam,
+} from '../../../hooks';
 import { useGetLineDraftDetails } from '../../../hooks/line-drafts/useGetLineDraftDetails';
 import { Column, Container, Row } from '../../../layoutComponents';
 import { CloseIconButton } from '../../../uiComponents';
@@ -13,7 +15,7 @@ const testIds = {
 
 export const LineDraftsPage = (): JSX.Element => {
   const { t } = useTranslation();
-  const { label } = useParams<{ label: string }>();
+  const { label } = useRequiredParams<{ label: string }>();
   const { routes } = useGetLineDraftDetails();
 
   const { onClose } = useRoutesAndLinesDraftReturnToQueryParam();

--- a/ui/src/components/timetables/import/ImportTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/ImportTimetablesPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { useTimetablesImport } from '../../../hooks/timetables-import/useTimetablesImport';
 import { Container, Row } from '../../../layoutComponents';
 import { Path } from '../../../router/routeDetails';
@@ -24,7 +24,7 @@ const testIds = {
 
 export const ImportTimetablesPage = (): JSX.Element => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const {
     vehicleJourneys,
     vehicleScheduleFrames,
@@ -37,7 +37,7 @@ export const ImportTimetablesPage = (): JSX.Element => {
   const [isSavingImport, setIsSavingImport] = useState(false);
 
   const handleClose = () => {
-    history.push(Path.timetables);
+    navigate(Path.timetables);
   };
 
   const handleCancel = () => {

--- a/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import {
   useConfirmTimetablesImportUIAction,
   useTimetablesImport,
@@ -31,7 +31,7 @@ const testIds = {
 
 export const PreviewTimetablesPage = (): JSX.Element => {
   const { t } = useTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const {
     vehicleJourneys,
     vehicleScheduleFrames,
@@ -69,7 +69,7 @@ export const PreviewTimetablesPage = (): JSX.Element => {
       state.timetableImportStrategy,
     );
 
-    history.push({
+    navigate({
       pathname: routeDetails[Path.timetablesImport].getLink(),
     });
   };

--- a/ui/src/components/timetables/substitute-day-settings/SubstituteDaySettingsPage.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/SubstituteDaySettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../../../hooks';
 import { Container, Row } from '../../../layoutComponents';
 import { selectTimetable } from '../../../redux';
@@ -24,7 +24,7 @@ export const SubstituteDaySettingsPage = (): JSX.Element => {
       isCommonSubstitutePeriodFormDirty,
     },
   } = useAppSelector(selectTimetable);
-  const history = useHistory();
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleClose = () => {
@@ -34,12 +34,12 @@ export const SubstituteDaySettingsPage = (): JSX.Element => {
     ) {
       setIsOpen(true);
     } else {
-      history.push(Path.timetables);
+      navigate(Path.timetables);
     }
   };
 
   const closePage = () => {
-    history.push(Path.timetables);
+    navigate(Path.timetables);
   };
 
   return (

--- a/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
@@ -1,11 +1,11 @@
 import orderBy from 'lodash/orderBy';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 import {
   TimetableVersionRowData,
   useGetJourneyPatternIdsByLineLabel,
   useGetTimetableVersions,
+  useRequiredParams,
   useTimeRangeQueryParams,
   useTimetableVersionsReturnToQueryParam,
 } from '../../../hooks';
@@ -22,7 +22,7 @@ const testIds = {
 
 export const TimetableVersionsPage = (): JSX.Element => {
   const { t } = useTranslation();
-  const { label } = useParams<{ label: string }>();
+  const { label } = useRequiredParams<{ label: string }>();
   const { startDate, endDate } = useTimeRangeQueryParams();
 
   // We first need to get the journey pattern ids for all line routes by line label

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -16,6 +16,7 @@ export * from './useDebouncedString';
 export * from './useGetJourneyPatternIdsByRouteLabel';
 export * from './useGetTimetableVersions';
 export * from './usePagination';
+export * from './useRequiredParams';
 export * from './useShowRoutesOnModal';
 export * from './useToggle';
 export * from './vehicle-schedule-frame';

--- a/ui/src/hooks/line-details/useGetLineDetails.ts
+++ b/ui/src/hooks/line-details/useGetLineDetails.ts
@@ -3,7 +3,6 @@ import produce from 'immer';
 import groupBy from 'lodash/groupBy';
 import { DateTime } from 'luxon';
 import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import {
   LineDefaultFieldsFragment,
   LineWithRoutesUniqueFieldsFragment,
@@ -22,6 +21,7 @@ import {
 } from '../../utils';
 import { getRouteLabelVariantText } from '../../utils/route';
 import { useObservationDateQueryParam } from '../urlQuery';
+import { useRequiredParams } from '../useRequiredParams';
 
 const GQL_INFRASTRUCTURE_LINK_WITH_STOPS_FRAGMENT = gql`
   fragment infrastructure_link_with_stops on infrastructure_network_infrastructure_link {
@@ -165,7 +165,7 @@ const buildLineDetailsGqlFilters = (
 
 /** Gets the line details depending on query parameters. */
 export const useGetLineDetails = () => {
-  const { id } = useParams<{ id: string }>();
+  const { id } = useRequiredParams<{ id: string }>();
 
   const { observationDate, setObservationDateToUrl } =
     useObservationDateQueryParam();

--- a/ui/src/hooks/line-drafts/useGetLineDraftDetails.ts
+++ b/ui/src/hooks/line-drafts/useGetLineDraftDetails.ts
@@ -1,5 +1,4 @@
-import { useParams } from 'react-router-dom';
-import { useObservationDateQueryParam } from '..';
+import { useObservationDateQueryParam, useRequiredParams } from '..';
 import { useGetRoutesWithStopsQuery } from '../../generated/graphql';
 import { Priority } from '../../types/enums';
 import {
@@ -10,7 +9,7 @@ import {
 } from '../../utils';
 
 export const useGetLineDraftDetails = () => {
-  const { label } = useParams<{ label: string }>();
+  const { label } = useRequiredParams<{ label: string }>();
 
   const { observationDate } = useObservationDateQueryParam();
 

--- a/ui/src/hooks/ui/useReturnToQueryParam.ts
+++ b/ui/src/hooks/ui/useReturnToQueryParam.ts
@@ -1,8 +1,8 @@
 import qs from 'qs';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 
 export const useReturnToQueryParam = () => {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   /**
    *  Attaches the 'returnTo' url to query string. This is used to return to the
@@ -17,7 +17,7 @@ export const useReturnToQueryParam = () => {
   };
 
   const onClose = (pathname: string) => {
-    history.push({
+    navigate({
       pathname,
     });
   };

--- a/ui/src/hooks/urlQuery/useUrlQuery.ts
+++ b/ui/src/hooks/urlQuery/useUrlQuery.ts
@@ -5,7 +5,7 @@ import isNumber from 'lodash/isNumber';
 import { DateTime } from 'luxon';
 import qs from 'qs';
 import { useCallback, useMemo } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   ReusableComponentsVehicleModeEnum,
   RouteTypeOfLineEnum,
@@ -49,21 +49,26 @@ export const useUrlQuery = () => {
     [query],
   );
 
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const setQueryString = useCallback(
     (queryString: string, replace: boolean, pathname?: string) => {
       replace
-        ? history.replace({
-            search: `?${queryString}`,
-            pathname,
-          })
-        : history.push({
+        ? navigate(
+            {
+              search: `?${queryString}`,
+              pathname,
+            },
+            {
+              replace: true,
+            },
+          )
+        : navigate({
             search: `?${queryString}`,
             pathname,
           });
     },
-    [history],
+    [navigate],
   );
 
   /** Sets parameter to URL query

--- a/ui/src/hooks/useBasePath.ts
+++ b/ui/src/hooks/useBasePath.ts
@@ -1,4 +1,4 @@
-import { useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Path } from '../router/routeDetails';
 
 /**
@@ -7,8 +7,8 @@ import { Path } from '../router/routeDetails';
  * E.g. in '/routes/search?observationDate=2022-12-07' the basePath is '/routes'
  */
 export const useBasePath = (): { basePath: Path } => {
-  const history = useHistory();
-  const basePath = `/${history.location.pathname.split('/')[1]}` as Path;
+  const location = useLocation();
+  const basePath = `/${location.pathname.split('/')[1]}` as Path;
 
   return { basePath };
 };

--- a/ui/src/hooks/usePagination.spec.tsx
+++ b/ui/src/hooks/usePagination.spec.tsx
@@ -4,12 +4,11 @@ import { usePagination, useUrlQuery } from '.';
 jest.mock('./urlQuery/useUrlQuery', () => ({
   useUrlQuery: jest.fn().mockReturnValue({}),
 }));
-const mockHistory = {
-  push: jest.fn(),
-};
 
-jest.mock('react-router', () => ({
-  useHistory: () => mockHistory,
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
 }));
 
 const urlQueryMock = useUrlQuery as jest.Mock;
@@ -99,7 +98,7 @@ describe(`${hookForNames.result.current.setPage.name}`, () => {
 
     result.current.setPage(5);
 
-    expect(mockHistory.push).toHaveBeenCalledWith({ search: 'page=5' });
+    expect(mockNavigate).toHaveBeenCalledWith({ search: 'page=5' });
   });
 
   test('should overwrite existing page query parameter', () => {
@@ -107,7 +106,7 @@ describe(`${hookForNames.result.current.setPage.name}`, () => {
     const { result } = renderHook(usePagination);
     result.current.setPage(10);
 
-    expect(mockHistory.push).toHaveBeenCalledWith({
+    expect(mockNavigate).toHaveBeenCalledWith({
       search: 'page=10',
     });
   });
@@ -119,7 +118,7 @@ describe(`${hookForNames.result.current.setPage.name}`, () => {
     const { result } = renderHook(usePagination);
     result.current.setPage(10);
 
-    expect(mockHistory.push).toHaveBeenCalledWith({
+    expect(mockNavigate).toHaveBeenCalledWith({
       search: 'name=TestName&line=TestLine&page=10',
     });
   });

--- a/ui/src/hooks/usePagination.ts
+++ b/ui/src/hooks/usePagination.ts
@@ -1,7 +1,7 @@
 import produce from 'immer';
 import range from 'lodash/range';
 import qs from 'qs';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { useUrlQuery } from './urlQuery/useUrlQuery';
 
 const ADDITIONAL_BUTTON_AMOUNT = 2;
@@ -17,7 +17,7 @@ export const usePagination = (): {
     totalPages: number,
   ) => number[];
 } => {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { queryParams } = useUrlQuery();
   const initialPage = parseInt(queryParams?.page as string, 10) || 1;
 
@@ -35,7 +35,7 @@ export const usePagination = (): {
     const updatedUrlQuery = produce(queryParams, (draft) => {
       draft.page = page.toString();
     });
-    history.push({
+    navigate({
       search: qs.stringify(updatedUrlQuery),
     });
   };

--- a/ui/src/hooks/useRequiredParams.ts
+++ b/ui/src/hooks/useRequiredParams.ts
@@ -1,0 +1,13 @@
+import { useParams } from 'react-router-dom';
+
+/**
+ * This is a workaround to get rid of possible undefined type from useParams
+ *
+ * After upgrading 'react-router-dom' library to v6 'useParams' typed the parameter from the
+ * URL path to be possibly undefined, which it should never be.
+ * Example: If you have foo/:bar/punz, the 'bar' parameter can never be undefined.
+ *
+ * More information in this issue thread: https://github.com/remix-run/react-router/issues/8498
+ */
+export const useRequiredParams = <T extends Record<string, unknown>>() =>
+  useParams() as T;

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import React, { FunctionComponent } from 'react';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { MainPage } from '../components/main/MainPage';
 import { MapLoader, ModalMap } from '../components/map';
 import { Navbar } from '../components/navbar';
@@ -28,84 +28,68 @@ const FallbackRoute: FunctionComponent = () => {
 export const Router: FunctionComponent = () => {
   interface Route {
     _routerRoute: Path;
-    _exact?: boolean; // When true, will only match if the path matches the location.pathname exactly.
     component: React.ComponentType;
   }
 
   const routes: Record<Path, Route> = {
     [Path.root]: {
       _routerRoute: Path.root,
-      _exact: true,
       component: MainPage,
     },
     [Path.routes]: {
       _routerRoute: Path.routes,
-      _exact: true,
       component: RoutesAndLinesMainPage,
     },
     [Path.timetables]: {
       _routerRoute: Path.timetables,
-      _exact: true,
       component: TimetablesMainPage,
     },
     [Path.routesSearch]: {
       _routerRoute: Path.routesSearch,
-      _exact: true,
       component: SearchResultPage,
     },
     [Path.timetablesSearch]: {
       _routerRoute: Path.timetablesSearch,
-      _exact: true,
       component: SearchResultPage,
     },
     [Path.editRoute]: {
       _routerRoute: Path.editRoute,
-      _exact: true,
       component: EditRoutePage,
     },
     [Path.createLine]: {
       _routerRoute: Path.createLine,
-      _exact: true,
       component: CreateNewLinePage,
     },
     [Path.lineDetails]: {
       _routerRoute: Path.lineDetails,
-      _exact: true,
       component: LineDetailsPage,
     },
     [Path.lineDrafts]: {
       _routerRoute: Path.lineDrafts,
-      _exact: true,
       component: LineDraftsPage,
     },
     [Path.editLine]: {
       _routerRoute: Path.editLine,
-      _exact: true,
       component: EditLinePage,
     },
     [Path.lineTimetables]: {
       _routerRoute: Path.lineTimetables,
-      _exact: true,
       component: VehicleScheduleDetailsPage,
     },
     [Path.timetablesImport]: {
       _routerRoute: Path.timetablesImport,
-      _exact: true,
       component: ImportTimetablesPage,
     },
     [Path.timetablesImportPreview]: {
       _routerRoute: Path.timetablesImportPreview,
-      _exact: true,
       component: PreviewTimetablesPage,
     },
     [Path.lineTimetableVersions]: {
       _routerRoute: Path.lineTimetableVersions,
-      _exact: true,
       component: TimetableVersionsPage,
     },
     [Path.substituteOperatingPeriodSettings]: {
       _routerRoute: Path.substituteOperatingPeriodSettings,
-      _exact: true,
       component: SubstituteDaySettingsPage,
     },
     [Path.fallback]: {
@@ -117,16 +101,15 @@ export const Router: FunctionComponent = () => {
   return (
     <BrowserRouter>
       <Navbar />
-      <Switch>
+      <Routes>
         {Object.values(routes).map((route) => (
           <Route
             key={route._routerRoute}
             path={route._routerRoute}
-            exact={route._exact || false}
-            component={route.component}
+            Component={route.component}
           />
         ))}
-      </Switch>
+      </Routes>
       <ModalMap />
       <MapLoader />
     </BrowserRouter>

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,7 +911,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -2492,6 +2492,11 @@
     redux "^4.1.2"
     redux-thunk "^2.4.1"
     reselect "^4.1.5"
+
+"@remix-run/router@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.11.0.tgz#e0e45ac3fff9d8a126916f166809825537e9f955"
+  integrity sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==
 
 "@repeaterjs/repeater@3.0.4":
   version "3.0.4"
@@ -7191,19 +7196,7 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7878,11 +7871,6 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -9221,7 +9209,7 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9463,14 +9451,6 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
-mini-create-react-context@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
-  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
-  dependencies:
-    "@babel/runtime" "^7.12.1"
-    tiny-warning "^1.0.3"
 
 minimatch@4.2.1:
   version "4.2.1"
@@ -10111,13 +10091,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -10523,7 +10496,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10712,7 +10685,7 @@ react-icons@^4.8.0:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
   integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
 
-react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -10766,34 +10739,20 @@ react-redux@^7.2.6:
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
-react-router-dom@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
-  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
+react-router-dom@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.18.0.tgz#0a50c167209d6e7bd2ed9de200a6579ea4fb1dca"
+  integrity sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.2.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    "@remix-run/router" "1.11.0"
+    react-router "6.18.0"
 
-react-router@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
-  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+react-router@6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.18.0.tgz#32e2bedc318e095a48763b5ed7758e54034cd36a"
+  integrity sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==
   dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    mini-create-react-context "^0.4.0"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    "@remix-run/router" "1.11.0"
 
 react-spinners@^0.13.8:
   version "0.13.8"
@@ -11024,11 +10983,6 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"
@@ -11821,16 +11775,6 @@ tiny-glob@^0.2.9:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
-tiny-invariant@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tinyqueue@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
@@ -12314,11 +12258,6 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 value-or-promise@1.0.11:
   version "1.0.11"


### PR DESCRIPTION
Making this version upgrade required some migration as well. This migration guide was followed: https://reactrouter.com/en/main/upgrading/v5 In a nutshell:
- useHistory hook is no more, replaced with useNavigate
- `<Redirect>` is no more, replaced with `<Navigate>`
- `<Switch>` is no more, replaced with `<Routes>`
- NavLink doesn't take activeClassName parameter anymore
  - also 'exact' flag is renamed to 'end'
- `<Route>` doesnt have 'exact' flag anymore

This also had one more side effect: for some reason they changed the useParams typing from <T> to <T or undefined> which makes no sense, since a path parameter is never optional. This is why the useRequiredParam custom hook was created for the workaround.

Resolves HSLdevcom/jore4#1291

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/696)
<!-- Reviewable:end -->
