### PR TITLE
Fix stop location change check on edit

### DIFF
--- a/ui/src/hooks/stops/useEditStop.ts
+++ b/ui/src/hooks/stops/useEditStop.ts
@@ -210,8 +210,9 @@ export const useEditStop = () => {
     // changes that are applied if the stop's location is changed
     const newLocation = patch.measured_location;
     const oldLocation = stopWithRouteGraphData.measured_location;
+
     const hasLocationChanged =
-      newLocation && !isEqual(newLocation, oldLocation);
+      newLocation && !isEqual(newLocation.coordinates, oldLocation.coordinates);
     const locationChanges = hasLocationChanged
       ? await onStopLocationChanged(stopWithRouteGraphData, patch, stopId)
       : {};


### PR DESCRIPTION
This check was always true, because 'oldLocation' had different properties in the object. We should only check if the coordinates change.

Azure ticket #35234

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/804)
<!-- Reviewable:end -->
