### PR TITLE
E2e test renovation 2

### DIFF
--- a/cypress/datasets/base.ts
+++ b/cypress/datasets/base.ts
@@ -189,7 +189,7 @@ export const routes: RouteInsertInput[] = [
   },
 ];
 
-const journeyPatterns: JourneyPatternInsertInput[] = [
+export const journeyPatterns: JourneyPatternInsertInput[] = [
   {
     journey_pattern_id: '6cae356b-20f4-4e04-a969-097999b351f0',
     on_route_id: routes[0].route_id,
@@ -357,7 +357,8 @@ const baseDbResources = {
   stopsInJourneyPattern,
 };
 
-/** Returns a clone of baseDbResources so that the caller can
+/**
+ * Returns a clone of baseDbResources so that the caller can
  * modify the data freely without side effects
  */
 export const getClonedBaseDbResources = () => cloneDeep(baseDbResources);

--- a/cypress/datasets/timetables.ts
+++ b/cypress/datasets/timetables.ts
@@ -1,0 +1,471 @@
+import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
+import cloneDeep from 'lodash/cloneDeep';
+import { DateTime, Duration } from 'luxon';
+import { journeyPatterns } from './base';
+
+/**
+ * This timetable base timetable data input is based on the routes and lines
+ * baseDbResources introduced in ./base.ts
+ *
+ * This data currently (27.5.24) consists of two vehicle services with each having
+ * 3 back and forth trips
+ */
+const baseTimetableDataInput = {
+  _journey_pattern_refs: {
+    route901outbound: {
+      route_label: '901',
+      route_direction: 'outbound',
+      journey_pattern_id: journeyPatterns[0].journey_pattern_id,
+      _stop_points: [
+        {
+          scheduled_stop_point_sequence: 1,
+          scheduled_stop_point_label: 'E2E001',
+          timing_place_label: '1AACKT',
+        },
+        {
+          scheduled_stop_point_sequence: 2,
+          scheduled_stop_point_label: 'E2E002',
+        },
+        {
+          scheduled_stop_point_sequence: 3,
+          scheduled_stop_point_label: 'E2E003',
+          timing_place_label: '1AURLA',
+        },
+        {
+          scheduled_stop_point_sequence: 4,
+          scheduled_stop_point_label: 'E2E004',
+        },
+        {
+          scheduled_stop_point_sequence: 5,
+          scheduled_stop_point_label: 'E2E005',
+          timing_place_label: '1EIRA',
+        },
+      ],
+    },
+    route901inbound: {
+      route_label: '901',
+      route_direction: 'inbound',
+      journey_pattern_id: journeyPatterns[1].journey_pattern_id,
+      _stop_points: [
+        {
+          scheduled_stop_point_sequence: 0,
+          scheduled_stop_point_label: 'E2E005',
+          timing_place_label: '1EIRA',
+        },
+        {
+          scheduled_stop_point_sequence: 1,
+          scheduled_stop_point_label: 'E2E006',
+          timing_place_label: '1AURLA',
+        },
+        {
+          scheduled_stop_point_sequence: 2,
+          scheduled_stop_point_label: 'E2E007',
+        },
+        {
+          scheduled_stop_point_sequence: 3,
+          scheduled_stop_point_label: 'E2E008',
+        },
+        {
+          scheduled_stop_point_sequence: 4,
+          scheduled_stop_point_label: 'E2E009',
+          timing_place_label: '1AACKT',
+        },
+      ],
+    },
+  },
+  _vehicle_schedule_frames: {
+    year2023: {
+      validity_start: DateTime.fromISO('2023-01-01'),
+      validity_end: DateTime.fromISO('2023-12-31'),
+      name: '2023',
+      booking_label: '2023 booking label',
+      _vehicle_services: {
+        saturdayFirstVehicle: {
+          day_type_id: defaultDayTypeIds.SATURDAY,
+          _blocks: {
+            block: {
+              _vehicle_journeys: {
+                route901Outbound1: {
+                  _journey_pattern_ref_name: 'route901outbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E001',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT7H05M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E002',
+                      arrival_time: Duration.fromISO('PT7H12M'),
+                      departure_time: Duration.fromISO('PT7H12M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E003',
+                      arrival_time: Duration.fromISO('PT7H19M'),
+                      departure_time: Duration.fromISO('PT7H20M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E004',
+                      arrival_time: Duration.fromISO('PT7H24M'),
+                      departure_time: Duration.fromISO('PT7H25M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: Duration.fromISO('PT7H29M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Inbound1: {
+                  _journey_pattern_ref_name: 'route901inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT7H30M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E006',
+                      arrival_time: Duration.fromISO('PT7H37M'),
+                      departure_time: Duration.fromISO('PT7H37M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E007',
+                      arrival_time: Duration.fromISO('PT7H40M'),
+                      departure_time: Duration.fromISO('PT7H41M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E008',
+                      arrival_time: Duration.fromISO('PT7H44M'),
+                      departure_time: Duration.fromISO('PT7H44M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E009',
+                      arrival_time: Duration.fromISO('PT7H48M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Outbound2: {
+                  _journey_pattern_ref_name: 'route901outbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E001',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT7H50M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E002',
+                      arrival_time: Duration.fromISO('PT7H57M'),
+                      departure_time: Duration.fromISO('PT7H57M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E003',
+                      arrival_time: Duration.fromISO('PT8H00M'),
+                      departure_time: Duration.fromISO('PT8H01M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E004',
+                      arrival_time: Duration.fromISO('PT8H05M'),
+                      departure_time: Duration.fromISO('PT8H06M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: Duration.fromISO('PT8H09M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Inbound2: {
+                  _journey_pattern_ref_name: 'route901inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT8H10M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E006',
+                      arrival_time: Duration.fromISO('PT8H17M'),
+                      departure_time: Duration.fromISO('PT8H17M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E007',
+                      arrival_time: Duration.fromISO('PT8H21M'),
+                      departure_time: Duration.fromISO('PT8H22M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E008',
+                      arrival_time: Duration.fromISO('PT8H29M'),
+                      departure_time: Duration.fromISO('PT8H29M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E009',
+                      arrival_time: Duration.fromISO('PT8H34M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Outbound3: {
+                  _journey_pattern_ref_name: 'route901outbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E001',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT9H30M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E002',
+                      arrival_time: Duration.fromISO('PT9H35M'),
+                      departure_time: Duration.fromISO('PT9H35M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E003',
+                      arrival_time: Duration.fromISO('PT9H42M'),
+                      departure_time: Duration.fromISO('PT9H46M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E004',
+                      arrival_time: Duration.fromISO('PT9H50M'),
+                      departure_time: Duration.fromISO('PT9H51M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: Duration.fromISO('PT9H53M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Inbound3: {
+                  _journey_pattern_ref_name: 'route901inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT9H55M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E006',
+                      arrival_time: Duration.fromISO('PT10H00M'),
+                      departure_time: Duration.fromISO('PT10H00M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E007',
+                      arrival_time: Duration.fromISO('PT10H04M'),
+                      departure_time: Duration.fromISO('PT10H05M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E008',
+                      arrival_time: Duration.fromISO('PT10H12M'),
+                      departure_time: Duration.fromISO('PT10H12M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E009',
+                      arrival_time: Duration.fromISO('PT10H17M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        saturdaySecondVehicle: {
+          day_type_id: defaultDayTypeIds.SATURDAY,
+          _blocks: {
+            block: {
+              _vehicle_journeys: {
+                route901Outbound1: {
+                  _journey_pattern_ref_name: 'route901outbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E001',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT7H15M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E002',
+                      arrival_time: Duration.fromISO('PT7H22M'),
+                      departure_time: Duration.fromISO('PT7H22M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E003',
+                      arrival_time: Duration.fromISO('PT7H29M'),
+                      departure_time: Duration.fromISO('PT7H30M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E004',
+                      arrival_time: Duration.fromISO('PT7H34M'),
+                      departure_time: Duration.fromISO('PT7H35M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: Duration.fromISO('PT7H39M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Inbound1: {
+                  _journey_pattern_ref_name: 'route901inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT7H40M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E006',
+                      arrival_time: Duration.fromISO('PT7H47M'),
+                      departure_time: Duration.fromISO('PT7H47M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E007',
+                      arrival_time: Duration.fromISO('PT7H50M'),
+                      departure_time: Duration.fromISO('PT7H51M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E008',
+                      arrival_time: Duration.fromISO('PT7H54M'),
+                      departure_time: Duration.fromISO('PT7H54M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E009',
+                      arrival_time: Duration.fromISO('PT7H58M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Outbound2: {
+                  _journey_pattern_ref_name: 'route901outbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E001',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT8H00M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E002',
+                      arrival_time: Duration.fromISO('PT8H07M'),
+                      departure_time: Duration.fromISO('PT8H07M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E003',
+                      arrival_time: Duration.fromISO('PT8H10M'),
+                      departure_time: Duration.fromISO('PT8H11M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E004',
+                      arrival_time: Duration.fromISO('PT8H15M'),
+                      departure_time: Duration.fromISO('PT8H16M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: Duration.fromISO('PT8H20M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Inbound2: {
+                  _journey_pattern_ref_name: 'route901inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT8H20M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E006',
+                      arrival_time: Duration.fromISO('PT8H27M'),
+                      departure_time: Duration.fromISO('PT8H27M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E007',
+                      arrival_time: Duration.fromISO('PT8H31M'),
+                      departure_time: Duration.fromISO('PT8H32M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E008',
+                      arrival_time: Duration.fromISO('PT8H39M'),
+                      departure_time: Duration.fromISO('PT8H39M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E009',
+                      arrival_time: Duration.fromISO('PT8H44M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Outbound3: {
+                  _journey_pattern_ref_name: 'route901outbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E001',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT9H40M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E002',
+                      arrival_time: Duration.fromISO('PT9H45M'),
+                      departure_time: Duration.fromISO('PT9H45M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E003',
+                      arrival_time: Duration.fromISO('PT9H52M'),
+                      departure_time: Duration.fromISO('PT9H56M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E004',
+                      arrival_time: Duration.fromISO('PT10H00M'),
+                      departure_time: Duration.fromISO('PT10H01M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: Duration.fromISO('PT10H03M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+                route901Inbound3: {
+                  _journey_pattern_ref_name: 'route901inbound',
+                  _passing_times: [
+                    {
+                      _scheduled_stop_point_label: 'E2E005',
+                      arrival_time: null,
+                      departure_time: Duration.fromISO('PT10H05M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E006',
+                      arrival_time: Duration.fromISO('PT10H10M'),
+                      departure_time: Duration.fromISO('PT10H10M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E007',
+                      arrival_time: Duration.fromISO('PT10H14M'),
+                      departure_time: Duration.fromISO('PT10H15M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E008',
+                      arrival_time: Duration.fromISO('PT10H22M'),
+                      departure_time: Duration.fromISO('PT10H22M'),
+                    },
+                    {
+                      _scheduled_stop_point_label: 'E2E009',
+                      arrival_time: Duration.fromISO('PT10H27M'),
+                      departure_time: null,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Returns a clone of baseTimetableDatainput for timetables datainserter
+ *  so that the caller can modify the data freely without side effects
+ */
+export const getClonedBaseTimetableDataInput = () =>
+  cloneDeep(baseTimetableDataInput);

--- a/cypress/e2e/commonSubstituteDays.cy.ts
+++ b/cypress/e2e/commonSubstituteDays.cy.ts
@@ -19,7 +19,7 @@ import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
 import { Tag } from '../enums';
 import {
-  RouteTimetablesSection,
+  RouteTimetablesSectionLegacy,
   SubstituteDaySettingsPage,
   TimetablesMainPage,
   Toast,
@@ -407,7 +407,7 @@ describe('Common substitute operating periods', () => {
     'Should create and delete a common substitute operating period successfully',
     { tags: [Tag.Timetables, Tag.Smoke] },
     () => {
-      const route1231InboundTimetableSection = new RouteTimetablesSection(
+      const route1231InboundTimetableSection = new RouteTimetablesSectionLegacy(
         '1232',
         'inbound',
       );
@@ -527,7 +527,7 @@ describe('Common substitute operating periods', () => {
     "Should create and delete a 'No traffic' common substitute operating period successfully",
     { tags: [Tag.Timetables, Tag.Smoke] },
     () => {
-      const route1231InboundTimetableSection = new RouteTimetablesSection(
+      const route1231InboundTimetableSection = new RouteTimetablesSectionLegacy(
         '1232',
         'inbound',
       );

--- a/cypress/e2e/occasionalSubstituteDays.cy.ts
+++ b/cypress/e2e/occasionalSubstituteDays.cy.ts
@@ -20,7 +20,7 @@ import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
 import { DateTime, Duration } from 'luxon';
 import { Tag } from '../enums';
 import {
-  RouteTimetablesSection,
+  RouteTimetablesSectionLegacy,
   SubstituteDaySettingsPage,
   Toast,
   VehicleScheduleDetailsPage,
@@ -380,7 +380,7 @@ const timetableDataInput = {
   },
 };
 
-const route99InboundTimetableSection = new RouteTimetablesSection(
+const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
   '99',
   'inbound',
 );

--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -26,7 +26,7 @@ import {
   Navbar,
   PassingTimesByStopSection,
   PreviewTimetablesPage,
-  RouteTimetablesSection,
+  RouteTimetablesSectionLegacy,
   RoutesAndLinesPage,
   TimetableVersionsPage,
   TimetablesMainPage,
@@ -309,7 +309,7 @@ const baseTimetableDataInput = {
 };
 
 const verifyBaseTimetableValidity = () => {
-  const route99InboundTimetableSection = new RouteTimetablesSection(
+  const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
     '99',
     'inbound',
   );
@@ -400,7 +400,7 @@ describe('Timetable import', () => {
 
       const IMPORT_FILENAME = 'hastusImport.exp';
 
-      const route99InboundTimetableSection = new RouteTimetablesSection(
+      const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
         '99',
         'inbound',
       );
@@ -567,7 +567,7 @@ describe('Timetable import', () => {
       'Should export a route and import a Hastus timetable as temporary',
       { tags: [Tag.Timetables, Tag.HastusImport] },
       () => {
-        const route99InboundTimetableSection = new RouteTimetablesSection(
+        const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
           '99',
           'inbound',
         );
@@ -758,7 +758,7 @@ describe('Timetable import', () => {
       'Should import a special day timetable for a route',
       { tags: [Tag.Timetables, Tag.HastusImport] },
       () => {
-        const route99InboundTimetableSection = new RouteTimetablesSection(
+        const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
           '99',
           'inbound',
         );

--- a/cypress/e2e/timetablePassingTimes.cy.ts
+++ b/cypress/e2e/timetablePassingTimes.cy.ts
@@ -1,31 +1,19 @@
+import { RouteDirectionEnum } from '@hsl/jore4-test-db-manager';
 import {
-  GetInfrastructureLinksByExternalIdsResult,
-  InfraLinkAlongRouteInsertInput,
-  JourneyPatternInsertInput,
-  LineInsertInput,
-  RouteDirectionEnum,
-  RouteInsertInput,
-  RouteTypeOfLineEnum,
-  StopInJourneyPatternInsertInput,
-  StopInsertInput,
-  TimetablePriority,
-  buildLine,
-  buildRoute,
-  buildStop,
-  buildStopInJourneyPattern,
-  buildTimingPlace,
-  extractInfrastructureLinkIdsFromResponse,
-  mapToGetInfrastructureLinksByExternalIdsQuery,
-} from '@hsl/jore4-test-db-manager';
-import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
-import { DateTime, Duration } from 'luxon';
+  buildInfraLinksAlongRoute,
+  buildStopsOnInfraLinks,
+  getClonedBaseDbResources,
+  testInfraLinkExternalIds,
+} from '../datasets/base';
+import { getClonedBaseTimetableDataInput } from '../datasets/timetables';
 import { Tag } from '../enums';
 import {
-  PassingTimesByStopSection,
-  RouteTimetablesSection,
+  SearchResultsPage,
+  TimetablesMainPage,
   VehicleScheduleDetailsPage,
-  VehicleServiceTable,
 } from '../pageObjects';
+import { PassingTimesByStopTable } from '../pageObjects/timetables/PassingTimesByStopTable';
+import { RouteTimetablesSection } from '../pageObjects/timetables/RouteTimetablesSection';
 import { UUID } from '../types';
 import {
   SupportedResources,
@@ -33,295 +21,29 @@ import {
   removeFromDbHelper,
 } from '../utils';
 
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
-
-const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
-
-const lines: LineInsertInput[] = [
-  {
-    ...buildLine({ label: '99' }),
-    line_id: 'f148d51b-36ff-4321-8cf1-049946f75f73',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-  },
-];
-
-const timingPlaces = [
-  buildTimingPlace('50623e7b-abd0-4c9a-85fa-f88ff7f65a06', '1AACKT'),
-  buildTimingPlace('f8a93c6f-5ef7-4b09-ae5e-0a04ea8597e9', '1ELIMK'),
-  buildTimingPlace('31a2592e-0af1-48b7-8f2f-373dcca39ddd', '1AURLA'),
-];
-
-const buildStopsOnInfrastrucureLinks = (
-  infrastructureLinkIds: UUID[],
-): StopInsertInput[] => [
-  {
-    ...buildStop({
-      label: stopLabels[0],
-      located_on_infrastructure_link_id: infrastructureLinkIds[0],
-    }),
-    scheduled_stop_point_id: 'd9f0bc78-45f2-4d44-9cac-4674f856a400',
-    timing_place_id: timingPlaces[0].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[1],
-      located_on_infrastructure_link_id: infrastructureLinkIds[1],
-    }),
-    scheduled_stop_point_id: '63bd05f9-de46-4fa3-bdd9-10e9a81702e3',
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[2],
-      located_on_infrastructure_link_id: infrastructureLinkIds[2],
-    }),
-    scheduled_stop_point_id: 'f732ceb2-fc41-4843-8164-ead6ec7dd33b',
-    timing_place_id: timingPlaces[1].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[3],
-      located_on_infrastructure_link_id: infrastructureLinkIds[3],
-    }),
-    scheduled_stop_point_id: '322a32cc-7a50-402b-9c01-5dc6a6b39af6',
-    timing_place_id: timingPlaces[2].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
-    },
-  },
-];
-
-const routes: RouteInsertInput[] = [
-  {
-    ...buildRoute({ label: '99' }),
-    route_id: '829e9d55-aa25-4ab9-858b-f2a5aa81d931',
-    on_line_id: lines[0].line_id,
-    validity_start: DateTime.fromISO('2023-01-01T13:08:43.315+03:00'),
-    validity_end: DateTime.fromISO('2043-06-30T13:08:43.315+03:00'),
-    direction: RouteDirectionEnum.Inbound,
-  },
-];
-
-const buildInfraLinksAlongRoute = (
-  infrastructureLinkIds: UUID[],
-): InfraLinkAlongRouteInsertInput[] => [
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[0],
-    infrastructure_link_sequence: 0,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[1],
-    infrastructure_link_sequence: 1,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[2],
-    infrastructure_link_sequence: 2,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[3],
-    infrastructure_link_sequence: 3,
-    is_traversal_forwards: true,
-  },
-];
-
-const journeyPatterns: JourneyPatternInsertInput[] = [
-  {
-    journey_pattern_id: '72ff8c33-33aa-4169-803e-53f2426a4508',
-    on_route_id: routes[0].route_id,
-  },
-];
-
-const stopsInJourneyPattern: StopInJourneyPatternInsertInput[] = [
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[0],
-    scheduledStopPointSequence: 0,
-    isUsedAsTimingPoint: true,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[1],
-    scheduledStopPointSequence: 1,
-    isUsedAsTimingPoint: false,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[2],
-    scheduledStopPointSequence: 2,
-    isUsedAsTimingPoint: true,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[3],
-    scheduledStopPointSequence: 3,
-    isUsedAsTimingPoint: true,
-  }),
-];
-
-const timetableDataInput = {
-  _journey_pattern_refs: {
-    route99inbound: {
-      route_label: '99',
-      route_direction: 'inbound',
-      journey_pattern_id: journeyPatterns[0].journey_pattern_id,
-      _stop_points: [
-        {
-          scheduled_stop_point_sequence: 1,
-          scheduled_stop_point_label: 'H1231',
-          timing_place_label: '1AACKT',
-        },
-        {
-          scheduled_stop_point_sequence: 2,
-          scheduled_stop_point_label: 'H1232',
-        },
-        {
-          scheduled_stop_point_sequence: 3,
-          scheduled_stop_point_label: 'H1233',
-          timing_place_label: '1ELIMK',
-        },
-        {
-          scheduled_stop_point_sequence: 4,
-          scheduled_stop_point_label: 'H1234',
-          timing_place_label: '1AURLA',
-        },
-      ],
-    },
-  },
-  _vehicle_schedule_frames: {
-    year2023: {
-      validity_start: DateTime.fromISO('2023-01-01'),
-      validity_end: DateTime.fromISO('2023-12-31'),
-      name: '2023',
-      booking_label: '2023 booking label',
-      _vehicle_services: {
-        saturday: {
-          day_type_id: defaultDayTypeIds.SATURDAY,
-          _blocks: {
-            block: {
-              _vehicle_journeys: {
-                route99Inbound1: {
-                  _journey_pattern_ref_name: 'route99inbound',
-                  _passing_times: [
-                    {
-                      _scheduled_stop_point_label: 'H1231',
-                      arrival_time: null,
-                      departure_time: Duration.fromISO('PT7H05M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1232',
-                      arrival_time: Duration.fromISO('PT7H12M'),
-                      departure_time: Duration.fromISO('PT7H12M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1233',
-                      arrival_time: Duration.fromISO('PT7H19M'),
-                      departure_time: Duration.fromISO('PT7H23M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1234',
-                      arrival_time: Duration.fromISO('PT7H27M'),
-                      departure_time: null,
-                    },
-                  ],
-                },
-                route99Inbound2: {
-                  _journey_pattern_ref_name: 'route99inbound',
-                  _passing_times: [
-                    {
-                      _scheduled_stop_point_label: 'H1231',
-                      arrival_time: null,
-                      departure_time: Duration.fromISO('PT8H20M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1232',
-                      arrival_time: Duration.fromISO('PT8H22M'),
-                      departure_time: Duration.fromISO('PT8H22M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1233',
-                      arrival_time: Duration.fromISO('PT8H26M'),
-                      departure_time: Duration.fromISO('PT8H27M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1234',
-                      arrival_time: Duration.fromISO('PT8H29M'),
-                      departure_time: null,
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-};
-
 describe('Timetable passing times', () => {
+  let timetablesMainPage: TimetablesMainPage;
   let vehicleScheduleDetailsPage: VehicleScheduleDetailsPage;
+  let searchResultsPage: SearchResultsPage;
+  let routeTimetablesSection: RouteTimetablesSection;
+  let passingTimesByStopTable: PassingTimesByStopTable;
 
-  const baseDbResources = {
-    lines,
-    routes,
-    journeyPatterns,
-    stopsInJourneyPattern,
-  };
   let dbResources: SupportedResources;
 
+  const baseDbResources = getClonedBaseDbResources();
+  const baseTimetableDataInput = getClonedBaseTimetableDataInput();
+
   before(() => {
-    cy.task<GetInfrastructureLinksByExternalIdsResult>(
-      'hasuraAPI',
-      mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
-      ),
-    ).then((res) => {
-      const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);
-      const stops = buildStopsOnInfrastrucureLinks(infraLinkIds);
+    cy.task<UUID[]>(
+      'getInfrastructureLinkIdsByExternalIds',
+      testInfraLinkExternalIds,
+    ).then((infraLinkIds) => {
+      const stops = buildStopsOnInfraLinks(infraLinkIds);
+
       const infraLinksAlongRoute = buildInfraLinksAlongRoute(infraLinkIds);
+
       dbResources = {
         ...baseDbResources,
-        timingPlaces,
         stops,
         infraLinksAlongRoute,
       };
@@ -332,13 +54,16 @@ describe('Timetable passing times', () => {
     cy.task('truncateTimetablesDatabase');
     removeFromDbHelper(dbResources);
     insertToDbHelper(dbResources);
-    cy.task('insertHslTimetablesDatasetToDb', timetableDataInput);
+    cy.task('insertHslTimetablesDatasetToDb', baseTimetableDataInput);
 
+    timetablesMainPage = new TimetablesMainPage();
     vehicleScheduleDetailsPage = new VehicleScheduleDetailsPage();
+    searchResultsPage = new SearchResultsPage();
+    routeTimetablesSection = new RouteTimetablesSection();
+    passingTimesByStopTable = new PassingTimesByStopTable();
 
     cy.setupTests();
     cy.mockLogin();
-    cy.visit('/');
   });
 
   afterEach(() => {
@@ -349,59 +74,159 @@ describe('Timetable passing times', () => {
   });
 
   it(
-    'Should show arrival times and highlight departures',
+    'Should highlight vehicle journey passing times',
     { tags: [Tag.Timetables, Tag.HastusImport] },
     () => {
-      const route99InboundTimetableSection = new RouteTimetablesSection(
-        '99',
-        'inbound',
+      cy.visit('/timetables');
+      timetablesMainPage.searchContainer.getSearchInput().type('901{enter}');
+
+      searchResultsPage.getRouteLineTableRowByLabel('901').click();
+
+      vehicleScheduleDetailsPage.observationDateControl.setObservationDate(
+        '2023-04-29',
       );
 
-      const route99InboundSaturdayVehicleService = new VehicleServiceTable(
-        route99InboundTimetableSection,
-        'LA',
+      routeTimetablesSection
+        .getRouteSectionHeadingButton('901', RouteDirectionEnum.Outbound)
+        .click();
+
+      routeTimetablesSection
+        .getRouteSection('901', RouteDirectionEnum.Outbound)
+        .within(() => {
+          const { row } = passingTimesByStopTable;
+          const { passingTime } = row;
+
+          passingTimesByStopTable.getStopRow('E2E001').within(() => {
+            row.getTimeContainerByHour('8').within(() => {
+              // Click one passing time to highlight the journey
+              passingTime.passingMinute.getMinute().click();
+
+              passingTime.assertNthMinuteShouldBeHighlighted(0);
+            });
+          });
+
+          passingTimesByStopTable.getStopRow('E2E002').within(() => {
+            row.getTimeContainerByHour('8').within(() => {
+              passingTime.assertNthMinuteShouldBeHighlighted(0);
+            });
+          });
+
+          passingTimesByStopTable.getStopRow('E2E003').within(() => {
+            row.getTimeContainerByHour('8').within(() => {
+              passingTime.assertNthMinuteShouldBeHighlighted(1);
+            });
+          });
+
+          passingTimesByStopTable.getStopRow('E2E004').within(() => {
+            row.getTimeContainerByHour('8').within(() => {
+              passingTime.assertNthMinuteShouldBeHighlighted(1);
+            });
+          });
+
+          passingTimesByStopTable.getStopRow('E2E005').within(() => {
+            row.getTimeContainerByHour('8').within(() => {
+              passingTime.assertNthMinuteShouldBeHighlighted(1);
+            });
+          });
+
+          // Check that we have the correct amount of elements highlighted
+          passingTimesByStopTable
+            .getAllHighlightedElements()
+            .should('have.length', 5);
+        });
+
+      // Check that the other direction route section has no highlighted elements
+      routeTimetablesSection
+        .getRouteSection('901', RouteDirectionEnum.Inbound)
+        .within(() => {
+          passingTimesByStopTable
+            .getAllHighlightedElements()
+            .should('have.length', 0);
+        });
+    },
+  );
+
+  it(
+    'Should show arrival times',
+    { tags: [Tag.Timetables, Tag.HastusImport] },
+    () => {
+      cy.visit('/timetables');
+      timetablesMainPage.searchContainer.getSearchInput().type('901{enter}');
+
+      searchResultsPage.getRouteLineTableRowByLabel('901').click();
+
+      vehicleScheduleDetailsPage.observationDateControl.setObservationDate(
+        '2023-04-29',
       );
 
-      const route99InboundSaturdayPassingTimesSection =
-        new PassingTimesByStopSection(
-          route99InboundTimetableSection,
-          'LA',
-          TimetablePriority.Standard,
-        );
+      routeTimetablesSection
+        .getRouteSectionHeadingButton('901', RouteDirectionEnum.Outbound)
+        .click();
 
-      // Check the imported timetable on a Saturday, which is the day type of the timetable
-      cy.visit(
-        `timetables/lines/${lines[0].line_id}?observationDate=2023-04-29&routeLabels=${routes[0].label}`,
-      );
-      route99InboundSaturdayVehicleService.getHeadingButton().click();
+      passingTimesByStopTable
+        .getAllPassingTimeArrivalTimes()
+        .should('have.length', 0);
+
       vehicleScheduleDetailsPage.getArrivalTimesSwitch().click();
 
-      route99InboundSaturdayPassingTimesSection.clickToHighlightNthPassingTimeOnStopRow(
-        stopLabels[0],
-        1,
-      );
+      routeTimetablesSection
+        .getRouteSection('901', RouteDirectionEnum.Outbound)
+        .within(() => {
+          const { row } = passingTimesByStopTable;
+          const { passingTime } = row;
+          // E2E003
+          passingTimesByStopTable.getStopRow('E2E003').within(() => {
+            // Hour 07
+            row.getTimeContainerByHour('7').within(() => {
+              passingTime.assertTotalMinuteCount(2);
+              passingTime.assertNthArrivalTime(0, '19');
+              passingTime.assertNthArrivalTime(1, '29');
+            });
 
-      // Assert that departures in the second column are highlighted
-      cy.wrap(stopLabels).each((stopLabel) => {
-        return route99InboundSaturdayPassingTimesSection.assertNthPassingTimeHighlightOnStopRow(
-          {
-            stopLabel: String(stopLabel),
-            nthPassingTime: 1,
-            isHighlighted: true,
-          },
-        );
-      });
+            // Hour 08
+            row.getTimeContainerByHour('8').within(() => {
+              passingTime.assertTotalMinuteCount(2);
+              passingTime.assertNthArrivalTime(0, '00');
+              passingTime.assertNthArrivalTime(1, '10');
+            });
 
-      // Assert that departures in the first column are not highlighted
-      cy.wrap(stopLabels).each((stopLabel) => {
-        return route99InboundSaturdayPassingTimesSection.assertNthPassingTimeHighlightOnStopRow(
-          {
-            stopLabel: String(stopLabel),
-            nthPassingTime: 0,
-            isHighlighted: false,
-          },
-        );
-      });
+            // Hour 09
+            row.getTimeContainerByHour('9').within(() => {
+              passingTime.assertTotalMinuteCount(2);
+              passingTime.assertNthArrivalTime(0, '42');
+              passingTime.assertNthArrivalTime(1, '52');
+            });
+          });
+
+          // E2E004
+          passingTimesByStopTable.getStopRow('E2E004').within(() => {
+            // Hour 07
+            row.getTimeContainerByHour('7').within(() => {
+              passingTime.assertTotalMinuteCount(2);
+              passingTime.assertNthArrivalTime(0, '24');
+              passingTime.assertNthArrivalTime(1, '34');
+            });
+
+            // Hour 08
+            row.getTimeContainerByHour('8').within(() => {
+              passingTime.assertTotalMinuteCount(2);
+              passingTime.assertNthArrivalTime(0, '05');
+              passingTime.assertNthArrivalTime(1, '15');
+            });
+
+            // Hour 09
+            row.getTimeContainerByHour('9').within(() => {
+              passingTime.assertTotalMinuteCount(1);
+              passingTime.assertNthArrivalTime(0, '50');
+            });
+
+            // Hour 10
+            row.getTimeContainerByHour('10').within(() => {
+              passingTime.assertTotalMinuteCount(1);
+              passingTime.assertNthArrivalTime(0, '00');
+            });
+          });
+        });
     },
   );
 });

--- a/cypress/e2e/timetableValidityPeriod.cy.ts
+++ b/cypress/e2e/timetableValidityPeriod.cy.ts
@@ -22,7 +22,7 @@ import { DateTime, Duration } from 'luxon';
 import { Tag } from '../enums';
 import {
   PassingTimesByStopSection,
-  RouteTimetablesSection,
+  RouteTimetablesSectionLegacy,
   VehicleScheduleDetailsPage,
   VehicleServiceTable,
 } from '../pageObjects';
@@ -396,7 +396,7 @@ describe('Timetable validity period', () => {
       cy.visit(
         `timetables/lines/${lines[0].line_id}?observationDate=2023-04-29&routeLabels=${routes[0].label}`,
       );
-      const route99InboundTimetableSection = new RouteTimetablesSection(
+      const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
         '99',
         'inbound',
       );
@@ -461,7 +461,7 @@ describe('Timetable validity period', () => {
         `timetables/lines/${lines[0].line_id}?routeLabels=${routes[0].label}&observationDate=2023-04-29&timetablesView=passingTimesByStop&dayType=LA`,
       );
 
-      const route99InboundTimetableSection = new RouteTimetablesSection(
+      const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
         '99',
         'inbound',
       );
@@ -529,7 +529,7 @@ describe('Timetable validity period', () => {
         cy.visit(
           `timetables/lines/${lines[0].line_id}?observationDate=2023-04-29&routeLabels=${routes[0].label}`,
         );
-        const route99InboundTimetableSection = new RouteTimetablesSection(
+        const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
           '99',
           'inbound',
         );

--- a/cypress/e2e/timetableVersionDetailsPanel.cy.ts
+++ b/cypress/e2e/timetableVersionDetailsPanel.cy.ts
@@ -1,23 +1,10 @@
 import {
-  GetInfrastructureLinksByExternalIdsResult,
-  InfraLinkAlongRouteInsertInput,
-  JourneyPatternInsertInput,
-  LineInsertInput,
-  RouteDirectionEnum,
-  RouteInsertInput,
-  RouteTypeOfLineEnum,
-  StopInJourneyPatternInsertInput,
-  StopInsertInput,
-  buildLine,
-  buildRoute,
-  buildStop,
-  buildStopInJourneyPattern,
-  buildTimingPlace,
-  extractInfrastructureLinkIdsFromResponse,
-  mapToGetInfrastructureLinksByExternalIdsQuery,
-} from '@hsl/jore4-test-db-manager';
-import { defaultDayTypeIds } from '@hsl/timetables-data-inserter';
-import { DateTime, Duration } from 'luxon';
+  buildInfraLinksAlongRoute,
+  buildStopsOnInfraLinks,
+  getClonedBaseDbResources,
+  testInfraLinkExternalIds,
+} from '../datasets/base';
+import { getClonedBaseTimetableDataInput } from '../datasets/timetables';
 import {
   ChangeTimetablesValidityForm,
   TimetableVersionDetailsPanel,
@@ -32,424 +19,7 @@ import {
   removeFromDbHelper,
 } from '../utils';
 
-// TODO: Extract the basedata somewhere, so that it can be used in multiple tests. No need
-// to copy paste 400+ lines in front of every test.
-
-// TODO: Also after extracting base data, expand the data so that we have different labeled routes
-// in the dataset and add asserts to the tests for those details
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.925682785, 60.163824160000004, 7.3515],
-  },
-  {
-    externalId: '442331',
-    coordinates: [24.927565858, 60.1644843305, 9.778500000000001],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.929825718, 60.165285984, 9.957],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.93312261043133, 60.16645636069328, 13.390046659939703],
-  },
-];
-
-const stopLabels = ['H1231', 'H1232', 'H1233', 'H1234'];
-
-const lines: LineInsertInput[] = [
-  {
-    ...buildLine({ label: '99' }),
-    line_id: 'f148d51b-36ff-4321-8cf1-049946f75f73',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-  },
-];
-
-const timingPlaces = [
-  buildTimingPlace('50623e7b-abd0-4c9a-85fa-f88ff7f65a06', '1AACKT'),
-  buildTimingPlace('f8a93c6f-5ef7-4b09-ae5e-0a04ea8597e9', '1ELIMK'),
-  buildTimingPlace('31a2592e-0af1-48b7-8f2f-373dcca39ddd', '1AURLA'),
-];
-
-const buildStopsOnInfrastrucureLinks = (
-  infrastructureLinkIds: UUID[],
-): StopInsertInput[] => [
-  {
-    ...buildStop({
-      label: stopLabels[0],
-      located_on_infrastructure_link_id: infrastructureLinkIds[0],
-    }),
-    scheduled_stop_point_id: 'd9f0bc78-45f2-4d44-9cac-4674f856a400',
-    timing_place_id: timingPlaces[0].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[1],
-      located_on_infrastructure_link_id: infrastructureLinkIds[1],
-    }),
-    scheduled_stop_point_id: '63bd05f9-de46-4fa3-bdd9-10e9a81702e3',
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[2],
-      located_on_infrastructure_link_id: infrastructureLinkIds[2],
-    }),
-    scheduled_stop_point_id: 'f732ceb2-fc41-4843-8164-ead6ec7dd33b',
-    timing_place_id: timingPlaces[1].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[3],
-      located_on_infrastructure_link_id: infrastructureLinkIds[3],
-    }),
-    scheduled_stop_point_id: '322a32cc-7a50-402b-9c01-5dc6a6b39af6',
-    timing_place_id: timingPlaces[2].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[3].coordinates,
-    },
-  },
-];
-
-const routes: RouteInsertInput[] = [
-  {
-    ...buildRoute({ label: '99' }),
-    route_id: '829e9d55-aa25-4ab9-858b-f2a5aa81d931',
-    on_line_id: lines[0].line_id,
-    validity_start: DateTime.fromISO('2023-01-01T13:08:43.315+03:00'),
-    validity_end: DateTime.fromISO('2043-06-30T13:08:43.315+03:00'),
-    direction: RouteDirectionEnum.Inbound,
-  },
-  {
-    ...buildRoute({ label: '99' }),
-    route_id: '06577560-4535-46ec-8240-0b989b0fed87',
-    on_line_id: lines[0].line_id,
-    validity_start: DateTime.fromISO('2023-01-01T13:08:43.315+03:00'),
-    validity_end: DateTime.fromISO('2043-06-30T13:08:43.315+03:00'),
-    direction: RouteDirectionEnum.Outbound,
-  },
-];
-
-const buildInfraLinksAlongRoute = (
-  infrastructureLinkIds: UUID[],
-): InfraLinkAlongRouteInsertInput[] => [
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[0],
-    infrastructure_link_sequence: 0,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[1],
-    infrastructure_link_sequence: 1,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[2],
-    infrastructure_link_sequence: 2,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[3],
-    infrastructure_link_sequence: 3,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[1].route_id,
-    infrastructure_link_id: infrastructureLinkIds[3],
-    infrastructure_link_sequence: 0,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[1].route_id,
-    infrastructure_link_id: infrastructureLinkIds[2],
-    infrastructure_link_sequence: 1,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[1].route_id,
-    infrastructure_link_id: infrastructureLinkIds[1],
-    infrastructure_link_sequence: 2,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[1].route_id,
-    infrastructure_link_id: infrastructureLinkIds[0],
-    infrastructure_link_sequence: 3,
-    is_traversal_forwards: true,
-  },
-];
-
-const journeyPatterns: JourneyPatternInsertInput[] = [
-  {
-    journey_pattern_id: '72ff8c33-33aa-4169-803e-53f2426a4508',
-    on_route_id: routes[0].route_id,
-  },
-  {
-    journey_pattern_id: '45217fb9-f95f-4193-8597-fb285e859d04',
-    on_route_id: routes[1].route_id,
-  },
-];
-
-const stopsInJourneyPattern: StopInJourneyPatternInsertInput[] = [
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[0],
-    scheduledStopPointSequence: 0,
-    isUsedAsTimingPoint: true,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[1],
-    scheduledStopPointSequence: 1,
-    isUsedAsTimingPoint: false,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[2],
-    scheduledStopPointSequence: 2,
-    isUsedAsTimingPoint: true,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[3],
-    scheduledStopPointSequence: 3,
-    isUsedAsTimingPoint: true,
-  }),
-];
-
-const stopInAnotherJourneyPattern: StopInJourneyPatternInsertInput[] = [
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[1].journey_pattern_id,
-    stopLabel: stopLabels[3],
-    scheduledStopPointSequence: 0,
-    isUsedAsTimingPoint: true,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[1].journey_pattern_id,
-    stopLabel: stopLabels[2],
-    scheduledStopPointSequence: 1,
-    isUsedAsTimingPoint: true,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[1].journey_pattern_id,
-    stopLabel: stopLabels[1],
-    scheduledStopPointSequence: 2,
-    isUsedAsTimingPoint: false,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[1].journey_pattern_id,
-    stopLabel: stopLabels[0],
-    scheduledStopPointSequence: 3,
-    isUsedAsTimingPoint: true,
-  }),
-];
-
-const timetableDataInput = {
-  _journey_pattern_refs: {
-    route99inbound: {
-      route_label: '99',
-      route_direction: 'inbound',
-      journey_pattern_id: journeyPatterns[0].journey_pattern_id,
-      _stop_points: [
-        {
-          scheduled_stop_point_sequence: 1,
-          scheduled_stop_point_label: 'H1231',
-          timing_place_label: '1AACKT',
-        },
-        {
-          scheduled_stop_point_sequence: 2,
-          scheduled_stop_point_label: 'H1232',
-        },
-        {
-          scheduled_stop_point_sequence: 3,
-          scheduled_stop_point_label: 'H1233',
-          timing_place_label: '1ELIMK',
-        },
-        {
-          scheduled_stop_point_sequence: 4,
-          scheduled_stop_point_label: 'H1234',
-          timing_place_label: '1AURLA',
-        },
-      ],
-    },
-    route99outbound: {
-      route_label: '99',
-      route_direction: 'outbound',
-      journey_pattern_id: journeyPatterns[1].journey_pattern_id,
-      _stop_points: [
-        {
-          scheduled_stop_point_sequence: 1,
-          scheduled_stop_point_label: 'H1234',
-          timing_place_label: '1AURLA',
-        },
-        {
-          scheduled_stop_point_sequence: 2,
-          scheduled_stop_point_label: 'H1233',
-          timing_place_label: '1ELIMK',
-        },
-        {
-          scheduled_stop_point_sequence: 3,
-          scheduled_stop_point_label: 'H1232',
-        },
-        {
-          scheduled_stop_point_sequence: 4,
-          scheduled_stop_point_label: 'H1231',
-          timing_place_label: '1AACKT',
-        },
-      ],
-    },
-  },
-  _vehicle_schedule_frames: {
-    year2023: {
-      validity_start: DateTime.fromISO('2023-01-01'),
-      validity_end: DateTime.fromISO('2023-12-31'),
-      name: '2023',
-      booking_label: '2023 booking label',
-      _vehicle_services: {
-        saturday: {
-          day_type_id: defaultDayTypeIds.SATURDAY,
-          _blocks: {
-            block: {
-              _vehicle_journeys: {
-                route99Inbound1: {
-                  _journey_pattern_ref_name: 'route99inbound',
-                  _passing_times: [
-                    {
-                      _scheduled_stop_point_label: 'H1231',
-                      arrival_time: null,
-                      departure_time: Duration.fromISO('PT7H05M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1232',
-                      arrival_time: Duration.fromISO('PT7H12M'),
-                      departure_time: Duration.fromISO('PT7H12M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1233',
-                      arrival_time: Duration.fromISO('PT7H19M'),
-                      departure_time: Duration.fromISO('PT7H23M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1234',
-                      arrival_time: Duration.fromISO('PT7H27M'),
-                      departure_time: null,
-                    },
-                  ],
-                },
-                route99Inbound2: {
-                  _journey_pattern_ref_name: 'route99inbound',
-                  _passing_times: [
-                    {
-                      _scheduled_stop_point_label: 'H1231',
-                      arrival_time: null,
-                      departure_time: Duration.fromISO('PT8H20M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1232',
-                      arrival_time: Duration.fromISO('PT8H22M'),
-                      departure_time: Duration.fromISO('PT8H22M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1233',
-                      arrival_time: Duration.fromISO('PT8H26M'),
-                      departure_time: Duration.fromISO('PT8H27M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1234',
-                      arrival_time: Duration.fromISO('PT8H29M'),
-                      departure_time: null,
-                    },
-                  ],
-                },
-                route99Inbound3: {
-                  _journey_pattern_ref_name: 'route99inbound',
-                  _passing_times: [
-                    {
-                      _scheduled_stop_point_label: 'H1231',
-                      arrival_time: null,
-                      departure_time: Duration.fromISO('PT8H30M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1232',
-                      arrival_time: Duration.fromISO('PT8H39M'),
-                      departure_time: Duration.fromISO('PT8H39M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1233',
-                      arrival_time: Duration.fromISO('PT8H50M'),
-                      departure_time: Duration.fromISO('PT8H50M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1234',
-                      arrival_time: Duration.fromISO('PT8H59M'),
-                      departure_time: null,
-                    },
-                  ],
-                },
-                route99Outbound1: {
-                  _journey_pattern_ref_name: 'route99outbound',
-                  _passing_times: [
-                    {
-                      _scheduled_stop_point_label: 'H1234',
-                      arrival_time: null,
-                      departure_time: Duration.fromISO('PT7H28M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1233',
-                      arrival_time: Duration.fromISO('PT7H38M'),
-                      departure_time: Duration.fromISO('PT7H38M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1232',
-                      arrival_time: Duration.fromISO('PT8H00M'),
-                      departure_time: Duration.fromISO('PT8H00M'),
-                    },
-                    {
-                      _scheduled_stop_point_label: 'H1231',
-                      arrival_time: Duration.fromISO('PT8H15M'),
-                      departure_time: null,
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-};
-
 describe('Timetable version details panel', () => {
-  const baseDbResources = {
-    lines,
-    routes,
-    journeyPatterns,
-    stopsInJourneyPattern,
-    stopInAnotherJourneyPattern,
-  };
   let dbResources: SupportedResources;
   let timetableVersionsPage: TimetableVersionsPage;
   let timetableVersionDetailsPanel: TimetableVersionDetailsPanel;
@@ -457,19 +27,20 @@ describe('Timetable version details panel', () => {
   let vehicleServiceRow: VehicleServiceRow;
   let toast: Toast;
 
+  const baseDbResources = getClonedBaseDbResources();
+  const baseTimetableDataInput = getClonedBaseTimetableDataInput();
+
   before(() => {
-    cy.task<GetInfrastructureLinksByExternalIdsResult>(
-      'hasuraAPI',
-      mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
-      ),
-    ).then((res) => {
-      const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);
-      const stops = buildStopsOnInfrastrucureLinks(infraLinkIds);
+    cy.task<UUID[]>(
+      'getInfrastructureLinkIdsByExternalIds',
+      testInfraLinkExternalIds,
+    ).then((infraLinkIds) => {
+      const stops = buildStopsOnInfraLinks(infraLinkIds);
+
       const infraLinksAlongRoute = buildInfraLinksAlongRoute(infraLinkIds);
+
       dbResources = {
         ...baseDbResources,
-        timingPlaces,
         stops,
         infraLinksAlongRoute,
       };
@@ -480,7 +51,7 @@ describe('Timetable version details panel', () => {
     cy.task('truncateTimetablesDatabase');
     removeFromDbHelper(dbResources);
     insertToDbHelper(dbResources);
-    cy.task('insertHslTimetablesDatasetToDb', timetableDataInput);
+    cy.task('insertHslTimetablesDatasetToDb', baseTimetableDataInput);
 
     timetableVersionsPage = new TimetableVersionsPage();
     timetableVersionDetailsPanel = new TimetableVersionDetailsPanel();
@@ -491,7 +62,7 @@ describe('Timetable version details panel', () => {
     cy.setupTests();
     cy.mockLogin();
     cy.visit(
-      `/timetables/lines/99/versions?startDate=2023-03-04&endDate=2024-03-04`,
+      `/timetables/lines/901/versions?startDate=2023-03-04&endDate=2024-03-04`,
     );
   });
 
@@ -522,35 +93,25 @@ describe('Timetable version details panel', () => {
       .findByTestId('DirectionBadge::outbound')
       .should('be.visible');
 
-    timetableVersionDetailsPanel.getRows().eq(0).should('contain', '99');
+    timetableVersionDetailsPanel.getRows().eq(0).should('contain', '901');
 
     timetableVersionDetailsPanel.toggleExpandNthRow(0);
-    timetableVersionDetailsPanel
-      .getRows()
-      .eq(0)
-      .findByTestId('VehicleServiceRow::row')
-      .findByTestId('VehicleServiceRow::hour')
-      .eq(0)
-      .should('contain', '07');
 
     timetableVersionDetailsPanel
       .getRows()
-      .eq(1)
-      .findByTestId('DirectionBadge::inbound')
-      .should('be.visible');
-
-    timetableVersionDetailsPanel.toggleExpandNthRow(1);
-    timetableVersionDetailsPanel
-      .getRows()
-      .eq(1)
+      .eq(0)
       .findByTestId('VehicleServiceRow::row')
       .then((rows) => {
+        cy.wrap(rows).should('have.length', 3);
         // hour 07 departures
         cy.wrap(rows)
           .eq(0)
           .within(() => {
             vehicleServiceRow.getHour().should('contain', '07');
-            vehicleServiceRow.getMinute().eq(0).contains('05');
+            vehicleServiceRow.getMinute().should('have.length', 3);
+            vehicleServiceRow.getMinute().eq(0).should('contain', '05');
+            vehicleServiceRow.getMinute().eq(1).should('contain', '15');
+            vehicleServiceRow.getMinute().eq(2).should('contain', '50');
           });
 
         // hour 08 departures
@@ -558,10 +119,72 @@ describe('Timetable version details panel', () => {
           .eq(1)
           .within(() => {
             vehicleServiceRow.getHour().should('contain', '08');
-            vehicleServiceRow.getMinute().eq(0).contains('20');
-            vehicleServiceRow.getMinute().eq(1).contains('30');
+            vehicleServiceRow.getMinute().should('have.length', 1);
+            vehicleServiceRow.getMinute().eq(0).should('contain', '00');
+          });
+
+        // hour 09 departures
+        cy.wrap(rows)
+          .eq(2)
+          .within(() => {
+            vehicleServiceRow.getHour().should('contain', '09');
+            vehicleServiceRow.getMinute().should('have.length', 2);
+            vehicleServiceRow.getMinute().eq(0).should('contain', '30');
+            vehicleServiceRow.getMinute().eq(1).should('contain', '40');
           });
       });
+
+    timetableVersionDetailsPanel.toggleExpandNthRow(1);
+    timetableVersionDetailsPanel
+      .getRows()
+      .eq(1)
+      .findByTestId('VehicleServiceRow::row')
+      .then((rows) => {
+        cy.wrap(rows).should('have.length', 4);
+        // hour 07 departures
+        cy.wrap(rows)
+          .eq(0)
+          .within(() => {
+            vehicleServiceRow.getHour().should('contain', '07');
+            vehicleServiceRow.getMinute().should('have.length', 2);
+            vehicleServiceRow.getMinute().eq(0).should('contain', '30');
+            vehicleServiceRow.getMinute().eq(1).should('contain', '40');
+          });
+
+        // hour 08 departures
+        cy.wrap(rows)
+          .eq(1)
+          .within(() => {
+            vehicleServiceRow.getHour().should('contain', '08');
+            vehicleServiceRow.getMinute().should('have.length', 2);
+            vehicleServiceRow.getMinute().eq(0).should('contain', '10');
+            vehicleServiceRow.getMinute().eq(1).should('contain', '20');
+          });
+
+        // hour 09 departures
+        cy.wrap(rows)
+          .eq(2)
+          .within(() => {
+            vehicleServiceRow.getHour().should('contain', '09');
+            vehicleServiceRow.getMinute().should('have.length', 1);
+            vehicleServiceRow.getMinute().eq(0).should('contain', '55');
+          });
+
+        // hour 10 departures
+        cy.wrap(rows)
+          .eq(3)
+          .within(() => {
+            vehicleServiceRow.getHour().should('contain', '10');
+            vehicleServiceRow.getMinute().should('have.length', 1);
+            vehicleServiceRow.getMinute().eq(0).should('contain', '05');
+          });
+      });
+
+    timetableVersionDetailsPanel
+      .getRows()
+      .eq(1)
+      .findByTestId('DirectionBadge::inbound')
+      .should('be.visible');
 
     timetableVersionDetailsPanel.close();
 
@@ -590,7 +213,9 @@ describe('Timetable version details panel', () => {
     toast.getSuccessToast().should('be.visible');
 
     // Check that the panel heading's validity changed
-    timetableVersionDetailsPanel.getHeading().contains('1.1.2023 - 31.3.2024');
+    timetableVersionDetailsPanel
+      .getHeading()
+      .should('contain', '1.1.2023 - 31.3.2024');
 
     timetableVersionDetailsPanel.toggleExpandNthRow(1);
 
@@ -598,17 +223,17 @@ describe('Timetable version details panel', () => {
     timetableVersionDetailsPanel.vehicleJourneyGroupInfo
       .getValidityTimeRange()
       .eq(0)
-      .contains('1.1.2023 - 31.3.2024');
+      .should('contain', '1.1.2023 - 31.3.2024');
     timetableVersionDetailsPanel.vehicleJourneyGroupInfo
       .getValidityTimeRange()
       .eq(1)
-      .contains('1.1.2023 - 31.3.2024');
+      .should('contain', '1.1.2023 - 31.3.2024');
 
     // Check that the version row's validity changed
     timetableVersionsPage.timetableVersionTableRow
       .getRows()
       .eq(0)
       .findByTestId('TimetableVersionTableRow::validityEnd')
-      .contains('31.3.2024');
+      .should('contain', '31.3.2024');
   });
 });

--- a/cypress/e2e/timetablesReplaceAndCombine.cy.ts
+++ b/cypress/e2e/timetablesReplaceAndCombine.cy.ts
@@ -25,7 +25,7 @@ import {
   Navbar,
   PassingTimesByStopSection,
   PreviewTimetablesPage,
-  RouteTimetablesSection,
+  RouteTimetablesSectionLegacy,
   RoutesAndLinesPage,
   TimetablesMainPage,
   VehicleServiceTable,
@@ -303,7 +303,7 @@ const timetableDataInput = {
   },
 };
 
-const route99InboundTimetableSection = new RouteTimetablesSection(
+const route99InboundTimetableSection = new RouteTimetablesSectionLegacy(
   '99',
   'inbound',
 );

--- a/cypress/pageObjects/PassingTimesByStopSection.ts
+++ b/cypress/pageObjects/PassingTimesByStopSection.ts
@@ -114,7 +114,7 @@ export class PassingTimesByStopSection {
         .eq(nthPassingTime)
         .within(() => {
           this.passingTimesByStopTableRowPassingTime.passingMinute
-            .getHighlightButton()
+            .getMinute()
             .click();
         });
     });
@@ -146,11 +146,11 @@ export class PassingTimesByStopSection {
         .within(() => {
           if (isHighlighted) {
             this.passingTimesByStopTableRowPassingTime.passingMinute
-              .getHighlightButton()
+              .getMinute()
               .should('have.class', 'bg-city-bicycle-yellow');
           } else {
             this.passingTimesByStopTableRowPassingTime.passingMinute
-              .getHighlightButton()
+              .getMinute()
               .should('not.have.class', 'bg-city-bicycle-yellow');
           }
         });

--- a/cypress/pageObjects/PassingTimesByStopTableRowPassingMinute.ts
+++ b/cypress/pageObjects/PassingTimesByStopTableRowPassingMinute.ts
@@ -11,7 +11,7 @@ export class PassingTimesByStopTableRowPassingMinute {
     );
   }
 
-  getHighlightButton() {
+  getMinute() {
     return cy.getByTestId('PassingTimesByStopTableRowPassingMinute::button');
   }
 }

--- a/cypress/pageObjects/PassingTimesByStopTableRowPassingTime.ts
+++ b/cypress/pageObjects/PassingTimesByStopTableRowPassingTime.ts
@@ -20,4 +20,19 @@ export class PassingTimesByStopTableRowPassingTime {
         '[data-testid="PassingTimesByStopTableRowPassingTime::timeContainer"]',
       );
   }
+
+  assertNthMinuteShouldBeHighlighted(nth: number) {
+    return this.passingMinute
+      .getMinute()
+      .eq(nth)
+      .should('have.attr', 'data-highlighted', 'true');
+  }
+
+  assertTotalMinuteCount(count: number) {
+    this.passingMinute.getMinute().should('have.length', count);
+  }
+
+  assertNthArrivalTime(nth: number, arrivalTime: string) {
+    this.passingMinute.getArrivalTime().eq(nth).should('contain', arrivalTime);
+  }
 }

--- a/cypress/pageObjects/RouteTimetablesSectionLegacy.ts
+++ b/cypress/pageObjects/RouteTimetablesSectionLegacy.ts
@@ -1,4 +1,11 @@
-export class RouteTimetablesSection {
+/**
+ * This page object is marked as legacy as the new simpler page object
+ * is taking place in pageObjects/timetables/RouteTimetablesSection.ts
+ * This constructor class pattern is probably a bit too heavy and we should
+ * stick with simpler page objects and using .within() and .findByTestId()
+ * methods
+ */
+export class RouteTimetablesSectionLegacy {
   label: string;
 
   direction: string;

--- a/cypress/pageObjects/SearchResultsPage.ts
+++ b/cypress/pageObjects/SearchResultsPage.ts
@@ -11,6 +11,12 @@ export class SearchResultsPage {
     return cy.getByTestId('LinesList::table');
   }
 
+  getRouteLineTableRowByLabel(label: string) {
+    return this.getLinesSearchResultTable().findByTestId(
+      `RouteLineTableRow::row::${label}`,
+    );
+  }
+
   getSearchResultsContainer() {
     return cy.getByTestId('SearchResultsPage::Container');
   }

--- a/cypress/pageObjects/index.ts
+++ b/cypress/pageObjects/index.ts
@@ -20,7 +20,7 @@ export * from './PreviewTimetablesPage';
 export * from './RouteEditor';
 export * from './RoutePropertiesForm';
 export * from './RouteStopsTable';
-export * from './RouteTimetablesSection';
+export * from './RouteTimetablesSectionLegacy';
 export * from './RoutesAndLinesPage';
 export * from './SearchResultsPage';
 export * from './StopForm';

--- a/cypress/pageObjects/timetables/PassingTimesByStopTable.ts
+++ b/cypress/pageObjects/timetables/PassingTimesByStopTable.ts
@@ -1,0 +1,25 @@
+import { PassingTimesByStopTableRow } from './PassingTimesByStopTableRow';
+
+export class PassingTimesByStopTable {
+  row = new PassingTimesByStopTableRow();
+
+  getTable() {
+    return cy.getByTestId('PassingTimesByStopTable::table');
+  }
+
+  getStopRow(stopLabel: string) {
+    return this.getTable().findByTestId(
+      `PassingTimesByStopTableRow::${stopLabel}`,
+    );
+  }
+
+  getAllHighlightedElements() {
+    return this.getTable().find('[data-highlighted="true"]');
+  }
+
+  getAllPassingTimeArrivalTimes() {
+    return cy.getByTestId(
+      'PassingTimesByStopTableRowPassingMinute::arrivalTime',
+    );
+  }
+}

--- a/cypress/pageObjects/timetables/PassingTimesByStopTableRow.ts
+++ b/cypress/pageObjects/timetables/PassingTimesByStopTableRow.ts
@@ -1,0 +1,14 @@
+import { PassingTimesByStopTableRowPassingTime } from '../PassingTimesByStopTableRowPassingTime';
+
+export class PassingTimesByStopTableRow {
+  passingTime = new PassingTimesByStopTableRowPassingTime();
+
+  getTimeContainerByHour(hour: string) {
+    return cy
+      .getByTestId('PassingTimesByStopTableRowPassingTime::hour')
+      .contains(hour)
+      .parent(
+        '[data-testid="PassingTimesByStopTableRowPassingTime::timeContainer"]',
+      );
+  }
+}

--- a/cypress/pageObjects/timetables/RouteTimetablesSection.ts
+++ b/cypress/pageObjects/timetables/RouteTimetablesSection.ts
@@ -1,0 +1,15 @@
+import { RouteDirectionEnum } from '@hsl/jore4-test-db-manager';
+
+export class RouteTimetablesSection {
+  getRouteSection(label: string, direction: RouteDirectionEnum) {
+    return cy.getByTestId(
+      `RouteTimetablesSection::section::${label}::${direction}`,
+    );
+  }
+
+  getRouteSectionHeadingButton(label: string, direction: RouteDirectionEnum) {
+    return this.getRouteSection(label, direction).findByTestId(
+      'VehicleServiceTable::headingButton',
+    );
+  }
+}

--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingMinute.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingMinute.tsx
@@ -66,6 +66,7 @@ export const PassingTimesByStopTableRowPassingMinute = ({
   return (
     <span className="inline-flex">
       <button
+        data-highlighted={isHighlighted}
         className={twMerge(
           'inline-flex flex-col items-end rounded-sm border border-transparent px-0.5 align-text-bottom text-xs',
           'px-1 hover:border-hsl-highlight-yellow-dark hover:bg-city-bicycle-yellow',


### PR DESCRIPTION
Create base dataset for timetables. This currently consists of two vehicle services, which each has 3 round trips. So total 6 departures per direction. These timetables are constructed to work with the base dataset route 901.

Also some refactoring and adding / enhancing tests. More info on commit messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/827)
<!-- Reviewable:end -->
