### PR TITLE
Fix e2e occasional substitute day test

### DIFF
--- a/cypress/e2e/occasionalSubstituteDays.cy.ts
+++ b/cypress/e2e/occasionalSubstituteDays.cy.ts
@@ -453,6 +453,12 @@ describe('Occasional substitute operating periods', () => {
     'Should create and delete an occasional substitute operating period successfully',
     { tags: [Tag.Timetables, Tag.Smoke] },
     () => {
+      // Set observation period so that the saved ocasional substitute day will
+      // not be in the range of this period
+      substituteDaySettingsPage.observationPeriodForm.setStartDate(
+        '2023-01-01',
+      );
+      substituteDaySettingsPage.observationPeriodForm.setEndDate('2023-12-31');
       // Add an occasional substitute day
       substituteDaySettingsPage.occasionalSubstitutePeriodForm
         .getAddOccasionalSubstitutePeriodButton()


### PR DESCRIPTION
We saved an occasional substitute day "in the future" so that the observation period should change due to that. We made an assertion that the observation period is changed and that we get a toast message for it. But since the test did not explicitly set the observation date and just used the default period, which is 1 year from "today". And since the occasional date was saved as 8.3.2025 this date would be inside the observation period when we hit 8.3.2024. That day was today and the test broke. So by explicitly setting the observation period, this test should always work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/786)
<!-- Reviewable:end -->
