### PR TITLE
Use correct env var for tiamat-e2e

### DIFF
--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -14,8 +14,7 @@ services:
     image: "hsldevcom/jore4-tiamat:main--20240308-e48810ff84b05790b2ea859c4ad21f3681df0206"
     container_name: "tiamat-e2e"
     environment:
-      - SKIP_SET_VARIABLE_SECRET_OVERRIDE=true
-      - JORE4_DB_HOSTNAME=jore4-testdb-e2e
+      - TIAMAT_DB_URL=jdbc:postgresql://jore4-testdb-e2e:5432/stopdb?stringtype=unspecified
     ports:
       - "127.0.0.1:3110:5432"
     depends_on:


### PR DESCRIPTION
Use TIAMAT_DB_URL for e2e environment in docker-compose.e2e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/790)
<!-- Reviewable:end -->
