### PR TITLE
Add observationDate to stopDetails and show highest priority

### DIFF
--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -269,7 +269,7 @@ describe('Stop details', () => {
     'should view details for a stop',
     { tags: [Tag.StopRegistry, Tag.Smoke] },
     () => {
-      stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+      stopDetailsPage.visit('H2003');
       stopDetailsPage.page().shouldBeVisible();
 
       stopDetailsPage.label().shouldHaveText('H2003');
@@ -297,7 +297,7 @@ describe('Stop details', () => {
       'should view and edit basic details text fields',
       { tags: [Tag.StopRegistry] },
       () => {
-        stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+        stopDetailsPage.visit('H2003');
         stopDetailsPage.page().shouldBeVisible();
 
         bdView.getContent().shouldBeVisible();
@@ -385,7 +385,7 @@ describe('Stop details', () => {
       'should view and edit basic details dropdowns and checkboxes',
       { tags: [Tag.StopRegistry] },
       () => {
-        stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+        stopDetailsPage.visit('H2003');
         stopDetailsPage.page().shouldBeVisible();
 
         bdView.getContent().shouldBeVisible();
@@ -480,7 +480,7 @@ describe('Stop details', () => {
         { tags: [Tag.StopRegistry] },
         () => {
           const { createTimingPlaceForm } = bdForm;
-          stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+          stopDetailsPage.visit('H2003');
           stopDetailsPage.page().shouldBeVisible();
 
           bdView.getContent().shouldBeVisible();
@@ -524,7 +524,7 @@ describe('Stop details', () => {
     });
 
     it('should view location details', { tags: [Tag.StopRegistry] }, () => {
-      stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+      stopDetailsPage.visit('H2003');
       stopDetailsPage.page().shouldBeVisible();
 
       verifyInitialLocationDetails();
@@ -587,7 +587,7 @@ describe('Stop details', () => {
       'should view and edit signage details',
       { tags: [Tag.StopRegistry] },
       () => {
-        stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+        stopDetailsPage.visit('H2003');
         stopDetailsPage.page().shouldBeVisible();
 
         verifyInitialSignageDetails();
@@ -631,7 +631,7 @@ describe('Stop details', () => {
 
   describe('technical features', () => {
     beforeEach(() => {
-      stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+      stopDetailsPage.visit('H2003');
       stopDetailsPage.page().shouldBeVisible();
       stopDetailsPage.label().shouldHaveText('H2003');
 
@@ -936,7 +936,7 @@ describe('Stop details', () => {
 
   describe('info spots', () => {
     it('should view info spots', { tags: [Tag.StopRegistry] }, () => {
-      stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+      stopDetailsPage.visit('H2003');
       stopDetailsPage.page().shouldBeVisible();
       stopDetailsPage.label().shouldHaveText('H2003');
 
@@ -950,7 +950,7 @@ describe('Stop details', () => {
 
   // A regression test to ensure that our mutations don't eg. reset any fields they are not supposed to.
   it('should keep stop place intact when submitting without actual changes', () => {
-    stopDetailsPage.visit(dbResources.stops[1].scheduled_stop_point_id);
+    stopDetailsPage.visit('H2003');
     stopDetailsPage.page().shouldBeVisible();
 
     verifyInitialBasicDetails();

--- a/cypress/pageObjects/stop-registry/StopDetailsPage.ts
+++ b/cypress/pageObjects/stop-registry/StopDetailsPage.ts
@@ -1,4 +1,3 @@
-import { UUID } from '../../types';
 import {
   BasicDetailsSection,
   LocationDetailsSection,
@@ -18,8 +17,8 @@ export class StopDetailsPage {
 
   measurements = new MeasurementsSection();
 
-  visit(scheduledStopPointId: UUID) {
-    cy.visit(`/stop-registry/stops/${scheduledStopPointId}`);
+  visit(label: string) {
+    cy.visit(`/stop-registry/stops/${label}`);
   }
 
   page() {

--- a/ui/src/components/map/stops/StopPopup.tsx
+++ b/ui/src/components/map/stops/StopPopup.tsx
@@ -52,9 +52,7 @@ export const StopPopup = ({
             <Row className="items-center">
               <h3>
                 <a
-                  href={routeDetails[Path.stopDetails].getLink(
-                    stop.scheduled_stop_point_id,
-                  )}
+                  href={routeDetails[Path.stopDetails].getLink(stop.label)}
                   target="_blank"
                   rel="noreferrer"
                   data-testid={testIds.label}

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsRow.tsx
@@ -96,9 +96,7 @@ export const RouteStopsRow = ({
     >
       <td className={`${alertStyle.listItemBorder || ''} p-4 pl-16 text-2xl`}>
         <a
-          href={routeDetails[Path.stopDetails].getLink(
-            stop.scheduled_stop_point_id,
-          )}
+          href={routeDetails[Path.stopDetails].getLink(stop.label)}
           data-testid={testIds.label}
           title={t('accessibility:stops.showStopDetails', { stopLabel })}
         >

--- a/ui/src/components/routes-and-lines/line-details/RouteStopsTable.spec.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopsTable.spec.tsx
@@ -586,9 +586,6 @@ describe(`<${RouteStopsTable.name} />`, () => {
     ).getByTestId('RouteStopsRow::label');
     expect(label).toHaveTextContent('H1234');
     expect(label.title).toContain('H1234');
-    expect(label).toHaveAttribute(
-      'href',
-      '/stop-registry/stops/e3528755-711f-4e4f-9461-7931a2c4bc6d',
-    );
+    expect(label).toHaveAttribute('href', '/stop-registry/stops/H1234');
   });
 });

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/RouteStopsTable.spec.tsx.snap
@@ -449,7 +449,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <a
               data-testid="RouteStopsRow::label"
-              href="/stop-registry/stops/e3528755-711f-4e4f-9461-7931a2c4bc6d"
+              href="/stop-registry/stops/H1234"
               title="Näytä pysäkin H1234 tiedot"
             >
               H1234
@@ -572,7 +572,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 2`]
           >
             <a
               data-testid="RouteStopsRow::label"
-              href="/stop-registry/stops/f8eace87-7901-4438-bfee-bb6f24f1c4c4"
+              href="/stop-registry/stops/H1236"
               title="Näytä pysäkin H1236 tiedot"
             >
               H1236
@@ -918,7 +918,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <a
               data-testid="RouteStopsRow::label"
-              href="/stop-registry/stops/e3528755-711f-4e4f-9461-7931a2c4bc6d"
+              href="/stop-registry/stops/H1234"
               title="Näytä pysäkin H1234 tiedot"
             >
               H1234
@@ -1041,7 +1041,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <a
               data-testid="RouteStopsRow::label"
-              href="/stop-registry/stops/4d294d62-df17-46ff-9248-23f66f17fa87"
+              href="/stop-registry/stops/H1235"
               title="Näytä pysäkin H1235 tiedot"
             >
               H1235
@@ -1164,7 +1164,7 @@ exports[`<RouteStopsTable /> Renders the route with stops along its geometry 3`]
           >
             <a
               data-testid="RouteStopsRow::label"
-              href="/stop-registry/stops/f8eace87-7901-4438-bfee-bb6f24f1c4c4"
+              href="/stop-registry/stops/H1236"
               title="Näytä pysäkin H1236 tiedot"
             >
               H1236

--- a/ui/src/components/stop-registry/search/StopTableRow.tsx
+++ b/ui/src/components/stop-registry/search/StopTableRow.tsx
@@ -29,9 +29,7 @@ export const StopTableRow = ({ className = '', stop }: Props): JSX.Element => {
       <td className={`w-auto px-8 py-3 pr-20 ${yBorderClassNames}`}>
         <Row className="mb-2 items-center font-bold leading-none">
           <Link
-            to={routeDetails[Path.stopDetails].getLink(
-              stop.scheduled_stop_point_id,
-            )}
+            to={routeDetails[Path.stopDetails].getLink(stop.label)}
             title={t('accessibility:stops.showStopDetails', {
               stopLabel: stop.label,
             })}

--- a/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useGetStopDetails } from '../../../../hooks';
+import { MdWarning } from 'react-icons/md';
+import { useGetStopDetails, useRequiredParams } from '../../../../hooks';
 import { Container, Visible } from '../../../../layoutComponents';
 import { mapToShortDate } from '../../../../time';
+import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
+import { ObservationDateControl } from '../../../common/ObservationDateControl';
+import { FormRow } from '../../../forms/common';
 import { BasicDetailsSection } from './basic-details/BasicDetailsSection';
 import {
   DetailTabSelector,
@@ -22,23 +26,25 @@ const testIds = {
   basicDetailsTabPanel: 'StopDetailsPage::basicDetailsTabPanel',
   technicalFeaturesTabPanel: 'StopDetailsPage::technicalFeaturesTabPanel',
   infoSpotsTabPanel: 'StopDetailsPage::infoSpotsTabPanel',
+  loadingStopDetails: 'StopDetailsPage::loadingStopDetails',
 };
 
 export const StopDetailsPage = (): JSX.Element => {
-  const { stopDetails } = useGetStopDetails();
+  const { stopDetails, isLoading } = useGetStopDetails();
   const { t } = useTranslation();
   const [activeDetailTab, selectDetailTab] = useState(
     DetailTabType.BasicDetailsTab,
   );
-
-  if (!stopDetails) {
-    return <></>;
-  }
+  const { label } = useRequiredParams<{ label: string }>();
 
   return (
     <Container testId={testIds.page}>
-      <StopTitleRow stopDetails={stopDetails} />
+      <StopTitleRow stopDetails={stopDetails} label={label} />
       <StopHeaderSummaryRow className="my-2" stopDetails={stopDetails} />
+      <FormRow mdColumns={6}>
+        {/* TODO: Stop/Announcement/Breakroom/Lines tabs */}
+        <ObservationDateControl className="col-start-6" />
+      </FormRow>
       <hr className="my-4" />
       <div className="my-4 flex items-center">
         <h2 className="">{t('stopDetails.stopDetails')}</h2>
@@ -47,48 +53,70 @@ export const StopDetailsPage = (): JSX.Element => {
           title={t('accessibility:stops.validityPeriod')}
           data-testid={testIds.validityPeriod}
         >
-          {mapToShortDate(stopDetails.validity_start)}
+          {mapToShortDate(stopDetails?.validity_start)}
           <span className="mx-1">-</span>
-          {mapToShortDate(stopDetails.validity_end)}
+          {mapToShortDate(stopDetails?.validity_end)}
         </div>
       </div>
       <DetailTabSelector
         activeDetailTab={activeDetailTab}
         selectDetailTab={selectDetailTab}
       />
-      <Visible visible={activeDetailTab === detailTabs.basic.type}>
-        <div
-          id={detailTabs.basic.panelId}
-          data-testid={testIds.basicDetailsTabPanel}
-          aria-labelledby={detailTabs.basic.buttonId}
-          role="tabpanel"
-        >
-          <BasicDetailsSection stop={stopDetails} />
-          <LocationDetailsSection stop={stopDetails} />
-          <SignageDetailsSection stop={stopDetails} />
-        </div>
-      </Visible>
-      <Visible visible={activeDetailTab === detailTabs.technical.type}>
-        <div
-          id={detailTabs.technical.panelId}
-          data-testid={testIds.technicalFeaturesTabPanel}
-          aria-labelledby={detailTabs.technical.buttonId}
-          role="tabpanel"
-        >
-          <SheltersSection stop={stopDetails} />
-          <MeasurementsSection stop={stopDetails} />
-        </div>
-      </Visible>
-      <Visible visible={activeDetailTab === detailTabs.info.type}>
-        <div
-          id={detailTabs.info.panelId}
-          data-testid={testIds.infoSpotsTabPanel}
-          aria-labelledby={detailTabs.info.buttonId}
-          role="tabpanel"
-        >
-          TODO: Info spots
-        </div>
-      </Visible>
+      <LoadingWrapper
+        className="flex justify-center p-20"
+        loading={isLoading}
+        testId={testIds.loadingStopDetails}
+      >
+        {stopDetails && (
+          <>
+            <Visible visible={activeDetailTab === detailTabs.basic.type}>
+              <div
+                id={detailTabs.basic.panelId}
+                data-testid={testIds.basicDetailsTabPanel}
+                aria-labelledby={detailTabs.basic.buttonId}
+                role="tabpanel"
+              >
+                <BasicDetailsSection stop={stopDetails} />
+                <LocationDetailsSection stop={stopDetails} />
+                <SignageDetailsSection stop={stopDetails} />
+              </div>
+            </Visible>
+            <Visible visible={activeDetailTab === detailTabs.technical.type}>
+              <div
+                id={detailTabs.technical.panelId}
+                data-testid={testIds.technicalFeaturesTabPanel}
+                aria-labelledby={detailTabs.technical.buttonId}
+                role="tabpanel"
+              >
+                <SheltersSection stop={stopDetails} />
+                <MeasurementsSection stop={stopDetails} />
+              </div>
+            </Visible>
+            <Visible visible={activeDetailTab === detailTabs.info.type}>
+              <div
+                id={detailTabs.info.panelId}
+                data-testid={testIds.infoSpotsTabPanel}
+                aria-labelledby={detailTabs.info.buttonId}
+                role="tabpanel"
+              >
+                TODO: Info spots
+              </div>
+            </Visible>
+          </>
+        )}
+        {!stopDetails && (
+          <div className="my-2 flex h-52 items-center justify-center rounded-md border border-light-grey bg-background">
+            <span className="">
+              <MdWarning
+                className={`mr-2 inline h-6 w-6 text-hsl-red `}
+                role="img"
+                title={t('stopDetails.notValidOnObservationDate')}
+              />
+              {t('stopDetails.notValidOnObservationDate')}
+            </span>
+          </div>
+        )}
+      </LoadingWrapper>
     </Container>
   );
 };

--- a/ui/src/components/stop-registry/stops/stop-details/StopHeaderSummaryRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopHeaderSummaryRow.tsx
@@ -7,7 +7,7 @@ import { StopPlaceState } from '../../../../types/stop-registry';
 import { StopTypeLabel } from './StopTypeLabel';
 
 interface Props {
-  stopDetails: StopWithDetails;
+  stopDetails: StopWithDetails | null | undefined;
   className?: string;
 }
 
@@ -17,12 +17,12 @@ export const StopHeaderSummaryRow: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
 
-  const accessibilityLevel = stopDetails.stop_place?.accessibilityLevel;
+  const accessibilityLevel = stopDetails?.stop_place?.accessibilityLevel;
   const isAccessible =
     accessibilityLevel === StopRegistryAccessibilityLevel.FullyAccessible;
   const anyIconsShown = isAccessible;
 
-  const stopState = stopDetails.stop_place?.stopState;
+  const stopState = stopDetails?.stop_place?.stopState;
 
   return (
     <div className={`flex items-center ${className}`}>
@@ -35,28 +35,30 @@ export const StopHeaderSummaryRow: React.FC<Props> = ({
         </Visible>
         <div className="mx-2 h-8 border-l border-dark-grey"> </div>
       </Visible>
-      <div className="flex items-center gap-5">
-        <StopTypeLabel
-          hasType={!!stopDetails?.stop_place?.stopType.mainLine}
-          text={t('stopPlaceTypes.mainLine')}
-        />
-        <StopTypeLabel
-          hasType={!!stopDetails?.stop_place?.stopType.interchange}
-          text={t('stopPlaceTypes.interchange')}
-        />
-        <StopTypeLabel
-          hasType={!!stopDetails?.stop_place?.stopType.railReplacement}
-          text={t('stopPlaceTypes.railReplacement')}
-        />
-        <StopTypeLabel
-          hasType={!!stopDetails?.stop_place?.stopType.virtual}
-          text={t('stopPlaceTypes.virtual')}
-        />
-        {stopState && stopState !== StopPlaceState.InOperation && (
-          <div className="rounded-md bg-dark-grey px-4 py-1 text-center text-sm uppercase leading-normal text-white">
-            {mapStopPlaceStateToUiName(stopState)}
-          </div>
-        )}
+      <div className="flex items-center justify-between gap-5">
+        <div className="flex items-center gap-5">
+          <StopTypeLabel
+            hasType={!!stopDetails?.stop_place?.stopType.mainLine}
+            text={t('stopPlaceTypes.mainLine')}
+          />
+          <StopTypeLabel
+            hasType={!!stopDetails?.stop_place?.stopType.interchange}
+            text={t('stopPlaceTypes.interchange')}
+          />
+          <StopTypeLabel
+            hasType={!!stopDetails?.stop_place?.stopType.railReplacement}
+            text={t('stopPlaceTypes.railReplacement')}
+          />
+          <StopTypeLabel
+            hasType={!!stopDetails?.stop_place?.stopType.virtual}
+            text={t('stopPlaceTypes.virtual')}
+          />
+          {stopState && stopState !== StopPlaceState.InOperation && (
+            <div className="rounded-md bg-dark-grey px-4 py-1 text-center text-sm uppercase leading-normal text-white">
+              {mapStopPlaceStateToUiName(stopState)}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/stop-registry/stops/stop-details/StopTitleRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopTitleRow.tsx
@@ -1,7 +1,8 @@
 import { StopWithDetails } from '../../../../hooks';
 
 interface Props {
-  stopDetails: StopWithDetails;
+  stopDetails: StopWithDetails | null | undefined;
+  label: string;
 }
 
 const testIds = {
@@ -9,17 +10,17 @@ const testIds = {
   names: 'StopTitleRow::names',
 };
 
-export const StopTitleRow: React.FC<Props> = ({ stopDetails }) => {
+export const StopTitleRow: React.FC<Props> = ({ stopDetails, label }) => {
   return (
     <div className="flex items-center">
       <i className="icon-bus-alt mr-2 text-3xl text-tweaked-brand" />
       <h2 className="mr-2 font-bold" data-testid={testIds.label}>
-        {stopDetails.label}
+        {label}
       </h2>
       <div className="text-xl" data-testid={testIds.names}>
-        <span>{stopDetails.stop_place?.nameFin || '-'}</span>
+        <span>{stopDetails?.stop_place?.nameFin || '-'}</span>
         <span className="mx-2">|</span>
-        <span>{stopDetails.stop_place?.nameSwe || '-'}</span>
+        <span>{stopDetails?.stop_place?.nameSwe || '-'}</span>
       </div>
     </div>
   );

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -66590,13 +66590,14 @@ export type ScheduledStopPointDetailFieldsFragment = {
   } | null;
 };
 
-export type GetStopDetailsByIdQueryVariables = Exact<{
-  scheduled_stop_point_id: Scalars['uuid'];
+export type GetHighestPriorityStopDetailsByLabelAndDateQueryVariables = Exact<{
+  label: Scalars['String'];
+  observationDate: Scalars['date'];
 }>;
 
-export type GetStopDetailsByIdQuery = {
+export type GetHighestPriorityStopDetailsByLabelAndDateQuery = {
   __typename?: 'query_root';
-  service_pattern_scheduled_stop_point_by_pk?: {
+  service_pattern_scheduled_stop_point: Array<{
     __typename?: 'service_pattern_scheduled_stop_point';
     priority: number;
     direction: InfrastructureNetworkDirectionEnum;
@@ -66780,7 +66781,7 @@ export type GetStopDetailsByIdQuery = {
       timing_place_id: UUID;
       label: string;
     } | null;
-  } | null;
+  }>;
 };
 
 export type ShelterEquipmentDetailsFragment = {
@@ -72309,10 +72310,25 @@ export type UpdateStopPlaceMutationOptions = Apollo.BaseMutationOptions<
   UpdateStopPlaceMutation,
   UpdateStopPlaceMutationVariables
 >;
-export const GetStopDetailsByIdDocument = gql`
-  query GetStopDetailsById($scheduled_stop_point_id: uuid!) {
-    service_pattern_scheduled_stop_point_by_pk(
-      scheduled_stop_point_id: $scheduled_stop_point_id
+export const GetHighestPriorityStopDetailsByLabelAndDateDocument = gql`
+  query GetHighestPriorityStopDetailsByLabelAndDate(
+    $label: String!
+    $observationDate: date!
+  ) {
+    service_pattern_scheduled_stop_point(
+      where: {
+        _and: [
+          { label: { _eq: $label } }
+          {
+            _and: [
+              { validity_start: { _lte: $observationDate } }
+              { validity_end: { _gte: $observationDate } }
+            ]
+          }
+        ]
+      }
+      order_by: { priority: desc }
+      limit: 1
     ) {
       ...scheduled_stop_point_detail_fields
       stop_place {
@@ -72325,55 +72341,55 @@ export const GetStopDetailsByIdDocument = gql`
 `;
 
 /**
- * __useGetStopDetailsByIdQuery__
+ * __useGetHighestPriorityStopDetailsByLabelAndDateQuery__
  *
- * To run a query within a React component, call `useGetStopDetailsByIdQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetStopDetailsByIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetHighestPriorityStopDetailsByLabelAndDateQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetHighestPriorityStopDetailsByLabelAndDateQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetStopDetailsByIdQuery({
+ * const { data, loading, error } = useGetHighestPriorityStopDetailsByLabelAndDateQuery({
  *   variables: {
- *      scheduled_stop_point_id: // value for 'scheduled_stop_point_id'
+ *      label: // value for 'label'
+ *      observationDate: // value for 'observationDate'
  *   },
  * });
  */
-export function useGetStopDetailsByIdQuery(
+export function useGetHighestPriorityStopDetailsByLabelAndDateQuery(
   baseOptions: Apollo.QueryHookOptions<
-    GetStopDetailsByIdQuery,
-    GetStopDetailsByIdQueryVariables
+    GetHighestPriorityStopDetailsByLabelAndDateQuery,
+    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
-    GetStopDetailsByIdQuery,
-    GetStopDetailsByIdQueryVariables
-  >(GetStopDetailsByIdDocument, options);
+    GetHighestPriorityStopDetailsByLabelAndDateQuery,
+    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
+  >(GetHighestPriorityStopDetailsByLabelAndDateDocument, options);
 }
-export function useGetStopDetailsByIdLazyQuery(
+export function useGetHighestPriorityStopDetailsByLabelAndDateLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetStopDetailsByIdQuery,
-    GetStopDetailsByIdQueryVariables
+    GetHighestPriorityStopDetailsByLabelAndDateQuery,
+    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetStopDetailsByIdQuery,
-    GetStopDetailsByIdQueryVariables
-  >(GetStopDetailsByIdDocument, options);
+    GetHighestPriorityStopDetailsByLabelAndDateQuery,
+    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
+  >(GetHighestPriorityStopDetailsByLabelAndDateDocument, options);
 }
-export type GetStopDetailsByIdQueryHookResult = ReturnType<
-  typeof useGetStopDetailsByIdQuery
->;
-export type GetStopDetailsByIdLazyQueryHookResult = ReturnType<
-  typeof useGetStopDetailsByIdLazyQuery
->;
-export type GetStopDetailsByIdQueryResult = Apollo.QueryResult<
-  GetStopDetailsByIdQuery,
-  GetStopDetailsByIdQueryVariables
->;
+export type GetHighestPriorityStopDetailsByLabelAndDateQueryHookResult =
+  ReturnType<typeof useGetHighestPriorityStopDetailsByLabelAndDateQuery>;
+export type GetHighestPriorityStopDetailsByLabelAndDateLazyQueryHookResult =
+  ReturnType<typeof useGetHighestPriorityStopDetailsByLabelAndDateLazyQuery>;
+export type GetHighestPriorityStopDetailsByLabelAndDateQueryResult =
+  Apollo.QueryResult<
+    GetHighestPriorityStopDetailsByLabelAndDateQuery,
+    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
+  >;
 export const PatchScheduledStopPointTimingSettingsDocument = gql`
   mutation PatchScheduledStopPointTimingSettings(
     $stopLabel: String!
@@ -74673,15 +74689,14 @@ export type SearchStopsAsyncQueryHookResult = ReturnType<
   typeof useSearchStopsAsyncQuery
 >;
 
-export function useGetStopDetailsByIdAsyncQuery() {
+export function useGetHighestPriorityStopDetailsByLabelAndDateAsyncQuery() {
   return useAsyncQuery<
-    GetStopDetailsByIdQuery,
-    GetStopDetailsByIdQueryVariables
-  >(GetStopDetailsByIdDocument);
+    GetHighestPriorityStopDetailsByLabelAndDateQuery,
+    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
+  >(GetHighestPriorityStopDetailsByLabelAndDateDocument);
 }
-export type GetStopDetailsByIdAsyncQueryHookResult = ReturnType<
-  typeof useGetStopDetailsByIdAsyncQuery
->;
+export type GetHighestPriorityStopDetailsByLabelAndDateAsyncQueryHookResult =
+  ReturnType<typeof useGetHighestPriorityStopDetailsByLabelAndDateAsyncQuery>;
 
 export function useGetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsAsyncQuery() {
   return useAsyncQuery<

--- a/ui/src/hooks/stop-registry/useGetStopDetails.ts
+++ b/ui/src/hooks/stop-registry/useGetStopDetails.ts
@@ -2,13 +2,14 @@ import { gql } from '@apollo/client';
 import {
   ScheduledStopPointDetailFieldsFragment,
   StopPlaceDetailsFragment,
-  useGetStopDetailsByIdQuery,
+  useGetHighestPriorityStopDetailsByLabelAndDateQuery,
 } from '../../generated/graphql';
 import {
   StopPlaceEnrichmentProperties,
   getStopPlaceDetailsForEnrichment,
   getStopPlaceFromQueryResult,
 } from '../../utils';
+import { useObservationDateQueryParam } from '../urlQuery';
 import { useRequiredParams } from '../useRequiredParams';
 
 const GQL_SCHEDULED_STOP_POINT_DETAIL_FIELDS = gql`
@@ -30,10 +31,25 @@ const GQL_SCHEDULED_STOP_POINT_DETAIL_FIELDS = gql`
   }
 `;
 
-const GQL_GET_STOP_DETAILS_BY_ID = gql`
-  query GetStopDetailsById($scheduled_stop_point_id: uuid!) {
-    service_pattern_scheduled_stop_point_by_pk(
-      scheduled_stop_point_id: $scheduled_stop_point_id
+const GQL_GET_HIGHEST_PRIORITY_STOP_DETAILS_BY_LABEL_AND_DATE = gql`
+  query GetHighestPriorityStopDetailsByLabelAndDate(
+    $label: String!
+    $observationDate: date!
+  ) {
+    service_pattern_scheduled_stop_point(
+      where: {
+        _and: [
+          { label: { _eq: $label } }
+          {
+            _and: [
+              { validity_start: { _lte: $observationDate } }
+              { validity_end: { _gte: $observationDate } }
+            ]
+          }
+        ]
+      }
+      order_by: { priority: desc }
+      limit: 1
     ) {
       ...scheduled_stop_point_detail_fields
       stop_place {
@@ -237,14 +253,16 @@ export type StopWithDetails = ScheduledStopPointDetailFieldsFragment & {
 
 export const useGetStopDetails = (): {
   stopDetails: StopWithDetails | null | undefined;
+  isLoading: boolean;
 } => {
-  const { id } = useRequiredParams<{ id: string }>();
-  // TODO: observation date?
+  const { label } = useRequiredParams<{ label: string }>();
+  const { observationDate } = useObservationDateQueryParam();
 
-  const result = useGetStopDetailsByIdQuery({
-    variables: { scheduled_stop_point_id: id },
+  const result = useGetHighestPriorityStopDetailsByLabelAndDateQuery({
+    variables: { label, observationDate },
   });
-  const stopDetails = result.data?.service_pattern_scheduled_stop_point_by_pk;
+
+  const stopDetails = result.data?.service_pattern_scheduled_stop_point[0];
 
   return {
     stopDetails: stopDetails && {
@@ -253,5 +271,6 @@ export const useGetStopDetails = (): {
         getStopPlaceFromQueryResult<StopPlace>(stopDetails.stop_place),
       ),
     },
+    isLoading: result.loading,
   };
 };

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -121,6 +121,7 @@
   },
   "stopDetails": {
     "stopDetails": "Stop details",
+    "notValidOnObservationDate": "Stop is not valid on chosen date.",
     "detailTabs": {
       "basic": "Basic information",
       "technical": "Technical features",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -121,6 +121,7 @@
   },
   "stopDetails": {
     "stopDetails": "Pysäkkitiedot",
+    "notValidOnObservationDate": "Pysäkki ei ole voimassa valittuna päivänä.",
     "detailTabs": {
       "basic": "Perustiedot",
       "technical": "Tekniset ominaisuudet",

--- a/ui/src/router/routeDetails.ts
+++ b/ui/src/router/routeDetails.ts
@@ -20,9 +20,9 @@ export enum Path {
 
   // Stop registry
   stopSearch = '/stop-registry/search',
-  stopDetails = '/stop-registry/stops/:id',
-  // stopVersions = '/stop-registry/stops/:id/versions',
-  // stopChangeHistory = '/stop-registry/stops/:id/history',
+  stopDetails = '/stop-registry/stops/:label',
+  // stopVersions = '/stop-registry/stops/:label/versions',
+  // stopChangeHistory = '/stop-registry/stops/:label/history',
   // terminalDetails = '/stop-registry/terminals/:id',
   // stopAreaDetails = '/stop-registry/stop-areas/:id',
 
@@ -118,7 +118,7 @@ export const routeDetails: Record<Path, RouteDetail> = {
     includeInNav: false,
   },
   [Path.stopDetails]: {
-    getLink: (id: string) => Path.stopDetails.replace(':id', id),
+    getLink: (label: string) => Path.stopDetails.replace(':label', label),
     includeInNav: false,
   },
 


### PR DESCRIPTION
To show the highest priority stop details on given observation date we also had to do couple of other changes. Mainly the URL is now `/stops/:label` instead of `/stops/:id` so that we can use the label and observation date to show the correct details. Also updated the stopDetails links to use the label instead of id.

There is also minor changes to StopTitleRow etc. so that it accepts null and undefined values when the observationDate + label doesn't find any results (stop is not valid on chosen date)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/840)
<!-- Reviewable:end -->
