### PR TITLE
Use separate hazelcast cluster for tiamat-e2e

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -40,7 +40,7 @@ services:
   jore4-tiamat:
     # Pin tiamat to a compatible version.
     # Note: also update jore4-tiamat-e2e in docker-compose.e2e when changing this.
-    image: "hsldevcom/jore4-tiamat:main--20240419-f868472f7131dc3aaee6e75ecc7d18f36a52d73d"
+    image: "hsldevcom/jore4-tiamat:main--20240422-c14cd3b74fe0258d0fa801bbe1edeed4a06577c4"
 
   jore4-timetablesapi:
     # Pin timetables api to a compatible version.

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -11,10 +11,11 @@ services:
     extends:
       file: docker-compose.base.yml
       service: jore4-tiamat-base
-    image: "hsldevcom/jore4-tiamat:main--20240419-f868472f7131dc3aaee6e75ecc7d18f36a52d73d"
+    image: "hsldevcom/jore4-tiamat:main--20240422-c14cd3b74fe0258d0fa801bbe1edeed4a06577c4"
     container_name: "tiamat-e2e"
     environment:
       - TIAMAT_DB_URL=jdbc:postgresql://jore4-testdb-e2e:5432/stopdb?stringtype=unspecified
+      - TIAMAT_HAZELCAST_CLUSTER=tiamatE2E
     ports:
       - "127.0.0.1:3110:1888"
     depends_on:


### PR DESCRIPTION
Use a separate Hazelcast cluster for e2e environment, so it will not
pollute the dev environment NeTEx IDs and vice versa.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/812)
<!-- Reviewable:end -->
