### PR TITLE
Add alternative texts to icons and buttons

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -167,7 +167,12 @@ module.exports = {
     'i18n-json/identical-keys': [
       'error',
       {
-        filePath: path.resolve('./ui/src/locales/fi-FI/common.json'),
+        filePath: {
+          'common.json': path.resolve('./ui/src/locales/fi-FI/common.json'),
+          'accessibility.json': path.resolve(
+            './ui/src/locales/fi-FI/accessibility.json',
+          ),
+        },
       },
     ],
     '@typescript-eslint/no-unused-vars': [

--- a/README.md
+++ b/README.md
@@ -414,6 +414,28 @@ Workspaces-specific dependencies should be installed to workspaces themselves an
 
 Prettier and eslint live currently on workspace root as that allows having same config for those for all workspaces.
 
+## Tips & Tricks
+
+### Yarn lock changed (for no reason)
+
+Did your `yarn.lock` file change without any reason? You can run the following chained commands to get a clean slate:
+
+```sh
+rm -rf node_modules; rm -rf cypress/node_modules/; rm -rf test-db-manager/node_modules/; rm -rf ui/node_modules/ &&
+yarn cache clean &&
+git checkout -- yarn.lock &&
+yarn install
+```
+
+### Docker prune
+
+Running a little low on memory, or the local setup doesn't work for a mystical reason?
+Try pruning your docker registry:
+
+```sh
+docker system prune --all --volumes
+```
+
 ## License
 
 The project license is in [`LICENSE`](./LICENSE).

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -9,7 +9,7 @@ services:
     # https://hub.docker.com/r/hsldevcom/jore4-hasura/tags?page=1&ordering=last_updated
     # The :hsl-tag contains the desired version of hsl specific hasura.
     # Waiting for merging feature-branch to main in hasura-repo
-    image: &hasura-image 'hsldevcom/jore4-hasura:hsl-main--20231222-48ba65d784d28460b8738f3e41161a0b13dc1741'
+    image: &hasura-image 'hsldevcom/jore4-hasura:hsl-main--20240202-67cf974a2a35efd96442a0fca44f35b90b66a9f4'
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:

--- a/ui/src/components/common/LineDetailsButton.tsx
+++ b/ui/src/components/common/LineDetailsButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Path, routeDetails } from '../../router/routeDetails';
 import { IconButton } from '../../uiComponents/IconButton';
@@ -10,6 +11,7 @@ const testIds = {
 interface Props {
   testId?: string;
   lineId: UUID;
+  label: string;
   routeLabel?: string;
   className?: string;
 }
@@ -17,19 +19,22 @@ interface Props {
 export const LineDetailsButton = ({
   testId,
   lineId,
+  label,
   routeLabel,
   className = '',
 }: Props): JSX.Element => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const onClick = () => {
     navigate(routeDetails[Path.lineDetails].getLink(lineId, routeLabel));
   };
   return (
     <IconButton
+      tooltip={t('accessibility:lines.details', { label })}
       className={`h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand ${commonHoverStyle} ${className}`}
       onClick={onClick}
-      icon={<i className="icon-bus-alt" />}
+      icon={<i className="icon-bus-alt" aria-hidden />}
       testId={testId || testIds.button}
     />
   );

--- a/ui/src/components/common/LineTimetablesButton.tsx
+++ b/ui/src/components/common/LineTimetablesButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Path, routeDetails } from '../../router/routeDetails';
 import { IconButton, commonHoverStyle } from '../../uiComponents';
@@ -11,6 +12,7 @@ interface Props {
   disabled?: boolean;
   lineId: UUID;
   routeLabel?: string;
+  label: string;
   className?: string;
 }
 
@@ -19,8 +21,10 @@ export const LineTimetablesButton = ({
   disabled,
   lineId,
   routeLabel,
+  label,
   className = '',
 }: Props): JSX.Element => {
+  const { t } = useTranslation();
   const disabledStyle = '!bg-background opacity-70 pointer-events-none';
   const navigate = useNavigate();
 
@@ -29,12 +33,13 @@ export const LineTimetablesButton = ({
   };
   return (
     <IconButton
+      tooltip={t('accessibility:lines.showTimetables', { label })}
       className={`h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand ${commonHoverStyle} ${
         disabled ? disabledStyle : ''
       } ${className}`}
       onClick={onClick}
       disabled={disabled}
-      icon={<i className="icon-calendar" />}
+      icon={<i className="icon-calendar" aria-hidden />}
       testId={testId || testIds.button}
     />
   );

--- a/ui/src/components/common/RouteLineTableRow.tsx
+++ b/ui/src/components/common/RouteLineTableRow.tsx
@@ -126,6 +126,29 @@ export const RouteLineTableRow = ({
 
   const disabledStyle = 'pointer-events-none text-zinc-400';
 
+  /**
+   * Determine the proper title text for the map button.
+   * The title is mainly relevant for screen readers, but it also helps mouse users with added details.
+   * TODO: This could be done better if the tables were refactored, especially if the "generic" line/route structure is removed at the same time.
+   * @param RowItem
+   * @returns An accessible translated text for this section's buttons.
+   */
+  function getMapButtonTooltip(item: RowItem): string {
+    const { label } = item;
+    // eslint-disable-next-line no-underscore-dangle
+    switch (item.__typename) {
+      case 'route_line': {
+        return t('accessibility:lines.showOnMap', { label });
+      }
+      case 'route_route': {
+        return t('accessibility:routes.showOnMap', { label });
+      }
+      default: {
+        return t('accessibility:common.showOnMap', { label });
+      }
+    }
+  }
+
   return (
     <tr className={className}>
       <Visible visible={!!onSelectChanged}>
@@ -202,6 +225,7 @@ export const RouteLineTableRow = ({
           onClick={onLocatorButtonClick!}
           disabled={!onLocatorButtonClick}
           testId={locatorButtonTestId}
+          tooltipText={getMapButtonTooltip(rowItem)}
         />
       </td>
     </tr>

--- a/ui/src/components/common/RouteLineTableRow.tsx
+++ b/ui/src/components/common/RouteLineTableRow.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import {
   LineTableRowFragment,
   RouteTableRowFragment,
+  ReusableComponentsVehicleModeEnum as VehicleMode,
 } from '../../generated/graphql';
 import { isRoute } from '../../graphql';
 import { useAlertsAndHighLights } from '../../hooks';
@@ -10,6 +11,7 @@ import { Column, Row, Visible } from '../../layoutComponents';
 import { Path, routeDetails } from '../../router/routeDetails';
 import { MAX_DATE, MIN_DATE, mapToShortDate } from '../../time';
 import { LocatorButton } from '../../uiComponents';
+import { VehicleIcon } from '../../uiComponents/VehicleIcon';
 import { AlertPopover } from './AlertPopover';
 import { LineDetailsButton } from './LineDetailsButton';
 import { LineTimetablesButton } from './LineTimetablesButton';
@@ -58,10 +60,16 @@ const getDisplayInformation = (
             className={`icon-calendar text-2xl ${
               hasTimetables ? 'text-tweaked-brand' : 'text-zinc-400'
             }`}
+            title="Timetable" // TODO: Not in a hook, so can't translate this. Refactor `VehicleIcon` or row completely?
+            role="img"
           />
         ),
         alternativeRowActionButton: (
-          <LineDetailsButton lineId={lineId} routeLabel={routeLabel} />
+          <LineDetailsButton
+            lineId={lineId}
+            routeLabel={routeLabel}
+            label={rowItem.label}
+          />
         ),
         linkTo: routeDetails[Path.lineTimetables].getLink(lineId, routeLabel),
         isDisabled: !hasTimetables,
@@ -69,12 +77,21 @@ const getDisplayInformation = (
     case RouteLineTableRowVariant.RoutesAndLines:
     default:
       return {
-        rowIcon: <i className="icon-bus-alt text-2xl text-tweaked-brand" />,
+        rowIcon: (
+          <VehicleIcon
+            className="text-2xl text-tweaked-brand"
+            vehicleMode={
+              VehicleMode.Bus /* TODO: This hardcode needs proper logic when other vehicles are implemented */
+            }
+            rowItem={rowItem}
+          />
+        ),
         alternativeRowActionButton: (
           <LineTimetablesButton
             disabled={!hasTimetables}
             lineId={lineId}
             routeLabel={routeLabel}
+            label={rowItem.label}
           />
         ),
         linkTo: routeDetails[Path.lineDetails].getLink(lineId, routeLabel),

--- a/ui/src/components/common/RouteLineTableRow.tsx
+++ b/ui/src/components/common/RouteLineTableRow.tsx
@@ -11,6 +11,7 @@ import { Column, Row, Visible } from '../../layoutComponents';
 import { Path, routeDetails } from '../../router/routeDetails';
 import { MAX_DATE, MIN_DATE, mapToShortDate } from '../../time';
 import { LocatorButton } from '../../uiComponents';
+import { TimetableIcon } from '../../uiComponents/TimetableIcon';
 import { VehicleIcon } from '../../uiComponents/VehicleIcon';
 import { AlertPopover } from './AlertPopover';
 import { LineDetailsButton } from './LineDetailsButton';
@@ -56,13 +57,7 @@ const getDisplayInformation = (
     case RouteLineTableRowVariant.Timetables:
       return {
         rowIcon: (
-          <i
-            className={`icon-calendar text-2xl ${
-              hasTimetables ? 'text-tweaked-brand' : 'text-zinc-400'
-            }`}
-            title="Timetable" // TODO: Not in a hook, so can't translate this. Refactor `VehicleIcon` or row completely?
-            role="img"
-          />
+          <TimetableIcon className="text-2xl" hasTimetables={hasTimetables} />
         ),
         alternativeRowActionButton: (
           <LineDetailsButton

--- a/ui/src/components/common/Tooltip.tsx
+++ b/ui/src/components/common/Tooltip.tsx
@@ -9,6 +9,8 @@ interface Props {
  * <Tooltip className="bottom-11 delay-700" message="Tooltip message">
  *   ...
  * </Tooltip>
+ * As of Jan 2024, not in active use anymore.
+ * There are designs for such an element to show extra information for Timing Points.
  */
 export const Tooltip: React.FC<Props> = ({
   message,

--- a/ui/src/components/forms/common/FormColumn.tsx
+++ b/ui/src/components/forms/common/FormColumn.tsx
@@ -3,10 +3,17 @@ import { Column } from '../../../layoutComponents';
 
 interface Props {
   className?: string;
+  id?: string;
 }
 
-export const FormColumn: React.FC<Props> = ({ className = '', children }) => {
+export const FormColumn: React.FC<Props> = ({
+  className = '',
+  id,
+  children,
+}) => {
   return (
-    <Column className={`${className} w-full space-y-5`}>{children}</Column>
+    <Column className={`${className} w-full space-y-5`} id={id}>
+      {children}
+    </Column>
   );
 };

--- a/ui/src/components/forms/common/PriorityForm.tsx
+++ b/ui/src/components/forms/common/PriorityForm.tsx
@@ -65,9 +65,8 @@ export const PriorityForm = ({ hiddenPriorities }: Props): JSX.Element => {
 
   return (
     <Column>
-      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-      <label>{t('priority.label')}</label>
-      <Row className="flex-wrap gap-2">
+      <label htmlFor="priorityButtons">{t('priority.label')}</label>
+      <Row identifier="priorityButtons" className="flex-wrap gap-2">
         {displayedPriorities.map(
           ({ priority, testIdPrefix, translationKey }) => (
             <SimpleButton

--- a/ui/src/components/forms/line/LinePropertiesForm.tsx
+++ b/ui/src/components/forms/line/LinePropertiesForm.tsx
@@ -85,9 +85,13 @@ export const LinePropertiesForm = ({ className = '' }: Props): JSX.Element => {
           />
         </FormRow>
         <Row className="items-center">
-          <label className="my-0 cursor-pointer text-base font-normal">
+          <label
+            htmlFor="showNameVersionsToggle"
+            className="my-0 cursor-pointer text-base font-normal"
+          >
             {t('lines.showNameVersions')}
             <AccordionButton
+              identifier="showNameVersionsToggle"
               className="ml-1"
               isOpen={showNameVersions}
               onToggle={setShowNameVersions}

--- a/ui/src/components/forms/line/LinePropertiesForm.tsx
+++ b/ui/src/components/forms/line/LinePropertiesForm.tsx
@@ -92,11 +92,14 @@ export const LinePropertiesForm = ({ className = '' }: Props): JSX.Element => {
               isOpen={showNameVersions}
               onToggle={setShowNameVersions}
               testId={testIds.showNameVersionsButton}
+              openTooltip={t('accessibility:lines.expandNameVersions')}
+              closeTooltip={t('accessibility:lines.closeNameVersions')}
+              controls="nameVersions"
             />
           </label>
         </Row>
         {showNameVersions && (
-          <FormColumn>
+          <FormColumn id="nameVersions">
             <FormRow mdColumns={3}>
               <InputField<FormState>
                 type="text"

--- a/ui/src/components/forms/line/LinePropertiesForm.tsx
+++ b/ui/src/components/forms/line/LinePropertiesForm.tsx
@@ -85,13 +85,15 @@ export const LinePropertiesForm = ({ className = '' }: Props): JSX.Element => {
           />
         </FormRow>
         <Row className="items-center">
-          <span>{t('lines.showNameVersions')}</span>
-          <AccordionButton
-            className="ml-1"
-            isOpen={showNameVersions}
-            onToggle={setShowNameVersions}
-            testId={testIds.showNameVersionsButton}
-          />
+          <label className="my-0 cursor-pointer text-base font-normal">
+            {t('lines.showNameVersions')}
+            <AccordionButton
+              className="ml-1"
+              isOpen={showNameVersions}
+              onToggle={setShowNameVersions}
+              testId={testIds.showNameVersionsButton}
+            />
+          </label>
         </Row>
         {showNameVersions && (
           <FormColumn>

--- a/ui/src/components/forms/route/TemplateRouteSelector.tsx
+++ b/ui/src/components/forms/route/TemplateRouteSelector.tsx
@@ -34,9 +34,8 @@ export const TemplateRouteSelector = ({
       <h3 className="mb-4">{t('routes.searchTemplate')}</h3>
       <Row className="mb-4">
         <Column>
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label>{t('priority.label')}</label>
-          <Row className="space-x-1">
+          <label htmlFor="priorityButtons">{t('priority.label')}</label>
+          <Row identifier="priorityButtons" className="space-x-1">
             <SimpleButton
               onClick={() => setPriority(Priority.Standard)}
               inverted={priority !== Priority.Standard}

--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -1,4 +1,5 @@
 import React, { Ref, useImperativeHandle, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { HTMLOverlay, Layer, MapEvent } from 'react-map-gl';
 import {
   useAppDispatch,
@@ -139,6 +140,8 @@ export const MapComponent = (
     }
   };
 
+  const { t } = useTranslation();
+
   return (
     <Maplibre
       width={width}
@@ -167,6 +170,7 @@ export const MapComponent = (
                     onToggle: setShowRoute,
                     disabled: !routeDisplayed,
                     testId: 'FilterPanel::toggleShowBusRoutes',
+                    tooltip: t('vehicleModeEnum.bus'),
                   },
                   // We want to show placeholder toggles of unimplemented features for visual purposes
                   ...placeholderToggles,
@@ -177,6 +181,7 @@ export const MapComponent = (
                     active: isFilterActive(FilterType.ShowAllBusStops),
                     onToggle: toggleFunction(FilterType.ShowAllBusStops),
                     testId: 'FilterPanel::toggleShowAllBusStops',
+                    tooltip: t('vehicleModeEnum.bus'),
                   },
                   ...placeholderToggles,
                 ]}

--- a/ui/src/components/map/ObservationDateOverlay.tsx
+++ b/ui/src/components/map/ObservationDateOverlay.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { MdLayers } from 'react-icons/md';
 import { useAppSelector, useFilterStops } from '../../hooks';
 import { Column, Row } from '../../layoutComponents';
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export const ObservationDateOverlay = ({ className = '' }: Props) => {
+  const { t } = useTranslation();
   const { toggleShowFilters } = useFilterStops();
   const hasChangesInProgress = useAppSelector(selectHasChangesInProgress);
 
@@ -23,8 +25,11 @@ export const ObservationDateOverlay = ({ className = '' }: Props) => {
           </Column>
           <Column>
             <IconButton
+              tooltip={t('accessibility:map.showFilters')}
               className="block h-11 w-11 self-stretch rounded-md border border-black"
-              icon={<MdLayers className="text-2xl text-tweaked-brand" />}
+              icon={
+                <MdLayers className="aria-hidden text-2xl text-tweaked-brand" />
+              }
               onClick={toggleShowFilters}
             />
           </Column>

--- a/ui/src/components/map/RouteStopsOverlay.tsx
+++ b/ui/src/components/map/RouteStopsOverlay.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { pipe } from 'remeda';
 import {
   belongsToJourneyPattern,
@@ -39,6 +40,8 @@ export const RouteStopsOverlay = ({ className = '' }: Props): JSX.Element => {
   const { selectedRouteId, creatingNewRoute } =
     useAppSelector(selectMapRouteEditor);
 
+  const { t } = useTranslation();
+
   const {
     routeMetadata,
     includedStopLabels,
@@ -68,7 +71,7 @@ export const RouteStopsOverlay = ({ className = '' }: Props): JSX.Element => {
     : highestPriorityStopsEligibleForJourneyPattern.filter((stop) =>
         belongsToJourneyPattern(includedStopLabels, stop.label),
       );
-
+  const routeName = routeMetadata?.name_i18n.fi_FI;
   return (
     <MapOverlay className={className}>
       <MapOverlayHeader testId={testIds.mapOverlayHeader}>
@@ -80,13 +83,12 @@ export const RouteStopsOverlay = ({ className = '' }: Props): JSX.Element => {
               variant={routeMetadata.variant}
             />
           </h2>
-          <p className="text-light text-xs text-gray-500">
-            {routeMetadata?.name_i18n.fi_FI}
-          </p>
+          <p className="text-light text-xs text-gray-500">{routeName}</p>
         </div>
         <Visible visible={creatingNewRoute}>
           <EditButton
             onClick={() => dispatch(setRouteMetadataFormOpenAction(true))}
+            tooltip={t('accessibility:map.editRoute', { routeName })}
           />
         </Visible>
       </MapOverlayHeader>

--- a/ui/src/components/map/RouteStopsOverlayRow.tsx
+++ b/ui/src/components/map/RouteStopsOverlayRow.tsx
@@ -62,6 +62,9 @@ export const RouteStopsOverlayRow = ({
           <SimpleDropdownMenu
             alignItems={AlignDirection.Left}
             testId={testIds.menuButton(stop.label)}
+            tooltip={t('accessibility:map.routeStopsOverlayRowActions', {
+              stopLabel: stop.label,
+            })}
           >
             <button
               type="button"

--- a/ui/src/components/routes-and-lines/line-details/AdditionalInformation.tsx
+++ b/ui/src/components/routes-and-lines/line-details/AdditionalInformation.tsx
@@ -38,6 +38,7 @@ export const AdditionalInformation: React.FC<Props> = ({
         <EditButton
           href={routeDetails[Path.editLine].getLink(line.line_id)}
           testId={testIds.editLineButton}
+          tooltip={t('accessibility:lines.edit', { label: line.label })}
         />
       </Row>
       <Row className="mb-5">

--- a/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
@@ -6,6 +6,7 @@ import {
   RouteDirectionEnum,
 } from '../../../generated/graphql';
 import { useAlertsAndHighLights, useShowRoutesOnModal } from '../../../hooks';
+import { mapDirectionToShortUiName } from '../../../i18n/uiNameMappings';
 import { parseI18nField } from '../../../i18n/utils';
 import { Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
@@ -61,11 +62,12 @@ export const ExpandableRouteRow = ({
   const onClickShowRouteOnMap = () => {
     showRouteOnMap(route);
   };
-
+  const { label } = route;
+  const directionNumber = mapDirectionToShortUiName(route.direction);
   return (
     <tr
       className={`border border-white bg-background ${className} p-4`}
-      data-testid={testIds.container(route.label)}
+      data-testid={testIds.container(label)}
     >
       <td className={`${alertStyle.listItemBorder || ''} p-4 pl-12`}>
         <Row className="items-center">
@@ -75,7 +77,7 @@ export const ExpandableRouteRow = ({
             titleName={t(`directionEnum.${route.direction}`)}
           />
           <span className="text-xl" data-testid={testIds.label}>
-            <RouteLabel label={route.label} variant={route.variant} />
+            <RouteLabel label={label} variant={route.variant} />
           </span>
         </Row>
       </td>
@@ -123,7 +125,10 @@ export const ExpandableRouteRow = ({
             !route.route_shape /* some routes imported from jore3 are missing the geometry */
           }
           testId={testIds.showRouteButton}
-          tooltipText={route.label}
+          tooltipText={t('accessibility:routes.showOnMapDirection', {
+            label,
+            directionNumber,
+          })}
         />
       </td>
       <td className="w-20">

--- a/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
@@ -115,11 +115,14 @@ export const ExpandableRouteRow = ({
         </Row>
       </td>
       <td className="p-4">
-        <Row className="items-center justify-end">
+        <Row
+          className="items-center justify-end"
+          tooltip={t('accessibility:lines.versionHistory')}
+        >
           <span data-testid={testIds.lastEdited}>
             !{mapToShortDateTime(DateTime.now())}
           </span>
-          <MdHistory className="ml-2 inline text-xl text-tweaked-brand" />
+          <MdHistory className="aria-hidden ml-2 inline text-xl text-tweaked-brand" />
         </Row>
       </td>
       <td className="w-20 border-l-4 border-r-4 border-white px-6 text-center">

--- a/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
@@ -138,6 +138,15 @@ export const ExpandableRouteRow = ({
           isOpen={isExpanded}
           onToggle={onToggle}
           testId={testIds.toggleAccordion}
+          openTooltip={t('accessibility:routes.expandStops', {
+            label,
+            directionNumber,
+          })}
+          closeTooltip={t('accessibility:routes.closeStops', {
+            label,
+            directionNumber,
+          })}
+          controls="" // The current structure does not support this logically, the expandable row is in the same section as the items it controls
         />
       </td>
     </tr>

--- a/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
@@ -123,6 +123,7 @@ export const ExpandableRouteRow = ({
             !route.route_shape /* some routes imported from jore3 are missing the geometry */
           }
           testId={testIds.showRouteButton}
+          tooltipText={route.label}
         />
       </td>
       <td className="w-20">

--- a/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
@@ -92,6 +92,10 @@ export const ExpandableRouteRow = ({
               observationDate.toISODate(),
             )}
             testId={testIds.editRouteButton(parseI18nField(route.name_i18n))}
+            tooltip={t('accessibility:routes.editRouteDirection', {
+              label,
+              directionNumber,
+            })}
           />
         </Row>
       </td>

--- a/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
@@ -54,7 +54,6 @@ export const LineTitle: React.FC<Props> = ({
   };
 
   const lineRoutes = uniqBy(line.line_routes, (route) => route.label);
-
   return (
     <Column>
       <Row className={`items-center ${className}`}>
@@ -74,7 +73,9 @@ export const LineTitle: React.FC<Props> = ({
         </span>
         {onCreateRoute && (
           <IconButton
-            title={t(`accessibility:routes.createNew`)}
+            tooltip={t(`accessibility:lines.createNewRoute`, {
+              label: line.label,
+            })}
             testId={testIds.createRouteButton}
             icon={<AiFillPlusCircle className="ml-2 text-3xl text-brand" />}
             onClick={onCreateRoute}

--- a/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
@@ -74,7 +74,7 @@ export const LineTitle: React.FC<Props> = ({
         </span>
         {onCreateRoute && (
           <IconButton
-            title={t(`accessibility:button.route.createNew`)}
+            title={t(`accessibility:routes.createNew`)}
             testId={testIds.createRouteButton}
             icon={<AiFillPlusCircle className="ml-2 text-3xl text-brand" />}
             onClick={onCreateRoute}

--- a/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
@@ -74,6 +74,7 @@ export const LineTitle: React.FC<Props> = ({
         </span>
         {onCreateRoute && (
           <IconButton
+            title={t(`accessibility:button.route.createNew`)}
             testId={testIds.createRouteButton}
             icon={<AiFillPlusCircle className="ml-2 text-3xl text-brand" />}
             onClick={onCreateRoute}

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
@@ -159,6 +159,7 @@ export const RouteStopsRow = ({
       </td>
       <td>
         <StopActionsDropdown
+          tooltip={t('accessibility:routes.showStopActions', { stopLabel })}
           stopLabel={stopLabel}
           stopBelongsToJourneyPattern={stopBelongsToJourneyPattern}
           isViaPoint={isViaPoint}

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsTable.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsTable.tsx
@@ -26,7 +26,7 @@ export const RouteStopsTable = ({ className = '', routes, testId }: Props) => {
     <div>
       <div className="flex items-center">
         <HuiSwitch.Group>
-          <SwitchLabel className="my-8 mr-8">
+          <SwitchLabel className="my-8 mr-4">
             {t('routes.showUnusedStops')}
           </SwitchLabel>
           <Switch

--- a/ui/src/components/routes-and-lines/line-details/StopActionsDropdown.tsx
+++ b/ui/src/components/routes-and-lines/line-details/StopActionsDropdown.tsx
@@ -24,6 +24,7 @@ interface Props {
   isViaPoint: boolean | undefined;
   onAddToRoute: (stopLabel: string) => void;
   onRemoveFromRoute: (stopLabel: string) => void;
+  tooltip: string;
 }
 
 export const StopActionsDropdown = ({
@@ -34,6 +35,7 @@ export const StopActionsDropdown = ({
   isViaPoint,
   onAddToRoute,
   onRemoveFromRoute,
+  tooltip,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -62,7 +64,11 @@ export const StopActionsDropdown = ({
   };
 
   return (
-    <SimpleDropdownMenu alignItems={AlignDirection.Left} testId={testIds.menu}>
+    <SimpleDropdownMenu
+      alignItems={AlignDirection.Left}
+      testId={testIds.menu}
+      tooltip={tooltip}
+    >
       {stopBelongsToJourneyPattern ? (
         <SimpleDropdownMenuItem
           onClick={() => onRemoveFromRoute(stopLabel)}

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -535,7 +535,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
                 type="button"
               >
                 <svg
-                  class="text-3xl"
+                  class="aria-hidden text-3xl"
                   fill="currentColor"
                   height="1em"
                   stroke="currentColor"
@@ -653,7 +653,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
                 type="button"
               >
                 <svg
-                  class="text-3xl"
+                  class="aria-hidden text-3xl"
                   fill="currentColor"
                   height="1em"
                   stroke="currentColor"
@@ -993,7 +993,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
                 type="button"
               >
                 <svg
-                  class="text-3xl"
+                  class="aria-hidden text-3xl"
                   fill="currentColor"
                   height="1em"
                   stroke="currentColor"
@@ -1111,7 +1111,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
                 type="button"
               >
                 <svg
-                  class="text-3xl"
+                  class="aria-hidden text-3xl"
                   fill="currentColor"
                   height="1em"
                   stroke="currentColor"
@@ -1229,7 +1229,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
                 type="button"
               >
                 <svg
-                  class="text-3xl"
+                  class="aria-hidden text-3xl"
                   fill="currentColor"
                   height="1em"
                   stroke="currentColor"

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
       class="flex items-center"
     >
       <label
-        class="my-8 mr-8 text-base font-normal"
+        class="my-8 mr-4 text-base font-normal"
         id="headlessui-label-:r0:"
       >
         Näytä reittiin kuulumattomat pysäkit
@@ -44,6 +44,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span
                 class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-4"
@@ -71,6 +72,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span
                 class="text-xl"
@@ -114,6 +116,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Voimassa 1.1.2000 - 13.12.2050
             </div>
@@ -123,6 +126,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title="Versiohistoria"
             >
               <span
                 data-testid="ExpandableRouteRow::lastEdited"
@@ -130,7 +134,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
                 !14.2.2017 14.51
               </span>
               <svg
-                class="ml-2 inline text-xl text-tweaked-brand"
+                class="aria-hidden ml-2 inline text-xl text-tweaked-brand"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
@@ -225,7 +229,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
       class="flex items-center"
     >
       <label
-        class="my-8 mr-8 text-base font-normal"
+        class="my-8 mr-4 text-base font-normal"
         id="headlessui-label-:r0:"
       >
         Näytä reittiin kuulumattomat pysäkit
@@ -262,6 +266,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span
                 class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-4"
@@ -289,6 +294,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span
                 class="text-xl"
@@ -332,6 +338,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Voimassa 1.1.2000 - 13.12.2050
             </div>
@@ -341,6 +348,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title="Versiohistoria"
             >
               <span
                 data-testid="ExpandableRouteRow::lastEdited"
@@ -348,7 +356,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
                 !14.2.2017 14.51
               </span>
               <svg
-                class="ml-2 inline text-xl text-tweaked-brand"
+                class="aria-hidden ml-2 inline text-xl text-tweaked-brand"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
@@ -446,6 +454,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span>
                 !Pysäkki X
@@ -458,6 +467,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Voimassa 1.1.2000 - 13.12.2050
             </div>
@@ -467,6 +477,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               <span
                 data-testid="RouteStopsRow::lastEdited"
@@ -496,6 +507,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           <td>
             <div
               class="flex flex-row justify-center"
+              title=""
             >
               <div>
                 <span
@@ -511,6 +523,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
             <div
               class="relative"
               data-headlessui-state=""
+              title="Lisää toimintoja pysäkille H1234"
             >
               <button
                 aria-expanded="false"
@@ -559,6 +572,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span>
                 !Pysäkki X
@@ -571,6 +585,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Voimassa 1.1.2000 - 13.12.2050
             </div>
@@ -580,6 +595,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               <span
                 data-testid="RouteStopsRow::lastEdited"
@@ -609,6 +625,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           <td>
             <div
               class="flex flex-row justify-center"
+              title=""
             >
               <div>
                 <span
@@ -624,6 +641,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
             <div
               class="relative"
               data-headlessui-state=""
+              title="Lisää toimintoja pysäkille H1236"
             >
               <button
                 aria-expanded="false"
@@ -669,7 +687,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
       class="flex items-center"
     >
       <label
-        class="my-8 mr-8 text-base font-normal"
+        class="my-8 mr-4 text-base font-normal"
         id="headlessui-label-:r0:"
       >
         Näytä reittiin kuulumattomat pysäkit
@@ -706,6 +724,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span
                 class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-4"
@@ -733,6 +752,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span
                 class="text-xl"
@@ -776,6 +796,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Voimassa 1.1.2000 - 13.12.2050
             </div>
@@ -785,6 +806,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title="Versiohistoria"
             >
               <span
                 data-testid="ExpandableRouteRow::lastEdited"
@@ -792,7 +814,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
                 !14.2.2017 14.51
               </span>
               <svg
-                class="ml-2 inline text-xl text-tweaked-brand"
+                class="aria-hidden ml-2 inline text-xl text-tweaked-brand"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
@@ -890,6 +912,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span>
                 !Pysäkki X
@@ -902,6 +925,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Voimassa 1.1.2000 - 13.12.2050
             </div>
@@ -911,6 +935,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               <span
                 data-testid="RouteStopsRow::lastEdited"
@@ -940,6 +965,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           <td>
             <div
               class="flex flex-row justify-center"
+              title=""
             >
               <div>
                 <span
@@ -955,6 +981,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
             <div
               class="relative"
               data-headlessui-state=""
+              title="Lisää toimintoja pysäkille H1234"
             >
               <button
                 aria-expanded="false"
@@ -1003,6 +1030,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span>
                 !Pysäkki X
@@ -1015,6 +1043,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Ei reitin käytössä
             </div>
@@ -1024,6 +1053,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               <span
                 data-testid="RouteStopsRow::lastEdited"
@@ -1053,6 +1083,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           <td>
             <div
               class="flex flex-row justify-center"
+              title=""
             >
               <div>
                 <span
@@ -1068,6 +1099,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
             <div
               class="relative"
               data-headlessui-state=""
+              title="Lisää toimintoja pysäkille H1235"
             >
               <button
                 aria-expanded="false"
@@ -1116,6 +1148,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <span>
                 !Pysäkki X
@@ -1128,6 +1161,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               Voimassa 1.1.2000 - 13.12.2050
             </div>
@@ -1137,6 +1171,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <div
               class="flex flex-row items-center justify-end"
+              title=""
             >
               <span
                 data-testid="RouteStopsRow::lastEdited"
@@ -1166,6 +1201,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           <td>
             <div
               class="flex flex-row justify-center"
+              title=""
             >
               <div>
                 <span
@@ -1181,6 +1217,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
             <div
               class="relative"
               data-headlessui-state=""
+              title="Lisää toimintoja pysäkille H1236"
             >
               <button
                 aria-expanded="false"

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -81,12 +81,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
               <a
                 data-testid="ExpandableRouteRow::editRouteButton::Reitti A - B FI"
                 href="/routes/03d55414-e5cf-4cce-9faf-d86ccb7e5f98/edit?observationDate=2017-02-14"
+                title="Muokkaa reittiä 65x, suunta 1"
               >
                 <div
                   class="ml-5 flex h-10 w-10 items-center justify-center rounded-full border border-grey bg-white hover:border-2 hover:border-tweaked-brand"
                 >
                   <svg
-                    class="text-2xl text-tweaked-brand"
+                    class="aria-hidden text-2xl text-tweaked-brand"
                     fill="currentColor"
                     height="1em"
                     stroke="currentColor"
@@ -154,7 +155,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
             <button
               class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
               data-testid="ExpandableRouteRow::showRouteButton"
-              title="65x"
+              title="Näytä kartalla reitti 65x, suunta 1"
               type="button"
             >
               <svg
@@ -186,12 +187,12 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
               aria-expanded="false"
               class="text-center h-full w-full"
               data-testid="ExpandableRouteRow::toggleAccordion"
-              title="Näytä pysäkit reitille Reitti A - B FI"
+              title="Näytä pysäkit reitille 65x, suunta 1"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="text-3xl text-tweaked-brand text-3xl  inline text-center"
+                class="text-3xl text-tweaked-brand text-3xl pointer-events-none inline text-center"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
@@ -298,12 +299,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
               <a
                 data-testid="ExpandableRouteRow::editRouteButton::Reitti A - B FI"
                 href="/routes/03d55414-e5cf-4cce-9faf-d86ccb7e5f98/edit?observationDate=2017-02-14"
+                title="Muokkaa reittiä 65x, suunta 1"
               >
                 <div
                   class="ml-5 flex h-10 w-10 items-center justify-center rounded-full border border-grey bg-white hover:border-2 hover:border-tweaked-brand"
                 >
                   <svg
-                    class="text-2xl text-tweaked-brand"
+                    class="aria-hidden text-2xl text-tweaked-brand"
                     fill="currentColor"
                     height="1em"
                     stroke="currentColor"
@@ -371,7 +373,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
             <button
               class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
               data-testid="ExpandableRouteRow::showRouteButton"
-              title="65x"
+              title="Näytä kartalla reitti 65x, suunta 1"
               type="button"
             >
               <svg
@@ -403,12 +405,12 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
               aria-expanded="true"
               class="text-center h-full w-full"
               data-testid="ExpandableRouteRow::toggleAccordion"
-              title="Piilota pysäkit reitiltä Reitti A - B FI"
+              title="Piilota pysäkit reitiltä 65x, suunta 1"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="text-3xl text-tweaked-brand text-3xl inline text-center"
+                class="text-3xl text-tweaked-brand text-3xl pointer-events-none inline text-center"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
@@ -741,12 +743,13 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
               <a
                 data-testid="ExpandableRouteRow::editRouteButton::Reitti A - B FI"
                 href="/routes/03d55414-e5cf-4cce-9faf-d86ccb7e5f98/edit?observationDate=2017-02-14"
+                title="Muokkaa reittiä 65x, suunta 1"
               >
                 <div
                   class="ml-5 flex h-10 w-10 items-center justify-center rounded-full border border-grey bg-white hover:border-2 hover:border-tweaked-brand"
                 >
                   <svg
-                    class="text-2xl text-tweaked-brand"
+                    class="aria-hidden text-2xl text-tweaked-brand"
                     fill="currentColor"
                     height="1em"
                     stroke="currentColor"
@@ -814,7 +817,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
             <button
               class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
               data-testid="ExpandableRouteRow::showRouteButton"
-              title="65x"
+              title="Näytä kartalla reitti 65x, suunta 1"
               type="button"
             >
               <svg
@@ -846,12 +849,12 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
               aria-expanded="true"
               class="text-center h-full w-full"
               data-testid="ExpandableRouteRow::toggleAccordion"
-              title="Piilota pysäkit reitiltä Reitti A - B FI"
+              title="Piilota pysäkit reitiltä 65x, suunta 1"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="text-3xl text-tweaked-brand text-3xl inline text-center"
+                class="text-3xl text-tweaked-brand text-3xl pointer-events-none inline text-center"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -151,50 +151,46 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
           <td
             class="w-20 border-l-4 border-r-4 border-white px-6 text-center"
           >
-            <div
-              class="group relative flex justify-center"
+            <button
+              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
+              data-testid="ExpandableRouteRow::showRouteButton"
+              title="65x"
+              type="button"
             >
-              <span
-                class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+              <svg
+                aria-hidden="true"
+                class="text-2xl inline text-center"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Näytä kartalla
-              </span>
-              <button
-                class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
-                data-testid="ExpandableRouteRow::showRouteButton"
-                type="button"
-              >
-                <svg
-                  class="text-2xl inline text-center"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                  />
-                </svg>
-              </button>
-            </div>
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+                />
+              </svg>
+            </button>
           </td>
           <td
             class="w-20"
           >
             <button
+              aria-controls=""
+              aria-expanded="false"
               class="text-center h-full w-full"
               data-testid="ExpandableRouteRow::toggleAccordion"
+              title="Näytä pysäkit reitille Reitti A - B FI"
               type="button"
             >
               <svg
+                aria-hidden="true"
                 class="text-3xl text-tweaked-brand text-3xl  inline text-center"
                 fill="currentColor"
                 height="1em"
@@ -372,50 +368,46 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           <td
             class="w-20 border-l-4 border-r-4 border-white px-6 text-center"
           >
-            <div
-              class="group relative flex justify-center"
+            <button
+              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
+              data-testid="ExpandableRouteRow::showRouteButton"
+              title="65x"
+              type="button"
             >
-              <span
-                class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+              <svg
+                aria-hidden="true"
+                class="text-2xl inline text-center"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Näytä kartalla
-              </span>
-              <button
-                class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
-                data-testid="ExpandableRouteRow::showRouteButton"
-                type="button"
-              >
-                <svg
-                  class="text-2xl inline text-center"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                  />
-                </svg>
-              </button>
-            </div>
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+                />
+              </svg>
+            </button>
           </td>
           <td
             class="w-20"
           >
             <button
+              aria-controls=""
+              aria-expanded="true"
               class="text-center h-full w-full"
               data-testid="ExpandableRouteRow::toggleAccordion"
+              title="Piilota pysäkit reitiltä Reitti A - B FI"
               type="button"
             >
               <svg
+                aria-hidden="true"
                 class="text-3xl text-tweaked-brand text-3xl inline text-center"
                 fill="currentColor"
                 height="1em"
@@ -819,50 +811,46 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           <td
             class="w-20 border-l-4 border-r-4 border-white px-6 text-center"
           >
-            <div
-              class="group relative flex justify-center"
+            <button
+              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
+              data-testid="ExpandableRouteRow::showRouteButton"
+              title="65x"
+              type="button"
             >
-              <span
-                class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+              <svg
+                aria-hidden="true"
+                class="text-2xl inline text-center"
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Näytä kartalla
-              </span>
-              <button
-                class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
-                data-testid="ExpandableRouteRow::showRouteButton"
-                type="button"
-              >
-                <svg
-                  class="text-2xl inline text-center"
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                  />
-                </svg>
-              </button>
-            </div>
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+                />
+              </svg>
+            </button>
           </td>
           <td
             class="w-20"
           >
             <button
+              aria-controls=""
+              aria-expanded="true"
               class="text-center h-full w-full"
               data-testid="ExpandableRouteRow::toggleAccordion"
+              title="Piilota pysäkit reitiltä Reitti A - B FI"
               type="button"
             >
               <svg
+                aria-hidden="true"
                 class="text-3xl text-tweaked-brand text-3xl inline text-center"
                 fill="currentColor"
                 height="1em"

--- a/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
@@ -34,6 +34,8 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
                   </h2>
                   <i
                     class="icon-bus-alt text-2xl text-tweaked-brand"
+                    role="img"
+                    title="Bussilinja"
                   />
                 </div>
                 <p>
@@ -62,9 +64,11 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
             class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
             data-testid="LocatorButton::button"
             disabled=""
+            title="Näytä aikataulut linjalle 65"
             type="button"
           >
             <i
+              aria-hidden="true"
               class="icon-calendar inline text-center"
             />
           </button>
@@ -72,40 +76,32 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
-          <div
-            class="group relative flex justify-center"
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
+            data-testid="LineTableRow::showLineRoutes"
+            title="Näytä kartalla linja 65"
+            type="button"
           >
-            <span
-              class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+            <svg
+              aria-hidden="true"
+              class="text-2xl inline text-center"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Näytä kartalla
-            </span>
-            <button
-              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
-              data-testid="LineTableRow::showLineRoutes"
-              type="button"
-            >
-              <svg
-                class="text-2xl inline text-center"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                />
-                <path
-                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -135,6 +131,8 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
                   </h2>
                   <i
                     class="icon-bus-alt text-2xl text-tweaked-brand"
+                    role="img"
+                    title="Bussilinja"
                   />
                 </div>
                 <p>
@@ -163,9 +161,11 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
             class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
             data-testid="LocatorButton::button"
             disabled=""
+            title="Näytä aikataulut linjalle 71"
             type="button"
           >
             <i
+              aria-hidden="true"
               class="icon-calendar inline text-center"
             />
           </button>
@@ -173,40 +173,32 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
-          <div
-            class="group relative flex justify-center"
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
+            data-testid="LineTableRow::showLineRoutes"
+            title="Näytä kartalla linja 71"
+            type="button"
           >
-            <span
-              class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+            <svg
+              aria-hidden="true"
+              class="text-2xl inline text-center"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Näytä kartalla
-            </span>
-            <button
-              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
-              data-testid="LineTableRow::showLineRoutes"
-              type="button"
-            >
-              <svg
-                class="text-2xl inline text-center"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                />
-                <path
-                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -236,6 +228,8 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
                   </h2>
                   <i
                     class="icon-bus-alt text-2xl text-tweaked-brand"
+                    role="img"
+                    title="Bussilinja"
                   />
                 </div>
                 <p>
@@ -264,9 +258,11 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
             class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
             data-testid="LocatorButton::button"
             disabled=""
+            title="Näytä aikataulut linjalle 785K"
             type="button"
           >
             <i
+              aria-hidden="true"
               class="icon-calendar inline text-center"
             />
           </button>
@@ -274,40 +270,32 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
-          <div
-            class="group relative flex justify-center"
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
+            data-testid="LineTableRow::showLineRoutes"
+            title="Näytä kartalla linja 785K"
+            type="button"
           >
-            <span
-              class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+            <svg
+              aria-hidden="true"
+              class="text-2xl inline text-center"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Näytä kartalla
-            </span>
-            <button
-              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
-              data-testid="LineTableRow::showLineRoutes"
-              type="button"
-            >
-              <svg
-                class="text-2xl inline text-center"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                />
-                <path
-                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+              />
+            </svg>
+          </button>
         </td>
       </tr>
       <tr
@@ -337,6 +325,8 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
                   </h2>
                   <i
                     class="icon-bus-alt text-2xl text-tweaked-brand"
+                    role="img"
+                    title="Bussilinja"
                   />
                 </div>
                 <p>
@@ -365,9 +355,11 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
             class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
             data-testid="LocatorButton::button"
             disabled=""
+            title="Näytä aikataulut linjalle 1234"
             type="button"
           >
             <i
+              aria-hidden="true"
               class="icon-calendar inline text-center"
             />
           </button>
@@ -375,40 +367,32 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
-          <div
-            class="group relative flex justify-center"
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
+            data-testid="LineTableRow::showLineRoutes"
+            title="Näytä kartalla linja 1234"
+            type="button"
           >
-            <span
-              class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+            <svg
+              aria-hidden="true"
+              class="text-2xl inline text-center"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Näytä kartalla
-            </span>
-            <button
-              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand  "
-              data-testid="LineTableRow::showLineRoutes"
-              type="button"
-            >
-              <svg
-                class="text-2xl inline text-center"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                />
-                <path
-                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+              />
+            </svg>
+          </button>
         </td>
       </tr>
     </tbody>
@@ -452,6 +436,8 @@ exports[`<RoutesTable /> Renders the table with route data (routes and lines) 1`
                   </h2>
                   <i
                     class="icon-bus-alt text-2xl text-tweaked-brand"
+                    role="img"
+                    title="Bussireitti"
                   />
                 </div>
                 <p>
@@ -480,9 +466,11 @@ exports[`<RoutesTable /> Renders the table with route data (routes and lines) 1`
             class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
             data-testid="LocatorButton::button"
             disabled=""
+            title="Näytä aikataulut linjalle 1"
             type="button"
           >
             <i
+              aria-hidden="true"
               class="icon-calendar inline text-center"
             />
           </button>
@@ -490,41 +478,33 @@ exports[`<RoutesTable /> Renders the table with route data (routes and lines) 1`
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
-          <div
-            class="group relative flex justify-center"
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="RouteTableRow::showRoute"
+            disabled=""
+            title="Näytä kartalla reitti 1"
+            type="button"
           >
-            <span
-              class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+            <svg
+              aria-hidden="true"
+              class="text-2xl inline text-center"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Näytä kartalla
-            </span>
-            <button
-              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
-              data-testid="RouteTableRow::showRoute"
-              disabled=""
-              type="button"
-            >
-              <svg
-                class="text-2xl inline text-center"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                />
-                <path
-                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+              />
+            </svg>
+          </button>
         </td>
       </tr>
     </tbody>
@@ -568,6 +548,8 @@ exports[`<RoutesTable /> Renders the table with route data (timetables) 1`] = `
                   </h2>
                   <i
                     class="icon-calendar text-2xl text-zinc-400"
+                    role="img"
+                    title="Timetable"
                   />
                   Ei aikatauluja
                 </div>
@@ -596,9 +578,11 @@ exports[`<RoutesTable /> Renders the table with route data (timetables) 1`] = `
           <button
             class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand "
             data-testid="LocatorButton::button"
+            title="Näytä tarkemmat tiedot linjalle 1"
             type="button"
           >
             <i
+              aria-hidden="true"
               class="icon-bus-alt inline text-center"
             />
           </button>
@@ -606,41 +590,33 @@ exports[`<RoutesTable /> Renders the table with route data (timetables) 1`] = `
         <td
           class="w-1/12 border-r p-6 text-right align-middle border-y border-y-light-grey"
         >
-          <div
-            class="group relative flex justify-center"
+          <button
+            class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
+            data-testid="RouteTableRow::showRoute"
+            disabled=""
+            title="Näytä kartalla reitti 1"
+            type="button"
           >
-            <span
-              class="absolute z-10 w-max scale-0 rounded-md bg-dark-grey p-2 text-xs 
-        text-white transition-all group-hover:scale-100 bottom-11 delay-700"
+            <svg
+              aria-hidden="true"
+              class="text-2xl inline text-center"
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Näytä kartalla
-            </span>
-            <button
-              class="text-center h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand hover:border-2 hover:border-tweaked-brand !bg-background opacity-70 pointer-events-none "
-              data-testid="RouteTableRow::showRoute"
-              disabled=""
-              type="button"
-            >
-              <svg
-                class="text-2xl inline text-center"
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                />
-                <path
-                  d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M18 8c0-3.31-2.69-6-6-6S6 4.69 6 8c0 4.5 6 11 6 11s6-6.5 6-11zm-8 0c0-1.1.9-2 2-2s2 .9 2 2a2 2 0 11-4 0zM5 20v2h14v-2H5z"
+              />
+            </svg>
+          </button>
         </td>
       </tr>
     </tbody>

--- a/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
@@ -22,12 +22,14 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
                 <div
                   class="flex flex-row items-center"
+                  title=""
                 >
                   <h2>
                     65
@@ -119,12 +121,14 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
                 <div
                   class="flex flex-row items-center"
+                  title=""
                 >
                   <h2>
                     71
@@ -216,12 +220,14 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
                 <div
                   class="flex flex-row items-center"
+                  title=""
                 >
                   <h2>
                     785K
@@ -313,12 +319,14 @@ exports[`<RoutesTable /> Renders the table with line data 1`] = `
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
                 <div
                   class="flex flex-row items-center"
+                  title=""
                 >
                   <h2>
                     1234
@@ -422,12 +430,14 @@ exports[`<RoutesTable /> Renders the table with route data (routes and lines) 1`
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
                 <div
                   class="flex flex-row items-center"
+                  title=""
                 >
                   <h2>
                     <b>
@@ -534,12 +544,14 @@ exports[`<RoutesTable /> Renders the table with route data (timetables) 1`] = `
           >
             <div
               class="flex flex-row items-center"
+              title=""
             >
               <div
                 class="flex flex-col w-1/2 font-bold"
               >
                 <div
                   class="flex flex-row items-center"
+                  title=""
                 >
                   <h2>
                     <b>

--- a/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/main/__snapshots__/RoutesTable.spec.tsx.snap
@@ -547,9 +547,9 @@ exports[`<RoutesTable /> Renders the table with route data (timetables) 1`] = `
                     </b>
                   </h2>
                   <i
-                    class="icon-calendar text-2xl text-zinc-400"
+                    class="icon-calendar text-zinc-400 text-2xl"
                     role="img"
-                    title="Timetable"
+                    title=""
                   />
                   Ei aikatauluja
                 </div>

--- a/ui/src/components/routes-and-lines/search/SearchContainer.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchContainer.tsx
@@ -73,12 +73,18 @@ export const SearchContainer = (): JSX.Element => {
               testId={testIds.toggleExpand}
               isToggled={isExpanded}
               onClick={toggleIsExpanded}
+              controls="advanced-search"
+              openTooltip={t('accessibility:common.expandSearch')}
+              closeTooltip={t('accessibility:common.closeSearch')}
             />
           </Row>
         </Column>
       </Row>
       <Visible visible={isExpanded}>
-        <div className="space-y-5 border-2 border-background p-10">
+        <div
+          id="advanced-search"
+          className="space-y-5 border-2 border-background p-10"
+        >
           <h2>{t('search.advancedSearchTitle')}</h2>
           <FormRow mdColumns={4}>
             <Column>

--- a/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
+++ b/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
@@ -1,6 +1,7 @@
 import orderBy from 'lodash/orderBy';
 import { useTranslation } from 'react-i18next';
 import { VehicleJourneyGroup, useAppDispatch } from '../../../hooks';
+import { parseI18nField } from '../../../i18n/utils';
 import { Row } from '../../../layoutComponents';
 import { openChangeTimetableValidityModalAction } from '../../../redux';
 import { mapDurationToShortTime, mapToShortDate } from '../../../time';
@@ -52,18 +53,20 @@ export const VehicleJourneyGroupInfo = ({
   // link to the substitute operating day's page
   const isDisabled = !vehicleJourneyGroup.vehicleScheduleFrameId;
   const hoverStyle = `${commonHoverStyle} hover:bg-light-grey`;
-
   return (
     <Row
       className={`items-center space-x-4 text-center text-sm text-hsl-dark-80 ${className}`}
     >
       <IconButton
+        tooltip={t('accessibility:timetables.changeValidityPeriod', {
+          dayType: parseI18nField(vehicleJourneyGroup.dayType.name_i18n),
+        })}
         className={`mr-2 h-8 w-16 rounded-sm border border-light-grey bg-white text-base  ${
           isDisabled ? 'text-light-grey' : hoverStyle
         }`}
         disabled={isDisabled}
         onClick={changeVehicleScheduleFrameValidity}
-        icon={<i className="icon-calendar" />}
+        icon={<i className="icon-calendar" aria-hidden />}
         testId={testIds.changeValidityButton}
       />
       <span data-testid={testIds.validityTimeRange}>

--- a/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
@@ -119,11 +119,15 @@ export const PreviewTimetablesPage = (): JSX.Element => {
             </h2>
           </div>
           <div className="flex items-center">
-            <label className="my-0 cursor-pointer text-base">
+            <label
+              htmlFor="timetablesPreviewToggle"
+              className="my-0 cursor-pointer text-base"
+            >
               {showStagingTimetables
                 ? t('timetablesPreview.closeContent')
                 : t('timetablesPreview.showContent')}
               <AccordionButton
+                identifier="timetablesPreviewToggle"
                 testId={testIds.toggleShowStagingTimetables}
                 isOpen={showStagingTimetables}
                 onToggle={toggleShowStagingTimetables}

--- a/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
@@ -128,6 +128,8 @@ export const PreviewTimetablesPage = (): JSX.Element => {
                 isOpen={showStagingTimetables}
                 onToggle={toggleShowStagingTimetables}
                 iconClassName="text-white text-[50px]"
+                ariaLabel={t('accessibility:timetables.preview')}
+                controls="fileContent"
               />
             </label>
           </div>
@@ -158,7 +160,7 @@ export const PreviewTimetablesPage = (): JSX.Element => {
             <SpecialDayMixedPrioritiesWarning />
           </Visible>
         </div>
-        <Visible visible={showStagingTimetables}>
+        <Visible identifier="fileContent" visible={showStagingTimetables}>
           <div className="items-center space-x-14 rounded-b-sm bg-hsl-neutral-blue py-9 px-16">
             <ImportContentsView vehicleScheduleFrames={vehicleScheduleFrames} />
           </div>

--- a/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
@@ -119,21 +119,17 @@ export const PreviewTimetablesPage = (): JSX.Element => {
             </h2>
           </div>
           <div className="flex items-center">
-            <button
-              onClick={toggleShowStagingTimetables}
-              type="button"
-              className="font-bold"
-            >
+            <label className="my-0 cursor-pointer text-base">
               {showStagingTimetables
                 ? t('timetablesPreview.closeContent')
                 : t('timetablesPreview.showContent')}
-            </button>
-            <AccordionButton
-              testId={testIds.toggleShowStagingTimetables}
-              isOpen={showStagingTimetables}
-              onToggle={toggleShowStagingTimetables}
-              iconClassName="text-white text-[50px]"
-            />
+              <AccordionButton
+                testId={testIds.toggleShowStagingTimetables}
+                isOpen={showStagingTimetables}
+                onToggle={toggleShowStagingTimetables}
+                iconClassName="text-white text-[50px]"
+              />
+            </label>
           </div>
         </Row>
         <div className="py-9 px-16">

--- a/ui/src/components/timetables/import/TimetablesImportPriorityForm.tsx
+++ b/ui/src/components/timetables/import/TimetablesImportPriorityForm.tsx
@@ -70,10 +70,9 @@ export const TimetablesImportPriorityForm = ({
   return (
     <Column>
       <Visible visible={showLabel}>
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-        <label>{t('priority.label')}</label>
+        <label htmlFor="priorityButtons">{t('priority.label')}</label>
       </Visible>
-      <Row className="flex-wrap gap-2">
+      <Row identifier="priorityButtons" className="flex-wrap gap-2">
         {displayedPriorities.map(
           ({ priority, testIdPrefix, translationKey }) => (
             <SimpleButton

--- a/ui/src/components/timetables/import/contents-view/BlockVehicleJourneysTable.tsx
+++ b/ui/src/components/timetables/import/contents-view/BlockVehicleJourneysTable.tsx
@@ -12,7 +12,7 @@ import { VehicleJourneyRow } from './VehicleJourneyRow';
 
 const testIds = {
   table: 'BlockVehicleJourneysTable::table',
-  title: 'BlockVehicleJourneysTable::title',
+  blockLabel: 'BlockVehicleJourneysTable::blockLabel',
   toggleShowTable: 'BlockVehicleJourneysTable::toggleShowTable',
   vehicleType: 'BlockVehicleJourneysTable::vehicleType',
   vehicleJourneyHeaders: 'BlockVehicleJourneysTable::vehicleJourneyHeaders',
@@ -26,30 +26,33 @@ interface Props {
     | Pick<TimetablesVehicleTypeVehicleType, 'description_i18n'>
     | null
     | undefined;
-  title: string;
+  blockLabel: string;
+  vehicleScheduleFrameLabel: string;
 }
 
 export const BlockVehicleJourneysTable = ({
   vehicleJourneys,
   vehicleService,
   vehicleType,
-  title,
+  blockLabel,
+  vehicleScheduleFrameLabel,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
   const [isOpen, toggleIsOpen] = useToggle();
-
+  const identifier = `${vehicleScheduleFrameLabel} ${blockLabel}`;
   return (
     <table
       className="border-brand-gray w-full border"
       data-testid={testIds.table}
+      id={identifier}
     >
       <thead className="[&>tr>th]:border [&>tr>th]:border-light-grey">
         <tr>
           <th
-            data-testid={testIds.title}
+            data-testid={testIds.blockLabel}
             className="w-1/6 bg-brand py-2 px-6 text-left text-white"
           >
-            {title}
+            {blockLabel}
           </th>
           <th
             className="border-l border-l-white bg-white py-2 px-4 text-left text-hsl-dark-80"
@@ -69,6 +72,15 @@ export const BlockVehicleJourneysTable = ({
                 isOpen={isOpen}
                 onToggle={toggleIsOpen}
                 iconClassName="text-brand text-[50px]"
+                openTooltip={t(
+                  'accessibility:timetables.expandScheduleBlocksPreview',
+                  { scheduleBlock: identifier },
+                )}
+                closeTooltip={t(
+                  'accessibility:timetables.closeScheduleBlocksPreview',
+                  { scheduleBlock: identifier },
+                )}
+                controls={identifier}
               />
             </Row>
           </th>

--- a/ui/src/components/timetables/import/contents-view/ImportContentsView.spec.tsx
+++ b/ui/src/components/timetables/import/contents-view/ImportContentsView.spec.tsx
@@ -251,7 +251,7 @@ describe('<ImportContentsView />', () => {
     ).getAllByTestId(blockVehicleJourneysTableTestIds.table)[0];
 
     expect(
-      within(block).getByTestId(blockVehicleJourneysTableTestIds.title),
+      within(block).getByTestId(blockVehicleJourneysTableTestIds.blockLabel),
     ).toHaveTextContent('Week day service');
     expect(
       within(block).getByTestId(blockVehicleJourneysTableTestIds.vehicleType),

--- a/ui/src/components/timetables/import/contents-view/VehicleScheduleFrameBlocksView.tsx
+++ b/ui/src/components/timetables/import/contents-view/VehicleScheduleFrameBlocksView.tsx
@@ -50,15 +50,16 @@ export const VehicleScheduleFrameBlocksView = ({
     validityPeriodString,
     blockCountString,
   ].join(' | ');
-
+  const vehicleScheduleFrameLabel = vehicleScheduleFrame.label;
+  const vehicleScheduleFrameBlocksId = `${vehicleScheduleFrameLabel}Blocks`;
   return (
-    <div data-testid={testIds.frameBlocks(vehicleScheduleFrame.label)}>
+    <div data-testid={testIds.frameBlocks(vehicleScheduleFrameLabel)}>
       <Row className="border-brand-gray w-full border text-white">
         <p
           data-testid={testIds.frameLabel}
           className="flex w-1/6 items-center border border-light-grey bg-brand py-2 px-6 font-bold"
         >
-          {vehicleScheduleFrame.label}
+          {vehicleScheduleFrameLabel}
         </p>
         <Row className="flex-1 border border-l border-light-grey border-l-white bg-brand py-2 px-4">
           <Row className="flex-1 items-center justify-between font-normal">
@@ -70,17 +71,25 @@ export const VehicleScheduleFrameBlocksView = ({
               isOpen={isOpen}
               onToggle={toggleIsOpen}
               iconClassName="text-white text-[50px]"
+              openTooltip={t('accessibility:timetables.expandSchedulePreview', {
+                vehicleScheduleFrameLabel,
+              })}
+              closeTooltip={t('accessibility:timetables.closeSchedulePreview', {
+                vehicleScheduleFrameLabel,
+              })}
+              controls={vehicleScheduleFrameBlocksId}
             />
           </Row>
         </Row>
       </Row>
 
       <Visible visible={isOpen}>
-        <div className="my-4 space-y-4">
+        <div id={vehicleScheduleFrameBlocksId} className="my-4 space-y-4">
           {blocks.map((block) => (
             <BlockVehicleJourneysTable
               key={block.block.block_id}
-              title={block.label}
+              blockLabel={block.label}
+              vehicleScheduleFrameLabel={vehicleScheduleFrameLabel}
               vehicleJourneys={block.block.vehicle_journeys}
               vehicleService={block.service}
               vehicleType={block.block.vehicle_type}

--- a/ui/src/components/timetables/import/contents-view/__snapshots__/ImportContentsView.spec.tsx.snap
+++ b/ui/src/components/timetables/import/contents-view/__snapshots__/ImportContentsView.spec.tsx.snap
@@ -22,6 +22,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
       >
         <div
           class="flex flex-row flex-1 items-center justify-between font-normal"
+          title=""
         >
           <p
             data-testid="BlockVehicleJourneysTable::vehicleType"
@@ -33,7 +34,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
             aria-expanded="true"
             class="text-center "
             data-testid="BlockVehicleJourneysTable::toggleShowTable"
-            title="Piilota lohkon SUMMER_SCHEDULES Week day service tiedot"
+            title="Piilota autokierron SUMMER_SCHEDULES Week day service tiedot"
             type="button"
           >
             <svg
@@ -89,6 +90,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
         <td>
           <div
             class="flex flex-row items-center font-bold"
+            title=""
           >
             <span
               class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
@@ -132,6 +134,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
         <td>
           <div
             class="flex flex-row items-center font-bold"
+            title=""
           >
             <span
               class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
@@ -175,6 +178,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
         <td>
           <div
             class="flex flex-row items-center font-bold"
+            title=""
           >
             <span
               class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
@@ -229,6 +233,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
     >
       <div
         class="flex flex-row border-brand-gray w-full border text-white"
+        title=""
       >
         <p
           class="flex w-1/6 items-center border border-light-grey bg-brand py-2 px-6 font-bold"
@@ -238,9 +243,11 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
         </p>
         <div
           class="flex flex-row flex-1 border border-l border-light-grey border-l-white bg-brand py-2 px-4"
+          title=""
         >
           <div
             class="flex flex-row flex-1 items-center justify-between font-normal"
+            title=""
           >
             <p
               data-testid="VehicleScheduleFrameBlocksView::validityTimeRangeText"
@@ -252,7 +259,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
               aria-expanded="true"
               class="text-center "
               data-testid="VehicleScheduleFrameBlocksView::toggleShowTable"
-              title="Piilota aikataulun SUMMER_SCHEDULES lohkot"
+              title="Piilota aikataulun SUMMER_SCHEDULES autokierrot"
               type="button"
             >
               <svg
@@ -304,6 +311,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
                 >
                   <div
                     class="flex flex-row flex-1 items-center justify-between font-normal"
+                    title=""
                   >
                     <p
                       data-testid="BlockVehicleJourneysTable::vehicleType"
@@ -315,7 +323,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
                       aria-expanded="false"
                       class="text-center "
                       data-testid="BlockVehicleJourneysTable::toggleShowTable"
-                      title="Näytä lohkon SUMMER_SCHEDULES Week day service tiedot"
+                      title="Näytä autokierron SUMMER_SCHEDULES Week day service tiedot"
                       type="button"
                     >
                       <svg
@@ -364,6 +372,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
                 >
                   <div
                     class="flex flex-row flex-1 items-center justify-between font-normal"
+                    title=""
                   >
                     <p
                       data-testid="BlockVehicleJourneysTable::vehicleType"
@@ -375,7 +384,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
                       aria-expanded="false"
                       class="text-center "
                       data-testid="BlockVehicleJourneysTable::toggleShowTable"
-                      title="Näytä lohkon SUMMER_SCHEDULES Saturday service tiedot"
+                      title="Näytä autokierron SUMMER_SCHEDULES Saturday service tiedot"
                       type="button"
                     >
                       <svg
@@ -411,6 +420,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
     >
       <div
         class="flex flex-row border-brand-gray w-full border text-white"
+        title=""
       >
         <p
           class="flex w-1/6 items-center border border-light-grey bg-brand py-2 px-6 font-bold"
@@ -420,9 +430,11 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
         </p>
         <div
           class="flex flex-row flex-1 border border-l border-light-grey border-l-white bg-brand py-2 px-4"
+          title=""
         >
           <div
             class="flex flex-row flex-1 items-center justify-between font-normal"
+            title=""
           >
             <p
               data-testid="VehicleScheduleFrameBlocksView::validityTimeRangeText"
@@ -434,7 +446,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
               aria-expanded="true"
               class="text-center "
               data-testid="VehicleScheduleFrameBlocksView::toggleShowTable"
-              title="Piilota aikataulun AUTUMN_SCHEDULES lohkot"
+              title="Piilota aikataulun AUTUMN_SCHEDULES autokierrot"
               type="button"
             >
               <svg
@@ -486,6 +498,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
                 >
                   <div
                     class="flex flex-row flex-1 items-center justify-between font-normal"
+                    title=""
                   >
                     <p
                       data-testid="BlockVehicleJourneysTable::vehicleType"
@@ -497,7 +510,7 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
                       aria-expanded="false"
                       class="text-center "
                       data-testid="BlockVehicleJourneysTable::toggleShowTable"
-                      title="Näytä lohkon AUTUMN_SCHEDULES Sunday service tiedot"
+                      title="Näytä autokierron AUTUMN_SCHEDULES Sunday service tiedot"
                       type="button"
                     >
                       <svg

--- a/ui/src/components/timetables/import/contents-view/__snapshots__/ImportContentsView.spec.tsx.snap
+++ b/ui/src/components/timetables/import/contents-view/__snapshots__/ImportContentsView.spec.tsx.snap
@@ -4,6 +4,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
 <table
   class="border-brand-gray w-full border"
   data-testid="BlockVehicleJourneysTable::table"
+  id="SUMMER_SCHEDULES Week day service"
 >
   <thead
     class="[&>tr>th]:border [&>tr>th]:border-light-grey"
@@ -11,7 +12,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
     <tr>
       <th
         class="w-1/6 bg-brand py-2 px-6 text-left text-white"
-        data-testid="BlockVehicleJourneysTable::title"
+        data-testid="BlockVehicleJourneysTable::blockLabel"
       >
         Week day service
       </th>
@@ -28,12 +29,16 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
             Kalustotyyppi - Mini B
           </p>
           <button
+            aria-controls="SUMMER_SCHEDULES Week day service"
+            aria-expanded="true"
             class="text-center "
             data-testid="BlockVehicleJourneysTable::toggleShowTable"
+            title="Piilota lohkon SUMMER_SCHEDULES Week day service tiedot"
             type="button"
           >
             <svg
-              class="text-3xl text-tweaked-brand text-brand text-[50px] inline text-center"
+              aria-hidden="true"
+              class="text-3xl text-tweaked-brand text-brand text-[50px] pointer-events-none inline text-center"
               fill="currentColor"
               height="1em"
               stroke="currentColor"
@@ -75,137 +80,139 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
       </th>
     </tr>
   </thead>
-  <tbody>
-    <tr
-      class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
-      data-testid="VehicleJourneyRow::35::outbound"
-    >
-      <td>
-        <div
-          class="flex flex-row items-center font-bold"
-        >
-          <span
-            class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
-            data-testid="DirectionBadge::container"
-            title="1 - Keskustasta pois"
+  <div>
+    <tbody>
+      <tr
+        class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
+        data-testid="VehicleJourneyRow::35::outbound"
+      >
+        <td>
+          <div
+            class="flex flex-row items-center font-bold"
           >
             <span
-              data-testid="DirectionBadge::outbound"
+              class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
+              data-testid="DirectionBadge::container"
+              title="1 - Keskustasta pois"
             >
-              1
+              <span
+                data-testid="DirectionBadge::outbound"
+              >
+                1
+              </span>
             </span>
-          </span>
-          35
-        </div>
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::dateTypeName"
-      >
-        Maanantai - Perjantai
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::startTime"
-      >
-        15:00
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::endTime"
-      >
-        15:25
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::contractNumber"
-      >
-        CONTRACT_1
-      </td>
-    </tr>
-    <tr
-      class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
-      data-testid="VehicleJourneyRow::35::inbound"
-    >
-      <td>
-        <div
-          class="flex flex-row items-center font-bold"
+            35
+          </div>
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::dateTypeName"
         >
-          <span
-            class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
-            data-testid="DirectionBadge::container"
-            title="2 - Keskustaan päin"
+          Maanantai - Perjantai
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::startTime"
+        >
+          15:00
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::endTime"
+        >
+          15:25
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::contractNumber"
+        >
+          CONTRACT_1
+        </td>
+      </tr>
+      <tr
+        class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
+        data-testid="VehicleJourneyRow::35::inbound"
+      >
+        <td>
+          <div
+            class="flex flex-row items-center font-bold"
           >
             <span
-              data-testid="DirectionBadge::inbound"
+              class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
+              data-testid="DirectionBadge::container"
+              title="2 - Keskustaan päin"
             >
-              2
+              <span
+                data-testid="DirectionBadge::inbound"
+              >
+                2
+              </span>
             </span>
-          </span>
-          35
-        </div>
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::dateTypeName"
-      >
-        Maanantai - Perjantai
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::startTime"
-      >
-        15:30
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::endTime"
-      >
-        15:55
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::contractNumber"
-      >
-        CONTRACT_1
-      </td>
-    </tr>
-    <tr
-      class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
-      data-testid="VehicleJourneyRow::35::outbound"
-    >
-      <td>
-        <div
-          class="flex flex-row items-center font-bold"
+            35
+          </div>
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::dateTypeName"
         >
-          <span
-            class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
-            data-testid="DirectionBadge::container"
-            title="1 - Keskustasta pois"
+          Maanantai - Perjantai
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::startTime"
+        >
+          15:30
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::endTime"
+        >
+          15:55
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::contractNumber"
+        >
+          CONTRACT_1
+        </td>
+      </tr>
+      <tr
+        class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
+        data-testid="VehicleJourneyRow::35::outbound"
+      >
+        <td>
+          <div
+            class="flex flex-row items-center font-bold"
           >
             <span
-              data-testid="DirectionBadge::outbound"
+              class="relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white mr-2 h-5 w-5 text-base"
+              data-testid="DirectionBadge::container"
+              title="1 - Keskustasta pois"
             >
-              1
+              <span
+                data-testid="DirectionBadge::outbound"
+              >
+                1
+              </span>
             </span>
-          </span>
-          35
-        </div>
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::dateTypeName"
-      >
-        Maanantai - Perjantai
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::startTime"
-      >
-        16:00
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::endTime"
-      >
-        16:25
-      </td>
-      <td
-        data-testid="VehicleJourneyRow::contractNumber"
-      >
-        CONTRACT_1
-      </td>
-    </tr>
-  </tbody>
+            35
+          </div>
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::dateTypeName"
+        >
+          Maanantai - Perjantai
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::startTime"
+        >
+          16:00
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::endTime"
+        >
+          16:25
+        </td>
+        <td
+          data-testid="VehicleJourneyRow::contractNumber"
+        >
+          CONTRACT_1
+        </td>
+      </tr>
+    </tbody>
+  </div>
 </table>
 `;
 
@@ -241,12 +248,16 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
               1.6.2023 - 31.8.2023 | 2 autokiertoa
             </p>
             <button
+              aria-controls="SUMMER_SCHEDULESBlocks"
+              aria-expanded="true"
               class="text-center "
               data-testid="VehicleScheduleFrameBlocksView::toggleShowTable"
+              title="Piilota aikataulun SUMMER_SCHEDULES lohkot"
               type="button"
             >
               <svg
-                class="text-3xl text-tweaked-brand text-white text-[50px] inline text-center"
+                aria-hidden="true"
+                class="text-3xl text-tweaked-brand text-white text-[50px] pointer-events-none inline text-center"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
@@ -267,119 +278,132 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="my-4 space-y-4"
-      >
-        <table
-          class="border-brand-gray w-full border"
-          data-testid="BlockVehicleJourneysTable::table"
+      <div>
+        <div
+          class="my-4 space-y-4"
+          id="SUMMER_SCHEDULESBlocks"
         >
-          <thead
-            class="[&>tr>th]:border [&>tr>th]:border-light-grey"
+          <table
+            class="border-brand-gray w-full border"
+            data-testid="BlockVehicleJourneysTable::table"
+            id="SUMMER_SCHEDULES Week day service"
           >
-            <tr>
-              <th
-                class="w-1/6 bg-brand py-2 px-6 text-left text-white"
-                data-testid="BlockVehicleJourneysTable::title"
-              >
-                Week day service
-              </th>
-              <th
-                class="border-l border-l-white bg-white py-2 px-4 text-left text-hsl-dark-80"
-                colspan="4"
-              >
-                <div
-                  class="flex flex-row flex-1 items-center justify-between font-normal"
+            <thead
+              class="[&>tr>th]:border [&>tr>th]:border-light-grey"
+            >
+              <tr>
+                <th
+                  class="w-1/6 bg-brand py-2 px-6 text-left text-white"
+                  data-testid="BlockVehicleJourneysTable::blockLabel"
                 >
-                  <p
-                    data-testid="BlockVehicleJourneysTable::vehicleType"
+                  Week day service
+                </th>
+                <th
+                  class="border-l border-l-white bg-white py-2 px-4 text-left text-hsl-dark-80"
+                  colspan="4"
+                >
+                  <div
+                    class="flex flex-row flex-1 items-center justify-between font-normal"
                   >
-                    Kalustotyyppi - Mini B
-                  </p>
-                  <button
-                    class="text-center "
-                    data-testid="BlockVehicleJourneysTable::toggleShowTable"
-                    type="button"
-                  >
-                    <svg
-                      class="text-3xl text-tweaked-brand text-brand text-[50px]  inline text-center"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <p
+                      data-testid="BlockVehicleJourneysTable::vehicleType"
                     >
-                      <path
-                        d="M0 0h24v24H0V0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </th>
-            </tr>
-          </thead>
-        </table>
-        <table
-          class="border-brand-gray w-full border"
-          data-testid="BlockVehicleJourneysTable::table"
-        >
-          <thead
-            class="[&>tr>th]:border [&>tr>th]:border-light-grey"
+                      Kalustotyyppi - Mini B
+                    </p>
+                    <button
+                      aria-controls="SUMMER_SCHEDULES Week day service"
+                      aria-expanded="false"
+                      class="text-center "
+                      data-testid="BlockVehicleJourneysTable::toggleShowTable"
+                      title="Näytä lohkon SUMMER_SCHEDULES Week day service tiedot"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="text-3xl text-tweaked-brand text-brand text-[50px] pointer-events-none inline text-center"
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0V0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+          </table>
+          <table
+            class="border-brand-gray w-full border"
+            data-testid="BlockVehicleJourneysTable::table"
+            id="SUMMER_SCHEDULES Saturday service"
           >
-            <tr>
-              <th
-                class="w-1/6 bg-brand py-2 px-6 text-left text-white"
-                data-testid="BlockVehicleJourneysTable::title"
-              >
-                Saturday service
-              </th>
-              <th
-                class="border-l border-l-white bg-white py-2 px-4 text-left text-hsl-dark-80"
-                colspan="4"
-              >
-                <div
-                  class="flex flex-row flex-1 items-center justify-between font-normal"
+            <thead
+              class="[&>tr>th]:border [&>tr>th]:border-light-grey"
+            >
+              <tr>
+                <th
+                  class="w-1/6 bg-brand py-2 px-6 text-left text-white"
+                  data-testid="BlockVehicleJourneysTable::blockLabel"
                 >
-                  <p
-                    data-testid="BlockVehicleJourneysTable::vehicleType"
+                  Saturday service
+                </th>
+                <th
+                  class="border-l border-l-white bg-white py-2 px-4 text-left text-hsl-dark-80"
+                  colspan="4"
+                >
+                  <div
+                    class="flex flex-row flex-1 items-center justify-between font-normal"
                   >
-                    Kalustotyyppi - Mini B
-                  </p>
-                  <button
-                    class="text-center "
-                    data-testid="BlockVehicleJourneysTable::toggleShowTable"
-                    type="button"
-                  >
-                    <svg
-                      class="text-3xl text-tweaked-brand text-brand text-[50px]  inline text-center"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <p
+                      data-testid="BlockVehicleJourneysTable::vehicleType"
                     >
-                      <path
-                        d="M0 0h24v24H0V0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </th>
-            </tr>
-          </thead>
-        </table>
+                      Kalustotyyppi - Mini B
+                    </p>
+                    <button
+                      aria-controls="SUMMER_SCHEDULES Saturday service"
+                      aria-expanded="false"
+                      class="text-center "
+                      data-testid="BlockVehicleJourneysTable::toggleShowTable"
+                      title="Näytä lohkon SUMMER_SCHEDULES Saturday service tiedot"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="text-3xl text-tweaked-brand text-brand text-[50px] pointer-events-none inline text-center"
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0V0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+          </table>
+        </div>
       </div>
     </div>
     <div
@@ -406,12 +430,16 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
               1.9.2023 - 31.12.2023 | 1 autokiertoa
             </p>
             <button
+              aria-controls="AUTUMN_SCHEDULESBlocks"
+              aria-expanded="true"
               class="text-center "
               data-testid="VehicleScheduleFrameBlocksView::toggleShowTable"
+              title="Piilota aikataulun AUTUMN_SCHEDULES lohkot"
               type="button"
             >
               <svg
-                class="text-3xl text-tweaked-brand text-white text-[50px] inline text-center"
+                aria-hidden="true"
+                class="text-3xl text-tweaked-brand text-white text-[50px] pointer-events-none inline text-center"
                 fill="currentColor"
                 height="1em"
                 stroke="currentColor"
@@ -432,64 +460,72 @@ exports[`<ImportContentsView /> should render correctly 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="my-4 space-y-4"
-      >
-        <table
-          class="border-brand-gray w-full border"
-          data-testid="BlockVehicleJourneysTable::table"
+      <div>
+        <div
+          class="my-4 space-y-4"
+          id="AUTUMN_SCHEDULESBlocks"
         >
-          <thead
-            class="[&>tr>th]:border [&>tr>th]:border-light-grey"
+          <table
+            class="border-brand-gray w-full border"
+            data-testid="BlockVehicleJourneysTable::table"
+            id="AUTUMN_SCHEDULES Sunday service"
           >
-            <tr>
-              <th
-                class="w-1/6 bg-brand py-2 px-6 text-left text-white"
-                data-testid="BlockVehicleJourneysTable::title"
-              >
-                Sunday service
-              </th>
-              <th
-                class="border-l border-l-white bg-white py-2 px-4 text-left text-hsl-dark-80"
-                colspan="4"
-              >
-                <div
-                  class="flex flex-row flex-1 items-center justify-between font-normal"
+            <thead
+              class="[&>tr>th]:border [&>tr>th]:border-light-grey"
+            >
+              <tr>
+                <th
+                  class="w-1/6 bg-brand py-2 px-6 text-left text-white"
+                  data-testid="BlockVehicleJourneysTable::blockLabel"
                 >
-                  <p
-                    data-testid="BlockVehicleJourneysTable::vehicleType"
+                  Sunday service
+                </th>
+                <th
+                  class="border-l border-l-white bg-white py-2 px-4 text-left text-hsl-dark-80"
+                  colspan="4"
+                >
+                  <div
+                    class="flex flex-row flex-1 items-center justify-between font-normal"
                   >
-                    Kalustotyyppi - Mini A
-                  </p>
-                  <button
-                    class="text-center "
-                    data-testid="BlockVehicleJourneysTable::toggleShowTable"
-                    type="button"
-                  >
-                    <svg
-                      class="text-3xl text-tweaked-brand text-brand text-[50px]  inline text-center"
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      stroke-width="0"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <p
+                      data-testid="BlockVehicleJourneysTable::vehicleType"
                     >
-                      <path
-                        d="M0 0h24v24H0V0z"
-                        fill="none"
-                      />
-                      <path
-                        d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </th>
-            </tr>
-          </thead>
-        </table>
+                      Kalustotyyppi - Mini A
+                    </p>
+                    <button
+                      aria-controls="AUTUMN_SCHEDULES Sunday service"
+                      aria-expanded="false"
+                      class="text-center "
+                      data-testid="BlockVehicleJourneysTable::toggleShowTable"
+                      title="Näytä lohkon AUTUMN_SCHEDULES Sunday service tiedot"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="text-3xl text-tweaked-brand text-brand text-[50px] pointer-events-none inline text-center"
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0V0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodItem.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodItem.tsx
@@ -1,4 +1,5 @@
 import { FieldArrayWithId, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { mapToShortDate } from '../../../../time';
 import { EditCloseButton } from '../../../../uiComponents/EditCloseButton';
 import { InputField } from '../../../forms/common';
@@ -54,9 +55,18 @@ export const CommonSubstitutePeriodItem = ({
   field,
   update,
 }: Props): JSX.Element => {
+  const { t } = useTranslation();
   const { register, watch } = useFormContext<FormState>();
   const edited = watch(`commonDays.${index}.created`);
   const toBeDeleted = watch(`commonDays.${index}.toBeDeleted`) ?? false;
+  const titleEdit=t(
+    `accessibility:button.timetables.substituteDayEdit`,
+    { substituteDay: field.periodName },
+  );
+  const titleCloseEdit=t(
+    `accessibility:button.timetables.substituteDayEditClose`,
+    { substituteDay: field.periodName },
+  );
 
   return (
     <div className="flex basis-[28%] flex-wrap" key={field.id}>
@@ -67,6 +77,8 @@ export const CommonSubstitutePeriodItem = ({
       <div className="flex basis-1/12 justify-end">
         {field.fromDatabase ? (
           <EditCloseButton
+            titleEdit={titleEdit}
+            titleClose={titleCloseEdit}
             showEdit={toBeDeleted}
             onEdit={() => update(index, toBeDeleted, 'toBeDeleted')}
             onClose={() => update(index, toBeDeleted, 'toBeDeleted')}
@@ -74,6 +86,8 @@ export const CommonSubstitutePeriodItem = ({
           />
         ) : (
           <EditCloseButton
+          titleEdit={titleEdit}
+          titleClose={titleCloseEdit}
             showEdit={!edited}
             onEdit={() => update(index, edited, 'created')}
             onClose={() => update(index, edited, 'created')}

--- a/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodItem.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodItem.tsx
@@ -59,14 +59,12 @@ export const CommonSubstitutePeriodItem = ({
   const { register, watch } = useFormContext<FormState>();
   const edited = watch(`commonDays.${index}.created`);
   const toBeDeleted = watch(`commonDays.${index}.toBeDeleted`) ?? false;
-  const titleEdit=t(
-    `accessibility:button.timetables.substituteDayEdit`,
-    { substituteDay: field.periodName },
-  );
-  const titleCloseEdit=t(
-    `accessibility:button.timetables.substituteDayEditClose`,
-    { substituteDay: field.periodName },
-  );
+  const titleEdit = t(`accessibility:timetables.substituteDayEdit`, {
+    substituteDay: field.periodName,
+  });
+  const titleCloseEdit = t(`accessibility:timetables.substituteDayEditClose`, {
+    substituteDay: field.periodName,
+  });
 
   return (
     <div className="flex basis-[28%] flex-wrap" key={field.id}>
@@ -86,8 +84,8 @@ export const CommonSubstitutePeriodItem = ({
           />
         ) : (
           <EditCloseButton
-          titleEdit={titleEdit}
-          titleClose={titleCloseEdit}
+            titleEdit={titleEdit}
+            titleClose={titleCloseEdit}
             showEdit={!edited}
             onEdit={() => update(index, edited, 'created')}
             onClose={() => update(index, edited, 'created')}

--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetableList.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetableList.tsx
@@ -7,8 +7,8 @@ interface Props {
 export const RouteTimetableList = ({ routeIds }: Props): JSX.Element => {
   return (
     <div className="grid gap-y-5">
-      {routeIds.map((item) => (
-        <RouteTimetablesSection key={item} routeId={item} />
+      {routeIds.map((item, index) => (
+        <RouteTimetablesSection key={item} routeId={item} index={index} />
       ))}
     </div>
   );

--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -31,6 +31,7 @@ const GQL_GET_ROUTE_WITH_JOURNEY_PATTERN = gql`
 interface Props {
   routeId: UUID;
   initiallyOpen?: boolean;
+  index: number;
 }
 
 const testIds = {
@@ -43,6 +44,7 @@ const testIds = {
 export const RouteTimetablesSection = ({
   routeId,
   initiallyOpen = true,
+  index,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
   const { showAllValid } = useAppSelector(selectTimetable);
@@ -73,6 +75,8 @@ export const RouteTimetablesSection = ({
       (item) => DayType[item.dayType.label as keyof typeof DayType],
     ]);
   })();
+  const routeName = parseI18nField(route.name_i18n);
+  const sectionIdentifier = index.toString();
 
   return (
     <div data-testid={testIds.timetableSection(route.label, route.direction)}>
@@ -86,7 +90,7 @@ export const RouteTimetablesSection = ({
           <h3 className="m-3.5">
             <RouteLabel label={route.label} variant={route.variant} />
           </h3>
-          <span className="text-xl">{parseI18nField(route.name_i18n)}</span>
+          <span className="text-xl">{routeName}</span>
         </div>
         <div className="ml-1 bg-background p-3">
           <AccordionButton
@@ -95,6 +99,13 @@ export const RouteTimetablesSection = ({
             isOpen={isOpen}
             onToggle={toggleIsOpen}
             testId={testIds.accordionToggle}
+            openTooltip={t('accessibility:routes.expandTimetable', {
+              routeName,
+            })}
+            closeTooltip={t('accessibility:routes.closeTimetable', {
+              routeName,
+            })}
+            controls={sectionIdentifier}
           />
         </div>
       </Row>
@@ -103,7 +114,7 @@ export const RouteTimetablesSection = ({
         loading={fetchRouteTimetables}
         testId={testIds.loadingRouteTimetables}
       >
-        <Visible visible={isOpen}>
+        <Visible visible={isOpen} identifier={sectionIdentifier}>
           <div className="mt-8">
             {activeView === TimetablesView.DEFAULT && (
               <div className="grid grid-cols-3 gap-x-8 gap-y-5">

--- a/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
@@ -84,6 +84,10 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
     data.vehicleScheduleFrame.priority,
   )} bg-opacity-25`;
 
+  const dayType = parseI18nField(data.dayType.nameI18n);
+  const vehicleScheduleFrameName = parseI18nField(
+    data.vehicleScheduleFrame.nameI18n,
+  );
   return (
     <tr
       className="h-14 text-center [&>td]:border [&>td]:border-light-grey"
@@ -91,7 +95,7 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
     >
       <td className={statusClassName}>{statusText}</td>
       <td className={dayTypeClassName}>
-        {parseI18nField(data.dayType.nameI18n)}
+        {dayType}
         {data.substituteDay?.supersededDate && (
           <span className="flex justify-center whitespace-nowrap text-xs">
             {substituteDayOperatingText}
@@ -101,12 +105,20 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
       <td>{mapToShortDate(data.vehicleScheduleFrame.validityStart)}</td>
       <td>{mapToShortDate(data.vehicleScheduleFrame.validityEnd)}</td>
       <td>{data.routeLabelAndVariant}</td>
-      <td>{parseI18nField(data.vehicleScheduleFrame.nameI18n)}</td>
+      <td>{vehicleScheduleFrameName}</td>
       <td>!Muokkaaja</td>
       <td>!Muokattu</td>
       <td>
         <Visible visible={!!data.vehicleScheduleFrame.id}>
-          <SimpleDropdownMenu alignItems={AlignDirection.Right} testId="menu">
+          <SimpleDropdownMenu
+            alignItems={AlignDirection.Right}
+            testId="menu"
+            tooltip={t('accessibility:timetables.versionActions', {
+              status: statusText,
+              schedule: vehicleScheduleFrameName,
+              dayType,
+            })}
+          >
             <SimpleDropdownMenuItem
               onClick={onClick}
               testId={testIds.deleteTimetableMenuItem}

--- a/ui/src/i18n.ts
+++ b/ui/src/i18n.ts
@@ -5,7 +5,7 @@ import translationsJson from './locales/fi-FI/common.json';
 export type SupportedLocale = 'fi-FI' | 'en-US';
 export const defaultLocale: SupportedLocale = 'fi-FI';
 
-const modules = ['common'];
+const modules = ['common', 'accessibility'];
 const locales = ['fi-FI', 'en-US'];
 const resources: Resource = {};
 locales.forEach((locale) => {
@@ -18,13 +18,12 @@ locales.forEach((locale) => {
     resources[locale][module] = tr;
   });
 });
-
 i18next.use(initReactI18next).init({
   lng: defaultLocale,
   fallbackLng: defaultLocale,
   resources,
   debug: false,
-  ns: ['common'],
+  ns: ['common', 'accessibility'],
   defaultNS: 'common',
   interpolation: {
     escapeValue: false, // not needed for react as it escapes by default

--- a/ui/src/layoutComponents/Column.tsx
+++ b/ui/src/layoutComponents/Column.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 
 interface Props {
   className?: string;
+  id?: string;
 }
 
-export const Column: React.FC<Props> = ({ className = '', children }) => {
-  return <div className={`flex flex-col ${className}`}>{children}</div>;
+export const Column: React.FC<Props> = ({ className = '', id, children }) => {
+  return (
+    <div id={id} className={`flex flex-col ${className}`}>
+      {children}
+    </div>
+  );
 };

--- a/ui/src/layoutComponents/Row.tsx
+++ b/ui/src/layoutComponents/Row.tsx
@@ -3,15 +3,21 @@ import React from 'react';
 interface Props {
   className?: string;
   testId?: string;
+  tooltip?: string;
 }
 
 export const Row: React.FC<Props> = ({
   className = '',
   children,
   testId = null,
+  tooltip = '',
 }) => {
   return (
-    <div className={`flex flex-row ${className}`} data-testid={testId}>
+    <div
+      className={`flex flex-row ${className}`}
+      title={tooltip}
+      data-testid={testId}
+    >
       {children}
     </div>
   );

--- a/ui/src/layoutComponents/Row.tsx
+++ b/ui/src/layoutComponents/Row.tsx
@@ -4,6 +4,7 @@ interface Props {
   className?: string;
   testId?: string;
   tooltip?: string;
+  identifier?: string;
 }
 
 export const Row: React.FC<Props> = ({
@@ -11,12 +12,14 @@ export const Row: React.FC<Props> = ({
   children,
   testId = null,
   tooltip = '',
+  identifier,
 }) => {
   return (
     <div
       className={`flex flex-row ${className}`}
       title={tooltip}
       data-testid={testId}
+      id={identifier}
     >
       {children}
     </div>

--- a/ui/src/layoutComponents/Visible.tsx
+++ b/ui/src/layoutComponents/Visible.tsx
@@ -4,6 +4,7 @@ interface Props {
   // This visible parameter has to be required, but the value can be undefined.
   visible: boolean | undefined;
   children: JSX.Element | JSX.Element[];
+  identifier?: string;
 }
 
 /*
@@ -12,6 +13,10 @@ interface Props {
  * same as `{myBooleanFlag && <MyComponent />}`, but this might
  * be easier to read if there are multiple children components.
  */
-export const Visible: React.FC<Props> = ({ visible = false, children }) => {
-  return visible ? <>{children}</> : null;
+export const Visible: React.FC<Props> = ({
+  visible = false,
+  identifier,
+  children,
+}) => {
+  return visible ? <div id={identifier}>{children}</div> : null;
 };

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -8,11 +8,13 @@
   },
   "lines": {
     "details": "Show details for line {{label}}",
+    "createNewRoute": "Create new route for line {{label}}",
     "showOnMap": "Show line {{label}} on the map",
     "showTimetables": "Show timetables for line {{label}}",
     "expandNameVersions": "Show name versions",
     "closeNameVersions": "Close the name version view",
     "edit": "Edit line {{label}}",
+    "versionHistory": "Version history",
     "bus": "Bus line"
   },
   "routes": {
@@ -20,11 +22,10 @@
     "showOnMapDirection": "Show route {{label}} on the map, direction {{directionNumber}}",
     "editRouteDirection": "Edit the route {{label}}, direction {{directionNumber}}",
     "showTimetables": "Show timetables for route {{label}}",
-    "createNew": "Create new route",
     "expandStops": "Open the stops list for the route {{label}}, direction {{directionNumber}}",
     "closeStops": "Hide the stops of the route {{label}, direction {{directionNumber}}",
-    "expandTimetable": "Open the timetables for the route {{label}}",
-    "closeTimetable": "Hide the timetables of the route {{label}}",
+    "expandTimetable": "Open the timetables for the route {{routeName}}",
+    "closeTimetable": "Hide the timetables of the route {{routeName}}",
     "bus": "Bus route"
   },
   "timetables": {

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -1,0 +1,17 @@
+{
+  "title": {},
+  "button": {
+    "showOnMap": "Show {{routeLabel}} on the map",
+    "nextPage": "Next page",
+    "prevPage": "Previous page",
+    "line": {
+      "details": "Show details for line {{label}}",
+      "showOnMap": "Show line {{label}} on the map",
+      "showTimetables": "Show timetables for line {{label}}"
+    },
+    "route": {
+      "showOnMap": "Show route {{label}} on the map",
+      "showTimetables": "Show timetables for route {{label}}"
+    }
+  }
+}

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -14,6 +14,7 @@
   },
   "routes": {
     "showOnMap": "Show route {{label}} on the map",
+    "showOnMapDirection": "Show route {{label}} on the map, direction {{directionNumber}}",
     "showTimetables": "Show timetables for route {{label}}",
     "createNew": "Create new route",
     "expandStops": "Open the stops list for the route {{label}}",

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -12,11 +12,13 @@
     "showTimetables": "Show timetables for line {{label}}",
     "expandNameVersions": "Show name versions",
     "closeNameVersions": "Close the name version view",
+    "edit": "Edit line {{label}}",
     "bus": "Bus line"
   },
   "routes": {
     "showOnMap": "Show route {{label}} on the map",
     "showOnMapDirection": "Show route {{label}} on the map, direction {{directionNumber}}",
+    "editRouteDirection": "Edit the route {{label}}, direction {{directionNumber}}",
     "showTimetables": "Show timetables for route {{label}}",
     "createNew": "Create new route",
     "expandStops": "Open the stops list for the route {{label}}, direction {{directionNumber}}",
@@ -37,6 +39,7 @@
     "closeScheduleBlocksPreview": "Hide the {{scheduleBlock}} block's information"
   },
   "map": {
-    "showFilters": "Show filters"
+    "showFilters": "Show filters",
+    "editRoute": "Edit route {{routeName}}'s data"
   }
 }

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -1,5 +1,15 @@
 {
-  "title": {},
+  "title": {
+    "line": {
+      "bus": "Bus line"
+    },
+    "route": {
+      "bus": "Bus route"
+    },
+    "timetable": {
+      "icon": "Timetables"
+    }
+  },
   "button": {
     "showOnMap": "Show {{routeLabel}} on the map",
     "nextPage": "Next page",

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -26,6 +26,7 @@
     "closeStops": "Hide the stops of the route {{label}, direction {{directionNumber}}",
     "expandTimetable": "Open the timetables for the route {{routeName}}",
     "closeTimetable": "Hide the timetables of the route {{routeName}}",
+    "showStopActions": "More actions for the stop {{stopLabel}}",
     "bus": "Bus route"
   },
   "timetables": {
@@ -37,10 +38,12 @@
     "expandSchedulePreview": "Show the schedule {{vehicleScheduleFrameLabel}}'s blocks",
     "closeSchedulePreview": "Hide the schedule {{vehicleScheduleFrameLabel}}'s blocks",
     "expandScheduleBlocksPreview": "Show the {{scheduleBlock}} block's information",
-    "closeScheduleBlocksPreview": "Hide the {{scheduleBlock}} block's information"
+    "closeScheduleBlocksPreview": "Hide the {{scheduleBlock}} block's information",
+    "versionActions": "More actions for the schedule {{status}} {{schedule}} {{dayType}}"
   },
   "map": {
     "showFilters": "Show filters",
-    "editRoute": "Edit route {{routeName}}'s data"
+    "editRoute": "Edit route {{routeName}}'s data",
+    "routeStopsOverlayRowActions": "More actions for stop {{stopLabel}}"
   }
 }

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -10,6 +10,8 @@
     "details": "Show details for line {{label}}",
     "showOnMap": "Show line {{label}} on the map",
     "showTimetables": "Show timetables for line {{label}}",
+    "expandNameVersions": "Show name versions",
+    "closeNameVersions": "Close the name version view",
     "bus": "Bus line"
   },
   "routes": {
@@ -17,8 +19,8 @@
     "showOnMapDirection": "Show route {{label}} on the map, direction {{directionNumber}}",
     "showTimetables": "Show timetables for route {{label}}",
     "createNew": "Create new route",
-    "expandStops": "Open the stops list for the route {{label}}",
-    "closeStops": "Hide the stops of the route {{label}}",
+    "expandStops": "Open the stops list for the route {{label}}, direction {{directionNumber}}",
+    "closeStops": "Hide the stops of the route {{label}, direction {{directionNumber}}",
     "expandTimetable": "Open the timetables for the route {{label}}",
     "closeTimetable": "Hide the timetables of the route {{label}}",
     "bus": "Bus route"
@@ -27,7 +29,12 @@
     "icon": "Timetable",
     "changeValidityPeriod": "Change the validity period for {{dayType}}",
     "substituteDayEdit": "Edit the substitute day of \"{{substituteDay}}\"",
-    "substituteDayEditClose": "Stop editing subsitute day \"{{substituteDay}}\""
+    "substituteDayEditClose": "Stop editing subsitute day \"{{substituteDay}}\"",
+    "preview": "Show the file's content",
+    "expandSchedulePreview": "Show the schedule {{vehicleScheduleFrameLabel}}'s blocks",
+    "closeSchedulePreview": "Hide the schedule {{vehicleScheduleFrameLabel}}'s blocks",
+    "expandScheduleBlocksPreview": "Show the {{scheduleBlock}} block's information",
+    "closeScheduleBlocksPreview": "Hide the {{scheduleBlock}} block's information"
   },
   "map": {
     "showFilters": "Show filters"

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -4,6 +4,8 @@
     "showOnMap": "Show {{routeLabel}} on the map",
     "nextPage": "Next page",
     "prevPage": "Previous page",
+    "expandSearch": "Open advanced search",
+    "closeSearch": "Close advanced search",
     "line": {
       "details": "Show details for line {{label}}",
       "showOnMap": "Show line {{label}} on the map",
@@ -11,7 +13,20 @@
     },
     "route": {
       "showOnMap": "Show route {{label}} on the map",
-      "showTimetables": "Show timetables for route {{label}}"
+      "showTimetables": "Show timetables for route {{label}}",
+      "createNew": "Create new route",
+      "expandStops": "Open the stops list for the route {{label}}",
+      "closeStops": "Hide the stops of the route {{label}}",
+      "expandTimetable": "Open the timetables for the route {{label}}",
+      "closeTimetable": "Hide the timetables of the route {{label}}"
+    },
+    "map": {
+      "showFilters": "Show filters"
+    },
+    "timetables": {
+      "changeValidityPeriod": "Change the validity period for {{validityPeriod}}",
+      "substituteDayEdit": "Edit the substitute day of \"{{substituteDay}}\"",
+      "substituteDayEditClose": "Stop editing subsitute day \"{{substituteDay}}\""
     }
   }
 }

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -7,7 +7,7 @@
       "bus": "Bus route"
     },
     "timetable": {
-      "icon": "Timetables"
+      "icon": "Timetable"
     }
   },
   "button": {

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -1,42 +1,34 @@
 {
-  "title": {
-    "line": {
-      "bus": "Bus line"
-    },
-    "route": {
-      "bus": "Bus route"
-    },
-    "timetable": {
-      "icon": "Timetable"
-    }
-  },
-  "button": {
+  "common": {
     "showOnMap": "Show {{routeLabel}} on the map",
     "nextPage": "Next page",
     "prevPage": "Previous page",
     "expandSearch": "Open advanced search",
-    "closeSearch": "Close advanced search",
-    "line": {
-      "details": "Show details for line {{label}}",
-      "showOnMap": "Show line {{label}} on the map",
-      "showTimetables": "Show timetables for line {{label}}"
-    },
-    "route": {
-      "showOnMap": "Show route {{label}} on the map",
-      "showTimetables": "Show timetables for route {{label}}",
-      "createNew": "Create new route",
-      "expandStops": "Open the stops list for the route {{label}}",
-      "closeStops": "Hide the stops of the route {{label}}",
-      "expandTimetable": "Open the timetables for the route {{label}}",
-      "closeTimetable": "Hide the timetables of the route {{label}}"
-    },
-    "map": {
-      "showFilters": "Show filters"
-    },
-    "timetables": {
-      "changeValidityPeriod": "Change the validity period for {{validityPeriod}}",
-      "substituteDayEdit": "Edit the substitute day of \"{{substituteDay}}\"",
-      "substituteDayEditClose": "Stop editing subsitute day \"{{substituteDay}}\""
-    }
+    "closeSearch": "Close advanced search"
+  },
+  "lines": {
+    "details": "Show details for line {{label}}",
+    "showOnMap": "Show line {{label}} on the map",
+    "showTimetables": "Show timetables for line {{label}}",
+    "bus": "Bus line"
+  },
+  "routes": {
+    "showOnMap": "Show route {{label}} on the map",
+    "showTimetables": "Show timetables for route {{label}}",
+    "createNew": "Create new route",
+    "expandStops": "Open the stops list for the route {{label}}",
+    "closeStops": "Hide the stops of the route {{label}}",
+    "expandTimetable": "Open the timetables for the route {{label}}",
+    "closeTimetable": "Hide the timetables of the route {{label}}",
+    "bus": "Bus route"
+  },
+  "timetables": {
+    "icon": "Timetable",
+    "changeValidityPeriod": "Change the validity period for {{dayType}}",
+    "substituteDayEdit": "Edit the substitute day of \"{{substituteDay}}\"",
+    "substituteDayEditClose": "Stop editing subsitute day \"{{substituteDay}}\""
+  },
+  "map": {
+    "showFilters": "Show filters"
   }
 }

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -1,5 +1,15 @@
 {
-  "title": {},
+  "title": {
+    "line": {
+      "bus": "bussilinja"
+    },
+    "route": {
+      "bus": "Bussireitti"
+    },
+    "timetable": {
+      "icon": "Aikataulut"
+    }
+  },
   "button": {
     "showOnMap": "Näytä kartalla {{label}}",
     "nextPage": "Seuraava sivu",

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -8,11 +8,13 @@
   },
   "lines": {
     "details": "Näytä tarkemmat tiedot linjalle {{label}}",
+    "createNewRoute": "Luo uusi reitti linjalle {{label}}",
     "showOnMap": "Näytä kartalla linja {{label}}",
     "showTimetables": "Näytä aikataulut linjalle {{label}}",
     "expandNameVersions": "Näytä nimiversiot",
     "closeNameVersions": "Sulje nimiversiot näkymä",
     "edit": "Muokkaa linjaa {{label}}",
+    "versionHistory": "Versiohistoria",
     "bus": "Bussilinja"
   },
   "routes": {
@@ -20,11 +22,10 @@
     "showOnMapDirection": "Näytä kartalla reitti {{label}}, suunta {{directionNumber}}",
     "editRouteDirection": "Muokkaa reittiä {{label}}, suunta {{directionNumber}}",
     "showTimetables": "Näytä aikataulut reitille {{label}}",
-    "createNew": "Luo uusi reitti",
     "expandStops": "Näytä pysäkit reitille {{label}}, suunta {{directionNumber}}",
     "closeStops": "Piilota pysäkit reitiltä {{label}}, suunta {{directionNumber}}",
-    "expandTimetable": "Avaa aikataulut reitille {{label}}",
-    "closeTimetable": "Piilota reitin {{label}} aikataulut",
+    "expandTimetable": "Avaa aikataulut reitille {{routeName}}",
+    "closeTimetable": "Piilota reitin {{routeName}} aikataulut",
     "bus": "Bussireitti"
   },
   "timetables": {

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -14,6 +14,7 @@
   },
   "routes": {
     "showOnMap": "Näytä kartalla reitti {{label}}",
+    "showOnMapDirection": "Näytä kartalla reitti {{label}}, suunta {{directionNumber}}",
     "showTimetables": "Näytä aikataulut reitille {{label}}",
     "createNew": "Luo uusi reitti",
     "expandStops": "Näytä pysäkit reitille {{label}}",

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -4,6 +4,8 @@
     "showOnMap": "Näytä kartalla {{label}}",
     "nextPage": "Seuraava sivu",
     "prevPage": "Edellinen sivu",
+    "expandSearch": "Avaa tarkennettu haku",
+    "closeSearch": "Sulje tarkennettu haku",
     "line": {
       "details": "Näytä tarkemmat tiedot linjalle {{label}}",
       "showOnMap": "Näytä kartalla linja {{label}}",
@@ -11,7 +13,20 @@
     },
     "route": {
       "showOnMap": "Näytä kartalla reitti {{label}}",
-      "showTimetables": "Näytä aikataulut reitille {{label}}"
+      "showTimetables": "Näytä aikataulut reitille {{label}}",
+      "createNew": "Luo uusi reitti",
+      "expandStops": "Näytä pysäkit reitille {{label}}",
+      "closeStops": "Piilota pysäkit reitiltä {{label}}",
+      "expandTimetable": "Avaa aikataulut reitille {{label}}",
+      "closeTimetable": "Piilota reitin {{label}} aikataulut"
+    },
+    "map": {
+      "showFilters": "Suodata näkymää"
+    },
+    "timetables": {
+      "changeValidityPeriod": "Muuta voimassaoloaikaa ajanjaksolle {{validityPeriod}}",
+      "substituteDayEdit": "Muokkaa poikkeuspäivää \"{{substituteDay}}\"",
+      "substituteDayEditClose": "Lopeta poikkeuspäivän \"{{substituteDay}}\" muokkaus"
     }
   }
 }

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -7,7 +7,7 @@
       "bus": "Bussireitti"
     },
     "timetable": {
-      "icon": "Aikataulut"
+      "icon": "Aikataulu"
     }
   },
   "button": {

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -10,6 +10,8 @@
     "details": "Näytä tarkemmat tiedot linjalle {{label}}",
     "showOnMap": "Näytä kartalla linja {{label}}",
     "showTimetables": "Näytä aikataulut linjalle {{label}}",
+    "expandNameVersions": "Näytä nimiversiot",
+    "closeNameVersions": "Sulje nimiversiot näkymä",
     "bus": "Bussilinja"
   },
   "routes": {
@@ -17,8 +19,8 @@
     "showOnMapDirection": "Näytä kartalla reitti {{label}}, suunta {{directionNumber}}",
     "showTimetables": "Näytä aikataulut reitille {{label}}",
     "createNew": "Luo uusi reitti",
-    "expandStops": "Näytä pysäkit reitille {{label}}",
-    "closeStops": "Piilota pysäkit reitiltä {{label}}",
+    "expandStops": "Näytä pysäkit reitille {{label}}, suunta {{directionNumber}}",
+    "closeStops": "Piilota pysäkit reitiltä {{label}}, suunta {{directionNumber}}",
     "expandTimetable": "Avaa aikataulut reitille {{label}}",
     "closeTimetable": "Piilota reitin {{label}} aikataulut",
     "bus": "Bussireitti"
@@ -27,7 +29,13 @@
     "icon": "Aikataulu",
     "changeValidityPeriod": "Muuta voimassaoloaikaa päivätyypille {{dayType}}",
     "substituteDayEdit": "Muokkaa poikkeuspäivää \"{{substituteDay}}\"",
-    "substituteDayEditClose": "Lopeta poikkeuspäivän \"{{substituteDay}}\" muokkaus"
+    "substituteDayEditClose": "Lopeta poikkeuspäivän \"{{substituteDay}}\" muokkaus",
+    "preview": "Näytä tiedoston sisältö",
+    "expandSchedulePreview": "Näytä aikataulun {{vehicleScheduleFrameLabel}} autokierrot",
+    "closeSchedulePreview": "Piilota aikataulun {{vehicleScheduleFrameLabel}} autokierrot",
+    "expandScheduleBlocksPreview": "Näytä autokierron {{scheduleBlock}} tiedot",
+    "closeScheduleBlocksPreview": "Piilota autokierron {{scheduleBlock}} tiedot",
+    "versionActions": "Lisää toimintoja aikataululle {{status}} {{schedule}} {{dayType}}"
   },
   "map": {
     "showFilters": "Suodata näkymää"

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -1,42 +1,34 @@
 {
-  "title": {
-    "line": {
-      "bus": "bussilinja"
-    },
-    "route": {
-      "bus": "Bussireitti"
-    },
-    "timetable": {
-      "icon": "Aikataulu"
-    }
-  },
-  "button": {
+  "common": {
     "showOnMap": "Näytä kartalla {{label}}",
     "nextPage": "Seuraava sivu",
     "prevPage": "Edellinen sivu",
     "expandSearch": "Avaa tarkennettu haku",
-    "closeSearch": "Sulje tarkennettu haku",
-    "line": {
-      "details": "Näytä tarkemmat tiedot linjalle {{label}}",
-      "showOnMap": "Näytä kartalla linja {{label}}",
-      "showTimetables": "Näytä aikataulut linjalle {{label}}"
-    },
-    "route": {
-      "showOnMap": "Näytä kartalla reitti {{label}}",
-      "showTimetables": "Näytä aikataulut reitille {{label}}",
-      "createNew": "Luo uusi reitti",
-      "expandStops": "Näytä pysäkit reitille {{label}}",
-      "closeStops": "Piilota pysäkit reitiltä {{label}}",
-      "expandTimetable": "Avaa aikataulut reitille {{label}}",
-      "closeTimetable": "Piilota reitin {{label}} aikataulut"
-    },
-    "map": {
-      "showFilters": "Suodata näkymää"
-    },
-    "timetables": {
-      "changeValidityPeriod": "Muuta voimassaoloaikaa ajanjaksolle {{validityPeriod}}",
-      "substituteDayEdit": "Muokkaa poikkeuspäivää \"{{substituteDay}}\"",
-      "substituteDayEditClose": "Lopeta poikkeuspäivän \"{{substituteDay}}\" muokkaus"
-    }
+    "closeSearch": "Sulje tarkennettu haku"
+  },
+  "lines": {
+    "details": "Näytä tarkemmat tiedot linjalle {{label}}",
+    "showOnMap": "Näytä kartalla linja {{label}}",
+    "showTimetables": "Näytä aikataulut linjalle {{label}}",
+    "bus": "Bussilinja"
+  },
+  "routes": {
+    "showOnMap": "Näytä kartalla reitti {{label}}",
+    "showTimetables": "Näytä aikataulut reitille {{label}}",
+    "createNew": "Luo uusi reitti",
+    "expandStops": "Näytä pysäkit reitille {{label}}",
+    "closeStops": "Piilota pysäkit reitiltä {{label}}",
+    "expandTimetable": "Avaa aikataulut reitille {{label}}",
+    "closeTimetable": "Piilota reitin {{label}} aikataulut",
+    "bus": "Bussireitti"
+  },
+  "timetables": {
+    "icon": "Aikataulu",
+    "changeValidityPeriod": "Muuta voimassaoloaikaa päivätyypille {{dayType}}",
+    "substituteDayEdit": "Muokkaa poikkeuspäivää \"{{substituteDay}}\"",
+    "substituteDayEditClose": "Lopeta poikkeuspäivän \"{{substituteDay}}\" muokkaus"
+  },
+  "map": {
+    "showFilters": "Suodata näkymää"
   }
 }

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -1,0 +1,17 @@
+{
+  "title": {},
+  "button": {
+    "showOnMap": "Näytä kartalla {{label}}",
+    "nextPage": "Seuraava sivu",
+    "prevPage": "Edellinen sivu",
+    "line": {
+      "details": "Näytä tarkemmat tiedot linjalle {{label}}",
+      "showOnMap": "Näytä kartalla linja {{label}}",
+      "showTimetables": "Näytä aikataulut linjalle {{label}}"
+    },
+    "route": {
+      "showOnMap": "Näytä kartalla reitti {{label}}",
+      "showTimetables": "Näytä aikataulut reitille {{label}}"
+    }
+  }
+}

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -12,11 +12,13 @@
     "showTimetables": "Näytä aikataulut linjalle {{label}}",
     "expandNameVersions": "Näytä nimiversiot",
     "closeNameVersions": "Sulje nimiversiot näkymä",
+    "edit": "Muokkaa linjaa {{label}}",
     "bus": "Bussilinja"
   },
   "routes": {
     "showOnMap": "Näytä kartalla reitti {{label}}",
     "showOnMapDirection": "Näytä kartalla reitti {{label}}, suunta {{directionNumber}}",
+    "editRouteDirection": "Muokkaa reittiä {{label}}, suunta {{directionNumber}}",
     "showTimetables": "Näytä aikataulut reitille {{label}}",
     "createNew": "Luo uusi reitti",
     "expandStops": "Näytä pysäkit reitille {{label}}, suunta {{directionNumber}}",
@@ -38,6 +40,7 @@
     "versionActions": "Lisää toimintoja aikataululle {{status}} {{schedule}} {{dayType}}"
   },
   "map": {
-    "showFilters": "Suodata näkymää"
+    "showFilters": "Suodata näkymää",
+    "editRoute": "Muokkaa reitin {{routeName}} tietoja"
   }
 }

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -26,6 +26,7 @@
     "closeStops": "Piilota pysäkit reitiltä {{label}}, suunta {{directionNumber}}",
     "expandTimetable": "Avaa aikataulut reitille {{routeName}}",
     "closeTimetable": "Piilota reitin {{routeName}} aikataulut",
+    "showStopActions": "Lisää toimintoja pysäkille {{stopLabel}}",
     "bus": "Bussireitti"
   },
   "timetables": {
@@ -42,6 +43,7 @@
   },
   "map": {
     "showFilters": "Suodata näkymää",
-    "editRoute": "Muokkaa reitin {{routeName}} tietoja"
+    "editRoute": "Muokkaa reitin {{routeName}} tietoja",
+    "routeStopsOverlayRowActions": "Lisää toimintoja pysäkille {{stopLabel}}"
   }
 }

--- a/ui/src/uiComponents/AccordionButton.tsx
+++ b/ui/src/uiComponents/AccordionButton.tsx
@@ -7,31 +7,59 @@ interface Props {
   isOpen: boolean;
   className?: string;
   iconClassName?: string;
+  controls: string;
+  openTooltip?: string;
+  closeTooltip?: string;
+  ariaLabel?: string;
+  identifier?: string;
 }
 
+/**
+ * A button that could be used as the toggle button of a section that can be hidden or shown.
+ * Contains logic to handle up and down chevrons (V-shape), that indicate the state for visual users.
+ * @param controls is required to indicate to screen readers what the button controls.
+ * @param openTooltip and `closeTooltip` should primarily be used for cases where there's no text or `<label>` for the button, e.g. if there's only an icon.
+ * @param ariaLabel should be used if the button's text or `<label>` is clear for visual users, making the tooltip redundant, but requires more context for screen readers.
+ * @returns
+ */
 export const AccordionButton = ({
   testId,
   onToggle,
   isOpen,
   className = '',
   iconClassName = '',
+  controls,
+  openTooltip,
+  closeTooltip,
+  ariaLabel,
+  identifier,
 }: Props) => {
+  const tooltip = isOpen ? closeTooltip : openTooltip;
   return (
     <IconButton
+      identifier={identifier}
+      tooltip={tooltip}
       testId={testId}
       onClick={() => onToggle(!isOpen)}
       icon={
         isOpen ? (
           <MdKeyboardArrowUp
-            className={`text-3xl text-tweaked-brand ${iconClassName}`}
+            className={`text-3xl text-tweaked-brand ${iconClassName} pointer-events-none`}
+            aria-hidden
           />
         ) : (
           <MdKeyboardArrowDown
-            className={`text-3xl text-tweaked-brand ${iconClassName} `}
+            className={`text-3xl text-tweaked-brand ${iconClassName} pointer-events-none`}
+            aria-hidden
           />
         )
       }
       className={className}
+      ariaAttributes={{
+        ariaExpanded: isOpen,
+        ariaControls: controls ?? '',
+        ariaLabel,
+      }}
     />
   );
 };

--- a/ui/src/uiComponents/ChevronToggle.tsx
+++ b/ui/src/uiComponents/ChevronToggle.tsx
@@ -5,24 +5,35 @@ type Props = {
   isToggled: boolean;
   testId?: string;
   onClick: () => void;
+  controls: string;
+  openTooltip: string;
+  closeTooltip: string;
 };
 
 export const ChevronToggle = ({
   isToggled,
   onClick,
   testId,
+  controls,
+  openTooltip,
+  closeTooltip,
 }: Props): JSX.Element => {
   const iconClassName = 'text-3xl text-tweaked-brand';
   return (
     <IconButton
+      tooltip={isToggled ? closeTooltip : openTooltip}
       onClick={onClick}
       icon={
         isToggled ? (
-          <FaChevronUp className={iconClassName} />
+          <FaChevronUp className={iconClassName} aria-hidden />
         ) : (
-          <FaChevronDown className={iconClassName} />
+          <FaChevronDown className={iconClassName} aria-hidden />
         )
       }
+      ariaAttributes={{
+        ariaExpanded: isToggled,
+        ariaControls: controls,
+      }}
       testId={testId}
     />
   );

--- a/ui/src/uiComponents/EditButton.tsx
+++ b/ui/src/uiComponents/EditButton.tsx
@@ -12,6 +12,7 @@ interface ButtonProps {
 }
 interface CommonProps {
   testId?: string;
+  tooltip: string;
 }
 
 type Props = CommonProps & (LinkProps | ButtonProps);
@@ -20,25 +21,30 @@ const ButtonContent = () => (
   <div
     className={`ml-5 flex h-10 w-10 items-center justify-center rounded-full border border-grey bg-white ${commonHoverStyle}`}
   >
-    <MdModeEdit className="text-2xl text-tweaked-brand" />
+    <MdModeEdit className="aria-hidden text-2xl text-tweaked-brand" />
   </div>
 );
 
 export const EditButton: React.FC<Props> = (props) => {
-  const { testId } = props;
+  const { testId, tooltip } = props;
   const href = (props as LinkProps)?.href;
   const onClick = (props as ButtonProps)?.onClick;
 
   if (href) {
     return (
-      <Link to={href} data-testid={testId}>
+      <Link to={href} data-testid={testId} title={tooltip}>
         <ButtonContent />
       </Link>
     );
   }
 
   return (
-    <button onClick={onClick} type="button" data-testid={testId}>
+    <button
+      onClick={onClick}
+      type="button"
+      data-testid={testId}
+      title={tooltip}
+    >
       <ButtonContent />
     </button>
   );

--- a/ui/src/uiComponents/EditCloseButton.tsx
+++ b/ui/src/uiComponents/EditCloseButton.tsx
@@ -3,6 +3,8 @@ import { Visible } from '../layoutComponents';
 import { IconButton } from './IconButton';
 
 interface Props {
+  titleEdit: string;
+  titleClose: string;
   showEdit: boolean;
   onEdit: () => void;
   onClose: () => void;
@@ -16,6 +18,8 @@ interface Props {
  * otherwise renders the close option
  */
 export const EditCloseButton = ({
+  titleEdit,
+  titleClose,
   showEdit,
   onEdit,
   onClose,
@@ -25,16 +29,18 @@ export const EditCloseButton = ({
     <div>
       <Visible visible={!showEdit}>
         <IconButton
+          tooltip={titleClose}
           className="text-base font-bold text-brand"
-          icon={<MdClose />}
+          icon={<MdClose aria-hidden />}
           onClick={onClose}
           testId={testId}
         />
       </Visible>
       <Visible visible={showEdit}>
         <IconButton
+          tooltip={titleEdit}
           className="text-base font-bold text-brand"
-          icon={<MdEdit />}
+          icon={<MdEdit aria-hidden />}
           onClick={onEdit}
           testId={testId}
         />

--- a/ui/src/uiComponents/FilterPanel.tsx
+++ b/ui/src/uiComponents/FilterPanel.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { i18n } from '../i18n';
 import { Row } from '../layoutComponents';
 import { Card } from './Card';
 import { IconToggle } from './IconToggle';
@@ -13,6 +14,7 @@ interface Toggle {
 interface IconToggle extends Toggle {
   iconClassName: string; // eslint-disable-line react/no-unused-prop-types
   disabled?: boolean; // eslint-disable-line react/no-unused-prop-types
+  tooltip: string; // eslint-disable-line react/no-unused-prop-types
 }
 
 interface ToggleRowProps {
@@ -24,7 +26,14 @@ const ToggleRow = ({ toggles }: ToggleRowProps): JSX.Element => {
     <Row className="mt-2">
       {toggles.map(
         (
-          { active, onToggle, iconClassName, disabled, testId }: IconToggle,
+          {
+            active,
+            onToggle,
+            iconClassName,
+            disabled,
+            testId,
+            tooltip,
+          }: IconToggle,
           index: number,
         ) => (
           <IconToggle
@@ -37,6 +46,7 @@ const ToggleRow = ({ toggles }: ToggleRowProps): JSX.Element => {
             onToggle={onToggle}
             disabled={disabled}
             testId={testId}
+            tooltip={tooltip}
           />
         ),
       )}
@@ -54,6 +64,7 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
+    tooltip: i18n.t('vehicleModeEnum.tram'),
   },
   {
     iconClassName: 'icon-train',
@@ -61,6 +72,7 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
+    tooltip: i18n.t('vehicleModeEnum.train'),
   },
   {
     iconClassName: 'icon-ferry',
@@ -68,6 +80,7 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
+    tooltip: i18n.t('vehicleModeEnum.ferry'),
   },
   {
     iconClassName: 'icon-metro',
@@ -75,6 +88,7 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
+    tooltip: i18n.t('vehicleModeEnum.metro'),
   },
 ];
 

--- a/ui/src/uiComponents/IconButton.tsx
+++ b/ui/src/uiComponents/IconButton.tsx
@@ -3,27 +3,42 @@ import { addClassName } from '../utils/components';
 
 interface Props {
   testId?: string;
+  tooltip?: string;
   className?: string;
   disabled?: boolean;
   icon: React.ReactNode;
+  ariaAttributes?: {
+    ariaExpanded?: boolean;
+    ariaControls?: string;
+    ariaLabel?: string;
+  };
+  identifier?: string;
   onClick: () => void;
 }
 
 export const IconButton: React.FC<Props> = ({
   testId,
+  tooltip,
   className = '',
   disabled,
   icon,
+  ariaAttributes,
+  identifier,
   onClick,
 }) => {
   const iconClassName = 'inline text-center';
   return (
     <button
+      id={identifier}
       data-testid={testId}
+      title={tooltip}
       className={`text-center ${className}`}
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-expanded={ariaAttributes?.ariaExpanded}
+      aria-controls={ariaAttributes?.ariaControls}
+      aria-label={ariaAttributes?.ariaLabel}
     >
       {React.isValidElement(icon) ? addClassName(icon, iconClassName) : icon}
     </button>

--- a/ui/src/uiComponents/IconToggle.tsx
+++ b/ui/src/uiComponents/IconToggle.tsx
@@ -7,6 +7,7 @@ interface Props {
   className?: string;
   iconClassName: string;
   testId: string;
+  tooltip: string;
 }
 
 export const IconToggle = ({
@@ -16,6 +17,7 @@ export const IconToggle = ({
   className = '',
   iconClassName = '',
   testId,
+  tooltip,
 }: Props): JSX.Element => {
   const colorClassNames = active
     ? 'bg-tweaked-brand text-white'
@@ -33,9 +35,11 @@ export const IconToggle = ({
         className,
       )}
       onClick={() => onToggle(!active)}
+      aria-disabled={active}
+      title={tooltip}
     >
       <i
-        className={`text-5xl ${iconClassName}`}
+        className={`text-5xl ${iconClassName} aria-hidden`}
         // our icon library's css file adds margins with ::before pseudo element and this inline style is hack to get rid of those
         style={{ marginLeft: '-.2em', marginRight: '-0.2em' }}
       />

--- a/ui/src/uiComponents/LocatorButton.tsx
+++ b/ui/src/uiComponents/LocatorButton.tsx
@@ -1,6 +1,4 @@
-import { useTranslation } from 'react-i18next';
 import { MdPinDrop } from 'react-icons/md';
-import { Tooltip } from '../components/common/Tooltip';
 import { IconButton } from './IconButton';
 import { commonHoverStyle } from './SimpleButton';
 
@@ -13,6 +11,7 @@ interface Props {
   disabled?: boolean;
   onClick: () => void;
   className?: string;
+  tooltipText: string;
 }
 
 export const LocatorButton = ({
@@ -20,23 +19,19 @@ export const LocatorButton = ({
   onClick,
   disabled,
   className = '',
+  tooltipText,
 }: Props): JSX.Element => {
   const disabledStyle = '!bg-background opacity-70 pointer-events-none';
-  const { t } = useTranslation();
   return (
-    <Tooltip
-      tooltipClassName="bottom-11 delay-700"
-      message={t('map.showOnMap')}
-    >
-      <IconButton
-        className={`h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand ${commonHoverStyle} ${
-          disabled ? disabledStyle : ''
-        } ${className}`}
-        onClick={onClick}
-        disabled={disabled}
-        icon={<MdPinDrop className="text-2xl" />}
-        testId={testId || testIds.button}
-      />
-    </Tooltip>
+    <IconButton
+      className={`h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand ${commonHoverStyle} ${
+        disabled ? disabledStyle : ''
+      } ${className}`}
+      tooltip={tooltipText}
+      onClick={onClick}
+      disabled={disabled}
+      icon={<MdPinDrop className="text-2xl" aria-hidden />}
+      testId={testId || testIds.button}
+    />
   );
 };

--- a/ui/src/uiComponents/Pagination.tsx
+++ b/ui/src/uiComponents/Pagination.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import { usePagination } from '../hooks/usePagination';
 import { IconButton } from './IconButton';
@@ -34,6 +35,7 @@ export const Pagination = ({
   itemsPerPage = DEFAULT_ITEMS_PER_PAGE,
   className = '',
 }: Props): JSX.Element => {
+  const { t } = useTranslation();
   const {
     currentPage,
     setPage,
@@ -83,15 +85,17 @@ export const Pagination = ({
   return (
     <div className={`flex justify-evenly ${className}`}>
       <IconButton
+        disabled={onFirstPage}
+        tooltip={t('accessibility:common.prevPage')}
+        onClick={() => setPage(currentPage - 1)}
         testId="prevPageButtonIcon"
         className="flex-1"
-        onClick={() => setPage(currentPage - 1)}
-        disabled={onFirstPage}
         icon={
           <FaChevronLeft
             className={`text-3xl ${
               onFirstPage ? 'text-light-grey' : 'text-tweaked-brand'
             }`}
+            aria-hidden
           />
         }
       />
@@ -121,6 +125,7 @@ export const Pagination = ({
       )}
       <IconButton
         disabled={onLastPage}
+        tooltip={t('accessibility:common.nextPage')}
         onClick={() => setPage(currentPage + 1)}
         testId="nextPageButtonIcon"
         className="flex-1"
@@ -129,6 +134,7 @@ export const Pagination = ({
             className={`text-3xl ${
               onLastPage ? 'text-light-grey' : 'text-tweaked-brand'
             }`}
+            aria-hidden
           />
         }
       />

--- a/ui/src/uiComponents/SimpleDropdownMenu.tsx
+++ b/ui/src/uiComponents/SimpleDropdownMenu.tsx
@@ -9,6 +9,7 @@ interface Props {
   testId?: string;
   /** Set value to align menu items to right or left. Default: no alignment */
   alignItems?: AlignDirection;
+  tooltip: string;
 }
 
 export enum AlignDirection {
@@ -32,20 +33,21 @@ export const SimpleDropdownMenu = ({
   children,
   testId,
   alignItems = AlignDirection.NoAlign,
+  tooltip,
 }: Props): JSX.Element => {
   const alignClassName = getAlignClassName(alignItems);
   const commonClassName = `${alignClassName} absolute z-10 origin-top-right overflow-visible bg-white text-black shadow-md focus:outline-none`;
   const menuItemClassName = `border-x border-b first-of-type:border-t whitespace-nowrap border-black w-full py-1 px-2 focus:outline-none text-left`;
 
   return (
-    <Menu as="div" className="relative">
+    <Menu as="div" className="relative" title={tooltip}>
       {({ open }) => (
         <>
           <Menu.Button
             className="mx-auto flex items-center px-3 focus:outline-none"
             data-testid={testId}
           >
-            <MdMoreVert className="text-3xl" />
+            <MdMoreVert className="aria-hidden text-3xl" />
           </Menu.Button>
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <Transition show={open} as={Fragment} {...dropdownTransition}>

--- a/ui/src/uiComponents/TimetableIcon.tsx
+++ b/ui/src/uiComponents/TimetableIcon.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  className?: string;
+  hasTimetables?: boolean;
+}
+
+/**
+ * A calendar icon, that has a translated title for screenreaders.
+ * If the line doesn't have timetables, the title is gone and the icon is greyed out.
+ *
+ * The title helps make sense of the row as a whole for screenreaders.
+ * @param hasTimetables defines the icons color and title
+ * @returns A calendar icon
+ */
+export const TimetableIcon = ({
+  className = '',
+  hasTimetables = false,
+}: Props) => {
+  const { t } = useTranslation();
+  const iconTitle = hasTimetables ? t('accessibility:timetables.icon') : '';
+  const fontColor = hasTimetables ? 'text-tweaked-brand' : 'text-zinc-400';
+  return (
+    <i
+      className={`icon-calendar ${fontColor} ${className}`}
+      title={iconTitle}
+      role="img"
+    />
+  );
+};

--- a/ui/src/uiComponents/VehicleIcon.tsx
+++ b/ui/src/uiComponents/VehicleIcon.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next';
+import {
+  LineTableRowFragment,
+  RouteTableRowFragment,
+  ReusableComponentsVehicleModeEnum as VehicleMode,
+} from '../generated/graphql';
+import { isLine } from '../graphql';
+
+type RowItem = LineTableRowFragment | RouteTableRowFragment;
+
+interface Props {
+  className?: string;
+  vehicleMode: VehicleMode;
+  rowItem: RowItem;
+}
+
+export const VehicleIcon = ({
+  className = '',
+  vehicleMode = VehicleMode.Bus,
+  rowItem,
+}: Props) => {
+  const { t } = useTranslation();
+  const iconTitle = t(
+    isLine(rowItem)
+      ? 'accessibility:title.line.bus'
+      : 'accessibility:title.route.bus',
+  );
+  return (
+    <i
+      className={`icon-${vehicleMode}-alt ${className}`}
+      title={iconTitle}
+      role="img"
+    />
+  );
+};

--- a/ui/src/uiComponents/VehicleIcon.tsx
+++ b/ui/src/uiComponents/VehicleIcon.tsx
@@ -21,9 +21,7 @@ export const VehicleIcon = ({
 }: Props) => {
   const { t } = useTranslation();
   const iconTitle = t(
-    isLine(rowItem)
-      ? 'accessibility:title.line.bus'
-      : 'accessibility:title.route.bus',
+    isLine(rowItem) ? 'accessibility:lines.bus' : 'accessibility:routes.bus',
   );
   return (
     <i


### PR DESCRIPTION
There are plenty of icons and buttons in the application that don't clearly indicate what they do, especially to screen readers. 

This is fixed by adding alternative texts to buttons and icons, where it makes sense. 

Multiple icons will be hidden with the `aria-hidden` label, this is because people using screen readers don't get any value out of many icons. 

E.g. knowing that there's an image of a calendar in a button that opens the calendar. Such a button should have the icon hidden from screen-readers and a "Open calendar" title, if the button didn't contain such a text in of itself.

The task was to add *alternative* texts, but most of my implementations use the `title` attribute instead. There are multiple `alt-text` (for images), `aria-label`, etc. attributes for such purposes, but those are for situations where the button's text itself, nor the title do not contain enough information for a screen reader user to understand it's functionality. Additionally, the `title` attribute can be helpful for all users, when they hover over the button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/756)
<!-- Reviewable:end -->
