### PR TITLE
Fine tune toggle button position when not toggled

### DIFF
--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 1`]
         type="button"
       >
         <span
-          class="-translate-x-1 border-grey inline-block h-6 w-6 transform rounded-full border bg-white transition-transform"
+          class="-translate-x-0.5 border-grey inline-block h-6 w-6 transform rounded-full border bg-white transition-transform"
         />
       </button>
     </div>
@@ -246,7 +246,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
         type="button"
       >
         <span
-          class="-translate-x-1 border-grey inline-block h-6 w-6 transform rounded-full border bg-white transition-transform"
+          class="-translate-x-0.5 border-grey inline-block h-6 w-6 transform rounded-full border bg-white transition-transform"
         />
       </button>
     </div>

--- a/ui/src/uiComponents/Switch.tsx
+++ b/ui/src/uiComponents/Switch.tsx
@@ -26,7 +26,9 @@ export const Switch: React.FC<Props> = ({
     >
       <span
         className={`${
-          checked ? 'translate-x-5 border-brand' : '-translate-x-1 border-grey'
+          checked
+            ? 'translate-x-5 border-brand'
+            : '-translate-x-0.5 border-grey'
         } inline-block h-6 w-6 transform rounded-full border bg-white transition-transform`}
       />
     </HuiSwitch>


### PR DESCRIPTION
Move the toggle button left position a bit to the right, so it will stay wihtin the base area.

Resolves https://github.com/HSLdevcom/jore4/issues/1690

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/783)
<!-- Reviewable:end -->
