### PR TITLE
Fix stop details dropdown placeholders to correct ones

### DIFF
--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopOtherDetailsFormRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopOtherDetailsFormRow.tsx
@@ -45,7 +45,7 @@ export const StopOtherDetailsFormRow = ({
           inputElementRenderer={(props) => (
             <EnumDropdown<JoreStopRegistryTransportModeType>
               enumType={JoreStopRegistryTransportModeType}
-              placeholder={t('stopDetails.transportMode')}
+              placeholder={t('stopDetails.basicDetails.transportMode')}
               uiNameMapper={mapStopRegistryTransportModeTypeToUiName}
               disabled={isRailReplacement}
               // eslint-disable-next-line react/jsx-props-no-spreading
@@ -89,7 +89,7 @@ export const StopOtherDetailsFormRow = ({
           inputElementRenderer={(props) => (
             <EnumDropdown<StopPlaceState>
               enumType={StopPlaceState}
-              placeholder={t('stopDetails.stopState')}
+              placeholder={t('stopDetails.basicDetails.stopState')}
               uiNameMapper={mapStopPlaceStateToUiName}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...props}


### PR DESCRIPTION
This came up when adding a completely new stop without any details.
_______
Before:
![Screenshot 2024-06-25 at 11 18 09](https://github.com/HSLdevcom/jore4-ui/assets/82645403/55c8232d-fbd9-43c0-a4ab-232560b86855)
After:
<img width="1411" alt="Screenshot 2024-06-25 at 15 36 02" src="https://github.com/HSLdevcom/jore4-ui/assets/82645403/563df5d1-5f7f-4a35-8c27-44fb0c1718cb">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/845)
<!-- Reviewable:end -->
