### PR TITLE
Add import loading indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,10 @@ It is possible to override tailwindcss styles by adding overriding classname aft
 
 It should be noted, that the order of classnames given to component does not automatically mean anything. The classes and styles are applied in the order that they are in the css file, which could be quite random and should not be relied on. For that reason we are using [tailwind-merge](https://www.npmjs.com/package/tailwind-merge) package, which takes the order in account and removes the classnames which are overridden. Therefore whenever classnames are used so that the order should be taken into account, `twMerge` function should be used to combine the classnames.
 
+## Loading state of async request handling / indication
+
+To have consistency and reduce duplicated code and passing loading states through components we use redux for the loading state of async requests. We have `enum Operation` in `loader.ts` which contains different async operations e.g. `ConfirmTimetablesImport`. When making an async request, you can use the `setLoadingAction` with the correct `Operation` to handle the state. After this you can use the state how you please, but if you want to show the global `LoadingOverlay`, just add the chosen `Operation` to `joreOperations` in `loader.ts`.
+
 ## Yarn workspaces / monorepo structure
 
 This repository has currently yarn workspaces in following folders:

--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -1,21 +1,21 @@
 import {
   GetInfrastructureLinksByExternalIdsResult,
+  InfraLinkAlongRouteInsertInput,
+  JourneyPatternInsertInput,
+  LineInsertInput,
+  RouteDirectionEnum,
+  RouteInsertInput,
+  RouteTypeOfLineEnum,
+  StopInJourneyPatternInsertInput,
+  StopInsertInput,
+  TimetablePriority,
   buildLine,
   buildRoute,
   buildStop,
   buildStopInJourneyPattern,
   buildTimingPlace,
   extractInfrastructureLinkIdsFromResponse,
-  InfraLinkAlongRouteInsertInput,
-  JourneyPatternInsertInput,
-  LineInsertInput,
   mapToGetInfrastructureLinksByExternalIdsQuery,
-  RouteDirectionEnum,
-  RouteInsertInput,
-  StopInJourneyPatternInsertInput,
-  RouteTypeOfLineEnum,
-  StopInsertInput,
-  TimetablePriority,
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
@@ -25,18 +25,18 @@ import {
   Navbar,
   PassingTimesByStopSection,
   PreviewTimetablesPage,
-  RoutesAndLinesPage,
   RouteTimetablesSection,
-  TimetablesMainpage,
+  RoutesAndLinesPage,
   TimetableVersionsPage,
-  VehicleServiceTable,
+  TimetablesMainpage,
   VehicleScheduleDetailsPage,
+  VehicleServiceTable,
 } from '../pageObjects';
 import { UUID } from '../types';
 import {
+  SupportedResources,
   insertToDbHelper,
   removeFromDbHelper,
-  SupportedResources,
 } from '../utils';
 
 // These infralink IDs exist in the 'infraLinks.sql' test data file.
@@ -953,7 +953,7 @@ describe('Timetable import', () => {
         importTimetablesPage.toast.checkSuccessToastHasMessage(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui!`,
         );
-        importTimetablesPage.getCancelButton().click();
+        importTimetablesPage.getAbortButton().click();
         importTimetablesPage.confirmationDialog.getConfirmButton().click();
         importTimetablesPage.toast.checkSuccessToastHasMessage(
           'Aikataulujen tuonti keskeytetty',

--- a/cypress/pageObjects/ImportTimetablesPage.ts
+++ b/cypress/pageObjects/ImportTimetablesPage.ts
@@ -6,8 +6,8 @@ export class ImportTimetablesPage {
 
   confirmationDialog = new ConfirmationDialog();
 
-  getCancelButton() {
-    return cy.getByTestId('ImportTimetablesPage::cancelButton');
+  getAbortButton() {
+    return cy.getByTestId('ImportTimetablesPage::abortButton');
   }
 
   getSaveButton() {
@@ -29,7 +29,7 @@ export class ImportTimetablesPage {
   }
 
   verifyImportFormButtonsDisabled = () => {
-    this.getCancelButton().should('be.disabled');
+    this.getAbortButton().should('be.disabled');
     this.getSaveButton().should('be.disabled');
     this.getPreviewButton()
       // This "button" is not actually a <button> so doesn't (and can't) have disabled attribute.

--- a/ui/src/components/map/JoreLoader.tsx
+++ b/ui/src/components/map/JoreLoader.tsx
@@ -1,0 +1,13 @@
+import { useAppSelector } from '../../hooks';
+import { selectIsJoreOperationLoading } from '../../redux';
+import { LoadingOverlay } from '../../uiComponents';
+
+const testIds = {
+  loader: 'JoreLoader::loader',
+};
+
+export const JoreLoader = (): JSX.Element => {
+  const isLoading = useAppSelector(selectIsJoreOperationLoading);
+
+  return <LoadingOverlay testId={testIds.loader} visible={isLoading} />;
+};

--- a/ui/src/components/timetables/import/ImportTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/ImportTimetablesPage.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { useAppSelector } from '../../../hooks';
 import { useTimetablesImport } from '../../../hooks/timetables-import/useTimetablesImport';
 import { Container, Row } from '../../../layoutComponents';
+import { selectIsJoreOperationLoading } from '../../../redux';
 import { Path } from '../../../router/routeDetails';
 import {
   CloseIconButton,
@@ -20,6 +22,7 @@ const testIds = {
   saveButton: 'ImportTimetablesPage::saveButton',
   previewButton: 'ImportTimetablesPage::previewButton',
   closeButton: 'ImportTimetablesPage::closeButton',
+  loading: 'ImportTimetablesPage::LoadingOverlay',
 };
 
 export const ImportTimetablesPage = (): JSX.Element => {
@@ -33,10 +36,11 @@ export const ImportTimetablesPage = (): JSX.Element => {
   } = useTimetablesImport();
 
   const [fileList, setFileList] = useState<File[] | null>(null);
-  const [isSendingToHastus, setIsSendingToHastus] = useState(false);
   const [isAbortImportModalOpen, setIsAbortImportModalOpen] = useState(false);
   const [isConfirmImportModalOpen, setIsConfirmImportModalOpen] =
     useState(false);
+
+  const isLoading = useAppSelector(selectIsJoreOperationLoading);
 
   const handleClose = () => {
     navigate(Path.timetables);
@@ -65,10 +69,8 @@ export const ImportTimetablesPage = (): JSX.Element => {
 
   const handleUpload = async () => {
     if (fileList?.length) {
-      setIsSendingToHastus(true);
       const result = await sendToHastusImporter(fileList);
       setFileList(result.failedFiles);
-      setIsSendingToHastus(false);
     }
   };
 
@@ -89,29 +91,29 @@ export const ImportTimetablesPage = (): JSX.Element => {
         <SimpleButton
           testId={testIds.uploadButton}
           onClick={handleUpload}
-          disabled={!fileList?.length || isSendingToHastus}
+          disabled={!fileList?.length || isLoading}
         >
           {t('import.uploadFiles')}
         </SimpleButton>
         <div className="flex justify-end space-x-4">
           <SimpleButton
-            disabled={!importedTimetablesExist || isSendingToHastus}
             testId={testIds.abortButton}
             onClick={openAbortImportModal}
+            disabled={!importedTimetablesExist || isLoading}
           >
             {t('import.abort')}
           </SimpleButton>
           <SimpleButton
             testId={testIds.saveButton}
-            disabled={!importedTimetablesExist || isSendingToHastus}
             onClick={openConfirmImportModal}
+            disabled={!importedTimetablesExist || isLoading}
           >
             {t('save')}
           </SimpleButton>
           <SimpleButton
             testId={testIds.previewButton}
             href={Path.timetablesImportPreview}
-            disabled={!importedTimetablesExist || isSendingToHastus}
+            disabled={!importedTimetablesExist || isLoading}
           >
             {t('import.openPreview')}
           </SimpleButton>

--- a/ui/src/components/timetables/import/ImportTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/ImportTimetablesPage.tsx
@@ -16,7 +16,7 @@ import { FileImportDragAndDrop } from './FileImportDragAndDrop';
 
 const testIds = {
   uploadButton: 'ImportTimetablesPage::uploadButton',
-  cancelButton: 'ImportTimetablesPage::cancelButton',
+  abortButton: 'ImportTimetablesPage::abortButton',
   saveButton: 'ImportTimetablesPage::saveButton',
   previewButton: 'ImportTimetablesPage::previewButton',
   closeButton: 'ImportTimetablesPage::closeButton',
@@ -29,13 +29,12 @@ export const ImportTimetablesPage = (): JSX.Element => {
     vehicleJourneys,
     vehicleScheduleFrames,
     sendToHastusImporter,
-    cancelTimetablesImport,
+    abortTimetablesImport,
   } = useTimetablesImport();
 
   const [fileList, setFileList] = useState<File[] | null>(null);
   const [isSendingToHastus, setIsSendingToHastus] = useState(false);
-  const [isCancelingImportModalOpen, setIsCancelingImportModalOpen] =
-    useState(false);
+  const [isAbortImportModalOpen, setIsAbortImportModalOpen] = useState(false);
   const [isConfirmImportModalOpen, setIsConfirmImportModalOpen] =
     useState(false);
 
@@ -43,18 +42,18 @@ export const ImportTimetablesPage = (): JSX.Element => {
     navigate(Path.timetables);
   };
 
-  const openCancelImportModal = () => {
-    setIsCancelingImportModalOpen(true);
+  const openAbortImportModal = () => {
+    setIsAbortImportModalOpen(true);
   };
 
-  const onConfirmCancelingImport = async () => {
+  const onConfirmAbortImport = async () => {
     try {
-      await cancelTimetablesImport(
+      await abortTimetablesImport(
         vehicleScheduleFrames.map((vsf) => vsf.vehicle_schedule_frame_id),
       );
 
-      setIsCancelingImportModalOpen(false);
-      showSuccessToast(t('import.cancelledSuccessfully'));
+      setIsAbortImportModalOpen(false);
+      showSuccessToast(t('import.abortedSuccessfully'));
     } catch (err) {
       showDangerToastWithError(t('errors.saveFailed'), err);
     }
@@ -96,16 +95,16 @@ export const ImportTimetablesPage = (): JSX.Element => {
         </SimpleButton>
         <div className="flex justify-end space-x-4">
           <SimpleButton
-            testId={testIds.cancelButton}
-            onClick={openCancelImportModal}
             disabled={!importedTimetablesExist || isSendingToHastus}
+            testId={testIds.abortButton}
+            onClick={openAbortImportModal}
           >
-            {t('import.cancel')}
+            {t('import.abort')}
           </SimpleButton>
           <SimpleButton
             testId={testIds.saveButton}
-            onClick={openConfirmImportModal}
             disabled={!importedTimetablesExist || isSendingToHastus}
+            onClick={openConfirmImportModal}
           >
             {t('save')}
           </SimpleButton>
@@ -119,14 +118,14 @@ export const ImportTimetablesPage = (): JSX.Element => {
         </div>
       </FormRow>
       <ConfirmationDialog
-        isOpen={isCancelingImportModalOpen}
-        onCancel={() => setIsCancelingImportModalOpen(false)}
-        onConfirm={onConfirmCancelingImport}
+        isOpen={isAbortImportModalOpen}
+        onCancel={() => setIsAbortImportModalOpen(false)}
+        onConfirm={onConfirmAbortImport}
         widthClassName="max-w-md"
-        title={t('confirmTimetablesCancelImportDialog.title')}
-        description={t('confirmTimetablesCancelImportDialog.description')}
-        confirmText={t('confirmTimetablesCancelImportDialog.confirm')}
-        cancelText={t('confirmTimetablesCancelImportDialog.cancel')}
+        title={t('confirmTimetablesAbortImportDialog.title')}
+        description={t('confirmTimetablesAbortImportDialog.description')}
+        confirmText={t('confirmTimetablesAbortImportDialog.confirm')}
+        cancelText={t('confirmTimetablesAbortImportDialog.abort')}
       />
       <ConfirmTimetablesImportModal
         isOpen={isConfirmImportModalOpen}

--- a/ui/src/components/timetables/import/ImportTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/ImportTimetablesPage.tsx
@@ -33,16 +33,18 @@ export const ImportTimetablesPage = (): JSX.Element => {
   } = useTimetablesImport();
 
   const [fileList, setFileList] = useState<File[] | null>(null);
-  const [isCancelingImport, setIsCancelingImport] = useState(false);
-  const [isSavingImport, setIsSavingImport] = useState(false);
   const [isSendingToHastus, setIsSendingToHastus] = useState(false);
+  const [isCancelingImportModalOpen, setIsCancelingImportModalOpen] =
+    useState(false);
+  const [isConfirmImportModalOpen, setIsConfirmImportModalOpen] =
+    useState(false);
 
   const handleClose = () => {
     navigate(Path.timetables);
   };
 
-  const handleCancel = () => {
-    setIsCancelingImport(true);
+  const openCancelImportModal = () => {
+    setIsCancelingImportModalOpen(true);
   };
 
   const onConfirmCancelingImport = async () => {
@@ -51,15 +53,15 @@ export const ImportTimetablesPage = (): JSX.Element => {
         vehicleScheduleFrames.map((vsf) => vsf.vehicle_schedule_frame_id),
       );
 
-      setIsCancelingImport(false);
+      setIsCancelingImportModalOpen(false);
       showSuccessToast(t('import.cancelledSuccessfully'));
     } catch (err) {
       showDangerToastWithError(t('errors.saveFailed'), err);
     }
   };
 
-  const handleSave = () => {
-    setIsSavingImport(true);
+  const openConfirmImportModal = () => {
+    setIsConfirmImportModalOpen(true);
   };
 
   const handleUpload = async () => {
@@ -95,14 +97,14 @@ export const ImportTimetablesPage = (): JSX.Element => {
         <div className="flex justify-end space-x-4">
           <SimpleButton
             testId={testIds.cancelButton}
-            onClick={handleCancel}
+            onClick={openCancelImportModal}
             disabled={!importedTimetablesExist || isSendingToHastus}
           >
             {t('import.cancel')}
           </SimpleButton>
           <SimpleButton
             testId={testIds.saveButton}
-            onClick={handleSave}
+            onClick={openConfirmImportModal}
             disabled={!importedTimetablesExist || isSendingToHastus}
           >
             {t('save')}
@@ -117,8 +119,8 @@ export const ImportTimetablesPage = (): JSX.Element => {
         </div>
       </FormRow>
       <ConfirmationDialog
-        isOpen={isCancelingImport}
-        onCancel={() => setIsCancelingImport(false)}
+        isOpen={isCancelingImportModalOpen}
+        onCancel={() => setIsCancelingImportModalOpen(false)}
         onConfirm={onConfirmCancelingImport}
         widthClassName="max-w-md"
         title={t('confirmTimetablesCancelImportDialog.title')}
@@ -127,8 +129,10 @@ export const ImportTimetablesPage = (): JSX.Element => {
         cancelText={t('confirmTimetablesCancelImportDialog.cancel')}
       />
       <ConfirmTimetablesImportModal
-        isOpen={isSavingImport}
-        onClose={() => setIsSavingImport(false)}
+        isOpen={isConfirmImportModalOpen}
+        onClose={() => {
+          setIsConfirmImportModalOpen(false);
+        }}
       />
     </Container>
   );

--- a/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
+  useAppSelector,
   useConfirmTimetablesImportUIAction,
   useTimetablesImport,
   useToggle,
@@ -13,6 +14,7 @@ import {
   useVehicleScheduleFrameWithRouteLabelAndLineId,
 } from '../../../hooks/timetables-import/deviations';
 import { Container, Row, Visible } from '../../../layoutComponents';
+import { selectIsJoreOperationLoading } from '../../../redux';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { AccordionButton, SimpleButton } from '../../../uiComponents';
 import { submitFormByRef } from '../../../utils';
@@ -27,6 +29,7 @@ const testIds = {
     'PreviewTimetablesPage::toggleShowStagingTimetables',
   saveButton: 'PreviewTimetablesPage::saveButton',
   closePreviewButton: 'PreviewTimetablesPage::closePreviewButton',
+  loading: 'PrieviewTimetablesPage::LoadingOverlay',
 };
 
 export const PreviewTimetablesPage = (): JSX.Element => {
@@ -51,6 +54,8 @@ export const PreviewTimetablesPage = (): JSX.Element => {
       fetchVehicleFrames,
       fetchStagingVehicleFrameIds,
     );
+
+  const isLoading = useAppSelector(selectIsJoreOperationLoading);
   const vehicleJourneyCount = vehicleJourneys?.length || 0;
   const importedTimetablesExist = vehicleJourneyCount > 0;
   // Default might be set incorrectly if data has not been fetched for the form.
@@ -133,6 +138,7 @@ export const PreviewTimetablesPage = (): JSX.Element => {
           <SimpleButton
             inverted
             testId={testIds.closePreviewButton}
+            disabled={isLoading}
             href={Path.timetablesImport}
           >
             {t('timetablesPreview.closePreview')}
@@ -140,7 +146,7 @@ export const PreviewTimetablesPage = (): JSX.Element => {
           <SimpleButton
             testId={testIds.saveButton}
             onClick={onSave}
-            disabled={!importedTimetablesExist}
+            disabled={!importedTimetablesExist || isLoading}
           >
             {t('timetablesPreview.save')}
           </SimpleButton>

--- a/ui/src/hooks/timetables-import/useTimetablesImport.ts
+++ b/ui/src/hooks/timetables-import/useTimetablesImport.ts
@@ -196,7 +196,7 @@ export const useTimetablesImport = () => {
     await importedVehicleScheduleFramesResult.refetch();
   };
 
-  const cancelTimetablesImport = async (stagingFrameIdsToDelete: UUID[]) => {
+  const abortTimetablesImport = async (stagingFrameIdsToDelete: UUID[]) => {
     // Note: this also deletes all the children of the staging frames, because of cascade delete.
     await deleteStagingTimetables(
       mapToVariables({
@@ -275,7 +275,7 @@ export const useTimetablesImport = () => {
   return {
     confirmTimetablesImportByCombining,
     confirmTimetablesImportByReplacing,
-    cancelTimetablesImport,
+    abortTimetablesImport,
     vehicleJourneys,
     vehicleScheduleFrames,
     sendToHastusImporter,

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -414,11 +414,11 @@
     "modified": "Modified",
     "modifier": "Modifier"
   },
-  "confirmTimetablesCancelImportDialog": {
-    "title": "Cancel importing timetables",
+  "confirmTimetablesAbortImportDialog": {
+    "title": "Abort importing timetables",
     "description": "The imported timetables will not be saved to JORE.",
-    "cancel": "Do not cancel",
-    "confirm": "Cancel import"
+    "abort": "Do not abort",
+    "confirm": "Abort import"
   },
   "confirmTimetablesImportModal": {
     "title": "Save changes",
@@ -442,8 +442,8 @@
     "specialDayMixedPrioritiesWarning1": "Imported timetables contain special days and other timetables.",
     "specialDayMixedPrioritiesWarning2": "Importing not possible. Cancel the import and import one day priority timetables separately.",
     "dragAndDrop": "Drag and drop Hastus files or",
-    "cancel": "Cancel",
-    "cancelledSuccessfully": "Timetables import cancelled.",
+    "abort": "Abort",
+    "abortedSuccessfully": "Timetables import aborted.",
     "openPreview": "Open preview",
     "uploadFiles": "Upload files",
     "browse": "Browse",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -414,10 +414,10 @@
     "modified": "Muokattu",
     "modifier": "Muokkaaja"
   },
-  "confirmTimetablesCancelImportDialog": {
+  "confirmTimetablesAbortImportDialog": {
     "title": "Aikataulujen tuonti keskeytetään",
     "description": "Tuomasi aikataulut eivät tallennu JOREen.",
-    "cancel": "Älä keskeytä",
+    "abort": "Älä keskeytä",
     "confirm": "Keskeytä tuonti"
   },
   "confirmTimetablesImportModal": {
@@ -442,8 +442,8 @@
     "specialDayMixedPrioritiesWarning1": "Tuoduissa aikatauluissa on erityispäivien lisäksi myös muita aikatauluja.",
     "specialDayMixedPrioritiesWarning2": "Tallennus ei ole mahdollista. Keskeytä aikataulujen tuonti ja tuo yhden päivän pituiset aikataulut erikseen.",
     "dragAndDrop": "Vedä ja pudota Hastus-tiedostoja tai",
-    "cancel": "Keskeytä",
-    "cancelledSuccessfully": "Aikataulujen tuonti keskeytetty.",
+    "abort": "Keskeytä",
+    "abortedSuccessfully": "Aikataulujen tuonti keskeytetty.",
     "openPreview": "Avaa esikatselu",
     "uploadFiles": "Lataa tiedostot",
     "browse": "Selaa",

--- a/ui/src/redux/selectors/loader.ts
+++ b/ui/src/redux/selectors/loader.ts
@@ -1,5 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { Operation, mapOperations } from '../slices/loader';
+import { Operation, joreOperations, mapOperations } from '../slices/loader';
 import { RootState } from '../store';
 
 export const selectLoader = (state: RootState) => state.loader;
@@ -9,5 +9,13 @@ export const selectIsMapOperationLoading = createSelector(
   (loaders) =>
     Object.entries(loaders)
       .filter(([operation]) => mapOperations.includes(operation as Operation))
+      .some(([, isLoading]) => isLoading),
+);
+
+export const selectIsJoreOperationLoading = createSelector(
+  selectLoader,
+  (loaders) =>
+    Object.entries(loaders)
+      .filter(([operation]) => joreOperations.includes(operation as Operation))
       .some(([, isLoading]) => isLoading),
 );

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -10,6 +10,8 @@ export enum Operation {
   CheckBrokenRoutes = 'checkBrokenRoutes',
   SaveTimingPlace = 'saveTimingPlace',
   ConfirmTimetablesImport = 'confirmTimetablesImport',
+  UploadFilesToHastusImport = 'uploadFilesToHastusImport',
+  AbortImport = 'abortImport',
 }
 
 export const mapOperations = [
@@ -22,6 +24,14 @@ export const mapOperations = [
   Operation.CheckBrokenRoutes,
   Operation.SaveTimingPlace,
 ];
+
+export const importOperations = [
+  Operation.ConfirmTimetablesImport,
+  Operation.UploadFilesToHastusImport,
+  Operation.AbortImport,
+];
+
+export const joreOperations = [...importOperations];
 
 type IState = {
   [key in Operation]: boolean;
@@ -37,6 +47,8 @@ const initialState: IState = {
   [Operation.CheckBrokenRoutes]: false,
   [Operation.SaveTimingPlace]: false,
   [Operation.ConfirmTimetablesImport]: false,
+  [Operation.UploadFilesToHastusImport]: false,
+  [Operation.AbortImport]: false,
 };
 
 const slice = createSlice({

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { getUserInfo } from '../api/user';
 import { MainPage } from '../components/main/MainPage';
 import { MapLoader, ModalMap } from '../components/map';
+import { JoreLoader } from '../components/map/JoreLoader';
 import { Navbar } from '../components/navbar';
 import { CreateNewLinePage } from '../components/routes-and-lines/create-line/CreateNewLinePage';
 import { EditLinePage } from '../components/routes-and-lines/edit-line/EditLinePage';
@@ -172,6 +173,7 @@ export const Router: FunctionComponent = () => {
       </Routes>
       <ModalMap />
       <MapLoader />
+      <JoreLoader />
     </BrowserRouter>
   );
 };


### PR DESCRIPTION
Note to reviewer: the two renaming commits have a small overlap, but since they are conceptually different renames, it is better to have them in their own commits.

Commits:
* Rename isModalOpen variables
Just to clarify that these are flags for modal being open or closed. `IsSaving` points towards something
actively happening while this is true, but that is a bit misleading. Also the onClick handlers
are renamed with the same reason.
* Rename cancel import to abort import
Abort implies towards some process that has already been started and requires revert actions.
Cancel implies more towards clearing something that has not yet been done. The finnish equivalents are
"Keskeytä" and "Peruuta"
* Add LoadingOverlay to import actions
Also disable save and close buttons on preview whilst loading.
Resolves https://github.com/HSLdevcom/jore4/issues/1605

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/729)
<!-- Reviewable:end -->
