### PR TITLE
Log GraphQL query name as part of Hasura URI

### DIFF
--- a/ui/src/graphql/client.ts
+++ b/ui/src/graphql/client.ts
@@ -2,6 +2,7 @@ import {
   ApolloClient,
   HttpLink,
   InMemoryCache,
+  UriFunction,
   from,
   split,
 } from '@apollo/client';
@@ -65,16 +66,27 @@ const buildScalarMappingLink = () => {
   return withScalars({ schema, typesMap });
 };
 
-const getGraphqlUrl = (isTesting: boolean, isWebsocket: boolean) => {
+function getGraphqlUrl(
+  isTesting: boolean,
+  isWebsocket: false,
+): string | UriFunction;
+function getGraphqlUrl(isTesting: boolean, isWebsocket: true): string;
+function getGraphqlUrl(
+  isTesting: boolean,
+  isWebsocket: boolean,
+): string | UriFunction {
   const path = '/api/graphql/v1/graphql';
+
   if (isTesting) {
     return `http://127.0.0.1:3300${path}`;
   }
+
   if (isWebsocket) {
     return mapHttpToWs(`${window.location.origin}${path}`);
   }
-  return path;
-};
+
+  return (operation) => `${path}?q=${operation.operationName}`;
+}
 
 const buildWebSocketLink = () => {
   return new WebSocketLink({


### PR DESCRIPTION
Appends the query name to the Hasura URI with ?param to make identifying HTTP requests relating to the queries, in broswser's Network dev tab.

![image](https://github.com/HSLdevcom/jore4-ui/assets/294363/ff42c6a9-d212-44b0-a790-df7e9e07d1a2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/838)
<!-- Reviewable:end -->
