### PR TITLE
Fix passingTime sorting

### DIFF
--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingTime.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingTime.tsx
@@ -23,7 +23,7 @@ export const PassingTimesByStopTableRowPassingTime = ({
 }: Props): JSX.Element => {
   const sortedPassingTimes = sortBy(
     passingTimes,
-    (passingTime) => passingTime.departure_time,
+    (passingTime) => passingTime.passing_time,
   );
 
   return (


### PR DESCRIPTION
We sorted passing times by `departure_time`, which won't work for last stops, because last stop naturally does not have a departure time. Passing time is a computed field: COALESCE(departure_time, arrival_time) which fixes this problem.

Resolves HSLdevcom/jore4#1617

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/745)
<!-- Reviewable:end -->
