### PR TITLE
Fix run-integration-tests actions order

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.18.2'
+
       - name: Install dependencies && check that lockfile is up-to-date
         run: yarn --frozen-lockfile
 
@@ -22,10 +26,6 @@ jobs:
 
       - name: start e2e env
         uses: HSLdevcom/jore4-tools/github-actions/setup-e2e-environment@setup-e2e-environment-v1
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18.18.2'
 
       - name: Build test db manager module
         run: yarn ws:db build


### PR DESCRIPTION
setup-node action is run after we install dependencies, which can cause the version restriction to fail to incompatible versions if the cache has another version at that time. So we need to first setup the correct node version, and then run yarn install. This is also the order in all other workflows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/742)
<!-- Reviewable:end -->
