### PR TITLE
Insert stop place on create

### DIFF
--- a/cypress/e2e/createStop.cy.ts
+++ b/cypress/e2e/createStop.cy.ts
@@ -4,7 +4,14 @@ import {
   timingPlaces,
 } from '@hsl/jore4-test-db-manager';
 import { Tag } from '../enums';
-import { ChangeValidityForm, MapModal } from '../pageObjects';
+import {
+  ChangeValidityForm,
+  MapModal,
+  Navbar,
+  StopDetailsPage,
+  StopSearchBar,
+  StopSearchResultsPage,
+} from '../pageObjects';
 import { FilterPanel } from '../pageObjects/FilterPanel';
 import { insertToDbHelper, removeFromDbHelper } from '../utils';
 import { deleteStopsByLabels } from './utils';
@@ -29,6 +36,10 @@ describe('Stop creation tests', () => {
   let mapModal: MapModal;
   let mapFilterPanel: FilterPanel;
   let changeValidityForm: ChangeValidityForm;
+  let navbar: Navbar;
+  let stopSearchBar: StopSearchBar;
+  let stopSearchResultsPage: StopSearchResultsPage;
+  let stopDetailsPage: StopDetailsPage;
 
   beforeEach(() => {
     clearDatabase();
@@ -37,6 +48,10 @@ describe('Stop creation tests', () => {
     mapModal = new MapModal();
     mapFilterPanel = new FilterPanel();
     changeValidityForm = new ChangeValidityForm();
+    navbar = new Navbar();
+    stopSearchBar = new StopSearchBar();
+    stopSearchResultsPage = new StopSearchResultsPage();
+    stopDetailsPage = new StopDetailsPage();
 
     cy.setupTests();
     cy.mockLogin();
@@ -192,6 +207,35 @@ describe('Stop creation tests', () => {
       mapModal.stopForm
         .getTimingPlaceDropdown()
         .should('contain', timingPlaces[0].label);
+    },
+  );
+
+  it(
+    'Should create stop and have its stop registry details correctly',
+    { tags: [Tag.Map, Tag.Stops, Tag.StopRegistry], scrollBehavior: 'bottom' },
+    () => {
+      mapModal.mapFooter.addStop();
+      mapModal.map.clickRelativePoint(43.5, 53);
+
+      mapModal.stopForm.fillForm({
+        label: 'T0001',
+        validityStartISODate: '2022-01-01',
+        priority: Priority.Standard,
+      });
+
+      mapModal.stopForm.save();
+
+      mapModal.checkStopSubmitSuccessToast();
+      mapModal.getCloseButton().click();
+
+      navbar.getStopsLink().click();
+
+      stopSearchBar.getSearchInput().type('T0001{enter}');
+      stopSearchResultsPage.getRowLinkByLabel('T0001').click();
+
+      // NOTE: After adding the name inputs to stop creation flow, this will fail and
+      // needs to be updated to the correct names
+      stopDetailsPage.names().shouldHaveText('T0001|-');
     },
   );
 });

--- a/cypress/pageObjects/MapModal.ts
+++ b/cypress/pageObjects/MapModal.ts
@@ -141,4 +141,8 @@ export class MapModal {
       .its('response.statusCode')
       .should('equal', 200);
   }
+
+  getCloseButton() {
+    return cy.getByTestId('MapHeader::closeButton');
+  }
 }

--- a/cypress/pageObjects/Navbar.ts
+++ b/cypress/pageObjects/Navbar.ts
@@ -11,6 +11,10 @@ export class Navbar {
     return cy.getByTestId('NavLinks::timetables.timetables');
   }
 
+  getStopsLink() {
+    return cy.getByTestId('NavLinks::stops.stops');
+  }
+
   getLanguageDropdown() {
     return cy.getByTestId('LanguageDropdown::toggleDropdown');
   }

--- a/cypress/pageObjects/stop-registry/StopSearchResultsPage.ts
+++ b/cypress/pageObjects/stop-registry/StopSearchResultsPage.ts
@@ -18,4 +18,8 @@ export class StopSearchResultsPage {
   getRowByLabel(label: string) {
     return cy.getByTestId(`StopTableRow::row::${label}`);
   }
+
+  getRowLinkByLabel(label: string) {
+    return this.getRowByLabel(label).findByTestId('StopTableRow::link');
+  }
 }

--- a/cypress/pageObjects/stop-registry/index.ts
+++ b/cypress/pageObjects/stop-registry/index.ts
@@ -1,2 +1,4 @@
 export * from './stop-details';
 export * from './StopDetailsPage';
+export * from './StopSearchBar';
+export * from './StopSearchResultsPage';

--- a/ui/src/components/stop-registry/search/StopTableRow.tsx
+++ b/ui/src/components/stop-registry/search/StopTableRow.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 const testIds = {
   row: (label: string) => `StopTableRow::row::${label}`,
+  link: 'StopTableRow::link',
 };
 
 export const StopTableRow = ({ className = '', stop }: Props): JSX.Element => {
@@ -30,6 +31,7 @@ export const StopTableRow = ({ className = '', stop }: Props): JSX.Element => {
         <Row className="mb-2 items-center font-bold leading-none">
           <Link
             to={routeDetails[Path.stopDetails].getLink(stop.label)}
+            data-testid={testIds.link}
             title={t('accessibility:stops.showStopDetails', {
               stopLabel: stop.label,
             })}

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -65088,25 +65088,6 @@ export type GetStopsByLabelsQuery = {
   }>;
 };
 
-export type InsertStopMutationVariables = Exact<{
-  object: ServicePatternScheduledStopPointInsertInput;
-}>;
-
-export type InsertStopMutation = {
-  __typename?: 'mutation_root';
-  insert_service_pattern_scheduled_stop_point_one?: {
-    __typename?: 'service_pattern_scheduled_stop_point';
-    scheduled_stop_point_id: UUID;
-    located_on_infrastructure_link_id: UUID;
-    direction: InfrastructureNetworkDirectionEnum;
-    priority: number;
-    measured_location: GeoJSON.Point;
-    label: string;
-    validity_start?: luxon.DateTime | null;
-    validity_end?: luxon.DateTime | null;
-  } | null;
-};
-
 export type EditStopMutationVariables = Exact<{
   stop_id: Scalars['uuid'];
   stop_label: Scalars['String'];
@@ -66401,6 +66382,26 @@ export type SearchStopsQuery = {
   } | null;
 };
 
+export type InsertStopPlaceMutationVariables = Exact<{
+  object?: InputMaybe<StopRegistryStopPlaceInput>;
+}>;
+
+export type InsertStopPlaceMutation = {
+  __typename?: 'mutation_root';
+  stop_registry?: {
+    __typename?: 'stop_registryStopPlaceMutation';
+    mutateStopPlace?: Array<{
+      __typename?: 'stop_registry_StopPlace';
+      publicCode?: string | null;
+      id?: string | null;
+      quays?: Array<{
+        __typename?: 'stop_registry_Quay';
+        publicCode?: string | null;
+      } | null> | null;
+    } | null> | null;
+  } | null;
+};
+
 export type UpdateStopPlaceMutationVariables = Exact<{
   input: StopRegistryStopPlaceInput;
 }>;
@@ -67101,6 +67102,39 @@ export type PatchScheduledStopPointTimingSettingsMutation = {
         on_route_id: UUID;
       };
     }>;
+  } | null;
+};
+
+export type InsertStopMutationVariables = Exact<{
+  object: ServicePatternScheduledStopPointInsertInput;
+}>;
+
+export type InsertStopMutation = {
+  __typename?: 'mutation_root';
+  insert_service_pattern_scheduled_stop_point_one?: {
+    __typename?: 'service_pattern_scheduled_stop_point';
+    scheduled_stop_point_id: UUID;
+    located_on_infrastructure_link_id: UUID;
+    direction: InfrastructureNetworkDirectionEnum;
+    priority: number;
+    measured_location: GeoJSON.Point;
+    label: string;
+    validity_start?: luxon.DateTime | null;
+    validity_end?: luxon.DateTime | null;
+  } | null;
+};
+
+export type UpdateScheduledStopPointStopPlaceRefMutationVariables = Exact<{
+  scheduled_stop_point_id: Scalars['uuid'];
+  stop_place_ref?: InputMaybe<Scalars['String']>;
+}>;
+
+export type UpdateScheduledStopPointStopPlaceRefMutation = {
+  __typename?: 'mutation_root';
+  update_service_pattern_scheduled_stop_point_by_pk?: {
+    __typename?: 'service_pattern_scheduled_stop_point';
+    scheduled_stop_point_id: UUID;
+    stop_place_ref?: string | null;
   } | null;
 };
 
@@ -71355,65 +71389,6 @@ export type GetStopsByLabelsQueryResult = Apollo.QueryResult<
   GetStopsByLabelsQuery,
   GetStopsByLabelsQueryVariables
 >;
-export const InsertStopDocument = gql`
-  mutation InsertStop(
-    $object: service_pattern_scheduled_stop_point_insert_input!
-  ) {
-    insert_service_pattern_scheduled_stop_point_one(object: $object) {
-      scheduled_stop_point_id
-      located_on_infrastructure_link_id
-      direction
-      priority
-      measured_location
-      label
-      validity_start
-      validity_end
-    }
-  }
-`;
-export type InsertStopMutationFn = Apollo.MutationFunction<
-  InsertStopMutation,
-  InsertStopMutationVariables
->;
-
-/**
- * __useInsertStopMutation__
- *
- * To run a mutation, you first call `useInsertStopMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useInsertStopMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [insertStopMutation, { data, loading, error }] = useInsertStopMutation({
- *   variables: {
- *      object: // value for 'object'
- *   },
- * });
- */
-export function useInsertStopMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    InsertStopMutation,
-    InsertStopMutationVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<InsertStopMutation, InsertStopMutationVariables>(
-    InsertStopDocument,
-    options,
-  );
-}
-export type InsertStopMutationHookResult = ReturnType<
-  typeof useInsertStopMutation
->;
-export type InsertStopMutationResult =
-  Apollo.MutationResult<InsertStopMutation>;
-export type InsertStopMutationOptions = Apollo.BaseMutationOptions<
-  InsertStopMutation,
-  InsertStopMutationVariables
->;
 export const EditStopDocument = gql`
   mutation EditStop(
     $stop_id: uuid!
@@ -72261,6 +72236,62 @@ export type SearchStopsQueryResult = Apollo.QueryResult<
   SearchStopsQuery,
   SearchStopsQueryVariables
 >;
+export const InsertStopPlaceDocument = gql`
+  mutation InsertStopPlace($object: stop_registry_StopPlaceInput) {
+    stop_registry {
+      mutateStopPlace(StopPlace: $object) {
+        publicCode
+        id
+        quays {
+          publicCode
+        }
+      }
+    }
+  }
+`;
+export type InsertStopPlaceMutationFn = Apollo.MutationFunction<
+  InsertStopPlaceMutation,
+  InsertStopPlaceMutationVariables
+>;
+
+/**
+ * __useInsertStopPlaceMutation__
+ *
+ * To run a mutation, you first call `useInsertStopPlaceMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useInsertStopPlaceMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [insertStopPlaceMutation, { data, loading, error }] = useInsertStopPlaceMutation({
+ *   variables: {
+ *      object: // value for 'object'
+ *   },
+ * });
+ */
+export function useInsertStopPlaceMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    InsertStopPlaceMutation,
+    InsertStopPlaceMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    InsertStopPlaceMutation,
+    InsertStopPlaceMutationVariables
+  >(InsertStopPlaceDocument, options);
+}
+export type InsertStopPlaceMutationHookResult = ReturnType<
+  typeof useInsertStopPlaceMutation
+>;
+export type InsertStopPlaceMutationResult =
+  Apollo.MutationResult<InsertStopPlaceMutation>;
+export type InsertStopPlaceMutationOptions = Apollo.BaseMutationOptions<
+  InsertStopPlaceMutation,
+  InsertStopPlaceMutationVariables
+>;
 export const UpdateStopPlaceDocument = gql`
   mutation UpdateStopPlace($input: stop_registry_StopPlaceInput!) {
     stop_registry {
@@ -72487,6 +72518,125 @@ export type PatchScheduledStopPointTimingSettingsMutationOptions =
   Apollo.BaseMutationOptions<
     PatchScheduledStopPointTimingSettingsMutation,
     PatchScheduledStopPointTimingSettingsMutationVariables
+  >;
+export const InsertStopDocument = gql`
+  mutation InsertStop(
+    $object: service_pattern_scheduled_stop_point_insert_input!
+  ) {
+    insert_service_pattern_scheduled_stop_point_one(object: $object) {
+      scheduled_stop_point_id
+      located_on_infrastructure_link_id
+      direction
+      priority
+      measured_location
+      label
+      validity_start
+      validity_end
+    }
+  }
+`;
+export type InsertStopMutationFn = Apollo.MutationFunction<
+  InsertStopMutation,
+  InsertStopMutationVariables
+>;
+
+/**
+ * __useInsertStopMutation__
+ *
+ * To run a mutation, you first call `useInsertStopMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useInsertStopMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [insertStopMutation, { data, loading, error }] = useInsertStopMutation({
+ *   variables: {
+ *      object: // value for 'object'
+ *   },
+ * });
+ */
+export function useInsertStopMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    InsertStopMutation,
+    InsertStopMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<InsertStopMutation, InsertStopMutationVariables>(
+    InsertStopDocument,
+    options,
+  );
+}
+export type InsertStopMutationHookResult = ReturnType<
+  typeof useInsertStopMutation
+>;
+export type InsertStopMutationResult =
+  Apollo.MutationResult<InsertStopMutation>;
+export type InsertStopMutationOptions = Apollo.BaseMutationOptions<
+  InsertStopMutation,
+  InsertStopMutationVariables
+>;
+export const UpdateScheduledStopPointStopPlaceRefDocument = gql`
+  mutation updateScheduledStopPointStopPlaceRef(
+    $scheduled_stop_point_id: uuid!
+    $stop_place_ref: String
+  ) {
+    update_service_pattern_scheduled_stop_point_by_pk(
+      pk_columns: { scheduled_stop_point_id: $scheduled_stop_point_id }
+      _set: { stop_place_ref: $stop_place_ref }
+    ) {
+      scheduled_stop_point_id
+      stop_place_ref
+    }
+  }
+`;
+export type UpdateScheduledStopPointStopPlaceRefMutationFn =
+  Apollo.MutationFunction<
+    UpdateScheduledStopPointStopPlaceRefMutation,
+    UpdateScheduledStopPointStopPlaceRefMutationVariables
+  >;
+
+/**
+ * __useUpdateScheduledStopPointStopPlaceRefMutation__
+ *
+ * To run a mutation, you first call `useUpdateScheduledStopPointStopPlaceRefMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateScheduledStopPointStopPlaceRefMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateScheduledStopPointStopPlaceRefMutation, { data, loading, error }] = useUpdateScheduledStopPointStopPlaceRefMutation({
+ *   variables: {
+ *      scheduled_stop_point_id: // value for 'scheduled_stop_point_id'
+ *      stop_place_ref: // value for 'stop_place_ref'
+ *   },
+ * });
+ */
+export function useUpdateScheduledStopPointStopPlaceRefMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateScheduledStopPointStopPlaceRefMutation,
+    UpdateScheduledStopPointStopPlaceRefMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateScheduledStopPointStopPlaceRefMutation,
+    UpdateScheduledStopPointStopPlaceRefMutationVariables
+  >(UpdateScheduledStopPointStopPlaceRefDocument, options);
+}
+export type UpdateScheduledStopPointStopPlaceRefMutationHookResult = ReturnType<
+  typeof useUpdateScheduledStopPointStopPlaceRefMutation
+>;
+export type UpdateScheduledStopPointStopPlaceRefMutationResult =
+  Apollo.MutationResult<UpdateScheduledStopPointStopPlaceRefMutation>;
+export type UpdateScheduledStopPointStopPlaceRefMutationOptions =
+  Apollo.BaseMutationOptions<
+    UpdateScheduledStopPointStopPlaceRefMutation,
+    UpdateScheduledStopPointStopPlaceRefMutationVariables
   >;
 export const GetScheduledStopPointsInJourneyPatternsUsedAsTimingPointsDocument = gql`
   query GetScheduledStopPointsInJourneyPatternsUsedAsTimingPoints(

--- a/ui/src/graphql/servicePattern.ts
+++ b/ui/src/graphql/servicePattern.ts
@@ -124,23 +124,6 @@ const GET_STOPS_BY_LABELS = gql`
   }
 `;
 
-const INSERT_STOP = gql`
-  mutation InsertStop(
-    $object: service_pattern_scheduled_stop_point_insert_input!
-  ) {
-    insert_service_pattern_scheduled_stop_point_one(object: $object) {
-      scheduled_stop_point_id
-      located_on_infrastructure_link_id
-      direction
-      priority
-      measured_location
-      label
-      validity_start
-      validity_end
-    }
-  }
-`;
-
 const EDIT_STOP = gql`
   mutation EditStop(
     $stop_id: uuid!

--- a/ui/src/hooks/stop-registry/index.ts
+++ b/ui/src/hooks/stop-registry/index.ts
@@ -1,5 +1,6 @@
 export * from './search';
 export * from './useCalculateStopAccessibilityLevel';
+export * from './useCreateStopPlace';
 export * from './useEditStopBasicDetails';
 export * from './useEditStopLocationDetails';
 export * from './useEditStopMeasurementDetails';

--- a/ui/src/hooks/stop-registry/useCreateStopPlace.ts
+++ b/ui/src/hooks/stop-registry/useCreateStopPlace.ts
@@ -1,0 +1,53 @@
+import { gql } from '@apollo/client';
+import { Position } from '@turf/helpers';
+import {
+  StopRegistryGeoJsonType,
+  useInsertStopPlaceMutation,
+} from '../../generated/graphql';
+
+export interface InsertStopPlaceInput {
+  label: string;
+  coordinates: Position;
+}
+
+const GQL_INSERT_STOP_PLACE = gql`
+  mutation InsertStopPlace($object: stop_registry_StopPlaceInput) {
+    stop_registry {
+      mutateStopPlace(StopPlace: $object) {
+        publicCode
+        id
+        quays {
+          publicCode
+        }
+      }
+    }
+  }
+`;
+
+export const useCreateStopPlace = () => {
+  const [insertStopPlaceMutation] = useInsertStopPlaceMutation();
+
+  const mapToInsertStopPlaceVariables = ({
+    label,
+    coordinates,
+  }: InsertStopPlaceInput) => ({
+    variables: {
+      object: {
+        // TODO: change the name to the actual name after we add the inputs for it.
+        // For now we use label as placeholder so that we can create the tiamat instance of the stop
+        name: { lang: 'fin', value: label },
+        quays: [{ publicCode: label }],
+        geometry: {
+          // Due to tiamat reasons, we need to wrap the coordinates in an array.
+          coordinates: [coordinates],
+          type: StopRegistryGeoJsonType.Point,
+        },
+      },
+    },
+  });
+
+  return {
+    mapToInsertStopPlaceVariables,
+    insertStopPlaceMutation,
+  };
+};


### PR DESCRIPTION
Add stop place insert when creating stop on map

Earlier when we created a stop, we only created the scheduled_stop_point to
routes and lines database, but we need to also add an stop place entry to tiamat.
After that we need to update the newly created scheduled_stop_point's stop_place_ref
to point to the newly created stopPlace.
NOTE: These three queries are needed, but they are not in a transaction yet. So if one of the latter
queries fail, there is no rollbacks. This could've been all in one "mutation" instead of three separate, but
I think that could give the impression that they are done in a transaction which it isn't since they are actually
in different databases and GQL does not support transactions between multiple databases.
Also a minor thing but moved GQL_INSERT_STOP to useCreateStop.ts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/844)
<!-- Reviewable:end -->
