### PR TITLE
Display a warning if stop main line selection and related signage don't match

### DIFF
--- a/ui/src/components/stop-registry/stops/stop-details/MainLineWarning.spec.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/MainLineWarning.spec.tsx
@@ -1,0 +1,35 @@
+import { screen } from '@testing-library/react';
+import { render } from '../../../../utils/test-utils';
+import { MainLineWarning } from './MainLineWarning';
+
+describe('MainLineWarning', () => {
+  test('should not show the warning when stop is not a main line stop and has no main line sign', async () => {
+    render(<MainLineWarning isMainLineStop={false} hasMainLineSign={false} />);
+
+    const warning = screen.queryByTestId('MainLineWarning::warning');
+    expect(warning).not.toBeInTheDocument();
+  });
+
+  test('should not show the warning when main line stop has a main line sign', async () => {
+    render(<MainLineWarning isMainLineStop hasMainLineSign />);
+
+    const warning = screen.queryByTestId('MainLineWarning::warning');
+    expect(warning).not.toBeInTheDocument();
+  });
+
+  test('should show warning when main line stop has no main line sign', async () => {
+    render(<MainLineWarning isMainLineStop hasMainLineSign={false} />);
+
+    const warning = screen.queryByTestId('MainLineWarning::warning');
+    expect(warning).toBeInTheDocument();
+    expect(warning).toBeVisible();
+  });
+
+  test('should show warning when a stop with main line sign is not a main line stop', async () => {
+    render(<MainLineWarning isMainLineStop={false} hasMainLineSign />);
+
+    const warning = screen.queryByTestId('MainLineWarning::warning');
+    expect(warning).toBeInTheDocument();
+    expect(warning).toBeVisible();
+  });
+});

--- a/ui/src/components/stop-registry/stops/stop-details/MainLineWarning.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/MainLineWarning.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next';
+import { MdWarning } from 'react-icons/md';
+import { Visible } from '../../../../layoutComponents';
+
+const testIds = {
+  warning: 'MainLineWarning::warning',
+};
+
+interface Props {
+  className?: string;
+  isMainLineStop: boolean;
+  hasMainLineSign: boolean;
+}
+
+export const MainLineWarning = ({
+  isMainLineStop,
+  hasMainLineSign,
+  className = '',
+}: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <Visible
+      visible={
+        (isMainLineStop && !hasMainLineSign) ||
+        (!isMainLineStop && hasMainLineSign)
+      }
+    >
+      <MdWarning
+        data-testid={testIds.warning}
+        className={`mr-2 inline h-6 w-6 text-hsl-red ${className}`}
+        role="img"
+        title={t('stopDetails.mainLineWarning')}
+      />
+    </Visible>
+  );
+};

--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsSection.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsSection.tsx
@@ -81,6 +81,9 @@ export const BasicDetailsSection = ({ stop }: Props): JSX.Element => {
           defaultValues={defaultValues}
           ref={formRef}
           onSubmit={onSubmit}
+          hasMainLineSign={
+            !!stop.stop_place?.placeEquipments?.generalSign?.[0]?.mainLineSign
+          }
         />
       ) : (
         <BasicDetailsViewCard stop={stop} />

--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsViewCard.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsViewCard.tsx
@@ -5,6 +5,7 @@ import {
   mapStopRegistryTransportModeTypeToUiName,
 } from '../../../../../i18n/uiNameMappings';
 import { DetailRow, HorizontalSeparator, LabeledDetail } from '../layout';
+import { MainLineWarning } from '../MainLineWarning';
 import { translateStopTypes } from '../utils';
 
 interface Props {
@@ -122,11 +123,19 @@ export const BasicDetailsViewCard = ({ stop }: Props) => {
           detail={stop.timing_place?.label}
           testId={testIds.timingPlaceId}
         />
-        <LabeledDetail
-          title={t('stopDetails.stopType')}
-          detail={stop.stop_place && translateStopTypes(stop.stop_place)}
-          testId={testIds.stopType}
-        />
+        <div className="flex items-center gap-4">
+          <LabeledDetail
+            title={t('stopDetails.stopType')}
+            detail={stop.stop_place && translateStopTypes(stop.stop_place)}
+            testId={testIds.stopType}
+          />
+          <MainLineWarning
+            isMainLineStop={!!stop.stop_place?.stopType.mainLine}
+            hasMainLineSign={
+              !!stop.stop_place?.placeEquipments?.generalSign?.[0]?.mainLineSign
+            }
+          />
+        </div>
         <LabeledDetail
           title={t('stopDetails.stopState')}
           detail={stopState}

--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopBasicDetailsForm.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopBasicDetailsForm.tsx
@@ -22,10 +22,11 @@ interface Props {
   className?: string;
   defaultValues: Partial<StopBasicDetailsFormState>;
   onSubmit: (state: StopBasicDetailsFormState) => void;
+  hasMainLineSign: boolean;
 }
 
 const StopBasicDetailsFormComponent = (
-  { className = '', defaultValues, onSubmit }: Props,
+  { className = '', defaultValues, onSubmit, hasMainLineSign }: Props,
   ref: ExplicitAny,
 ): JSX.Element => {
   const dispatch = useDispatch();
@@ -55,7 +56,7 @@ const StopBasicDetailsFormComponent = (
           <StopLongNameAndLocationFormRow />
           <StopAbbreviationsFormRow />
           <HorizontalSeparator />
-          <StopTypesFormRow />
+          <StopTypesFormRow hasMainLineSign={hasMainLineSign} />
           <StopOtherDetailsFormRow
             onClickOpenTimingSettingsModal={openTimingPlaceModal}
           />

--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopTypesFormRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopTypesFormRow.tsx
@@ -2,7 +2,12 @@ import { t } from 'i18next';
 import { useFormContext } from 'react-hook-form';
 import { StopRegistryTransportModeType } from '../../../../../../generated/graphql';
 import { FormRow, InputElement } from '../../../../../forms/common';
+import { MainLineWarning } from '../../MainLineWarning';
 import { StopBasicDetailsFormState } from './schema';
+
+interface Props {
+  hasMainLineSign: boolean;
+}
 
 const testIds = {
   mainLine: 'StopBasicDetailsForm::mainLine',
@@ -11,10 +16,11 @@ const testIds = {
   virtual: 'StopBasicDetailsForm::virtual',
 };
 
-export const StopTypesFormRow = () => {
+export const StopTypesFormRow = ({ hasMainLineSign }: Props) => {
   const { watch } = useFormContext();
   const isBusTransportMode =
     watch('transportMode') === StopRegistryTransportModeType.Bus;
+  const isMainLineStop = watch('stopTypes.mainLine');
 
   return (
     <FormRow mdColumns={4}>
@@ -27,6 +33,11 @@ export const StopTypesFormRow = () => {
           testId={testIds.mainLine}
         />
         {t('stopPlaceTypes.mainLine')}
+        <MainLineWarning
+          className="ml-2"
+          isMainLineStop={isMainLineStop}
+          hasMainLineSign={hasMainLineSign}
+        />
       </label>
       <label htmlFor="interchange" className="inline-flex font-normal">
         <InputElement<StopBasicDetailsFormState>

--- a/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsForm.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsForm.tsx
@@ -11,6 +11,7 @@ import {
   InputField,
   TextAreaElement,
 } from '../../../../forms/common';
+import { MainLineWarning } from '../MainLineWarning';
 import { SignageDetailsFormState, signageDetailsFormSchema } from './schema';
 
 const testIds = {
@@ -27,10 +28,11 @@ interface Props {
   className?: string;
   defaultValues: Partial<SignageDetailsFormState>;
   onSubmit: (state: SignageDetailsFormState) => void;
+  isMainLineStop: boolean;
 }
 
 const SignageDetailsFormComponent = (
-  { className = '', defaultValues, onSubmit }: Props,
+  { className = '', defaultValues, onSubmit, isMainLineStop }: Props,
   ref: ExplicitAny,
 ): JSX.Element => {
   const { t } = useTranslation();
@@ -38,7 +40,8 @@ const SignageDetailsFormComponent = (
     defaultValues,
     resolver: zodResolver(signageDetailsFormSchema),
   });
-  const { handleSubmit } = methods;
+  const { handleSubmit, watch } = methods;
+  const hasMainLineSign = !!watch('mainLineSign');
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
@@ -91,6 +94,11 @@ const SignageDetailsFormComponent = (
                   testId={testIds.mainLineSign}
                 />
                 {t('stopDetails.signs.mainLineSign')}
+                <MainLineWarning
+                  className="ml-2"
+                  isMainLineStop={isMainLineStop}
+                  hasMainLineSign={hasMainLineSign}
+                />
               </label>
               <label
                 htmlFor="replacesRailSign"

--- a/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsSection.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsSection.tsx
@@ -71,6 +71,7 @@ export const SignageDetailsSection = ({ stop }: Props): JSX.Element => {
           defaultValues={defaultValues}
           ref={formRef}
           onSubmit={onSubmit}
+          isMainLineStop={!!stop.stop_place?.stopType.mainLine}
         />
       ) : (
         <SignageDetailsViewCard stop={stop} />

--- a/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsViewCard.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsViewCard.tsx
@@ -3,6 +3,7 @@ import { StopWithDetails } from '../../../../../hooks';
 import { mapStopPlaceSignTypeToUiName } from '../../../../../i18n/uiNameMappings';
 import { StopPlaceSignType } from '../../../../../types/stop-registry';
 import { DetailRow, LabeledDetail } from '../layout';
+import { MainLineWarning } from '../MainLineWarning';
 import { optionalBooleanToUiText } from '../utils';
 
 const testIds = {
@@ -57,11 +58,19 @@ export const SignageDetailsViewCard = ({ stop }: Props): JSX.Element => {
           detail={optionalBooleanToUiText(generalSign?.lineSignage)}
           testId={testIds.lineSignage}
         />
-        <LabeledDetail
-          title={t('stopDetails.signs.mainLineSign')}
-          detail={optionalBooleanToUiText(generalSign?.mainLineSign)}
-          testId={testIds.mainLineSign}
-        />
+        <div className="flex items-center gap-4">
+          <LabeledDetail
+            title={t('stopDetails.signs.mainLineSign')}
+            detail={optionalBooleanToUiText(generalSign?.mainLineSign)}
+            testId={testIds.mainLineSign}
+          />
+          <MainLineWarning
+            isMainLineStop={!!stop.stop_place?.stopType.mainLine}
+            hasMainLineSign={
+              !!stop.stop_place?.placeEquipments?.generalSign?.[0]?.mainLineSign
+            }
+          />
+        </div>
         <LabeledDetail
           title={t('stopDetails.signs.replacesRailSign')}
           detail={optionalBooleanToUiText(generalSign?.replacesRailSign)}

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -138,6 +138,7 @@
     "stopType": "Stop type",
     "stopState": "Stop state",
     "elyNumber": "ELY number",
+    "mainLineWarning": "The stop's main line setting and related signage setting do not match.",
     "location": {
       "title": "Location",
       "stopAddress": "Stop address",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -138,6 +138,7 @@
     "stopType": "Pysäkkityyppi",
     "stopState": "Pysäkin tila",
     "elyNumber": "ELY-numero",
+    "mainLineWarning": "Pysäkin runkolinja-asetus ja kilvityksen asetukset eivät täsmää",
     "location": {
       "title": "Sijainti",
       "stopAddress": "Pysäkin osoite",


### PR DESCRIPTION
That is, if main line has no main line sign
or main line sign is set despite stop not being a main line stop.

To keep things simple(ish), decided to use a text that kind of works for all cases. More specific messages would depend both on the error case and on which section the warning is shown,
so didn't see further detailing worth the added complexity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/805)
<!-- Reviewable:end -->
