### PR TITLE
Use PriorityForm in TemplateRouteSelector 

### DIFF
--- a/cypress/pageObjects/TemplateRouteSelector.ts
+++ b/cypress/pageObjects/TemplateRouteSelector.ts
@@ -1,4 +1,5 @@
 import { Priority } from '@hsl/jore4-test-db-manager';
+import { PriorityForm } from './PriorityForm';
 
 export interface TemplateRouteSelectorInfo {
   priority?: Priority;
@@ -6,36 +7,30 @@ export interface TemplateRouteSelectorInfo {
 }
 
 export class TemplateRouteSelector {
-  setAsStandard() {
-    return cy
-      .getByTestId('TemplateRouteSelector::standardPriorityButton')
-      .click();
-  }
-
-  setAsDraft() {
-    return cy.getByTestId('TemplateRouteSelector::draftPriorityButton').click();
-  }
-
-  setAsTemporary() {
-    return cy
-      .getByTestId('TemplateRouteSelector::temporaryPriorityButton')
-      .click();
-  }
+  private priorityForm = new PriorityForm();
 
   setPriority = (priority: Priority) => {
-    switch (priority) {
-      case Priority.Draft:
-        this.setAsDraft();
-        break;
-      case Priority.Temporary:
-        this.setAsTemporary();
-        break;
-      case Priority.Standard:
-        this.setAsStandard();
-        break;
-      default:
-        throw new Error(`Unknown priority "${priority}"`);
-    }
+    // With some screen sizes the element is just outside view and tests will fail...
+    cy.getByTestId('TemplateRouteSelector::container').scrollIntoView({
+      offset: { top: 500, left: 0 },
+    });
+    // scrollIntoView is unsafe so can't chain further.
+
+    cy.getByTestId('TemplateRouteSelector::container').within(() => {
+      switch (priority) {
+        case Priority.Draft:
+          this.priorityForm.setAsDraft();
+          break;
+        case Priority.Temporary:
+          this.priorityForm.setAsTemporary();
+          break;
+        case Priority.Standard:
+          this.priorityForm.setAsStandard();
+          break;
+        default:
+          throw new Error(`Unknown priority "${priority}"`);
+      }
+    });
   };
 
   getChooseRouteDropdown() {

--- a/ui/src/components/forms/route/TemplateRouteSelector.tsx
+++ b/ui/src/components/forms/route/TemplateRouteSelector.tsx
@@ -46,7 +46,7 @@ export const TemplateRouteSelector = ({
   return (
     <div
       data-testid={testIds.container}
-      className="prelative relative w-full rounded-md border border-light-grey bg-background px-3 py-4"
+      className="relative w-full rounded-md border border-light-grey bg-background px-3 py-4"
     >
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <FormProvider {...methods}>

--- a/ui/src/components/forms/route/TemplateRouteSelector.tsx
+++ b/ui/src/components/forms/route/TemplateRouteSelector.tsx
@@ -1,10 +1,17 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { DateTime } from 'luxon';
 import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Column, Row } from '../../../layoutComponents';
 import { Priority } from '../../../types/enums';
-import { SimpleButton, ValueFn } from '../../../uiComponents';
-import { ObservationDateInput } from '../common';
+import { ValueFn } from '../../../uiComponents';
+import {
+  ObservationDateInput,
+  PriorityForm,
+  PriorityFormState,
+  priorityFormSchema,
+} from '../common';
 import { ChooseRouteDropdown } from './ChooseRouteDropdown';
 
 interface Props {
@@ -13,9 +20,7 @@ interface Props {
 }
 
 const testIds = {
-  standardPriorityButton: `TemplateRouteSelector::standardPriorityButton`,
-  draftPriorityButton: `TemplateRouteSelector::draftPriorityButton`,
-  temporaryPriorityButton: `TemplateRouteSelector::temporaryPriorityButton`,
+  container: 'TemplateRouteSelector::container',
   observationDateInput: 'TemplateRouteSelector::observationDateInput',
   chooseRouteDropdown: 'TemplateRouteSelector::chooseRouteDropdown',
 };
@@ -26,60 +31,48 @@ export const TemplateRouteSelector = ({
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
-  const [priority, setPriority] = useState(Priority.Standard);
+  // PriorityForm uses a FormState.
+  // However our parent component already has one with "priority" field,
+  // which we don't want to mess with, so need to create a new one.
+  const methods = useForm<PriorityFormState>({
+    values: {
+      priority: Priority.Standard,
+    },
+    resolver: zodResolver(priorityFormSchema),
+  });
+
   const [observationDate, setObservationDate] = useState(DateTime.now());
 
   return (
-    <div className="prelative relative w-full rounded-md border border-light-grey bg-background px-3 py-4">
-      <h3 className="mb-4">{t('routes.searchTemplate')}</h3>
-      <Row className="mb-4">
-        <Column>
-          <fieldset>
-            <legend className="font-bold">{t('priority.label')}</legend>
-            <Row className="space-x-1">
-              <SimpleButton
-                onClick={() => setPriority(Priority.Standard)}
-                inverted={priority !== Priority.Standard}
-                testId={testIds.standardPriorityButton}
-              >
-                {t('priority.standard')}
-              </SimpleButton>
-              <SimpleButton
-                onClick={() => setPriority(Priority.Draft)}
-                inverted={priority !== Priority.Draft}
-                testId={testIds.draftPriorityButton}
-              >
-                {t('priority.draft')}
-              </SimpleButton>
-              <SimpleButton
-                onClick={() => setPriority(Priority.Temporary)}
-                inverted={priority !== Priority.Temporary}
-                testId={testIds.temporaryPriorityButton}
-              >
-                {t('priority.temporary')}
-              </SimpleButton>
-            </Row>
-          </fieldset>
+    <div
+      data-testid={testIds.container}
+      className="prelative relative w-full rounded-md border border-light-grey bg-background px-3 py-4"
+    >
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <FormProvider {...methods}>
+        <h3 className="mb-4">{t('routes.searchTemplate')}</h3>
+        <Row className="mb-4">
+          <PriorityForm hiddenPriorities={[]} />
+        </Row>
+        <Column className="mb-4">
+          <ObservationDateInput
+            value={observationDate}
+            onChange={setObservationDate}
+            testId={testIds.observationDateInput}
+            className="flex-1"
+          />
         </Column>
-      </Row>
-      <Column className="mb-4">
-        <ObservationDateInput
-          value={observationDate}
-          onChange={setObservationDate}
-          testId={testIds.observationDateInput}
-          className="flex-1"
-        />
-      </Column>
-      <label htmlFor="choose-route-combobox">{t('routes.label')}</label>
-      <Row className="mb-4">
-        <ChooseRouteDropdown
-          value={value}
-          onChange={onChange}
-          date={observationDate}
-          priorities={[priority]}
-          testId={testIds.chooseRouteDropdown}
-        />
-      </Row>
+        <label htmlFor="choose-route-combobox">{t('routes.label')}</label>
+        <Row className="mb-4">
+          <ChooseRouteDropdown
+            value={value}
+            onChange={onChange}
+            date={observationDate}
+            priorities={[methods.getValues('priority')]}
+            testId={testIds.chooseRouteDropdown}
+          />
+        </Row>
+      </FormProvider>
     </div>
   );
 };


### PR DESCRIPTION
To share implementation and remove a basically copypasted structure.

This changes the order of priority buttons:
- from: Standard, Draft, Temporary
-   to: Draft, Standard, Temporary
Which is the same as in other priority forms, so I think this is acceptable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/780)
<!-- Reviewable:end -->
