### PR TITLE
Prevent duplicate unauthorized toast

### DIFF
--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -50,7 +50,7 @@ export const ProtectedRoute: FunctionComponent = ({ children }) => {
     if (!userInfo) {
       fetchUser();
     }
-  }, [userInfo, isLoading, t]);
+  }, [userInfo, t]);
 
   if (isLoading) {
     return <Spinner className="m-16 flex justify-center" showSpinner />;


### PR DESCRIPTION
While not logged, after an unauthrorized request the user were redirected to front page and shown two "Unauthorized" toasts, because this useEffect was ran two times. It had "IsLoading" in the dependency array, which is changed before the request. Fixed simply by removing the isLoading from the dependency array.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/720)
<!-- Reviewable:end -->
