### PR TITLE
Remove disabling of focus:outline from DropdownMenu

### DIFF
--- a/ui/src/components/navbar/DropdownMenu.tsx
+++ b/ui/src/components/navbar/DropdownMenu.tsx
@@ -19,7 +19,7 @@ export const DropdownMenu = ({
       {({ open }) => (
         <>
           <Menu.Button
-            className="mx-4 flex h-full items-center border-b-4 border-transparent px-3 hover:border-white focus:outline-none"
+            className="mx-4 flex h-full items-center border-b-4 border-transparent px-3 hover:border-white"
             data-testid={testId}
           >
             {buttonContent}
@@ -34,7 +34,7 @@ export const DropdownMenu = ({
           <Transition show={open} as={Fragment} {...dropdownTransition}>
             <Menu.Items
               static
-              className="absolute right-0 w-full origin-top-right rounded-b-md border-t border-black border-opacity-20 bg-brand shadow-md focus:outline-none"
+              className="absolute right-0 w-full origin-top-right rounded-b-md border-t border-black border-opacity-20 bg-brand shadow-md"
             >
               <div className="my-4">
                 {React.Children.map(children, (child) => (


### PR DESCRIPTION
Remove focus:outline-none from DrowdownMenu and use the global setting for buttons.

Assumes the PR for general button style has been done, as that fixes the global style.

Resolves https://github.com/HSLdevcom/jore4/issues/1684

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/778)
<!-- Reviewable:end -->
