### PR TITLE
Fix an e2e failure due to year changing

### DIFF
--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -237,11 +237,11 @@ const baseTimetableDataInput = {
     },
   },
   _vehicle_schedule_frames: {
-    year2023: {
-      validity_start: DateTime.fromISO('2023-01-01'),
-      validity_end: DateTime.fromISO('2023-12-31'),
-      name: '2023',
-      booking_label: '2023 booking label',
+    defaultFrame: {
+      validity_start: DateTime.fromISO('2020-01-01'),
+      validity_end: DateTime.fromISO('2049-12-31'),
+      name: '2020-2049',
+      booking_label: '2020-2049 booking label',
       _vehicle_services: {
         sunday: {
           day_type_id: defaultDayTypeIds.SUNDAY,
@@ -331,7 +331,7 @@ const verifyBaseTimetableValidity = () => {
     .should('contain', 'Sunnuntai');
   route99InboundSundayPassingTimesSectionStandard.vehicleJourneyGroupInfo
     .getValidityTimeRange()
-    .should('contain', '1.1.2023 - 31.12.2023');
+    .should('contain', '1.1.2020 - 31.12.2049');
 };
 
 describe('Timetable import', () => {
@@ -733,8 +733,8 @@ describe('Timetable import', () => {
           .eq(0)
           .should('contain', 'Voimassa')
           .and('contain', 'Sunnuntai')
-          .and('contain', '1.1.2023')
-          .and('contain', '31.12.2023')
+          .and('contain', '1.1.2020')
+          .and('contain', '31.12.2049')
           .and('contain', '99');
         timetableVersionsPage.timetableVersionTableRow
           .getRow()


### PR DESCRIPTION
The TimetableVersionTableRow component shows a status text for each vehicle schedule frame, which is "Voimassa" for a frame that is still valid today and priority otherwise.
The frame validity ended at the end of last year,
aka not valid anymore, thus the text changed and tests failed.

Could maybe fix by mocking the current date in browser/app or something, but don't see this as worth the effort so just kicking the can down the road (hi 50s?).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/755)
<!-- Reviewable:end -->
