### PR TITLE
Add .graphqlrc & Datime scalar config for Tiamat types

### DIFF
--- a/codegen/codegen.js
+++ b/codegen/codegen.js
@@ -10,6 +10,7 @@ const scalars = {
   timestamptz: 'luxon.DateTime',
   date: 'luxon.DateTime',
   interval: 'luxon.Duration',
+  stop_registry_DateTime: 'luxon.DateTime',
   float8: 'number',
   smallint: 'number',
 };

--- a/test-db-manager/src/datasets/stopRegistry/stopArea.ts
+++ b/test-db-manager/src/datasets/stopRegistry/stopArea.ts
@@ -32,8 +32,8 @@ const mapToStopAreaInput = (seedStopArea: StopAreaSeedData): StopAreaInput => {
         value: seedStopArea.name,
       },
       validBetween: {
-        fromDate: seedStopArea.validityStart.toISO(),
-        toDate: seedStopArea.validityEnd?.toISO() || null,
+        fromDate: seedStopArea.validityStart,
+        toDate: seedStopArea.validityEnd || null,
       },
       geometry: seedStopArea.locationLat &&
         seedStopArea.locationLong && {

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -39,7 +39,7 @@ export type Scalars = {
   stop_registry_BigInteger: any;
   stop_registry_Coordinates: any;
   /** Date time using the format: yyyy-MM-dd'T'HH:mm:ss.SSSXXXX. Example: 2017-04-23T18:25:43.511+0100 */
-  stop_registry_DateTime: any;
+  stop_registry_DateTime: luxon.DateTime;
   timestamp: any;
   timestamptz: luxon.DateTime;
   uuid: UUID;

--- a/ui/.graphqlrc
+++ b/ui/.graphqlrc
@@ -1,0 +1,3 @@
+{
+  "schema": "./graphql.schema.json"
+}

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -43,7 +43,7 @@ export type Scalars = {
   stop_registry_BigInteger: any;
   stop_registry_Coordinates: any;
   /** Date time using the format: yyyy-MM-dd'T'HH:mm:ss.SSSXXXX. Example: 2017-04-23T18:25:43.511+0100 */
-  stop_registry_DateTime: any;
+  stop_registry_DateTime: luxon.DateTime;
   timestamp: any;
   timestamptz: luxon.DateTime;
   uuid: UUID;


### PR DESCRIPTION
* Add .graphqlrc to enable autocompletion for GraphQL queries
* Add Luxon scalar mapping for Timat DataTime types

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/846)
<!-- Reviewable:end -->
