### PR TITLE
Use 2px focus offset outline for a and button elements

### DIFF
--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -3,7 +3,11 @@
 @tailwind utilities;
 
 button:focus {
-  outline: none;
+  outline-offset: 2px;
+}
+
+a:focus {
+  outline-offset: 2px;
 }
 
 input {


### PR DESCRIPTION
Buttons, implemented either as <a type=button> or
<button> elements should have the same focus outline. Add a 2px offset focus outline for <a> and <button> elements

Resolves https://github.com/HSLdevcom/jore4/issues/1687

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/777)
<!-- Reviewable:end -->
