### PR TITLE
Use em for focus offset outline

### DIFF
--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -3,11 +3,11 @@
 @tailwind utilities;
 
 button:focus {
-  outline-offset: 2px;
+  outline-offset: 0.2em;
 }
 
 a:focus {
-  outline-offset: 2px;
+  outline-offset: 0.2em;
 }
 
 input {


### PR DESCRIPTION
Use a size better for cross browser compatibility for focus outline offset.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/782)
<!-- Reviewable:end -->
