### PR TITLE
Fix daytype order in timetables view

### DIFF
--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -11,9 +11,10 @@ import {
 } from '../../../hooks';
 import { parseI18nField } from '../../../i18n/utils';
 import { Row, Visible } from '../../../layoutComponents';
-import { selectTimetable } from '../../../redux';
+import { selectLoader, selectTimetable } from '../../../redux';
 import { DayType } from '../../../types/enums';
 import { AccordionButton } from '../../../uiComponents';
+import { LoadingWrapper } from '../../../uiComponents/LoadingWrapper';
 import { RouteLabel } from '../../common/RouteLabel';
 import { DirectionBadge } from '../../routes-and-lines/line-details/DirectionBadge';
 import { PassingTimesByStopSection } from '../passing-times-by-stop/PassingTimesByStopSection';
@@ -36,6 +37,7 @@ const testIds = {
   accordionToggle: 'RouteTimetablesSection::AccordionToggle',
   timetableSection: (routeLabel: string, routeDirection: string) =>
     `RouteTimetablesSection::section::${routeLabel}::${routeDirection}`,
+  loadingRouteTimetables: 'LoadingWrapper::loadingRouteTimetables',
 };
 
 export const RouteTimetablesSection = ({
@@ -46,7 +48,7 @@ export const RouteTimetablesSection = ({
   const { showAllValid } = useAppSelector(selectTimetable);
   const [isOpen, toggleIsOpen] = useToggle(initiallyOpen);
   const { activeView, setShowPassingTimesByStop } = useTimetablesViewState();
-
+  const { fetchRouteTimetables } = useAppSelector(selectLoader);
   const routeResult = useGetRouteWithJourneyPatternQuery({
     variables: { routeId },
   });
@@ -96,33 +98,39 @@ export const RouteTimetablesSection = ({
           />
         </div>
       </Row>
-      <Visible visible={isOpen}>
-        <div className="mt-8">
-          {activeView === TimetablesView.DEFAULT && (
-            <div className="grid grid-cols-3 gap-x-8 gap-y-5">
-              {displayedVehicleJourneyGroups?.map((item) => (
-                <VehicleServiceTable
-                  vehicleJourneyGroup={item}
-                  key={`${item.priority}-${item.dayType.day_type_id}`}
-                  onClick={() =>
-                    setShowPassingTimesByStop(route.label, item.dayType.label)
-                  }
-                />
-              ))}
-            </div>
-          )}
-          {activeView === TimetablesView.PASSING_TIMES_BY_STOP &&
-            timetables && (
-              <PassingTimesByStopSection
-                vehicleJourneyGroups={timetables.vehicleJourneyGroups}
-                route={route}
-              />
+      <LoadingWrapper
+        className="flex justify-center p-5"
+        loading={fetchRouteTimetables}
+        testId={testIds.loadingRouteTimetables}
+      >
+        <Visible visible={isOpen}>
+          <div className="mt-8">
+            {activeView === TimetablesView.DEFAULT && (
+              <div className="grid grid-cols-3 gap-x-8 gap-y-5">
+                {displayedVehicleJourneyGroups?.map((item) => (
+                  <VehicleServiceTable
+                    vehicleJourneyGroup={item}
+                    key={`${item.priority}-${item.dayType.day_type_id}`}
+                    onClick={() =>
+                      setShowPassingTimesByStop(route.label, item.dayType.label)
+                    }
+                  />
+                ))}
+              </div>
             )}
-        </div>
-        <Visible visible={!timetables?.vehicleJourneyGroups.length}>
-          <p>{t('timetables.noSchedules')}</p>
+            {activeView === TimetablesView.PASSING_TIMES_BY_STOP &&
+              timetables && (
+                <PassingTimesByStopSection
+                  vehicleJourneyGroups={timetables.vehicleJourneyGroups}
+                  route={route}
+                />
+              )}
+          </div>
+          <Visible visible={!timetables?.vehicleJourneyGroups.length}>
+            <p>{t('timetables.noSchedules')}</p>
+          </Visible>
         </Visible>
-      </Visible>
+      </LoadingWrapper>
     </div>
   );
 };

--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client';
-import orderBy from 'lodash/orderBy';
+import sortBy from 'lodash/sortBy';
 import { useTranslation } from 'react-i18next';
 import { useGetRouteWithJourneyPatternQuery } from '../../../generated/graphql';
 import {
@@ -12,6 +12,7 @@ import {
 import { parseI18nField } from '../../../i18n/utils';
 import { Row, Visible } from '../../../layoutComponents';
 import { selectTimetable } from '../../../redux';
+import { DayType } from '../../../types/enums';
 import { AccordionButton } from '../../../uiComponents';
 import { RouteLabel } from '../../common/RouteLabel';
 import { DirectionBadge } from '../../routes-and-lines/line-details/DirectionBadge';
@@ -60,13 +61,15 @@ export const RouteTimetablesSection = ({
   }
 
   // depending on the showAll mode, we either show all day type timetables
-  // which are currently ordered only by priority
+  // which are currently ordered only by day type
   // OR we only show the one with inEffect value as true.
   const displayedVehicleJourneyGroups = (() => {
     const vehicleJourneyGroups = showAllValid
       ? timetables?.vehicleJourneyGroups
       : timetables?.vehicleJourneyGroups.filter((vjGroup) => vjGroup.inEffect);
-    return orderBy(vehicleJourneyGroups, ['priority'], ['desc']);
+    return sortBy(vehicleJourneyGroups, [
+      (item) => DayType[item.dayType.label as keyof typeof DayType],
+    ]);
   })();
 
   return (

--- a/ui/src/hooks/vehicle-service/useGetRouteTimetables.ts
+++ b/ui/src/hooks/vehicle-service/useGetRouteTimetables.ts
@@ -7,10 +7,11 @@ import {
   VehicleScheduleFragment,
   useGetVehicleSchedulesForDateAsyncQuery,
 } from '../../generated/graphql';
-import { selectChangeTimetableValidityModal } from '../../redux';
+import { Operation, selectChangeTimetableValidityModal } from '../../redux';
 import { findEarliestTime, findLatestTime } from '../../time';
 import { TimetablePriority } from '../../types/enums';
 import { useAppSelector } from '../redux';
+import { useLoader } from '../ui';
 import { useObservationDateQueryParam } from '../urlQuery';
 
 const GQL_DAY_TYPE_FRAGMENT = gql`
@@ -240,6 +241,7 @@ export const useGetRouteTimetables = (journeyPatternId?: UUID) => {
   const changeTimetableValidityModalState = useAppSelector(
     selectChangeTimetableValidityModal,
   );
+  const { setIsLoading } = useLoader(Operation.FetchRouteTimetables);
 
   const [timetables, setTimetables] = useState<TimetableWithMetadata>();
 
@@ -250,7 +252,7 @@ export const useGetRouteTimetables = (journeyPatternId?: UUID) => {
     if (!journeyPatternId) {
       return;
     }
-
+    setIsLoading(true);
     const response = await getVehicleSchedulesForDate({
       journey_pattern_id: journeyPatternId,
       observation_date: observationDate,
@@ -284,7 +286,13 @@ export const useGetRouteTimetables = (journeyPatternId?: UUID) => {
     };
 
     setTimetables(timetableWithMetadata);
-  }, [journeyPatternId, getVehicleSchedulesForDate, observationDate]);
+    setIsLoading(false);
+  }, [
+    journeyPatternId,
+    setIsLoading,
+    getVehicleSchedulesForDate,
+    observationDate,
+  ]);
 
   useEffect(() => {
     getTimetablesForRoute();

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -12,6 +12,7 @@ export enum Operation {
   ConfirmTimetablesImport = 'confirmTimetablesImport',
   UploadFilesToHastusImport = 'uploadFilesToHastusImport',
   AbortImport = 'abortImport',
+  FetchRouteTimetables = 'fetchRouteTimetables',
 }
 
 export const mapOperations = [
@@ -49,6 +50,7 @@ const initialState: IState = {
   [Operation.ConfirmTimetablesImport]: false,
   [Operation.UploadFilesToHastusImport]: false,
   [Operation.AbortImport]: false,
+  [Operation.FetchRouteTimetables]: false,
 };
 
 const slice = createSlice({

--- a/ui/src/types/enums.ts
+++ b/ui/src/types/enums.ts
@@ -52,3 +52,18 @@ export enum SubstituteDayOfWeek {
   Saturday = 'saturday',
   Sunday = 'sunday',
 }
+
+/**
+ * Day type used for example, to sort day types
+ */
+export enum DayType {
+  MA = 1, // Monday
+  TI = 2, // Tuesday
+  KE = 3, // Wednesday
+  TO = 4, // Thursday
+  MT = 5, // Monday-Thursday
+  PE = 6, // Friday
+  MP = 7, // Monday-Friday
+  LA = 8, // Saturday
+  SU = 9, // Sunday
+}


### PR DESCRIPTION
- Added new enum to ease sorting with a day type label. 
- Second commit is refactoring to add a loading indicator when loading timetables.

Closes https://github.com/HSLdevcom/jore4/issues/1618

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/749)
<!-- Reviewable:end -->
