### PR TITLE
Remove unnecessary database seeding from run-cypress-tests.yml

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -31,25 +31,7 @@ jobs:
         run: |
           sudo apt-get -yqq install postgresql-client
 
-      - name: Seed db1 with infrastructure links
-        env:
-          DUMP_PATH: ./test-db-manager/src/dumps/infraLinks/infraLinks.sql
-        run: |
-          psql postgresql://dbadmin:adminpassword@localhost:6532/jore4e2e < ${{ env.DUMP_PATH }}
-
-      - name: Seed db2 with infrastructure links
-        env:
-          DUMP_PATH: ./test-db-manager/src/dumps/infraLinks/infraLinks.sql
-        run: |
-          psql postgresql://dbadmin:adminpassword@localhost:6533/jore4e2e < ${{ env.DUMP_PATH }}
-
-      - name: Seed db3 with infrastructure links
-        env:
-          DUMP_PATH: ./test-db-manager/src/dumps/infraLinks/infraLinks.sql
-        run: |
-          psql postgresql://dbadmin:adminpassword@localhost:6534/jore4e2e < ${{ env.DUMP_PATH }}
-
-      - name: Seed db4 with infrastructure links
+      - name: Seed db with infrastructure links
         env:
           DUMP_PATH: ./test-db-manager/src/dumps/infraLinks/infraLinks.sql
         run: |


### PR DESCRIPTION
- Parallel test execution does not work anymore, so we can remove unnecessary database instances from the CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/728)
<!-- Reviewable:end -->
