### PR TITLE
Create infralink datasets for e2e tests

### DIFF
--- a/cypress/datasets/index.ts
+++ b/cypress/datasets/index.ts
@@ -1,0 +1,1 @@
+export * from './infralinks';

--- a/cypress/datasets/infralinks.ts
+++ b/cypress/datasets/infralinks.ts
@@ -1,0 +1,43 @@
+// TODO: These two infralink sets could probably be combined,
+// but currently a straightforward 'use the testInfraLinksFour
+// on all tests' is not working, so going to do this iteratively
+
+// These infralink IDs exist in the 'infraLinks.sql' test data file.
+// These form a straight line on Eerikinkatu in Helsinki.
+// Coordinates are partial since they are needed only for the stop creation.
+export const testInfraLinksThree = [
+  {
+    externalId: '445156',
+    coordinates: [24.925682785, 60.163824160000004, 7.3515],
+  },
+  {
+    externalId: '442424',
+    coordinates: [24.929275791498405, 60.1651950480433, 0],
+  },
+  {
+    externalId: '442325',
+    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
+  },
+];
+
+// These infralink IDs exist in the 'infraLinks.sql' test data file.
+// These form a straight line on Eerikinkatu in Helsinki.
+// Coordinates are partial since they are needed only for the stop creation.
+export const testInfraLinksFour = [
+  {
+    externalId: '445156',
+    coordinates: [24.925682785, 60.163824160000004, 7.3515],
+  },
+  {
+    externalId: '442331',
+    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
+  },
+  {
+    externalId: '442424',
+    coordinates: [24.929825718, 60.165285984, 9.957],
+  },
+  {
+    externalId: '442325',
+    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
+  },
+];

--- a/cypress/e2e/commonSubstituteDays.cy.ts
+++ b/cypress/e2e/commonSubstituteDays.cy.ts
@@ -17,6 +17,7 @@ import {
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
+import { testInfraLinksThree } from '../datasets';
 import { Tag } from '../enums';
 import {
   RouteTimetablesSection,
@@ -32,25 +33,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.926699622176628, 60.164181083308065, 10.0969999999943],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.92904198486008, 60.16490775039894, 0],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.932072417514647, 60.166003223527824, 0],
-  },
-];
 
 const stopLabels = ['H1234', 'H1235', 'H1236'];
 
@@ -79,7 +61,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksThree[0].coordinates,
     },
   },
   {
@@ -90,7 +72,7 @@ const buildStopsOnInfrastrucureLinks = (
     scheduled_stop_point_id: '359da508-e6a0-4474-bc96-3ab52c3453b0',
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksThree[1].coordinates,
     },
   },
   {
@@ -102,7 +84,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksThree[2].coordinates,
     },
   },
 ];
@@ -367,7 +349,7 @@ describe('Common substitute operating periods', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksThree.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/createRoute.cy.ts
+++ b/cypress/e2e/createRoute.cy.ts
@@ -19,6 +19,7 @@ import {
   mapToGetInfrastructureLinksByExternalIdsQuery,
 } from '@hsl/jore4-test-db-manager';
 import { DateTime } from 'luxon';
+import { testInfraLinksThree } from '../datasets';
 import { Tag } from '../enums';
 import { MapModal, RouteEditor } from '../pageObjects';
 import { FilterPanel } from '../pageObjects/FilterPanel';
@@ -38,25 +39,6 @@ const testRouteLabels = {
   label4: 'Indefinite end time route',
   label5: 'Template route',
 };
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.926699622176628, 60.164181083308065, 10.0969999999943],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.92904198486008, 60.16490775039894, 0],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.932072417514647, 60.166003223527824, 0],
-  },
-];
 
 const stopLabels = ['Test stop 1', 'Test stop 2', 'Test stop 3'];
 
@@ -101,7 +83,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksThree[0].coordinates,
     },
   },
   {
@@ -113,7 +95,7 @@ const buildStopsOnInfrastrucureLinks = (
     scheduled_stop_point_id: '431a6791-f1f5-45d4-8c9d-9e154a2531e0',
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksThree[1].coordinates,
     },
   },
   {
@@ -126,7 +108,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksThree[2].coordinates,
     },
   },
 ];
@@ -214,7 +196,7 @@ describe('Route creation', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksThree.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/editRoute.cy.ts
+++ b/cypress/e2e/editRoute.cy.ts
@@ -18,6 +18,7 @@ import {
   mapToGetInfrastructureLinksByExternalIdsQuery,
 } from '@hsl/jore4-test-db-manager';
 import { DateTime } from 'luxon';
+import { testInfraLinksThree } from '../datasets';
 import { Tag } from '../enums';
 import {
   EditRoutePage,
@@ -33,25 +34,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.926699622176628, 60.164181083308065, 10.0969999999943],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.92904198486008, 60.16490775039894, 0],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.932072417514647, 60.166003223527824, 0],
-  },
-];
 
 const stopLabels = ['Test stop 1', 'Test stop 2'];
 
@@ -87,7 +69,7 @@ const buildStopsOnInfrastrucureLinks = (
     priority: Priority.Draft,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksThree[0].coordinates,
     },
   },
   {
@@ -100,7 +82,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksThree[1].coordinates,
     },
   },
 ];
@@ -204,7 +186,7 @@ describe('Route editing', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksThree.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/editRouteShape.cy.ts
+++ b/cypress/e2e/editRouteShape.cy.ts
@@ -57,15 +57,15 @@ const timingPlaces = [
 const testInfraLinks = [
   {
     externalId: '445156',
-    coordinates: [24.926699622176628, 60.164181083308065, 10.0969999999943],
+    coordinates: [24.925682785, 60.163824160000004, 7.3515],
   },
   {
     externalId: '442424',
-    coordinates: [24.92904198486008, 60.16490775039894, 0],
+    coordinates: [24.929275791498405, 60.1651950480433, 0],
   },
   {
     externalId: '442325',
-    coordinates: [24.932072417514647, 60.166003223527824, 0],
+    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
   },
 ];
 
@@ -91,7 +91,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinks[2].coordinates,
     },
   },
   {
@@ -114,7 +114,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinks[0].coordinates,
     },
   },
 ];
@@ -136,19 +136,19 @@ const buildInfraLinksAlongRoute = (
     route_id: routes[0].route_id,
     infrastructure_link_id: infrastructureLinkIds[0],
     infrastructure_link_sequence: 0,
-    is_traversal_forwards: true,
+    is_traversal_forwards: false,
   },
   {
     route_id: routes[0].route_id,
     infrastructure_link_id: infrastructureLinkIds[1],
     infrastructure_link_sequence: 1,
-    is_traversal_forwards: true,
+    is_traversal_forwards: false,
   },
   {
     route_id: routes[0].route_id,
     infrastructure_link_id: infrastructureLinkIds[2],
     infrastructure_link_sequence: 2,
-    is_traversal_forwards: true,
+    is_traversal_forwards: false,
   },
 ];
 

--- a/cypress/e2e/editRouteShape.cy.ts
+++ b/cypress/e2e/editRouteShape.cy.ts
@@ -18,6 +18,7 @@ import {
   mapToGetInfrastructureLinksByExternalIdsQuery,
 } from '@hsl/jore4-test-db-manager';
 import { DateTime } from 'luxon';
+import { testInfraLinksThree } from '../datasets';
 import { Tag } from '../enums';
 import {
   Map,
@@ -45,28 +46,9 @@ const testCreatedRouteLabels = {
   templateRoute: 'T-reitti 2',
 };
 
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
 const timingPlaces = [
   buildTimingPlace('f7fd2b8c-380b-48da-b87c-78bfa1690aa3', '1AACKT'),
   buildTimingPlace('3faa5ec1-aa5c-423e-9064-1523c460299e', '1AURLA'),
-];
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929275791498405, 60.1651950480433, 0],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
 ];
 
 const stopLabels = ['E2E001', 'E2E002', 'E2E003'];
@@ -91,7 +73,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksThree[2].coordinates,
     },
   },
   {
@@ -102,7 +84,7 @@ const buildStopsOnInfrastrucureLinks = (
     scheduled_stop_point_id: '779e9352-ae03-42f6-bd1e-2519887cdaa3',
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksThree[1].coordinates,
     },
   },
   {
@@ -114,7 +96,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksThree[0].coordinates,
     },
   },
 ];
@@ -202,7 +184,7 @@ describe('Edit route geometry', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksThree.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/occasionalSubstituteDays.cy.ts
+++ b/cypress/e2e/occasionalSubstituteDays.cy.ts
@@ -18,6 +18,7 @@ import {
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
+import { testInfraLinksFour } from '../datasets';
 import { Tag } from '../enums';
 import {
   RouteTimetablesSection,
@@ -32,29 +33,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
 
 const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
 
@@ -84,7 +62,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksFour[0].coordinates,
     },
   },
   {
@@ -96,7 +74,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: null,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksFour[1].coordinates,
     },
   },
   {
@@ -108,7 +86,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksFour[2].coordinates,
     },
   },
   {
@@ -120,7 +98,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[2].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
+      coordinates: testInfraLinksFour[3].coordinates,
     },
   },
 ];
@@ -412,7 +390,7 @@ describe('Occasional substitute operating periods', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksFour.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -11,6 +11,7 @@ import {
   mapToGetInfrastructureLinksByExternalIdsQuery,
 } from '@hsl/jore4-test-db-manager';
 import { DateTime } from 'luxon';
+import { testInfraLinksThree } from '../../datasets';
 import { Tag } from '../../enums';
 import { StopDetailsPage } from '../../pageObjects';
 import { UUID } from '../../types';
@@ -19,25 +20,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.926699622176628, 60.164181083308065, 10.0969999999943],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.92904198486008, 60.16490775039894, 0],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.932072417514647, 60.166003223527824, 0],
-  },
-];
 
 const timingPlaces = [
   buildTimingPlace('352f8fd6-0eaa-4b01-a2db-734431092d62', '1AACKT'),
@@ -73,7 +55,7 @@ const buildScheduledStopPoints = (
     priority: Priority.Draft,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksThree[0].coordinates,
     },
   },
   {
@@ -87,7 +69,7 @@ const buildScheduledStopPoints = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksThree[1].coordinates,
     },
   },
 ];
@@ -105,7 +87,7 @@ describe('Stop details', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksThree.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/stop-registry/stopSearch.cy.ts
+++ b/cypress/e2e/stop-registry/stopSearch.cy.ts
@@ -11,6 +11,7 @@ import {
   mapToGetInfrastructureLinksByExternalIdsQuery,
 } from '@hsl/jore4-test-db-manager';
 import { DateTime } from 'luxon';
+import { testInfraLinksThree } from '../../datasets';
 import { Tag } from '../../enums';
 import { StopSearchBar } from '../../pageObjects/stop-registry/StopSearchBar';
 import { StopSearchResultsPage } from '../../pageObjects/stop-registry/StopSearchResultsPage';
@@ -20,25 +21,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.926699622176628, 60.164181083308065, 10.0969999999943],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.92904198486008, 60.16490775039894, 0],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.932072417514647, 60.166003223527824, 0],
-  },
-];
 
 const timingPlaces = [
   buildTimingPlace('057ebb3f-61bc-46f1-9018-f65257d11efb', '1AACKT'),
@@ -77,7 +59,7 @@ const buildScheduledStopPoints = (
     priority: Priority.Draft,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksThree[0].coordinates,
     },
   },
   {
@@ -91,7 +73,7 @@ const buildScheduledStopPoints = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksThree[1].coordinates,
     },
   },
   {
@@ -105,7 +87,7 @@ const buildScheduledStopPoints = (
     timing_place_id: null,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksThree[2].coordinates,
     },
   },
 ];
@@ -124,7 +106,7 @@ describe('Stop search', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksThree.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -19,6 +19,7 @@ import {
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
+import { testInfraLinksFour } from '../datasets';
 import { Tag } from '../enums';
 import {
   ErrorModal,
@@ -39,29 +40,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
 
 const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
 
@@ -91,7 +69,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksFour[0].coordinates,
     },
   },
   {
@@ -103,7 +81,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: null,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksFour[1].coordinates,
     },
   },
   {
@@ -115,7 +93,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksFour[2].coordinates,
     },
   },
   {
@@ -127,7 +105,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[2].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
+      coordinates: testInfraLinksFour[3].coordinates,
     },
   },
 ];
@@ -355,7 +333,7 @@ describe('Timetable import', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksFour.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/timetablePassingTimes.cy.ts
+++ b/cypress/e2e/timetablePassingTimes.cy.ts
@@ -19,6 +19,7 @@ import {
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
+import { testInfraLinksFour } from '../datasets';
 import { Tag } from '../enums';
 import {
   PassingTimesByStopSection,
@@ -32,29 +33,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
 
 const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
 
@@ -84,7 +62,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksFour[0].coordinates,
     },
   },
   {
@@ -95,7 +73,7 @@ const buildStopsOnInfrastrucureLinks = (
     scheduled_stop_point_id: '63bd05f9-de46-4fa3-bdd9-10e9a81702e3',
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksFour[1].coordinates,
     },
   },
   {
@@ -107,7 +85,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksFour[2].coordinates,
     },
   },
   {
@@ -119,7 +97,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[2].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
+      coordinates: testInfraLinksFour[3].coordinates,
     },
   },
 ];
@@ -313,7 +291,7 @@ describe('Timetable passing times', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksFour.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/timetableValidityPeriod.cy.ts
+++ b/cypress/e2e/timetableValidityPeriod.cy.ts
@@ -19,6 +19,7 @@ import {
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
+import { testInfraLinksFour } from '../datasets';
 import { Tag } from '../enums';
 import {
   PassingTimesByStopSection,
@@ -32,29 +33,6 @@ import {
   insertToDbHelper,
   removeFromDbHelper,
 } from '../utils';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
 
 const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
 
@@ -84,7 +62,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksFour[0].coordinates,
     },
   },
   {
@@ -95,7 +73,7 @@ const buildStopsOnInfrastrucureLinks = (
     scheduled_stop_point_id: '9a9cbf66-44ce-4aea-8c2a-23ae963d24fb',
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksFour[1].coordinates,
     },
   },
   {
@@ -107,7 +85,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksFour[2].coordinates,
     },
   },
   {
@@ -119,7 +97,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[2].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
+      coordinates: testInfraLinksFour[3].coordinates,
     },
   },
 ];
@@ -355,7 +333,7 @@ describe('Timetable validity period', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksFour.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/timetableVersionDetailsPanel.cy.ts
+++ b/cypress/e2e/timetableVersionDetailsPanel.cy.ts
@@ -18,6 +18,7 @@ import {
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
+import { testInfraLinksFour } from '../datasets';
 import {
   ChangeTimetablesValidityForm,
   TimetableVersionDetailsPanel,
@@ -37,29 +38,6 @@ import {
 
 // TODO: Also after extracting base data, expand the data so that we have different labeled routes
 // in the dataset and add asserts to the tests for those details
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
 
 const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
 
@@ -89,7 +67,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksFour[0].coordinates,
     },
   },
   {
@@ -100,7 +78,7 @@ const buildStopsOnInfrastrucureLinks = (
     scheduled_stop_point_id: '63bd05f9-de46-4fa3-bdd9-10e9a81702e3',
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksFour[1].coordinates,
     },
   },
   {
@@ -112,7 +90,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksFour[2].coordinates,
     },
   },
   {
@@ -124,7 +102,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[2].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
+      coordinates: testInfraLinksFour[3].coordinates,
     },
   },
 ];
@@ -461,7 +439,7 @@ describe('Timetable version details panel', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksFour.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);

--- a/cypress/e2e/timetablesReplaceAndCombine.cy.ts
+++ b/cypress/e2e/timetablesReplaceAndCombine.cy.ts
@@ -19,6 +19,7 @@ import {
 } from '@hsl/jore4-test-db-manager';
 import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
+import { testInfraLinksFour } from '../datasets';
 import { Tag } from '../enums';
 import {
   ImportTimetablesPage,
@@ -39,29 +40,6 @@ import {
 
 const REPLACE_IMPORT_FILENAME = 'timetablesReplace1.exp';
 const COMBINE_IMPORT_FILENAME = 'timetablesCombine1.exp';
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
 
 const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
 
@@ -91,7 +69,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
+      coordinates: testInfraLinksFour[0].coordinates,
     },
   },
   {
@@ -103,7 +81,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: null,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
+      coordinates: testInfraLinksFour[1].coordinates,
     },
   },
   {
@@ -115,7 +93,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
+      coordinates: testInfraLinksFour[2].coordinates,
     },
   },
   {
@@ -127,7 +105,7 @@ const buildStopsOnInfrastrucureLinks = (
     timing_place_id: timingPlaces[2].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
+      coordinates: testInfraLinksFour[3].coordinates,
     },
   },
 ];
@@ -504,7 +482,7 @@ describe('Timetable replacement and combination', () => {
     cy.task<GetInfrastructureLinksByExternalIdsResult>(
       'hasuraAPI',
       mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
+        testInfraLinksFour.map((infralink) => infralink.externalId),
       ),
     ).then((res) => {
       const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);


### PR DESCRIPTION
We are copypasting initial data to all tests which is like 200-500 lines of code in front of every test file. We should use some base datasets for the tests. Going to do this iteratively and bit by bit. First going to just move the easy ones.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/787)
<!-- Reviewable:end -->
