### PR TITLE
Disable import form buttons after successful submit from import page

### DIFF
--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -436,6 +436,9 @@ describe('Timetable import', () => {
       importTimetablesPage.toast.checkSuccessToastHasMessage(
         `Tiedoston ${IMPORT_FILENAME} lataus onnistui!`,
       );
+      // Files uploaded -> nothing left to upload.
+      importTimetablesPage.getUploadButton().should('be.disabled');
+
       importTimetablesPage.clickPreviewButton();
 
       // Not a single day timetable -> can't select special day.

--- a/cypress/e2e/timetablesReplaceAndCombine.cy.ts
+++ b/cypress/e2e/timetablesReplaceAndCombine.cy.ts
@@ -704,6 +704,9 @@ describe('Timetable replacement and combination', () => {
         'Aikataulujen tuonti onnistui!',
       );
 
+      // No staging timetables exist anymore -> import form should be disabled.
+      importTimetablesPage.verifyImportFormButtonsDisabled();
+
       confirmTimetablesInReplaceCase();
     },
   );
@@ -743,6 +746,9 @@ describe('Timetable replacement and combination', () => {
       importTimetablesPage.toast.checkSuccessToastHasMessage(
         'Aikataulujen tuonti onnistui!',
       );
+
+      // No staging timetables exist anymore -> import form should be disabled.
+      importTimetablesPage.verifyImportFormButtonsDisabled();
 
       confirmTimetablesInCombineCase();
     },

--- a/cypress/pageObjects/ImportTimetablesPage.ts
+++ b/cypress/pageObjects/ImportTimetablesPage.ts
@@ -3,6 +3,10 @@ import { Toast } from './Toast';
 export class ImportTimetablesPage {
   toast = new Toast();
 
+  getCancelButton() {
+    return cy.getByTestId('ImportTimetablesPage::cancelButton');
+  }
+
   getSaveButton() {
     return cy.getByTestId('ImportTimetablesPage::saveButton');
   }
@@ -20,6 +24,14 @@ export class ImportTimetablesPage {
         .click()
     );
   }
+
+  verifyImportFormButtonsDisabled = () => {
+    this.getCancelButton().should('be.disabled');
+    this.getSaveButton().should('be.disabled');
+    this.getPreviewButton()
+      // This "button" is not actually a <button> so doesn't (and can't) have disabled attribute.
+      .should('have.attr', 'aria-disabled', 'true');
+  };
 
   getUploadButton() {
     return cy.getByTestId('ImportTimetablesPage::uploadButton');

--- a/ui/src/hooks/timetables-import/useTimetablesImport.ts
+++ b/ui/src/hooks/timetables-import/useTimetablesImport.ts
@@ -177,6 +177,8 @@ export const useTimetablesImport = () => {
         targetPriority: priority,
       }),
     );
+
+    await importedVehicleScheduleFramesResult.refetch();
   };
 
   const confirmTimetablesImportByReplacing = async (
@@ -190,6 +192,8 @@ export const useTimetablesImport = () => {
         targetPriority: priority,
       }),
     );
+
+    await importedVehicleScheduleFramesResult.refetch();
   };
 
   const cancelTimetablesImport = async (stagingFrameIdsToDelete: UUID[]) => {


### PR DESCRIPTION
Was already working when saving from preview page because of redirect.

Resolves https://github.com/HSLdevcom/jore4/issues/1583

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/704)
<!-- Reviewable:end -->
