### PR TITLE
Improve focus on dropdown selection

### DIFF
--- a/ui/src/uiComponents/ListboxOptions.tsx
+++ b/ui/src/uiComponents/ListboxOptions.tsx
@@ -42,8 +42,8 @@ export const ListboxOptions = forwardRef<HTMLUListElement, Props>(
                   ? addClassName(
                       child,
                       `${
-                        optionProps.active ? 'bg-background' : ''
-                      } flex group text-left px-2 py-2 focus:outline-none border-b border-grey`,
+                        optionProps.active ? 'bg-dark-grey text-white' : ''
+                      } flex group text-left px-2 py-2 border-b border-grey`,
                     )
                   : child;
               }}


### PR DESCRIPTION
Invert colors according to figma suggestion for headlessui listbox selections. The whole dropdown list has the focus and thus individual elements within cannot get focus.

Resolves https://github.com/HSLdevcom/jore4/issues/1688

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/779)
<!-- Reviewable:end -->
