### PR TITLE
Remove volumes when stopping dependencies

### DIFF
--- a/scripts/stop-dependencies.sh
+++ b/scripts/stop-dependencies.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 cd $(dirname "$0")/..
 
-docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.custom.yml -f ./docker/docker-compose.e2e.yml down
+docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.custom.yml -f ./docker/docker-compose.e2e.yml down --volumes


### PR DESCRIPTION
Previously they were left dangling, even if not used. This was using lots of disc space over time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/819)
<!-- Reviewable:end -->
