### PR TITLE
Use light grey for disabled buttons

### DIFF
--- a/ui/src/uiComponents/SimpleButton.tsx
+++ b/ui/src/uiComponents/SimpleButton.tsx
@@ -60,7 +60,9 @@ export const SimpleButton: React.FC<Props> = (props) => {
   const colorClassNames = inverted
     ? `text-brand bg-white border border-grey active:border-brand ${invertedClassName}`
     : `text-white bg-brand border border-brand active:bg-opacity-50`;
-  const disabledClassNames = disabled ? 'cursor-not-allowed opacity-70' : '';
+  const disabledClassNames = disabled
+    ? 'cursor-not-allowed opacity-70 text-white bg-light-grey border-light-grey'
+    : '';
   const commonClassNames = `px-4 py-2 font-bold rounded-full ${colorClassNames} ${getHoverStyles(
     inverted,
     disabled,


### PR DESCRIPTION
Figma spec has light grey for disabled buttons, and it was used only for some of them. Apply light grey for all disabled SimpleButtons.

Resolves https://github.com/HSLdevcom/jore4/issues/1689

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/781)
<!-- Reviewable:end -->
