### PR TITLE
Fix observationDate gql filters on stop details

### DIFF
--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -72321,8 +72321,18 @@ export const GetHighestPriorityStopDetailsByLabelAndDateDocument = gql`
           { label: { _eq: $label } }
           {
             _and: [
-              { validity_start: { _lte: $observationDate } }
-              { validity_end: { _gte: $observationDate } }
+              {
+                _or: [
+                  { validity_start: { _lte: $observationDate } }
+                  { validity_start: { _is_null: true } }
+                ]
+              }
+              {
+                _or: [
+                  { validity_end: { _gte: $observationDate } }
+                  { validity_end: { _is_null: true } }
+                ]
+              }
             ]
           }
         ]

--- a/ui/src/hooks/stop-registry/useGetStopDetails.ts
+++ b/ui/src/hooks/stop-registry/useGetStopDetails.ts
@@ -42,8 +42,18 @@ const GQL_GET_HIGHEST_PRIORITY_STOP_DETAILS_BY_LABEL_AND_DATE = gql`
           { label: { _eq: $label } }
           {
             _and: [
-              { validity_start: { _lte: $observationDate } }
-              { validity_end: { _gte: $observationDate } }
+              {
+                _or: [
+                  { validity_start: { _lte: $observationDate } }
+                  { validity_start: { _is_null: true } }
+                ]
+              }
+              {
+                _or: [
+                  { validity_end: { _gte: $observationDate } }
+                  { validity_end: { _is_null: true } }
+                ]
+              }
             ]
           }
         ]


### PR DESCRIPTION
We checked that the observationDate had to explicitly be before the stops validity_end, and explicitly be after the stops validity_start. But missed that the validity_end and validity_start are also nullable fields. So it is possible that a stop does not have e.g. validity_end set, which would not have taken in to result set without these changes. Now we include the ones that doesn't have validity_end and/or validity_start set.
NOTE: The UI forces the user to set validity_start, but despite that the field in database is nullable and that is why we have to deal with that one as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/841)
<!-- Reviewable:end -->
