### PR TITLE
Add spinner to each route row on line details page

### DIFF
--- a/ui/src/components/routes-and-lines/line-details/RouteRowLoader.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteRowLoader.tsx
@@ -1,0 +1,22 @@
+import { PulseLoader } from 'react-spinners';
+import { theme } from '../../../generated/theme';
+
+interface Props {
+  className?: string;
+}
+
+export const RouteRowLoader = ({ className = '' }: Props): JSX.Element => {
+  return (
+    <tr className={`border border-white bg-lighter-grey ${className} p-4`}>
+      <td className="p-4" colSpan={6}>
+        <div className="mt-1 inline-flex w-full flex-col items-center">
+          <PulseLoader
+            size={15}
+            color={theme.colors.brand}
+            speedMultiplier={0.7}
+          />
+        </div>
+      </td>
+    </tr>
+  );
+};

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsSection.tsx
@@ -18,6 +18,7 @@ import {
   showSuccessToast,
 } from '../../../utils';
 import { ExpandableRouteRow } from './ExpandableRouteRow';
+import { RouteRowLoader } from './RouteRowLoader';
 import { RouteStopsRow } from './RouteStopsRow';
 
 interface Props {
@@ -53,7 +54,14 @@ export const RouteStopsSection = ({
   const route = routeResult.data?.route_route_by_pk;
 
   if (!route) {
-    return <></>;
+    // Display a loader until all details have been loaded.
+    // Note: we would actually have some information about the route that we could display already,
+    // but made a design decision not to show anything until whole row can be shown.
+    return (
+      <tbody>
+        <RouteRowLoader className="[&>td]:h-[75px]" />
+      </tbody>
+    );
   }
 
   /**
@@ -113,6 +121,7 @@ export const RouteStopsSection = ({
   return (
     <tbody className={className}>
       <ExpandableRouteRow
+        className="[&>td]:h-[75px]"
         key={route.route_id}
         route={route}
         observationDate={observationDate}

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -36,7 +36,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
         class=""
       >
         <tr
-          class="border border-white bg-background  p-4"
+          class="border border-white bg-background [&>td]:h-[75px] p-4"
           data-testid="ExpandableRouteRow::65x"
         >
           <td
@@ -257,7 +257,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
         class=""
       >
         <tr
-          class="border border-white bg-background  p-4"
+          class="border border-white bg-background [&>td]:h-[75px] p-4"
           data-testid="ExpandableRouteRow::65x"
         >
           <td
@@ -704,7 +704,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
         class=""
       >
         <tr
-          class="border border-white bg-background  p-4"
+          class="border border-white bg-background [&>td]:h-[75px] p-4"
           data-testid="ExpandableRouteRow::65x"
         >
           <td


### PR DESCRIPTION
The line details in general load fast enough that it wasn't deemed necessary to have a whole page spinner.
The route details on the other hand might take a moment (less than a second really, on dev), so show a loader animation until each is ready.

Hardcoded the row height to help ensure the loader height matches actual row and to make it more robust against small layout changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/762)
<!-- Reviewable:end -->
