### PR TITLE
Timetables version details sidepanel

### DIFF
--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -727,10 +727,10 @@ describe('Timetable import', () => {
           '2023-06-30',
         );
         timetableVersionsPage.timetableVersionTableRow
-          .getRow()
+          .getRows()
           .should('have.length', 2);
         timetableVersionsPage.timetableVersionTableRow
-          .getRow()
+          .getRows()
           .eq(0)
           .should('contain', 'Voimassa')
           .and('contain', 'Sunnuntai')
@@ -738,7 +738,7 @@ describe('Timetable import', () => {
           .and('contain', '31.12.2049')
           .and('contain', '99');
         timetableVersionsPage.timetableVersionTableRow
-          .getRow()
+          .getRows()
           .eq(1)
           .should('contain', 'Luonnos')
           .and('contain', 'Sunnuntai')

--- a/cypress/e2e/timetableVersionDetailsPanel.cy.ts
+++ b/cypress/e2e/timetableVersionDetailsPanel.cy.ts
@@ -1,0 +1,612 @@
+import {
+  GetInfrastructureLinksByExternalIdsResult,
+  InfraLinkAlongRouteInsertInput,
+  JourneyPatternInsertInput,
+  LineInsertInput,
+  RouteDirectionEnum,
+  RouteInsertInput,
+  RouteTypeOfLineEnum,
+  StopInJourneyPatternInsertInput,
+  StopInsertInput,
+  buildLine,
+  buildRoute,
+  buildStop,
+  buildStopInJourneyPattern,
+  buildTimingPlace,
+  extractInfrastructureLinkIdsFromResponse,
+  mapToGetInfrastructureLinksByExternalIdsQuery,
+} from '@hsl/jore4-test-db-manager';
+import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
+import { DateTime, Duration } from 'luxon';
+import {
+  ChangeTimetablesValidityForm,
+  TimetableVersionDetailsPanel,
+  TimetableVersionsPage,
+  Toast,
+  VehicleServiceRow,
+} from '../pageObjects';
+import { UUID } from '../types';
+import {
+  SupportedResources,
+  insertToDbHelper,
+  removeFromDbHelper,
+} from '../utils';
+
+// TODO: Extract the basedata somewhere, so that it can be used in multiple tests. No need
+// to copy paste 400+ lines in front of every test.
+
+// TODO: Also after extracting base data, expand the data so that we have different labeled routes
+// in the dataset and add asserts to the tests for those details
+
+// These infralink IDs exist in the 'infraLinks.sql' test data file.
+// These form a straight line on Eerikinkatu in Helsinki.
+// Coordinates are partial since they are needed only for the stop creation.
+
+const testInfraLinks = [
+  {
+    externalId: '445156',
+    coordinates: [24.925682785, 60.163824160000004, 7.3515],
+  },
+  {
+    externalId: '442331',
+    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
+  },
+  {
+    externalId: '442424',
+    coordinates: [24.929825718, 60.165285984, 9.957],
+  },
+  {
+    externalId: '442325',
+    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
+  },
+];
+
+const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
+
+const lines: LineInsertInput[] = [
+  {
+    ...buildLine({ label: '99' }),
+    line_id: 'f148d51b-36ff-4321-8cf1-049946f75f73',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
+  },
+];
+
+const timingPlaces = [
+  buildTimingPlace('50623e7b-abd0-4c9a-85fa-f88ff7f65a06', '1AACKT'),
+  buildTimingPlace('f8a93c6f-5ef7-4b09-ae5e-0a04ea8597e9', '1ELIMK'),
+  buildTimingPlace('31a2592e-0af1-48b7-8f2f-373dcca39ddd', '1AURLA'),
+];
+
+const buildStopsOnInfrastrucureLinks = (
+  infrastructureLinkIds: UUID[],
+): StopInsertInput[] => [
+  {
+    ...buildStop({
+      label: stopLabels[0],
+      located_on_infrastructure_link_id: infrastructureLinkIds[0],
+    }),
+    scheduled_stop_point_id: 'd9f0bc78-45f2-4d44-9cac-4674f856a400',
+    timing_place_id: timingPlaces[0].timing_place_id,
+    measured_location: {
+      type: 'Point',
+      coordinates: testInfraLinks[0].coordinates,
+    },
+  },
+  {
+    ...buildStop({
+      label: stopLabels[1],
+      located_on_infrastructure_link_id: infrastructureLinkIds[1],
+    }),
+    scheduled_stop_point_id: '63bd05f9-de46-4fa3-bdd9-10e9a81702e3',
+    measured_location: {
+      type: 'Point',
+      coordinates: testInfraLinks[1].coordinates,
+    },
+  },
+  {
+    ...buildStop({
+      label: stopLabels[2],
+      located_on_infrastructure_link_id: infrastructureLinkIds[2],
+    }),
+    scheduled_stop_point_id: 'f732ceb2-fc41-4843-8164-ead6ec7dd33b',
+    timing_place_id: timingPlaces[1].timing_place_id,
+    measured_location: {
+      type: 'Point',
+      coordinates: testInfraLinks[2].coordinates,
+    },
+  },
+  {
+    ...buildStop({
+      label: stopLabels[3],
+      located_on_infrastructure_link_id: infrastructureLinkIds[3],
+    }),
+    scheduled_stop_point_id: '322a32cc-7a50-402b-9c01-5dc6a6b39af6',
+    timing_place_id: timingPlaces[2].timing_place_id,
+    measured_location: {
+      type: 'Point',
+      coordinates: testInfraLinks[3].coordinates,
+    },
+  },
+];
+
+const routes: RouteInsertInput[] = [
+  {
+    ...buildRoute({ label: '99' }),
+    route_id: '829e9d55-aa25-4ab9-858b-f2a5aa81d931',
+    on_line_id: lines[0].line_id,
+    validity_start: DateTime.fromISO('2023-01-01T13:08:43.315+03:00'),
+    validity_end: DateTime.fromISO('2043-06-30T13:08:43.315+03:00'),
+    direction: RouteDirectionEnum.Inbound,
+  },
+  {
+    ...buildRoute({ label: '99' }),
+    route_id: '06577560-4535-46ec-8240-0b989b0fed87',
+    on_line_id: lines[0].line_id,
+    validity_start: DateTime.fromISO('2023-01-01T13:08:43.315+03:00'),
+    validity_end: DateTime.fromISO('2043-06-30T13:08:43.315+03:00'),
+    direction: RouteDirectionEnum.Outbound,
+  },
+];
+
+const buildInfraLinksAlongRoute = (
+  infrastructureLinkIds: UUID[],
+): InfraLinkAlongRouteInsertInput[] => [
+  {
+    route_id: routes[0].route_id,
+    infrastructure_link_id: infrastructureLinkIds[0],
+    infrastructure_link_sequence: 0,
+    is_traversal_forwards: true,
+  },
+  {
+    route_id: routes[0].route_id,
+    infrastructure_link_id: infrastructureLinkIds[1],
+    infrastructure_link_sequence: 1,
+    is_traversal_forwards: true,
+  },
+  {
+    route_id: routes[0].route_id,
+    infrastructure_link_id: infrastructureLinkIds[2],
+    infrastructure_link_sequence: 2,
+    is_traversal_forwards: true,
+  },
+  {
+    route_id: routes[0].route_id,
+    infrastructure_link_id: infrastructureLinkIds[3],
+    infrastructure_link_sequence: 3,
+    is_traversal_forwards: true,
+  },
+  {
+    route_id: routes[1].route_id,
+    infrastructure_link_id: infrastructureLinkIds[3],
+    infrastructure_link_sequence: 0,
+    is_traversal_forwards: true,
+  },
+  {
+    route_id: routes[1].route_id,
+    infrastructure_link_id: infrastructureLinkIds[2],
+    infrastructure_link_sequence: 1,
+    is_traversal_forwards: true,
+  },
+  {
+    route_id: routes[1].route_id,
+    infrastructure_link_id: infrastructureLinkIds[1],
+    infrastructure_link_sequence: 2,
+    is_traversal_forwards: true,
+  },
+  {
+    route_id: routes[1].route_id,
+    infrastructure_link_id: infrastructureLinkIds[0],
+    infrastructure_link_sequence: 3,
+    is_traversal_forwards: true,
+  },
+];
+
+const journeyPatterns: JourneyPatternInsertInput[] = [
+  {
+    journey_pattern_id: '72ff8c33-33aa-4169-803e-53f2426a4508',
+    on_route_id: routes[0].route_id,
+  },
+  {
+    journey_pattern_id: '45217fb9-f95f-4193-8597-fb285e859d04',
+    on_route_id: routes[1].route_id,
+  },
+];
+
+const stopsInJourneyPattern: StopInJourneyPatternInsertInput[] = [
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[0].journey_pattern_id,
+    stopLabel: stopLabels[0],
+    scheduledStopPointSequence: 0,
+    isUsedAsTimingPoint: true,
+  }),
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[0].journey_pattern_id,
+    stopLabel: stopLabels[1],
+    scheduledStopPointSequence: 1,
+    isUsedAsTimingPoint: false,
+  }),
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[0].journey_pattern_id,
+    stopLabel: stopLabels[2],
+    scheduledStopPointSequence: 2,
+    isUsedAsTimingPoint: true,
+  }),
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[0].journey_pattern_id,
+    stopLabel: stopLabels[3],
+    scheduledStopPointSequence: 3,
+    isUsedAsTimingPoint: true,
+  }),
+];
+
+const stopInAnotherJourneyPattern: StopInJourneyPatternInsertInput[] = [
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[1].journey_pattern_id,
+    stopLabel: stopLabels[3],
+    scheduledStopPointSequence: 0,
+    isUsedAsTimingPoint: true,
+  }),
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[1].journey_pattern_id,
+    stopLabel: stopLabels[2],
+    scheduledStopPointSequence: 1,
+    isUsedAsTimingPoint: true,
+  }),
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[1].journey_pattern_id,
+    stopLabel: stopLabels[1],
+    scheduledStopPointSequence: 2,
+    isUsedAsTimingPoint: false,
+  }),
+  buildStopInJourneyPattern({
+    journeyPatternId: journeyPatterns[1].journey_pattern_id,
+    stopLabel: stopLabels[0],
+    scheduledStopPointSequence: 3,
+    isUsedAsTimingPoint: true,
+  }),
+];
+
+const timetableDataInput = {
+  _journey_pattern_refs: {
+    route99inbound: {
+      route_label: '99',
+      route_direction: 'inbound',
+      journey_pattern_id: journeyPatterns[0].journey_pattern_id,
+      _stop_points: [
+        {
+          scheduled_stop_point_sequence: 1,
+          scheduled_stop_point_label: 'H1231',
+          timing_place_label: '1AACKT',
+        },
+        {
+          scheduled_stop_point_sequence: 2,
+          scheduled_stop_point_label: 'H1232',
+        },
+        {
+          scheduled_stop_point_sequence: 3,
+          scheduled_stop_point_label: 'H1233',
+          timing_place_label: '1ELIMK',
+        },
+        {
+          scheduled_stop_point_sequence: 4,
+          scheduled_stop_point_label: 'H1234',
+          timing_place_label: '1AURLA',
+        },
+      ],
+    },
+    route99outbound: {
+      route_label: '99',
+      route_direction: 'outbound',
+      journey_pattern_id: journeyPatterns[1].journey_pattern_id,
+      _stop_points: [
+        {
+          scheduled_stop_point_sequence: 1,
+          scheduled_stop_point_label: 'H1234',
+          timing_place_label: '1AURLA',
+        },
+        {
+          scheduled_stop_point_sequence: 2,
+          scheduled_stop_point_label: 'H1233',
+          timing_place_label: '1ELIMK',
+        },
+        {
+          scheduled_stop_point_sequence: 3,
+          scheduled_stop_point_label: 'H1232',
+        },
+        {
+          scheduled_stop_point_sequence: 4,
+          scheduled_stop_point_label: 'H1231',
+          timing_place_label: '1AACKT',
+        },
+      ],
+    },
+  },
+  _vehicle_schedule_frames: {
+    year2023: {
+      validity_start: DateTime.fromISO('2023-01-01'),
+      validity_end: DateTime.fromISO('2023-12-31'),
+      name: '2023',
+      booking_label: '2023 booking label',
+      _vehicle_services: {
+        saturday: {
+          day_type_id: defaultDayTypeIds.SATURDAY,
+          _blocks: {
+            block: {
+              _vehicle_journeys: {
+                route99Inbound1: {
+                  _journey_pattern_ref_name: 'route99inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'H1231',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT7H05M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1232',
+                      arrival_time: Duration.fromISO('PT7H12M'),
+                      departure_time: Duration.fromISO('PT7H12M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1233',
+                      arrival_time: Duration.fromISO('PT7H19M'),
+                      departure_time: Duration.fromISO('PT7H23M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1234',
+                      arrival_time: Duration.fromISO('PT7H27M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route99Inbound2: {
+                  _journey_pattern_ref_name: 'route99inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'H1231',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT8H20M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1232',
+                      arrival_time: Duration.fromISO('PT8H22M'),
+                      departure_time: Duration.fromISO('PT8H22M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1233',
+                      arrival_time: Duration.fromISO('PT8H26M'),
+                      departure_time: Duration.fromISO('PT8H27M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1234',
+                      arrival_time: Duration.fromISO('PT8H29M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route99Inbound3: {
+                  _journey_pattern_ref_name: 'route99inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'H1231',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT8H30M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1232',
+                      arrival_time: Duration.fromISO('PT8H39M'),
+                      departure_time: Duration.fromISO('PT8H39M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1233',
+                      arrival_time: Duration.fromISO('PT8H50M'),
+                      departure_time: Duration.fromISO('PT8H50M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1234',
+                      arrival_time: Duration.fromISO('PT8H59M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route99Outbound1: {
+                  _journey_pattern_ref_name: 'route99outbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'H1234',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT7H28M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1233',
+                      arrival_time: Duration.fromISO('PT7H38M'),
+                      departure_time: Duration.fromISO('PT7H38M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1232',
+                      arrival_time: Duration.fromISO('PT8H00M'),
+                      departure_time: Duration.fromISO('PT8H00M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'H1231',
+                      arrival_time: Duration.fromISO('PT8H15M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('Timetable version details panel', () => {
+  const baseDbResources = {
+    lines,
+    routes,
+    journeyPatterns,
+    stopsInJourneyPattern,
+    stopInAnotherJourneyPattern,
+  };
+  let dbResources: SupportedResources;
+  let timetableVersionsPage: TimetableVersionsPage;
+  let timetableVersionDetailsPanel: TimetableVersionDetailsPanel;
+  let changeTimetablesValidityForm: ChangeTimetablesValidityForm;
+  let vehicleServiceRow: VehicleServiceRow;
+  let toast: Toast;
+
+  before(() => {
+    cy.task<GetInfrastructureLinksByExternalIdsResult>(
+      'hasuraAPI',
+      mapToGetInfrastructureLinksByExternalIdsQuery(
+        testInfraLinks.map((infralink) => infralink.externalId),
+      ),
+    ).then((res) => {
+      const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);
+      const stops = buildStopsOnInfrastrucureLinks(infraLinkIds);
+      const infraLinksAlongRoute = buildInfraLinksAlongRoute(infraLinkIds);
+      dbResources = {
+        ...baseDbResources,
+        timingPlaces,
+        stops,
+        infraLinksAlongRoute,
+      };
+    });
+  });
+
+  beforeEach(() => {
+    cy.task('truncateTimetablesDatabase');
+    removeFromDbHelper(dbResources);
+    insertToDbHelper(dbResources);
+    cy.task('insertHslTimetablesDatasetToDb', timetableDataInput);
+
+    timetableVersionsPage = new TimetableVersionsPage();
+    timetableVersionDetailsPanel = new TimetableVersionDetailsPanel();
+    changeTimetablesValidityForm = new ChangeTimetablesValidityForm();
+    vehicleServiceRow = new VehicleServiceRow();
+    toast = new Toast();
+
+    cy.setupTests();
+    cy.mockLogin();
+    cy.visit(
+      `/timetables/lines/99/versions?startDate=2023-03-04&endDate=2024-03-04`,
+    );
+  });
+
+  afterEach(() => {
+    removeFromDbHelper(dbResources);
+    cy.task('truncateTimetablesDatabase');
+  });
+
+  it('Should open, have correct details, and close', () => {
+    timetableVersionsPage.timetableVersionTableRow
+      .getRow()
+      .should('have.length', 1);
+
+    timetableVersionsPage.timetableVersionTableRow.openNthRowVersionDetailsPanel(
+      0,
+    );
+
+    timetableVersionDetailsPanel
+      .getHeading()
+      .should('contain', 'Aikataulu voimassa')
+      .and('contain', '1.1.2023 - 31.12.2023');
+
+    timetableVersionDetailsPanel.getRows().should('have.length', 2);
+
+    timetableVersionDetailsPanel
+      .getRows()
+      .eq(0)
+      .findByTestId('DirectionBadge::outbound')
+      .should('be.visible');
+
+    timetableVersionDetailsPanel.getRows().eq(0).should('contain', '99');
+
+    timetableVersionDetailsPanel.toggleExpandNthRow(0);
+    timetableVersionDetailsPanel.getRows()
+      .eq(0)
+      .findByTestId('VehicleServiceRow::row')
+      .findByTestId('VehicleServiceRow::hour')
+      .eq(0)
+      .should('contain', '07');
+
+    timetableVersionDetailsPanel
+      .getRows()
+      .eq(1)
+      .findByTestId('DirectionBadge::inbound')
+      .should('be.visible');
+
+    timetableVersionDetailsPanel.toggleExpandNthRow(1);
+    timetableVersionDetailsPanel.getRows()
+      .eq(1)
+      .findByTestId('VehicleServiceRow::row')
+      .then((rows) => {
+        // hour 07 departures
+        cy.wrap(rows)
+          .eq(0)
+          .within(() => {
+            vehicleServiceRow.getHour().should('contain', '07');
+            vehicleServiceRow.getMinute().eq(0).contains('05');
+          });
+
+        // hour 08 departures
+        cy.wrap(rows)
+          .eq(1)
+          .within(() => {
+            vehicleServiceRow.getHour().should('contain', '08');
+            vehicleServiceRow.getMinute().eq(0).contains('20');
+            vehicleServiceRow.getMinute().eq(1).contains('30');
+          });
+      });
+
+    timetableVersionDetailsPanel.close();
+
+    timetableVersionDetailsPanel.getHeading().should('not.exist');
+  });
+
+  it('Should change the validity period and update all correct validities', () => {
+    timetableVersionsPage.timetableVersionTableRow.openNthRowVersionDetailsPanel(
+      0,
+    );
+
+    timetableVersionDetailsPanel
+      .getHeading()
+      .should('contain', 'Aikataulu voimassa')
+      .and('contain', '1.1.2023 - 31.12.2023');
+
+    timetableVersionDetailsPanel.toggleExpandNthRow(0);
+    timetableVersionDetailsPanel.vehicleJourneyGroupInfo
+      .getChangeValidityButton()
+      .eq(0)
+      .click();
+
+    changeTimetablesValidityForm.setValidityEndDate('2024-03-31');
+    changeTimetablesValidityForm.getSaveButton().click();
+
+    toast.getSuccessToast().should('be.visible');
+
+    // Check that the panel heading's validity changed
+    timetableVersionDetailsPanel.getHeading().contains('1.1.2023 - 31.3.2024');
+
+    timetableVersionDetailsPanel.toggleExpandNthRow(1);
+
+    // Check that both timetable card validity periods changed
+    timetableVersionDetailsPanel.vehicleJourneyGroupInfo
+      .getValidityTimeRange()
+      .eq(0)
+      .contains('1.1.2023 - 31.3.2024');
+    timetableVersionDetailsPanel.vehicleJourneyGroupInfo
+      .getValidityTimeRange()
+      .eq(1)
+      .contains('1.1.2023 - 31.3.2024');
+
+    // Check that the version row's validity changed
+    timetableVersionsPage.timetableVersionTableRow
+      .getRow()
+      .eq(0)
+      .findByTestId('TimetableVersionTableRow::validityEnd')
+      .contains('31.3.2024');
+  });
+});

--- a/cypress/e2e/timetableVersionDetailsPanel.cy.ts
+++ b/cypress/e2e/timetableVersionDetailsPanel.cy.ts
@@ -502,7 +502,7 @@ describe('Timetable version details panel', () => {
 
   it('Should open, have correct details, and close', () => {
     timetableVersionsPage.timetableVersionTableRow
-      .getRow()
+      .getRows()
       .should('have.length', 1);
 
     timetableVersionsPage.timetableVersionTableRow.openNthRowVersionDetailsPanel(
@@ -525,7 +525,8 @@ describe('Timetable version details panel', () => {
     timetableVersionDetailsPanel.getRows().eq(0).should('contain', '99');
 
     timetableVersionDetailsPanel.toggleExpandNthRow(0);
-    timetableVersionDetailsPanel.getRows()
+    timetableVersionDetailsPanel
+      .getRows()
       .eq(0)
       .findByTestId('VehicleServiceRow::row')
       .findByTestId('VehicleServiceRow::hour')
@@ -539,7 +540,8 @@ describe('Timetable version details panel', () => {
       .should('be.visible');
 
     timetableVersionDetailsPanel.toggleExpandNthRow(1);
-    timetableVersionDetailsPanel.getRows()
+    timetableVersionDetailsPanel
+      .getRows()
       .eq(1)
       .findByTestId('VehicleServiceRow::row')
       .then((rows) => {
@@ -604,7 +606,7 @@ describe('Timetable version details panel', () => {
 
     // Check that the version row's validity changed
     timetableVersionsPage.timetableVersionTableRow
-      .getRow()
+      .getRows()
       .eq(0)
       .findByTestId('TimetableVersionTableRow::validityEnd')
       .contains('31.3.2024');

--- a/cypress/pageObjects/TimetableVersionTableRow.ts
+++ b/cypress/pageObjects/TimetableVersionTableRow.ts
@@ -1,10 +1,10 @@
 export class TimetableVersionTableRow {
-  getRow() {
+  getRows() {
     return cy.getByTestId('TimetableVersionTableRow::row');
   }
 
   openNthRowVersionDetailsPanel(rowNumber: number) {
-    this.getRow()
+    this.getRows()
       .eq(rowNumber)
       .findByTestId('TimetableVersionTableRow::actions')
       .click();

--- a/cypress/pageObjects/TimetableVersionTableRow.ts
+++ b/cypress/pageObjects/TimetableVersionTableRow.ts
@@ -2,4 +2,13 @@ export class TimetableVersionTableRow {
   getRow() {
     return cy.getByTestId('TimetableVersionTableRow::row');
   }
+
+  openNthRowVersionDetailsPanel(rowNumber: number) {
+    this.getRow()
+      .eq(rowNumber)
+      .findByTestId('TimetableVersionTableRow::actions')
+      .click();
+
+    cy.getByTestId('TimetableVersionTableRow::versionPanelMenuItem').click();
+  }
 }

--- a/cypress/pageObjects/index.ts
+++ b/cypress/pageObjects/index.ts
@@ -1,3 +1,4 @@
+export * from './ChangeTimetablesValidityForm';
 export * from './ChangeValidityForm';
 export * from './ConfirmationDialog';
 export * from './EditRoutePage';
@@ -20,7 +21,6 @@ export * from './RouteTimetablesSection';
 export * from './RoutesAndLinesPage';
 export * from './SearchResultsPage';
 export * from './StopForm';
-export * from './stop-registry';
 export * from './SubstituteDaySettingsPage';
 export * from './TemplateRouteSelector';
 export * from './TerminusNameInputs';
@@ -29,3 +29,5 @@ export * from './TimetablesMainPage';
 export * from './Toast';
 export * from './VehicleScheduleDetailsPage';
 export * from './VehicleServiceTable';
+export * from './stop-registry';
+export * from './timetables';

--- a/cypress/pageObjects/timetables/index.ts
+++ b/cypress/pageObjects/timetables/index.ts
@@ -1,0 +1,1 @@
+export * from './versions';

--- a/cypress/pageObjects/timetables/versions/VehicleServiceRow.ts
+++ b/cypress/pageObjects/timetables/versions/VehicleServiceRow.ts
@@ -1,0 +1,9 @@
+export class VehicleServiceRow {
+  getHour = () => {
+    return cy.getByTestId('VehicleServiceRow::hour');
+  };
+
+  getMinute = () => {
+    return cy.getByTestId('VehicleServiceRow::minute');
+  };
+}

--- a/cypress/pageObjects/timetables/versions/index.ts
+++ b/cypress/pageObjects/timetables/versions/index.ts
@@ -1,0 +1,2 @@
+export * from './VehicleServiceRow';
+export * from './timetable-version-details-panel';

--- a/cypress/pageObjects/timetables/versions/timetable-version-details-panel/TimetableVersionDetailsPanel.ts
+++ b/cypress/pageObjects/timetables/versions/timetable-version-details-panel/TimetableVersionDetailsPanel.ts
@@ -1,0 +1,24 @@
+import { VehicleJourneyGroupInfo } from '../../../VehicleJourneyGroupInfo';
+
+export class TimetableVersionDetailsPanel {
+  vehicleJourneyGroupInfo = new VehicleJourneyGroupInfo();
+
+  getHeading = () => {
+    return cy.getByTestId('TimetableVersionPanelHeading::heading');
+  };
+
+  getRows = () => {
+    return cy.getByTestId('ExpandableRouteTimetableRow::row');
+  };
+
+  toggleExpandNthRow = (rowNumber: number) => {
+    this.getRows()
+      .eq(rowNumber)
+      .findByTestId('ExpandableRouteTimetableRow::AccordionButton')
+      .click();
+  };
+
+  close = () => {
+    cy.getByTestId('TimetableVersionPanelHeading::closeButton').click();
+  };
+}

--- a/cypress/pageObjects/timetables/versions/timetable-version-details-panel/index.ts
+++ b/cypress/pageObjects/timetables/versions/timetable-version-details-panel/index.ts
@@ -1,0 +1,1 @@
+export * from './TimetableVersionDetailsPanel';

--- a/ui/src/components/map/modal/Modal.tsx
+++ b/ui/src/components/map/modal/Modal.tsx
@@ -1,5 +1,6 @@
-import { FunctionComponent, useEffect } from 'react';
+import { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useCallbackOnKeyEscape } from '../../../hooks';
 import { Row } from '../../../layoutComponents';
 import { SimpleButton } from '../../../uiComponents';
 import { ModalBody } from './ModalBody';
@@ -54,17 +55,7 @@ export const Modal: FunctionComponent<Props> = ({
   onSave,
   children,
 }) => {
-  const closeOnEscape = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      onClose();
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('keydown', closeOnEscape, true);
-    return () => document.removeEventListener('keydown', closeOnEscape, true);
-  });
+  useCallbackOnKeyEscape(onClose);
 
   return (
     <div data-testid={testId} className="overflow-auto bg-white">

--- a/ui/src/components/map/stops/CreateStopMarker.tsx
+++ b/ui/src/components/map/stops/CreateStopMarker.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch } from 'react-redux';
 import { theme } from '../../../generated/theme';
+import { useCallbackOnKeyEscape } from '../../../hooks';
 import { resetEnabledModesAction } from '../../../redux';
 import { Coords } from '../../../types';
 import { Circle } from '../markers';
@@ -34,17 +35,8 @@ export const CreateStopMarker = ({ onCursorMove }: Props): JSX.Element => {
     setMouseCoords(undefined);
   };
 
-  const detectKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      dispatch(resetEnabledModesAction());
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('keydown', detectKeyDown, true);
-    return () => document.removeEventListener('keydown', detectKeyDown, true);
-  });
+  const resetModes = () => dispatch(resetEnabledModesAction());
+  useCallbackOnKeyEscape(resetModes);
 
   return (
     <div

--- a/ui/src/components/routes-and-lines/line-details/DirectionBadge.tsx
+++ b/ui/src/components/routes-and-lines/line-details/DirectionBadge.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { RouteDirectionEnum } from '../../../generated/graphql';
 import { mapDirectionToShortUiName } from '../../../i18n/uiNameMappings';
 
@@ -9,19 +10,15 @@ const testIds = {
 export const directionBadgeTestIds = testIds;
 
 type Props = {
-  titleName: string;
   direction: RouteDirectionEnum;
   className?: string;
 };
 
-export const DirectionBadge = ({
-  titleName,
-  direction,
-  className = '',
-}: Props) => {
+export const DirectionBadge = ({ direction, className = '' }: Props) => {
+  const { t } = useTranslation();
   return (
     <span
-      title={titleName}
+      title={t(`directionEnum.${direction}`)}
       data-testid={testIds.container}
       className={`relative flex h-9 w-9 items-center justify-center bg-brand text-2xl font-bold text-white ${className}`}
     >

--- a/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/ExpandableRouteRow.tsx
@@ -74,7 +74,6 @@ export const ExpandableRouteRow = ({
           <DirectionBadge
             direction={route.direction as RouteDirectionEnum}
             className="mr-4"
-            titleName={t(`directionEnum.${route.direction}`)}
           />
           <span className="text-xl" data-testid={testIds.label}>
             <RouteLabel label={label} variant={route.variant} />

--- a/ui/src/components/timetables/common/ChangeTimetablesValidityModal.tsx
+++ b/ui/src/components/timetables/common/ChangeTimetablesValidityModal.tsx
@@ -23,12 +23,14 @@ import {
 interface Props {
   isOpen: boolean;
   onClose: () => void;
+  onChange?: () => void;
   className?: string;
 }
 
 export const ChangeTimetablesValidityModal: React.FC<Props> = ({
   isOpen,
   onClose,
+  onChange,
   className = '',
 }) => {
   const { t } = useTranslation();
@@ -57,7 +59,9 @@ export const ChangeTimetablesValidityModal: React.FC<Props> = ({
           }),
         );
       }
-
+      if (onChange) {
+        onChange();
+      }
       onClose();
     } catch (err) {
       showDangerToastWithError(t('errors.saveFailed'), err);

--- a/ui/src/components/timetables/common/VehicleJourneyGroupInfo.spec.tsx
+++ b/ui/src/components/timetables/common/VehicleJourneyGroupInfo.spec.tsx
@@ -72,7 +72,13 @@ describe(`<${VehicleJourneyGroupInfo.name} />`, () => {
 
   test('Renders VehicleJourneyGroupInfo with imported timetable', async () => {
     const { getByText, getByTestId } = render(
-      <VehicleJourneyGroupInfo vehicleJourneyGroup={vehicleJourneyGroup} />,
+      <VehicleJourneyGroupInfo
+        vehicleJourneys={vehicleJourneyGroup.vehicleJourneys}
+        vehicleScheduleFrameId={vehicleJourneyGroup.vehicleScheduleFrameId}
+        validityStart={vehicleJourneyGroup.validity.validityStart}
+        validityEnd={vehicleJourneyGroup.validity.validityEnd}
+        dayTypeNameI18n={vehicleJourneyGroup.dayType.name_i18n}
+      />,
     );
 
     expect(getByText('1.1.2023 - 31.5.2023')).toBeVisible();
@@ -86,10 +92,11 @@ describe(`<${VehicleJourneyGroupInfo.name} />`, () => {
   test('Render VehicleJourneyGroupInfo with substitute timetable (no vsf id)', async () => {
     const { getByText, getByTestId } = render(
       <VehicleJourneyGroupInfo
-        vehicleJourneyGroup={{
-          ...vehicleJourneyGroup,
-          vehicleScheduleFrameId: null,
-        }}
+        vehicleJourneys={vehicleJourneyGroup.vehicleJourneys}
+        vehicleScheduleFrameId={null}
+        validityStart={vehicleJourneyGroup.validity.validityStart}
+        validityEnd={vehicleJourneyGroup.validity.validityEnd}
+        dayTypeNameI18n={vehicleJourneyGroup.dayType.name_i18n}
       />,
     );
 

--- a/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
+++ b/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
@@ -1,6 +1,8 @@
 import orderBy from 'lodash/orderBy';
+import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
-import { VehicleJourneyGroup, useAppDispatch } from '../../../hooks';
+import { VehicleJourneyWithServiceFragment } from '../../../generated/graphql';
+import { useAppDispatch } from '../../../hooks';
 import { parseI18nField } from '../../../i18n/utils';
 import { Row } from '../../../layoutComponents';
 import { openChangeTimetableValidityModalAction } from '../../../redux';
@@ -14,7 +16,13 @@ const testIds = {
 };
 
 export interface Props {
-  vehicleJourneyGroup: VehicleJourneyGroup;
+  vehicleScheduleFrameId: UUID | null | undefined;
+  vehicleJourneys:
+    | Pick<VehicleJourneyWithServiceFragment, 'start_time'>[]
+    | null;
+  validityStart: DateTime;
+  validityEnd: DateTime;
+  dayTypeNameI18n: LocalizedString;
   className?: string;
 }
 
@@ -23,23 +31,21 @@ export interface Props {
  * number of trips and first and last trip
  */
 export const VehicleJourneyGroupInfo = ({
-  vehicleJourneyGroup,
+  vehicleScheduleFrameId,
+  vehicleJourneys,
+  validityStart,
+  validityEnd,
+  dayTypeNameI18n,
   className = '',
 }: Props): JSX.Element => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
   const changeVehicleScheduleFrameValidity = () => {
-    if (vehicleJourneyGroup.vehicleScheduleFrameId) {
-      dispatch(
-        openChangeTimetableValidityModalAction(
-          vehicleJourneyGroup.vehicleScheduleFrameId,
-        ),
-      );
+    if (vehicleScheduleFrameId) {
+      dispatch(openChangeTimetableValidityModalAction(vehicleScheduleFrameId));
     }
   };
-
-  const { vehicleJourneys } = vehicleJourneyGroup;
 
   const hasTimetables = !!vehicleJourneys;
   const tripCount = vehicleJourneys?.length;
@@ -51,7 +57,7 @@ export const VehicleJourneyGroupInfo = ({
   // disable the button in case of substitute operating day
   // TODO: in the future there might be a need for using this button to
   // link to the substitute operating day's page
-  const isDisabled = !vehicleJourneyGroup.vehicleScheduleFrameId;
+  const isDisabled = !vehicleScheduleFrameId;
   const hoverStyle = `${commonHoverStyle} hover:bg-light-grey`;
   return (
     <Row
@@ -59,7 +65,7 @@ export const VehicleJourneyGroupInfo = ({
     >
       <IconButton
         tooltip={t('accessibility:timetables.changeValidityPeriod', {
-          dayType: parseI18nField(vehicleJourneyGroup.dayType.name_i18n),
+          dayType: parseI18nField(dayTypeNameI18n),
         })}
         className={`mr-2 h-8 w-16 rounded-sm border border-light-grey bg-white text-base  ${
           isDisabled ? 'text-light-grey' : hoverStyle
@@ -70,9 +76,7 @@ export const VehicleJourneyGroupInfo = ({
         testId={testIds.changeValidityButton}
       />
       <span data-testid={testIds.validityTimeRange}>
-        {`${mapToShortDate(
-          vehicleJourneyGroup.validity.validityStart,
-        )} - ${mapToShortDate(vehicleJourneyGroup.validity.validityEnd)}`}
+        {`${mapToShortDate(validityStart)} - ${mapToShortDate(validityEnd)}`}
       </span>
       {hasTimetables && (
         <>

--- a/ui/src/components/timetables/import/contents-view/VehicleJourneyRow.tsx
+++ b/ui/src/components/timetables/import/contents-view/VehicleJourneyRow.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next';
 import {
   VehicleJourneyWithRouteInfoFragment,
   VehicleServiceWithJourneysFragment,
@@ -26,7 +25,6 @@ export const VehicleJourneyRow = ({
   vehicleJourney: VehicleJourneyWithRouteInfoFragment;
   vehicleService: VehicleServiceWithJourneysFragment;
 }): JSX.Element => {
-  const { t } = useTranslation();
   const route =
     vehicleJourney.journey_pattern_ref.journey_pattern_instance
       ?.journey_pattern_route;
@@ -49,7 +47,6 @@ export const VehicleJourneyRow = ({
           <DirectionBadge
             direction={route.direction}
             className="mr-2 h-5 w-5 text-base"
-            titleName={t(`directionEnum.${route.direction}`)}
           />
           {getRouteLabelVariantText(route)}
         </Row>

--- a/ui/src/components/timetables/import/missing-route-deviations/RouteDeviationLink.tsx
+++ b/ui/src/components/timetables/import/missing-route-deviations/RouteDeviationLink.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { VehicleScheduleFrameInfo } from '../../../../hooks';
 import { parseI18nField } from '../../../../i18n/utils';
@@ -21,7 +20,6 @@ export const RouteDeviationLink = ({
   isLast,
   testIdPrefix,
 }: Props) => {
-  const { t } = useTranslation();
   const { lineId, uniqueLabel, direction } = deviation;
   return (
     <Link
@@ -32,7 +30,6 @@ export const RouteDeviationLink = ({
       <div className="flex items-center">
         <DirectionBadge
           direction={direction}
-          titleName={t(`directionEnum.${direction}`)}
           className="mx-1 !h-4 !w-4 text-sm"
         />
         <span

--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopSection.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopSection.tsx
@@ -79,7 +79,13 @@ export const PassingTimesByStopSection = ({
               />
             </div>
             <VehicleJourneyGroupInfo
-              vehicleJourneyGroup={vehicleJourneyGroup}
+              vehicleJourneys={vehicleJourneyGroup.vehicleJourneys}
+              vehicleScheduleFrameId={
+                vehicleJourneyGroup.vehicleScheduleFrameId
+              }
+              validityStart={vehicleJourneyGroup.validity.validityStart}
+              validityEnd={vehicleJourneyGroup.validity.validityEnd}
+              dayTypeNameI18n={vehicleJourneyGroup.dayType.name_i18n}
             />
           </Row>
           {vehicleJourneyGroup.vehicleJourneys ? (

--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -80,11 +80,7 @@ export const RouteTimetablesSection = ({
     <div data-testid={testIds.timetableSection(route.label, route.direction)}>
       <Row>
         <div className="flex flex-1 items-center bg-background">
-          <DirectionBadge
-            direction={route.direction}
-            className="my-5 ml-12"
-            titleName={t(`directionEnum.${route.direction}`)}
-          />
+          <DirectionBadge direction={route.direction} className="my-5 ml-12" />
           <h3 className="m-3.5">
             <RouteLabel label={route.label} variant={route.variant} />
           </h3>

--- a/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceRow.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceRow.tsx
@@ -8,10 +8,13 @@ export interface VehicleServiceRowData {
 
 interface Props {
   data: VehicleServiceRowData;
-  oddRowColor: string;
+  oddRowColor?: string;
 }
 
-export const VehicleServiceRow = ({ data, oddRowColor }: Props) => {
+export const VehicleServiceRow = ({
+  data,
+  oddRowColor = 'bg-hsl-neutral-blue',
+}: Props) => {
   const { hours, minutes } = data;
   return (
     <Row className={`items-center gap-x-3 odd:${oddRowColor}`}>

--- a/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceRow.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceRow.tsx
@@ -11,15 +11,25 @@ interface Props {
   oddRowColor?: string;
 }
 
+const testIds = {
+  row: 'VehicleServiceRow::row',
+  hour: 'VehicleServiceRow::hour',
+  minute: 'VehicleServiceRow::minute',
+};
+
 export const VehicleServiceRow = ({
   data,
   oddRowColor = 'bg-hsl-neutral-blue',
 }: Props) => {
   const { hours, minutes } = data;
   return (
-    <Row className={`items-center gap-x-3 odd:${oddRowColor}`}>
+    <Row
+      testId={testIds.row}
+      className={`items-center gap-x-3 odd:${oddRowColor}`}
+    >
       {/* TODO: Maybe we can get monospaced arial in the future */}
       <span
+        data-testid={testIds.hour}
         className="border-r border-dark-grey px-4 font-mono text-lg font-bold "
         aria-label={`The departure minutes for the hour ${hours} are as follows:`}
       >
@@ -27,6 +37,7 @@ export const VehicleServiceRow = ({
       </span>
       {minutes.map((item, key) => (
         <span
+          data-testid={testIds.minute}
           className="text-sm"
           aria-label={`${item},`}
           // eslint-disable-next-line react/no-array-index-key

--- a/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
@@ -107,7 +107,11 @@ export const VehicleServiceTable = ({
         </Column>
       </div>
       <VehicleJourneyGroupInfo
-        vehicleJourneyGroup={vehicleJourneyGroup}
+        vehicleJourneys={vehicleJourneyGroup.vehicleJourneys}
+        validityStart={vehicleJourneyGroup.validity.validityStart}
+        validityEnd={vehicleJourneyGroup.validity.validityEnd}
+        vehicleScheduleFrameId={vehicleJourneyGroup.vehicleScheduleFrameId}
+        dayTypeNameI18n={vehicleJourneyGroup.dayType.name_i18n}
         className="space-x-2"
       />
       <Visible visible={hasVehicleJourneys}>

--- a/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
@@ -22,8 +22,12 @@ import { SimpleDropdownMenuItem } from '../../routes-and-lines/line-details/Simp
 
 const testIds = {
   timetableVersionTableRow: 'TimetableVersionTableRow::row',
+  timetableVersionTableRowValidityStart:
+    'TimetableVersionTableRow::validityStart',
+  timetableVersionTableRowValidityEnd: 'TimetableVersionTableRow::validityEnd',
+  timetableVersionTableRowActions: 'TimetableVersionTableRow::actions',
   deleteTimetableMenuItem: 'TimetableVersionTableRow::deleteTimetableMenuItem',
-  versionPanelMenuItem: 'TimetableVersionTableRow:versionPanelMenuItem',
+  versionPanelMenuItem: 'TimetableVersionTableRow::versionPanelMenuItem',
 };
 
 const getStatusClassName = ({
@@ -127,8 +131,12 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
           </span>
         )}
       </td>
-      <td>{mapToShortDate(data.vehicleScheduleFrame.validityStart)}</td>
-      <td>{mapToShortDate(data.vehicleScheduleFrame.validityEnd)}</td>
+      <td data-testid={testIds.timetableVersionTableRowValidityStart}>
+        {mapToShortDate(data.vehicleScheduleFrame.validityStart)}
+      </td>
+      <td data-testid={testIds.timetableVersionTableRowValidityEnd}>
+        {mapToShortDate(data.vehicleScheduleFrame.validityEnd)}
+      </td>
       <td>{data.routeLabelAndVariant}</td>
       <td>{vehicleScheduleFrameName}</td>
       <td>!Muokkaaja</td>
@@ -137,7 +145,7 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
         <Visible visible={!!data.vehicleScheduleFrame.id}>
           <SimpleDropdownMenu
             alignItems={AlignDirection.Right}
-            testId="menu"
+            testId={testIds.timetableVersionTableRowActions}
             tooltip={t('accessibility:timetables.versionActions', {
               status: statusText,
               schedule: vehicleScheduleFrameName,

--- a/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
@@ -7,15 +7,23 @@ import {
 } from '../../../i18n/uiNameMappings';
 import { parseI18nField } from '../../../i18n/utils';
 import { Visible } from '../../../layoutComponents';
-import { openDeleteTimetableModalAction } from '../../../redux';
+import {
+  openDeleteTimetableModalAction,
+  openVersionPanelAction,
+} from '../../../redux';
 import { mapToShortDate } from '../../../time';
 import { TimetablePriority } from '../../../types/enums';
-import { AlignDirection, SimpleDropdownMenu } from '../../../uiComponents';
+import {
+  AlignDirection,
+  IconButton,
+  SimpleDropdownMenu,
+} from '../../../uiComponents';
 import { SimpleDropdownMenuItem } from '../../routes-and-lines/line-details/SimpleDropdownMenuItem';
 
 const testIds = {
   timetableVersionTableRow: 'TimetableVersionTableRow::row',
   deleteTimetableMenuItem: 'TimetableVersionTableRow::deleteTimetableMenuItem',
+  versionPanelMenuItem: 'TimetableVersionTableRow:versionPanelMenuItem',
 };
 
 const getStatusClassName = ({
@@ -65,6 +73,16 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
     }
   };
 
+  const openVersionPanel = () => {
+    if (data.vehicleScheduleFrame.id) {
+      dispatch(
+        openVersionPanelAction({
+          vehicleScheduleFrameId: data.vehicleScheduleFrame.id,
+        }),
+      );
+    }
+  };
+
   const statusClassName = ` ${getStatusClassName({
     priority: data.vehicleScheduleFrame.priority,
     inEffect: data.inEffect,
@@ -96,6 +114,13 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
       <td className={statusClassName}>{statusText}</td>
       <td className={dayTypeClassName}>
         {dayType}
+        <Visible visible={!!data.vehicleScheduleFrame.id}>
+          <IconButton
+            onClick={openVersionPanel}
+            tooltip={t('accessibility:timetables.showTimetable')}
+            icon={<i className="icon-calendar" />}
+          />
+        </Visible>
         {data.substituteDay?.supersededDate && (
           <span className="flex justify-center whitespace-nowrap text-xs">
             {substituteDayOperatingText}
@@ -123,6 +148,11 @@ export const TimetableVersionTableRow = ({ data }: Props): JSX.Element => {
               onClick={onClick}
               testId={testIds.deleteTimetableMenuItem}
               text={t('timetables.versions.deleteTimetable')}
+            />
+            <SimpleDropdownMenuItem
+              onClick={openVersionPanel}
+              testId={testIds.versionPanelMenuItem}
+              text={t('timetables.versions.showInfo')}
             />
           </SimpleDropdownMenu>
         </Visible>

--- a/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
@@ -3,6 +3,8 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   TimetableVersionRowData,
+  useAppDispatch,
+  useAppSelector,
   useGetJourneyPatternIdsByLineLabel,
   useGetTimetableVersions,
   useRequiredParams,
@@ -10,11 +12,17 @@ import {
   useTimetableVersionsReturnToQueryParam,
 } from '../../../hooks';
 import { Container } from '../../../layoutComponents';
+import {
+  closeChangeTimetableValidityModalAction,
+  selectChangeTimetableValidityModal,
+} from '../../../redux';
 import { TimetablePriority } from '../../../types/enums';
 import { CloseIconButton } from '../../../uiComponents';
 import { TimeRangeControl } from '../../common';
 import { FormColumn, FormRow } from '../../forms/common';
+import { ChangeTimetablesValidityModal } from '../common/ChangeTimetablesValidityModal';
 import { DeleteTimetableModal } from './DeleteTimetableModal';
+import { TimetableVersionDetailsPanel } from './timetable-version-details-panel/TimetableVersionDetailsPanel';
 import { TimetableVersionTable } from './TimetableVersionTable';
 
 const testIds = {
@@ -25,6 +33,14 @@ export const TimetableVersionsPage = (): JSX.Element => {
   const { t } = useTranslation();
   const { label } = useRequiredParams<{ label: string }>();
   const { startDate, endDate } = useTimeRangeQueryParams();
+  const dispatch = useAppDispatch();
+
+  const onCloseTimetableValidityModal = () => {
+    dispatch(closeChangeTimetableValidityModalAction());
+  };
+  const changeTimetableValidityModalState = useAppSelector(
+    selectChangeTimetableValidityModal,
+  );
 
   // We first need to get the journey pattern ids for all line routes by line label
   const { journeyPatternIdsGroupedByRouteLabel, loading } =
@@ -71,6 +87,12 @@ export const TimetableVersionsPage = (): JSX.Element => {
     );
   };
 
+  // If the validity of a vehicleScheduleFrame is changed, we need to
+  // re-fetch the timetableVersion to update the view
+  const onChangeValidity = () => {
+    fetchTimetableVersions();
+  };
+
   return (
     <Container>
       <FormRow mdColumns={2}>
@@ -101,6 +123,12 @@ export const TimetableVersionsPage = (): JSX.Element => {
         />
       </Container>
       <DeleteTimetableModal fetchTimetableVersions={fetchTimetableVersions} />
+      <TimetableVersionDetailsPanel />
+      <ChangeTimetablesValidityModal
+        isOpen={changeTimetableValidityModalState.isOpen}
+        onClose={onCloseTimetableValidityModal}
+        onChange={onChangeValidity}
+      />
     </Container>
   );
 };

--- a/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
@@ -96,9 +96,10 @@ export const TimetableVersionsPage = (): JSX.Element => {
   return (
     <Container>
       <FormRow mdColumns={2}>
-        <h2>{`${t('timetables.versionsTitle')} | ${t('lines.line', {
-          label,
-        })}`}</h2>
+        <h1 className="text-2xl">
+          {`${t('timetables.versionsTitle')} |
+          ${t('lines.line', { label })}`}
+        </h1>
         <FormColumn className="items-end">
           <CloseIconButton
             label={t('close')}
@@ -109,14 +110,14 @@ export const TimetableVersionsPage = (): JSX.Element => {
         </FormColumn>
       </FormRow>
       <Container>
-        <h3>{t('timetables.timeline')}</h3>
+        <h2 className="text-xl">{t('timetables.timeline')}</h2>
         <TimeRangeControl className="mb-8" />
-        <h3>{t('timetables.operatingCalendar')}</h3>
+        <h2 className="text-xl">{t('timetables.operatingCalendar')}</h2>
         <TimetableVersionTable
           className="mb-8 w-full"
           data={sortTimetables(timetablesExcludingDrafts)}
         />
-        <h3>{t('timetables.drafts')}</h3>
+        <h2 className="text-xl">{t('timetables.drafts')}</h2>
         <TimetableVersionTable
           className="mb-8 w-full"
           data={onlyDraftTimetables}

--- a/ui/src/components/timetables/versions/index.ts
+++ b/ui/src/components/timetables/versions/index.ts
@@ -1,3 +1,4 @@
-export * from './TimetableVersionsPage';
 export * from './TimetableVersionTable';
 export * from './TimetableVersionTableRow';
+export * from './TimetableVersionsPage';
+export * from './timetable-version-details-panel';

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/ExpandableRouteTimetableRow.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/ExpandableRouteTimetableRow.tsx
@@ -31,11 +31,7 @@ export const ExpandableRouteTimetableRow: React.FC<Props> = ({
     <div className={className}>
       <Row>
         <div className="flex flex-1 items-center bg-background">
-          <DirectionBadge
-            direction={direction}
-            className="my-5 ml-12"
-            titleName={t(`directionEnum.${direction}`)}
-          />
+          <DirectionBadge direction={direction} className="my-5 ml-12" />
           <div className="ml-3.5 mt-1">
             <h3 className="text-base">{routeLabel}</h3>
             {routeName}

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/ExpandableRouteTimetableRow.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/ExpandableRouteTimetableRow.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { RouteDirectionEnum } from '../../../../generated/graphql';
+import { Row, Visible } from '../../../../layoutComponents';
+import { AccordionButton } from '../../../../uiComponents';
+import { DirectionBadge } from '../../../routes-and-lines/line-details/DirectionBadge';
+
+interface Props {
+  direction: RouteDirectionEnum;
+  routeLabel: string;
+  routeName: string;
+  sectionIdentifier: string;
+  className?: string;
+}
+
+const testIds = {
+  expandButton: 'ExpandableRouteTimetableRow::AccordionButton',
+};
+
+export const ExpandableRouteTimetableRow: React.FC<Props> = ({
+  children,
+  direction,
+  routeLabel,
+  routeName,
+  sectionIdentifier,
+  className = '',
+}) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <div className={className}>
+      <Row>
+        <div className="flex flex-1 items-center bg-background">
+          <DirectionBadge
+            direction={direction}
+            className="my-5 ml-12"
+            titleName={t(`directionEnum.${direction}`)}
+          />
+          <div className="ml-3.5 mt-1">
+            <h3 className="text-base">{routeLabel}</h3>
+            {routeName}
+          </div>
+        </div>
+        <div className="ml-1 bg-background p-3">
+          <AccordionButton
+            className="h-full w-full"
+            iconClassName="text-3xl"
+            isOpen={isExpanded}
+            onToggle={setIsExpanded}
+            testId={testIds.expandButton}
+            controls={sectionIdentifier}
+            openTooltip={t('accessibility:routes.expandTimetable', {
+              routeName,
+            })}
+            closeTooltip={t('accessibility:routes.closeTimetable', {
+              routeName,
+            })}
+          />
+        </div>
+      </Row>
+      <Visible visible={isExpanded}>{children}</Visible>
+    </div>
+  );
+};

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/ExpandableRouteTimetableRow.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/ExpandableRouteTimetableRow.tsx
@@ -14,6 +14,7 @@ interface Props {
 }
 
 const testIds = {
+  row: 'ExpandableRouteTimetableRow::row',
   expandButton: 'ExpandableRouteTimetableRow::AccordionButton',
 };
 
@@ -28,7 +29,7 @@ export const ExpandableRouteTimetableRow: React.FC<Props> = ({
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   return (
-    <div className={className}>
+    <div data-testid={testIds.row} className={className}>
       <Row>
         <div className="flex flex-1 items-center bg-background">
           <DirectionBadge direction={direction} className="my-5 ml-12" />

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/RouteTimetableCard.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/RouteTimetableCard.tsx
@@ -1,0 +1,51 @@
+import { DateTime } from 'luxon';
+import { RouteTimetableRowInfo } from '../../../../hooks';
+import { parseI18nField } from '../../../../i18n/utils';
+import { VehicleJourneyGroupInfo } from '../../common/VehicleJourneyGroupInfo';
+import { VehicleServiceRow } from '../../vehicle-schedule-details';
+import { ExpandableRouteTimetableRow } from './ExpandableRouteTimetableRow';
+import { TimetableHeading } from './TimetableHeading';
+
+interface Props {
+  routeTimetableRowInfo: RouteTimetableRowInfo;
+  dayTypeNameI18n: LocalizedString;
+  createdAt?: DateTime;
+}
+
+export const RouteTimetableCard: React.FC<Props> = ({
+  routeTimetableRowInfo,
+  dayTypeNameI18n,
+  createdAt,
+}) => {
+  const sectionIdentifier = `ExpandableRouteTimetableRow.${routeTimetableRowInfo.label}.${routeTimetableRowInfo.direction}`;
+  return (
+    <ExpandableRouteTimetableRow
+      className="mb-4"
+      key={`${routeTimetableRowInfo.label}.${routeTimetableRowInfo.direction}`}
+      routeLabel={routeTimetableRowInfo.label}
+      direction={routeTimetableRowInfo.direction}
+      routeName={parseI18nField(routeTimetableRowInfo.nameI18n)}
+      sectionIdentifier={sectionIdentifier}
+    >
+      <div className="mt-4 space-y-2" id={sectionIdentifier}>
+        <TimetableHeading
+          priority={routeTimetableRowInfo.priority}
+          dayTypeI18n={dayTypeNameI18n}
+          createdAt={createdAt}
+        />
+        <VehicleJourneyGroupInfo
+          vehicleJourneys={routeTimetableRowInfo.vehicleJourneys}
+          validityStart={routeTimetableRowInfo.validity.validityStart}
+          validityEnd={routeTimetableRowInfo.validity.validityEnd}
+          vehicleScheduleFrameId={routeTimetableRowInfo.vehicleScheduleFrameId}
+          dayTypeNameI18n={dayTypeNameI18n}
+        />
+        <div>
+          {routeTimetableRowInfo.vehicleServiceRowData.map((item) => (
+            <VehicleServiceRow key={item.hours} data={item} />
+          ))}
+        </div>
+      </div>
+    </ExpandableRouteTimetableRow>
+  );
+};

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableHeading.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableHeading.tsx
@@ -1,0 +1,33 @@
+import { DateTime } from 'luxon';
+import { MdHistory } from 'react-icons/md';
+import { twMerge } from 'tailwind-merge';
+import { parseI18nField } from '../../../../i18n/utils';
+import { Column, Row } from '../../../../layoutComponents';
+import { mapToShortDateTime } from '../../../../time';
+import { TimetablePriority } from '../../../../types/enums';
+import { getTimetableHeadingBgColor } from '../../vehicle-schedule-details';
+
+export const TimetableHeading: React.FC<{
+  priority: TimetablePriority;
+  dayTypeI18n?: LocalizedString;
+  createdAt?: DateTime;
+  className?: string;
+}> = ({ priority, dayTypeI18n, createdAt, className = '' }) => (
+  <Row
+    className={twMerge(
+      'justify-between rounded-md border-2 border-transparent bg-opacity-50 px-4 py-1',
+      getTimetableHeadingBgColor(priority),
+      className,
+    )}
+  >
+    <Column>
+      <span className="text-lg font-bold">{parseI18nField(dayTypeI18n)}</span>
+    </Column>
+    <Column className="justify-center">
+      <p className="text-sm">
+        {mapToShortDateTime(createdAt)}
+        <MdHistory className="ml-2 inline" />
+      </p>
+    </Column>
+  </Row>
+);

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableVersionDetailsPanel.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableVersionDetailsPanel.tsx
@@ -1,0 +1,73 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
+import {
+  useAppSelector,
+  useCallbackOnKeyEscape,
+  useVehicleScheduleFrameSchedules,
+} from '../../../../hooks';
+import { Visible } from '../../../../layoutComponents';
+import {
+  closeVersionPanelAction,
+  selectTimetableVersionPanel,
+} from '../../../../redux';
+import {
+  sortAlphabetically,
+  sortReverseAlphabetically,
+} from '../../../../utils';
+import { RouteTimetableCard } from './RouteTimetableCard';
+import { TimetableVersionPanelHeading } from './TimetableVersionPanelHeading';
+
+export const TimetableVersionDetailsPanel = () => {
+  const { isOpen, vehicleScheduleFrameId } = useAppSelector(
+    selectTimetableVersionPanel,
+  );
+  const location = useLocation();
+  const dispatch = useDispatch();
+
+  const { timetableRowInfo, dayType, createdAt, validityStart, validityEnd } =
+    useVehicleScheduleFrameSchedules(vehicleScheduleFrameId);
+
+  const onClose = () => {
+    dispatch(closeVersionPanelAction());
+  };
+
+  useCallbackOnKeyEscape(onClose);
+
+  // Close the panel in case we navigate elsewhere
+  useEffect(() => {
+    return () => {
+      dispatch(closeVersionPanelAction());
+    };
+  }, [dispatch, location.pathname]);
+
+  const sortedByDirectionRouteTimetableRowInfo =
+    timetableRowInfo &&
+    sortAlphabetically(
+      sortReverseAlphabetically(timetableRowInfo, 'direction'),
+      'label',
+    );
+
+  return (
+    <Visible visible={isOpen}>
+      <div
+        role="dialog"
+        className="fixed top-0 right-0 mt-20 mr-4 h-[90%] w-1/3 overflow-auto rounded-md bg-white p-4 shadow-[0_3px_10px_rgb(0,0,0,0.2)] shadow-slate-500"
+      >
+        <TimetableVersionPanelHeading
+          validityStart={validityStart}
+          validityEnd={validityEnd}
+          onClose={onClose}
+        />
+        {sortedByDirectionRouteTimetableRowInfo?.map((rowInfo) => (
+          <RouteTimetableCard
+            key={`${rowInfo.label}.${rowInfo.direction}`}
+            routeTimetableRowInfo={rowInfo}
+            dayTypeNameI18n={dayType?.name_i18n}
+            createdAt={createdAt}
+          />
+        ))}
+      </div>
+    </Visible>
+  );
+};

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableVersionPanelHeading.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableVersionPanelHeading.tsx
@@ -1,0 +1,30 @@
+import { t } from 'i18next';
+import { DateTime } from 'luxon';
+import { Row } from '../../../../layoutComponents';
+import { mapToShortDate } from '../../../../time';
+import { CloseIconButton } from '../../../../uiComponents';
+
+const testIds = {
+  closeButton: 'TimetableVersionPanelHeading::closeButton',
+};
+
+export const TimetableVersionPanelHeading: React.FC<{
+  onClose: () => void;
+  validityStart?: DateTime;
+  validityEnd?: DateTime;
+}> = ({ validityStart, validityEnd, onClose }) => (
+  <Row className="mb-4 ml-2 justify-between">
+    <h2>
+      <span className="block text-sm">{t('timetables.scheduleValid')}</span>
+      <span className="text-2xl">{`${mapToShortDate(
+        validityStart,
+      )} - ${mapToShortDate(validityEnd)}`}</span>
+    </h2>
+    <CloseIconButton
+      label={t('close')}
+      className="text-base font-bold text-brand"
+      onClick={onClose}
+      testId={testIds.closeButton}
+    />
+  </Row>
+);

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableVersionPanelHeading.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableVersionPanelHeading.tsx
@@ -5,6 +5,7 @@ import { mapToShortDate } from '../../../../time';
 import { CloseIconButton } from '../../../../uiComponents';
 
 const testIds = {
+  heading: 'TimetableVersionPanelHeading::heading',
   closeButton: 'TimetableVersionPanelHeading::closeButton',
 };
 
@@ -14,7 +15,7 @@ export const TimetableVersionPanelHeading: React.FC<{
   validityEnd?: DateTime;
 }> = ({ validityStart, validityEnd, onClose }) => (
   <Row className="mb-4 ml-2 justify-between">
-    <h2>
+    <h2 data-testid={testIds.heading}>
       <span className="block text-sm">{t('timetables.scheduleValid')}</span>
       <span className="text-2xl">{`${mapToShortDate(
         validityStart,

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/index.ts
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/index.ts
@@ -1,0 +1,5 @@
+export * from './ExpandableRouteTimetableRow';
+export * from './RouteTimetableCard';
+export * from './TimetableHeading';
+export * from './TimetableVersionDetailsPanel';
+export * from './TimetableVersionPanelHeading';

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -23588,6 +23588,80 @@ export type DeleteVehicleScheduleFrameMutation = {
   } | null;
 };
 
+export type GetVehicleScheduleFrameSchedulesQueryVariables = Exact<{
+  vehicle_schedule_frame_id: Scalars['uuid'];
+}>;
+
+export type GetVehicleScheduleFrameSchedulesQuery = {
+  __typename?: 'query_root';
+  timetables?: {
+    __typename?: 'timetables_timetables_query';
+    timetables_vehicle_schedule_vehicle_schedule_frame_by_pk?: {
+      __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
+      vehicle_schedule_frame_id: UUID;
+      validity_start: luxon.DateTime;
+      validity_end: luxon.DateTime;
+      priority: number;
+      created_at: luxon.DateTime;
+      vehicle_services: Array<{
+        __typename?: 'timetables_vehicle_service_vehicle_service';
+        vehicle_service_id: UUID;
+        day_type: {
+          __typename?: 'timetables_service_calendar_day_type';
+          day_type_id: UUID;
+          label: string;
+          name_i18n: any;
+        };
+        blocks: Array<{
+          __typename?: 'timetables_vehicle_service_block';
+          block_id: UUID;
+          vehicle_journeys: Array<{
+            __typename?: 'timetables_vehicle_journey_vehicle_journey';
+            vehicle_journey_id: UUID;
+            start_time: luxon.Duration;
+            journey_pattern_ref: {
+              __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+              journey_pattern_ref_id: UUID;
+              journey_pattern_instance?: {
+                __typename?: 'journey_pattern_journey_pattern';
+                journey_pattern_id: UUID;
+                journey_pattern_route?: {
+                  __typename?: 'route_route';
+                  route_id: UUID;
+                  unique_label: string;
+                  direction: RouteDirectionEnum;
+                  name_i18n: LocalizedString;
+                } | null;
+              } | null;
+            };
+          }>;
+        }>;
+      }>;
+    } | null;
+  } | null;
+};
+
+export type VehicleJourneyWithStartTimeInfoFragment = {
+  __typename?: 'timetables_vehicle_journey_vehicle_journey';
+  vehicle_journey_id: UUID;
+  start_time: luxon.Duration;
+  journey_pattern_ref: {
+    __typename?: 'timetables_journey_pattern_journey_pattern_ref';
+    journey_pattern_ref_id: UUID;
+    journey_pattern_instance?: {
+      __typename?: 'journey_pattern_journey_pattern';
+      journey_pattern_id: UUID;
+      journey_pattern_route?: {
+        __typename?: 'route_route';
+        route_id: UUID;
+        unique_label: string;
+        direction: RouteDirectionEnum;
+        name_i18n: LocalizedString;
+      } | null;
+    } | null;
+  };
+};
+
 export type VehicleScheduleFrameWithRoutesFragment = {
   __typename?: 'timetables_vehicle_schedule_vehicle_schedule_frame';
   vehicle_schedule_frame_id: UUID;
@@ -24607,6 +24681,24 @@ export const TimetableVersionFragmentDoc = gql`
     validity_end
     priority
     in_effect
+  }
+`;
+export const VehicleJourneyWithStartTimeInfoFragmentDoc = gql`
+  fragment vehicle_journey_with_start_time_info on timetables_vehicle_journey_vehicle_journey {
+    vehicle_journey_id
+    start_time
+    journey_pattern_ref {
+      journey_pattern_ref_id
+      journey_pattern_instance {
+        journey_pattern_id
+        journey_pattern_route {
+          route_id
+          unique_label
+          direction
+          name_i18n
+        }
+      }
+    }
   }
 `;
 export const VehicleScheduleFrameWithRoutesFragmentDoc = gql`
@@ -29483,6 +29575,87 @@ export type DeleteVehicleScheduleFrameMutationOptions =
     DeleteVehicleScheduleFrameMutation,
     DeleteVehicleScheduleFrameMutationVariables
   >;
+export const GetVehicleScheduleFrameSchedulesDocument = gql`
+  query GetVehicleScheduleFrameSchedules($vehicle_schedule_frame_id: uuid!) {
+    timetables {
+      timetables_vehicle_schedule_vehicle_schedule_frame_by_pk(
+        vehicle_schedule_frame_id: $vehicle_schedule_frame_id
+      ) {
+        vehicle_schedule_frame_id
+        validity_start
+        validity_end
+        priority
+        created_at
+        vehicle_services {
+          vehicle_service_id
+          day_type {
+            day_type_id
+            label
+            name_i18n
+          }
+          blocks {
+            block_id
+            vehicle_journeys {
+              ...vehicle_journey_with_start_time_info
+            }
+          }
+        }
+      }
+    }
+  }
+  ${VehicleJourneyWithStartTimeInfoFragmentDoc}
+`;
+
+/**
+ * __useGetVehicleScheduleFrameSchedulesQuery__
+ *
+ * To run a query within a React component, call `useGetVehicleScheduleFrameSchedulesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetVehicleScheduleFrameSchedulesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetVehicleScheduleFrameSchedulesQuery({
+ *   variables: {
+ *      vehicle_schedule_frame_id: // value for 'vehicle_schedule_frame_id'
+ *   },
+ * });
+ */
+export function useGetVehicleScheduleFrameSchedulesQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetVehicleScheduleFrameSchedulesQuery,
+    GetVehicleScheduleFrameSchedulesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetVehicleScheduleFrameSchedulesQuery,
+    GetVehicleScheduleFrameSchedulesQueryVariables
+  >(GetVehicleScheduleFrameSchedulesDocument, options);
+}
+export function useGetVehicleScheduleFrameSchedulesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetVehicleScheduleFrameSchedulesQuery,
+    GetVehicleScheduleFrameSchedulesQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetVehicleScheduleFrameSchedulesQuery,
+    GetVehicleScheduleFrameSchedulesQueryVariables
+  >(GetVehicleScheduleFrameSchedulesDocument, options);
+}
+export type GetVehicleScheduleFrameSchedulesQueryHookResult = ReturnType<
+  typeof useGetVehicleScheduleFrameSchedulesQuery
+>;
+export type GetVehicleScheduleFrameSchedulesLazyQueryHookResult = ReturnType<
+  typeof useGetVehicleScheduleFrameSchedulesLazyQuery
+>;
+export type GetVehicleScheduleFrameSchedulesQueryResult = Apollo.QueryResult<
+  GetVehicleScheduleFrameSchedulesQuery,
+  GetVehicleScheduleFrameSchedulesQueryVariables
+>;
 export const GetVehicleScheduleFrameWithRoutesDocument = gql`
   query GetVehicleScheduleFrameWithRoutes($vehicle_schedule_frame_id: uuid!) {
     timetables {
@@ -30149,6 +30322,15 @@ export function useGetTimetableVersionsByJourneyPatternIdsAsyncQuery() {
 export type GetTimetableVersionsByJourneyPatternIdsAsyncQueryHookResult =
   ReturnType<typeof useGetTimetableVersionsByJourneyPatternIdsAsyncQuery>;
 
+export function useGetVehicleScheduleFrameSchedulesAsyncQuery() {
+  return useAsyncQuery<
+    GetVehicleScheduleFrameSchedulesQuery,
+    GetVehicleScheduleFrameSchedulesQueryVariables
+  >(GetVehicleScheduleFrameSchedulesDocument);
+}
+export type GetVehicleScheduleFrameSchedulesAsyncQueryHookResult = ReturnType<
+  typeof useGetVehicleScheduleFrameSchedulesAsyncQuery
+>;
 export function useGetVehicleScheduleFrameWithRoutesAsyncQuery() {
   return useAsyncQuery<
     GetVehicleScheduleFrameWithRoutesQuery,

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -13,6 +13,7 @@ export * from './ui';
 export * from './urlQuery';
 export * from './useAsyncQuery';
 export * from './useCheckValidityAndPriorityConflicts';
+export * from './useCallbackOnKeyEscape';
 export * from './useDebouncedString';
 export * from './useGetJourneyPatternIdsByRouteLabel';
 export * from './useGetTimetableVersions';

--- a/ui/src/hooks/useCallbackOnKeyEscape.ts
+++ b/ui/src/hooks/useCallbackOnKeyEscape.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export const useCallbackOnKeyEscape = (callback: () => void) => {
+  useEffect(() => {
+    const onKeyEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        callback();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyEscape, true);
+
+    return () => document.removeEventListener('keydown', onKeyEscape, true);
+  }, [callback]);
+};

--- a/ui/src/hooks/vehicle-schedule-frame/index.ts
+++ b/ui/src/hooks/vehicle-schedule-frame/index.ts
@@ -1,1 +1,2 @@
+export * from './useVehicleScheduleFrameSchedules';
 export * from './useVehicleScheduleFrameValidity';

--- a/ui/src/hooks/vehicle-schedule-frame/useVehicleScheduleFrameSchedules.ts
+++ b/ui/src/hooks/vehicle-schedule-frame/useVehicleScheduleFrameSchedules.ts
@@ -1,0 +1,210 @@
+import { gql } from '@apollo/client';
+import { DateTime } from 'luxon/src/datetime';
+import { groupBy, pipe } from 'remeda';
+import { VehicleServiceRowData } from '../../components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceRow';
+import {
+  RouteDirectionEnum,
+  VehicleJourneyWithStartTimeInfoFragment,
+  useGetVehicleScheduleFrameSchedulesQuery,
+} from '../../generated/graphql';
+import { TimetablePriority } from '../../types/enums';
+
+const GQL_VEHICLE_SCHEDULE_FRAME_SCHEDULES = gql`
+  query GetVehicleScheduleFrameSchedules($vehicle_schedule_frame_id: uuid!) {
+    timetables {
+      timetables_vehicle_schedule_vehicle_schedule_frame_by_pk(
+        vehicle_schedule_frame_id: $vehicle_schedule_frame_id
+      ) {
+        vehicle_schedule_frame_id
+        validity_start
+        validity_end
+        priority
+        created_at
+        vehicle_services {
+          vehicle_service_id
+          day_type {
+            day_type_id
+            label
+            name_i18n
+          }
+          blocks {
+            block_id
+            vehicle_journeys {
+              ...vehicle_journey_with_start_time_info
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GQL_VEHICLE_JOURNEY_WITH_START_TIME_INFO = gql`
+  fragment vehicle_journey_with_start_time_info on timetables_vehicle_journey_vehicle_journey {
+    vehicle_journey_id
+    start_time
+    journey_pattern_ref {
+      journey_pattern_ref_id
+      journey_pattern_instance {
+        journey_pattern_id
+        journey_pattern_route {
+          route_id
+          unique_label
+          direction
+          name_i18n
+        }
+      }
+    }
+  }
+`;
+
+export type RouteTimetableRowInfo = {
+  direction: RouteDirectionEnum;
+  nameI18n: LocalizedString;
+  label: string;
+  vehicleServiceRowData: VehicleServiceRowData[];
+  vehicleJourneys: VehicleJourneyWithStartTimeInfoFragment[];
+  priority: TimetablePriority;
+  vehicleScheduleFrameId: UUID;
+  validity: {
+    validityStart: DateTime;
+    validityEnd: DateTime;
+  };
+};
+
+type JourneysGroupedByLabelAndDirection = {
+  [key: string]: {
+    [key: string]: {
+      journeys: VehicleJourneyWithStartTimeInfoFragment[];
+      nameI18n: LocalizedString;
+    };
+  };
+};
+
+const groupJourneysByLabelAndDirection = (
+  journeys: VehicleJourneyWithStartTimeInfoFragment[],
+) => {
+  return journeys.reduce((acc: JourneysGroupedByLabelAndDirection, item) => {
+    const updatedAcc = { ...acc };
+    const route =
+      item.journey_pattern_ref.journey_pattern_instance?.journey_pattern_route;
+
+    if (!route) {
+      return updatedAcc;
+    }
+    const { direction, unique_label: label, name_i18n: nameI18n } = route;
+
+    if (!updatedAcc[label]) {
+      updatedAcc[label] = {};
+    }
+    if (!updatedAcc[label][direction]) {
+      updatedAcc[label][direction] = {
+        journeys: [],
+        nameI18n: nameI18n || {},
+      };
+    }
+    updatedAcc[label][direction]?.journeys.push(item);
+
+    return updatedAcc;
+  }, {});
+};
+
+const createTimetableRowInfo = (
+  allJourneys: VehicleJourneyWithStartTimeInfoFragment[],
+  priority: TimetablePriority,
+  vehicleScheduleFrameId: UUID,
+  validityStart: DateTime,
+  validityEnd: DateTime,
+) => {
+  const timetableRowInfo: RouteTimetableRowInfo[] = [];
+
+  const journeysGroupedByLabelAndDirection =
+    groupJourneysByLabelAndDirection(allJourneys);
+
+  Object.keys(journeysGroupedByLabelAndDirection).forEach((routeLabel) => {
+    Object.keys(journeysGroupedByLabelAndDirection[routeLabel]).forEach(
+      (directionKey) => {
+        const direction = directionKey as RouteDirectionEnum;
+        const { journeys, nameI18n } =
+          journeysGroupedByLabelAndDirection[routeLabel][direction];
+
+        const groupedStartTimes = pipe(
+          journeys
+            .map((journey) => journey.start_time)
+            .sort(
+              (time1, time2) =>
+                time1.as('millisecond') - time2.as('millisecond'),
+            ),
+          groupBy((item) => item.hours),
+        );
+
+        const vehicleServiceRowData: VehicleServiceRowData[] = Object.entries(
+          groupedStartTimes,
+        ).map(([key, value]) => ({
+          hours: Number(key),
+          minutes: value.map((item) => item.minutes),
+        }));
+
+        timetableRowInfo.push({
+          direction,
+          nameI18n,
+          label: routeLabel,
+          vehicleServiceRowData,
+          vehicleJourneys: journeys,
+          priority,
+          vehicleScheduleFrameId,
+          validity: {
+            validityStart,
+            validityEnd,
+          },
+        });
+      },
+    );
+  });
+  return timetableRowInfo;
+};
+
+export const useVehicleScheduleFrameSchedules = (
+  vehicleScheduleFrameId: UUID,
+) => {
+  const vsfResult = useGetVehicleScheduleFrameSchedulesQuery({
+    variables: { vehicle_schedule_frame_id: vehicleScheduleFrameId },
+  });
+
+  const vehicleScheduleFrame =
+    vsfResult.data?.timetables
+      ?.timetables_vehicle_schedule_vehicle_schedule_frame_by_pk;
+  if (!vehicleScheduleFrame) {
+    return {
+      timetableRowInfo: [],
+      dayType: undefined,
+      createdAt: undefined,
+      validityStart: undefined,
+      validityEnd: undefined,
+    };
+  }
+
+  // One vsf can have only one day type, so we can use any of the vehicle services day type
+  const dayType = vehicleScheduleFrame.vehicle_services[0].day_type;
+  const {
+    priority,
+    created_at: createdAt,
+    validity_start: validityStart,
+    validity_end: validityEnd,
+  } = vehicleScheduleFrame;
+
+  const allJourneys = vehicleScheduleFrame.vehicle_services.flatMap((vs) =>
+    vs.blocks.flatMap((block) =>
+      block.vehicle_journeys.map((journey) => journey),
+    ),
+  );
+
+  const timetableRowInfo = createTimetableRowInfo(
+    allJourneys,
+    priority,
+    vehicleScheduleFrameId,
+    validityStart,
+    validityEnd,
+  );
+  return { timetableRowInfo, dayType, createdAt, validityStart, validityEnd };
+};

--- a/ui/src/layoutComponents/Visible.tsx
+++ b/ui/src/layoutComponents/Visible.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 interface Props {
   // This visible parameter has to be required, but the value can be undefined.
   visible: boolean | undefined;
-  children: JSX.Element | JSX.Element[];
 }
 
 /*

--- a/ui/src/locales/en-US/accessibility.json
+++ b/ui/src/locales/en-US/accessibility.json
@@ -42,6 +42,7 @@
     "substituteDayEditClose": "Stop editing subsitute day \"{{substituteDay}}\"",
     "showPreview": "Show the file's content",
     "closePreview": "Close the file's content",
+    "showTimetable": "Show timetable",
     "expandSchedulePreview": "Show the schedule {{vehicleScheduleFrameLabel}}'s blocks",
     "closeSchedulePreview": "Hide the schedule {{vehicleScheduleFrameLabel}}'s blocks",
     "expandScheduleBlocksPreview": "Show the {{scheduleBlock}} block's information",

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -336,6 +336,7 @@
   "timetables": {
     "timetables": "Timetables",
     "timetableValidity": "Valid {{ validityStart }} - {{ validityEnd }}",
+    "scheduleValid": "Schedule valid",
     "departures": "Departures",
     "noSchedules": "No schedules",
     "noTraffic": "No traffic",
@@ -389,7 +390,8 @@
     },
     "chooseSubstituteDay": "Select...",
     "versions": {
-      "deleteTimetable": "Delete timetable"
+      "deleteTimetable": "Delete timetable",
+      "showInfo": "Show info"
     }
   },
   "timetablesImportPriorityForm": {

--- a/ui/src/locales/fi-FI/accessibility.json
+++ b/ui/src/locales/fi-FI/accessibility.json
@@ -42,6 +42,7 @@
     "substituteDayEditClose": "Lopeta poikkeuspäivän \"{{substituteDay}}\" muokkaus",
     "showPreview": "Näytä tiedoston sisältö",
     "closePreview": "Sulje tiedoston sisältö",
+    "showTimetable": "Näytä aikataulu",
     "expandSchedulePreview": "Näytä aikataulun {{vehicleScheduleFrameLabel}} autokierrot",
     "closeSchedulePreview": "Piilota aikataulun {{vehicleScheduleFrameLabel}} autokierrot",
     "expandScheduleBlocksPreview": "Näytä autokierron {{scheduleBlock}} tiedot",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -336,6 +336,7 @@
   "timetables": {
     "timetables": "Aikataulut",
     "timetableValidity": "Voimassa {{ validityStart }} - {{ validityEnd }}",
+    "scheduleValid": "Aikataulu voimassa",
     "departures": "Lähdöt",
     "noSchedules": "Ei vuoroja",
     "noTraffic": "Ei liikennöintiä",
@@ -389,7 +390,8 @@
     },
     "chooseSubstituteDay": "Valitse...",
     "versions": {
-      "deleteTimetable": "Poista aikataulu"
+      "deleteTimetable": "Poista aikataulu",
+      "showInfo": "Näytä tietoja"
     }
   },
   "timetablesImportPriorityForm": {

--- a/ui/src/redux/index.ts
+++ b/ui/src/redux/index.ts
@@ -8,6 +8,7 @@ export * from './slices/mapFilter';
 export * from './slices/mapModal';
 export * from './slices/mapRouteEditor';
 export * from './slices/mapStopEditor';
+export * from './slices/timetableVersionPanel';
 export * from './slices/modals';
 export * from './slices/user';
 export * from './store';

--- a/ui/src/redux/rootReducer.ts
+++ b/ui/src/redux/rootReducer.ts
@@ -8,6 +8,7 @@ import { mapRouteEditorReducer } from './slices/mapRouteEditor';
 import { mapStopEditorReducer } from './slices/mapStopEditor';
 import { modalsReducer } from './slices/modals';
 import { timetableReducer } from './slices/timetable';
+import { timetableVersionPanelReducer } from './slices/timetableVersionPanel';
 import { loginFailedAction, userReducer } from './slices/user';
 
 const appReducer = combineReducers({
@@ -21,6 +22,7 @@ const appReducer = combineReducers({
   user: userReducer,
   modals: modalsReducer,
   timetable: timetableReducer,
+  timetableVersionPanel: timetableVersionPanelReducer,
 });
 
 export const rootReducer = (state: ExplicitAny, action: AnyAction) => {

--- a/ui/src/redux/selectors/index.ts
+++ b/ui/src/redux/selectors/index.ts
@@ -7,4 +7,5 @@ export * from './mapRouteEditor';
 export * from './mapStopEditor';
 export * from './modals';
 export * from './timetable';
+export * from './timetableVersionPanel';
 export * from './user';

--- a/ui/src/redux/selectors/timetableVersionPanel.ts
+++ b/ui/src/redux/selectors/timetableVersionPanel.ts
@@ -1,0 +1,4 @@
+import { RootState } from '../store';
+
+export const selectTimetableVersionPanel = (state: RootState) =>
+  state.timetableVersionPanel;

--- a/ui/src/redux/slices/timetableVersionPanel.ts
+++ b/ui/src/redux/slices/timetableVersionPanel.ts
@@ -1,0 +1,38 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+interface IState {
+  isOpen: boolean;
+  vehicleScheduleFrameId: UUID;
+}
+
+const initialState: IState = {
+  isOpen: false,
+  vehicleScheduleFrameId: '',
+};
+
+const slice = createSlice({
+  name: 'timetableVersionPanel',
+  initialState,
+  reducers: {
+    openVersionPanel: (
+      state: IState,
+      action: PayloadAction<{
+        vehicleScheduleFrameId: UUID;
+      }>,
+    ) => {
+      state.vehicleScheduleFrameId = action.payload.vehicleScheduleFrameId;
+      state.isOpen = true;
+    },
+    closeVersionPanel: (state: IState) => {
+      state.vehicleScheduleFrameId = '';
+      state.isOpen = false;
+    },
+  },
+});
+
+export const {
+  openVersionPanel: openVersionPanelAction,
+  closeVersionPanel: closeVersionPanelAction,
+} = slice.actions;
+
+export const timetableVersionPanelReducer = slice.reducer;

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -14,6 +14,7 @@ export * from './route';
 export * from './routeShape';
 export * from './search';
 export * from './servicePattern';
+export * from './sort';
 export * from './stop-registry';
 export * from './stops';
 export * from './substituteOperatingPeriod';

--- a/ui/src/utils/sort.ts
+++ b/ui/src/utils/sort.ts
@@ -1,0 +1,9 @@
+export const sortAlphabetically = <T>(array: T[], attribute: keyof T): T[] =>
+  [...array].sort((a, b) =>
+    String(a[attribute]).localeCompare(String(b[attribute])),
+  );
+
+export const sortReverseAlphabetically = <T>(
+  array: T[],
+  attribute: keyof T,
+): T[] => sortAlphabetically(array, attribute).reverse();


### PR DESCRIPTION
Commits: 
* Refactor VehicleJourneyGroupInfo parameters to require only necessary
This component had unnecessary requirements for parameters. It required `VehicleJourneyGroup`
as parameter, even though it did not need all attributes within that type.
Also the VehicleJourneyGroup made the requirements to be so that vehicleJourney's had to be
type `VehicleJourneyWithService` which reduced the reusability greatly or forced to use that fragment.
Only the start_time's are required for this component which is now the only required attribute. (<Pick..>)

* Add timetable version details panel functionality
This version details will open the timetable schedules of the selected version, which corresponds to the selected
versions vehicleScheduleFrame's schedules. This view is now currently the only way you can view all the timetables
within one vehileScheduleFrame, which is crucial if the user wants to change the validity of a timetable, because
it affects the validity period of the whole vehicle schedule frame.
This is pretty big commit and it has some overlapping components with existing code, and the existing code can be also refactored
to use some of the new components. For example `TimetableHeading` can be relocated and used with the existing
  * Added a optional `onChange` callback function to `ChangeTimetablesValidityModal`, so that we add custom
functionality in case of change e.g. re-fetching some view data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/769)
<!-- Reviewable:end -->
