### PR TITLE
Visualize stop areas on map

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -10,7 +10,7 @@ services:
     # The :hsl-tag contains the desired version of hsl specific hasura.
     # Waiting for merging feature-branch to main in hasura-repo
     # Note: also update jore4-hasura-e2e in docker-compose.e2e when changing this.
-    image: 'hsldevcom/jore4-hasura:hsl-main--20240422-e9d5cd9c45df915c55dbb84b5b65bc8f4f342522'
+    image: 'hsldevcom/jore4-hasura:hsl-main--20240628-b4f5563633409df00cbb6390cbfc410afc0b67a5'
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -41,7 +41,7 @@ services:
     extends:
       file: docker-compose.base.yml
       service: jore4-hasura-base
-    image: 'hsldevcom/jore4-hasura:hsl-main--20240422-e9d5cd9c45df915c55dbb84b5b65bc8f4f342522'
+    image: 'hsldevcom/jore4-hasura:hsl-main--20240628-b4f5563633409df00cbb6390cbfc410afc0b67a5'
     container_name: "hasura-e2e"
     ports:
       - "127.0.0.1:3211:8080"

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -21289,6 +21289,8 @@ export type StopsDatabaseGroupOfStopPlacesMembers = {
   __typename?: 'stops_database_group_of_stop_places_members';
   group_of_stop_places_id: Scalars['bigint'];
   ref?: Maybe<Scalars['String']>;
+  /** An object relationship */
+  stop_place_newest_version?: Maybe<StopsDatabaseStopPlaceNewestVersion>;
   version?: Maybe<Scalars['String']>;
 };
 
@@ -21361,6 +21363,7 @@ export type StopsDatabaseGroupOfStopPlacesMembersBoolExp = {
   _or?: InputMaybe<Array<StopsDatabaseGroupOfStopPlacesMembersBoolExp>>;
   group_of_stop_places_id?: InputMaybe<BigintComparisonExp>;
   ref?: InputMaybe<StringComparisonExp>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionBoolExp>;
   version?: InputMaybe<StringComparisonExp>;
 };
 
@@ -21373,6 +21376,7 @@ export type StopsDatabaseGroupOfStopPlacesMembersIncInput = {
 export type StopsDatabaseGroupOfStopPlacesMembersInsertInput = {
   group_of_stop_places_id?: InputMaybe<Scalars['bigint']>;
   ref?: InputMaybe<Scalars['String']>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionObjRelInsertInput>;
   version?: InputMaybe<Scalars['String']>;
 };
 
@@ -21419,6 +21423,7 @@ export type StopsDatabaseGroupOfStopPlacesMembersMutationResponse = {
 export type StopsDatabaseGroupOfStopPlacesMembersOrderBy = {
   group_of_stop_places_id?: InputMaybe<OrderBy>;
   ref?: InputMaybe<OrderBy>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionOrderBy>;
   version?: InputMaybe<OrderBy>;
 };
 
@@ -38971,6 +38976,59 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   weighting?: InputMaybe<StringComparisonExp>;
 };
 
+/** input type for inserting data into table "stop_place_newest_version" */
+export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
+  accessibility_assessment_id?: InputMaybe<Scalars['bigint']>;
+  air_submode?: InputMaybe<Scalars['String']>;
+  all_areas_wheelchair_accessible?: InputMaybe<Scalars['Boolean']>;
+  border_crossing?: InputMaybe<Scalars['Boolean']>;
+  bus_submode?: InputMaybe<Scalars['String']>;
+  centroid?: InputMaybe<Scalars['geometry']>;
+  changed?: InputMaybe<Scalars['timestamp']>;
+  changed_by?: InputMaybe<Scalars['String']>;
+  coach_submode?: InputMaybe<Scalars['String']>;
+  covered?: InputMaybe<Scalars['Int']>;
+  created?: InputMaybe<Scalars['timestamp']>;
+  description_lang?: InputMaybe<Scalars['String']>;
+  description_value?: InputMaybe<Scalars['String']>;
+  from_date?: InputMaybe<Scalars['timestamp']>;
+  funicular_submode?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['bigint']>;
+  metro_submode?: InputMaybe<Scalars['String']>;
+  modification_enumeration?: InputMaybe<Scalars['String']>;
+  name_lang?: InputMaybe<Scalars['String']>;
+  name_value?: InputMaybe<Scalars['String']>;
+  netex_id?: InputMaybe<Scalars['String']>;
+  parent_site_ref?: InputMaybe<Scalars['String']>;
+  parent_site_ref_version?: InputMaybe<Scalars['String']>;
+  parent_stop_place?: InputMaybe<Scalars['Boolean']>;
+  place_equipments_id?: InputMaybe<Scalars['bigint']>;
+  polygon_id?: InputMaybe<Scalars['bigint']>;
+  private_code_type?: InputMaybe<Scalars['String']>;
+  private_code_value?: InputMaybe<Scalars['String']>;
+  public_code?: InputMaybe<Scalars['String']>;
+  rail_submode?: InputMaybe<Scalars['String']>;
+  short_name_lang?: InputMaybe<Scalars['String']>;
+  short_name_value?: InputMaybe<Scalars['String']>;
+  stop_place_access_spaces?: InputMaybe<StopsDatabaseStopPlaceAccessSpacesArrRelInsertInput>;
+  stop_place_alternative_names?: InputMaybe<StopsDatabaseStopPlaceAlternativeNamesArrRelInsertInput>;
+  stop_place_children?: InputMaybe<StopsDatabaseStopPlaceChildrenArrRelInsertInput>;
+  stop_place_equipment_places?: InputMaybe<StopsDatabaseStopPlaceEquipmentPlacesArrRelInsertInput>;
+  stop_place_key_values?: InputMaybe<StopsDatabaseStopPlaceKeyValuesArrRelInsertInput>;
+  stop_place_quays?: InputMaybe<StopsDatabaseStopPlaceQuaysArrRelInsertInput>;
+  stop_place_tariff_zones?: InputMaybe<StopsDatabaseStopPlaceTariffZonesArrRelInsertInput>;
+  stop_place_type?: InputMaybe<Scalars['String']>;
+  telecabin_submode?: InputMaybe<Scalars['String']>;
+  to_date?: InputMaybe<Scalars['timestamp']>;
+  topographic_place_id?: InputMaybe<Scalars['bigint']>;
+  tram_submode?: InputMaybe<Scalars['String']>;
+  transport_mode?: InputMaybe<Scalars['String']>;
+  version?: InputMaybe<Scalars['bigint']>;
+  version_comment?: InputMaybe<Scalars['String']>;
+  water_submode?: InputMaybe<Scalars['String']>;
+  weighting?: InputMaybe<Scalars['String']>;
+};
+
 /** aggregate max on columns */
 export type StopsDatabaseStopPlaceNewestVersionMaxFields = {
   __typename?: 'stops_database_stop_place_newest_version_max_fields';
@@ -39055,6 +39113,11 @@ export type StopsDatabaseStopPlaceNewestVersionMinFields = {
   version_comment?: Maybe<Scalars['String']>;
   water_submode?: Maybe<Scalars['String']>;
   weighting?: Maybe<Scalars['String']>;
+};
+
+/** input type for inserting object relation for remote table "stop_place_newest_version" */
+export type StopsDatabaseStopPlaceNewestVersionObjRelInsertInput = {
+  data: StopsDatabaseStopPlaceNewestVersionInsertInput;
 };
 
 /** Ordering options when selecting data from "stop_place_newest_version". */

--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -35,6 +35,7 @@ import {
 } from './routes';
 import { ExistingRouteGeometryLayer } from './routes/ExistingRouteGeometryLayer';
 import { RouteStopsOverlay } from './RouteStopsOverlay';
+import { StopAreas } from './stop-areas';
 import { StopFilterOverlay } from './StopFilterOverlay';
 import { Stops } from './stops';
 
@@ -144,6 +145,7 @@ export const MapComponent = (
       className={className}
     >
       <Stops ref={stopsRef} />
+      <StopAreas />
       <CustomOverlay position="top-left">
         <Column className="items-start overflow-hidden p-2">
           <FilterPanel

--- a/ui/src/components/map/markers/StopAreaMarker.tsx
+++ b/ui/src/components/map/markers/StopAreaMarker.tsx
@@ -1,0 +1,40 @@
+import { MouseEventHandler } from 'react';
+
+type StopAreaProps = {
+  selected?: boolean;
+  onClick?: MouseEventHandler<SVGElement>;
+  size?: number;
+  testId?: string;
+};
+
+export const StopAreaMarker = ({
+  onClick,
+  selected = false,
+  size = 28,
+  testId,
+}: StopAreaProps) => {
+  const strokeClassName = selected
+    ? 'stroke-black'
+    : 'stroke-dark-grey hover:stroke-tweaked-brand';
+
+  return (
+    <svg
+      data-testid={testId}
+      width={size}
+      height={size}
+      viewBox="0 0 28 28"
+      fill="none"
+      className={strokeClassName}
+      xmlns="http://www.w3.org/2000/svg"
+      onClick={onClick}
+    >
+      <circle className="fill-white" cx="14" cy="14" r="12.5" strokeWidth="3" />
+
+      <g strokeWidth="2">
+        <circle cx="18.763" cy="16.75" r="3" />
+        <circle cx="9.237" cy="16.75" r="3" />
+        <circle cx="14" cy="8.5" r="3" />
+      </g>
+    </svg>
+  );
+};

--- a/ui/src/components/map/markers/index.ts
+++ b/ui/src/components/map/markers/index.ts
@@ -1,1 +1,2 @@
 export * from './Circle';
+export * from './StopAreaMarker';

--- a/ui/src/components/map/routes/LineRenderLayer.tsx
+++ b/ui/src/components/map/routes/LineRenderLayer.tsx
@@ -14,10 +14,10 @@ interface LineLayout {
 }
 interface Props {
   layerId: string;
-  geometry: GeoJSON.LineString;
+  geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
   beforeId?: string;
-  layout?: LineLayout;
-  paint?: LinePaint;
+  layout?: Partial<LineLayout>;
+  paint?: Partial<LinePaint>;
 }
 
 // this layer renders a static line

--- a/ui/src/components/map/stop-areas/EditStopAreaLayer.tsx
+++ b/ui/src/components/map/stop-areas/EditStopAreaLayer.tsx
@@ -1,0 +1,14 @@
+import { StopAreaMinimalShowOnMapFieldsFragment } from '../../../generated/graphql';
+import { StopAreaPopup } from './StopAreaPopup';
+
+type EditStopAreaLayerProps = {
+  editedArea: StopAreaMinimalShowOnMapFieldsFragment;
+  onPopupClose: () => void;
+};
+
+export const EditStopAreaLayer = ({
+  editedArea,
+  onPopupClose,
+}: EditStopAreaLayerProps) => {
+  return <StopAreaPopup area={editedArea} onClose={onPopupClose} />;
+};

--- a/ui/src/components/map/stop-areas/MemberStop.tsx
+++ b/ui/src/components/map/stop-areas/MemberStop.tsx
@@ -1,0 +1,34 @@
+import { Marker } from 'react-map-gl/maplibre';
+import { MemberStopFieldsFragment } from '../../../generated/graphql';
+import { theme } from '../../../generated/theme';
+import { getGeometryPoint } from '../../../utils';
+import { Circle } from '../markers';
+
+const testIds = {
+  memberStop: ({ id }: MemberStopFieldsFragment) =>
+    `Map::StopArea::memberStop::${id}`,
+};
+
+type MemberStopProps = {
+  stop: MemberStopFieldsFragment;
+};
+
+export const MemberStop = ({ stop }: MemberStopProps) => {
+  const point = getGeometryPoint(stop.centroid);
+
+  if (!point) {
+    return null;
+  }
+
+  console.log('Stop at:', point);
+
+  return (
+    <Marker latitude={point.latitude} longitude={point.longitude}>
+      <Circle
+        borderColor={theme.colors.tweakedBrand}
+        size={30}
+        testId={testIds.memberStop(stop)}
+      />
+    </Marker>
+  );
+};

--- a/ui/src/components/map/stop-areas/MemberStop.tsx
+++ b/ui/src/components/map/stop-areas/MemberStop.tsx
@@ -1,7 +1,15 @@
+import { useTranslation } from 'react-i18next';
 import { Marker } from 'react-map-gl/maplibre';
 import { MemberStopFieldsFragment } from '../../../generated/graphql';
 import { theme } from '../../../generated/theme';
-import { getGeometryPoint } from '../../../utils';
+import { useAppAction } from '../../../hooks';
+import { useResolveScheduledStopPointByStopPlaceRef } from '../../../hooks/stop-areas/useResolveScheduledStopPointByStopPlaceRef';
+import {
+  setEditedStopDataAction,
+  setSelectedMapStopAreaIdAction,
+  setSelectedStopIdAction,
+} from '../../../redux';
+import { getGeometryPoint, showDangerToastWithError } from '../../../utils';
 import { Circle } from '../markers';
 
 const testIds = {
@@ -14,18 +22,42 @@ type MemberStopProps = {
 };
 
 export const MemberStop = ({ stop }: MemberStopProps) => {
-  const point = getGeometryPoint(stop.centroid);
+  const { t } = useTranslation();
 
+  const resolveScheduledStopPoint =
+    useResolveScheduledStopPointByStopPlaceRef();
+  const setSelectedMapStopAreaId = useAppAction(setSelectedMapStopAreaIdAction);
+  const setSelectedStopId = useAppAction(setSelectedStopIdAction);
+  const setEditedStopData = useAppAction(setEditedStopDataAction);
+
+  const onClick = async () => {
+    if (!stop.netex_id) {
+      return;
+    }
+
+    try {
+      const scheduledStopPoint = await resolveScheduledStopPoint(stop.netex_id);
+      setSelectedMapStopAreaId(undefined);
+      setSelectedStopId(scheduledStopPoint.scheduled_stop_point_id);
+      setEditedStopData(scheduledStopPoint);
+    } catch (e) {
+      showDangerToastWithError(
+        t('stopArea.errors.failedToResolveScheduledStopPoint'),
+        e,
+      );
+    }
+  };
+
+  const point = getGeometryPoint(stop.centroid);
   if (!point) {
     return null;
   }
-
-  console.log('Stop at:', point);
 
   return (
     <Marker latitude={point.latitude} longitude={point.longitude}>
       <Circle
         borderColor={theme.colors.tweakedBrand}
+        onClick={onClick}
         size={30}
         testId={testIds.memberStop(stop)}
       />

--- a/ui/src/components/map/stop-areas/MemberStops.tsx
+++ b/ui/src/components/map/stop-areas/MemberStops.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import { StopAreaMinimalShowOnMapFieldsFragment } from '../../../generated/graphql';
+import { getPointPosition, notNullish } from '../../../utils';
+import { LinePaint, LineRenderLayer } from '../routes';
+import { MemberStop } from './MemberStop';
+
+const memberLinePaint: Partial<LinePaint> = {
+  'line-offset': 0,
+  'line-width': 4,
+};
+
+function useMemberLines(
+  area: StopAreaMinimalShowOnMapFieldsFragment,
+): GeoJSON.MultiLineString | null {
+  return useMemo(() => {
+    const areaPosition = getPointPosition(area.centroid);
+    const nonNullStops = area.members
+      .map((member) => member.stop_place)
+      .filter(notNullish);
+
+    if (!areaPosition || !nonNullStops) {
+      return null;
+    }
+
+    return {
+      type: 'MultiLineString',
+      coordinates: nonNullStops
+        .map((it) => it.centroid)
+        .map(getPointPosition)
+        .filter(notNullish)
+        .map((memberPosition) => [areaPosition, memberPosition]),
+    };
+  }, [area]);
+}
+
+function useMemberStops(area: StopAreaMinimalShowOnMapFieldsFragment) {
+  return useMemo(
+    () => area.members?.map((member) => member?.stop_place).filter(notNullish),
+    [area],
+  );
+}
+
+type MemberStopsProps = {
+  area: StopAreaMinimalShowOnMapFieldsFragment;
+};
+
+export const MemberStops = ({ area }: MemberStopsProps) => {
+  const memberLines = useMemberLines(area);
+  const memberStops = useMemberStops(area);
+
+  return (
+    <>
+      {memberStops.map((stop) => (
+        <MemberStop key={stop.id} stop={stop} />
+      ))}
+
+      {memberLines ? (
+        <LineRenderLayer
+          layerId="MemberLines"
+          geometry={memberLines}
+          paint={memberLinePaint}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/ui/src/components/map/stop-areas/StopArea.tsx
+++ b/ui/src/components/map/stop-areas/StopArea.tsx
@@ -1,0 +1,33 @@
+import { Marker } from 'react-map-gl/maplibre';
+import { StopAreaMinimalShowOnMapFieldsFragment } from '../../../generated/graphql';
+import { getGeometryPoint } from '../../../utils';
+import { StopAreaMarker } from '../markers';
+
+const testIds = {
+  stopArea: ({ id }: StopAreaMinimalShowOnMapFieldsFragment) =>
+    `Map::StopArea::stopArea::${id}`,
+};
+
+type StopAreaProps = {
+  area: StopAreaMinimalShowOnMapFieldsFragment;
+  onClick: (area: StopAreaMinimalShowOnMapFieldsFragment) => void;
+  selected: boolean;
+};
+
+export const StopArea = ({ area, selected, onClick }: StopAreaProps) => {
+  const point = getGeometryPoint(area.centroid);
+  if (!point) {
+    return null;
+  }
+
+  return (
+    <Marker longitude={point.longitude} latitude={point.latitude}>
+      <StopAreaMarker
+        onClick={() => onClick(area)}
+        selected={selected}
+        size={selected ? 32 : 30}
+        testId={testIds.stopArea(area)}
+      />
+    </Marker>
+  );
+};

--- a/ui/src/components/map/stop-areas/StopAreaPopup.tsx
+++ b/ui/src/components/map/stop-areas/StopAreaPopup.tsx
@@ -1,0 +1,100 @@
+import noop from 'lodash/noop';
+import { useTranslation } from 'react-i18next';
+import { MdDelete } from 'react-icons/md';
+import { Popup } from 'react-map-gl/maplibre';
+import { StopAreaMinimalShowOnMapFieldsFragment } from '../../../generated/graphql';
+import { Column, Row } from '../../../layoutComponents';
+import { CloseIconButton, SimpleButton } from '../../../uiComponents';
+import {
+  getGeometryPoint,
+  getNameFromAlternatives,
+  mapToValidityPeriod,
+} from '../../../utils';
+
+const testIds = {
+  label: 'StopAreaPopup::label',
+  closeButton: 'StopAreaPopup::closeButton',
+  deleteButton: 'StopAreaPopup::deleteButton',
+  editButton: 'StopAreaPopup::editButton',
+  moveButton: 'StopAreaPopup::moveButton',
+};
+
+type StopAreaPopupProps = {
+  area: StopAreaMinimalShowOnMapFieldsFragment;
+  onClose: () => void;
+};
+
+export const StopAreaPopup = ({ area, onClose }: StopAreaPopupProps) => {
+  const { t } = useTranslation();
+
+  const point = getGeometryPoint(area.centroid);
+  const areaLabel = getNameFromAlternatives(
+    area.name_value,
+    area.name_lang,
+    area.alternative_names.map((it) => it.alternative_name),
+  );
+
+  if (!point || !areaLabel) {
+    return null;
+  }
+
+  return (
+    <Popup
+      anchor="top"
+      className="min-w-80"
+      closeOnClick={false}
+      closeButton={false}
+      latitude={point.latitude}
+      longitude={point.longitude}
+    >
+      <div className="p-2">
+        <Row>
+          <Column className="w-full">
+            <Row className="items-center">
+              <h3 data-testid={testIds.label}>
+                {t('stopArea.areaWithLabel', { areaLabel })}
+              </h3>
+              <CloseIconButton
+                className="ml-auto"
+                onClick={onClose}
+                testId={testIds.closeButton}
+              />
+            </Row>
+          </Column>
+        </Row>
+
+        <Row className="text-sm">
+          {mapToValidityPeriod(t, area.from_date, area.to_date)}
+        </Row>
+
+        <Row className="mt-16">
+          <SimpleButton
+            className="h-full !px-3"
+            disabled
+            onClick={noop}
+            inverted
+            testId={testIds.deleteButton}
+          >
+            <MdDelete aria-label={t('stopArea.delete')} className="text-xl" />
+          </SimpleButton>
+          <SimpleButton
+            containerClassName="ml-auto"
+            disabled
+            onClick={noop}
+            testId={testIds.moveButton}
+          >
+            {t('move')}
+          </SimpleButton>
+          <SimpleButton
+            containerClassName="ml-2"
+            disabled
+            onClick={noop}
+            testId={testIds.editButton}
+          >
+            {t('edit')}
+          </SimpleButton>
+        </Row>
+      </div>
+    </Popup>
+  );
+};

--- a/ui/src/components/map/stop-areas/StopAreas.tsx
+++ b/ui/src/components/map/stop-areas/StopAreas.tsx
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import {
+  StopAreaMinimalShowOnMapFieldsFragment,
+  useGetStopAreasByLocationQuery,
+} from '../../../generated/graphql';
+import { useAppAction, useAppSelector, useLoader } from '../../../hooks';
+import {
+  Operation,
+  selectMapViewport,
+  selectSelectedStopAreaId,
+  setSelectedMapStopAreaIdAction,
+} from '../../../redux';
+import {
+  buildWithinViewportGqlGeometryFilter,
+  notNullish,
+} from '../../../utils';
+import { EditStopAreaLayer } from './EditStopAreaLayer';
+import { StopArea } from './StopArea';
+
+export const StopAreas = () => {
+  const setSelectedMapStopAreaId = useAppAction(setSelectedMapStopAreaIdAction);
+  const selectedStopAreaId = useAppSelector(selectSelectedStopAreaId);
+
+  const { setIsLoading } = useLoader(Operation.FetchStopAreas);
+
+  const viewport = useAppSelector(selectMapViewport);
+  const stopAreasResult = useGetStopAreasByLocationQuery({
+    variables: {
+      measured_location_filter: buildWithinViewportGqlGeometryFilter(viewport),
+    },
+  });
+
+  useEffect(() => {
+    /**
+     * Here we sync getStopAreasByLocationQuery query loading state with useLoader hook state.
+     *
+     * We could also use useLoader's immediatelyOn option instead of useEffect,
+     * but using options to dynamically control loading state feels semantically wrong.
+     */
+    setIsLoading(stopAreasResult.loading);
+  }, [setIsLoading, stopAreasResult.loading]);
+
+  const onClick = (area: StopAreaMinimalShowOnMapFieldsFragment) =>
+    setSelectedMapStopAreaId(area.netex_id ?? undefined);
+
+  const onPopupClose = () => setSelectedMapStopAreaId(undefined);
+
+  const data = stopAreasResult.loading
+    ? stopAreasResult.previousData
+    : stopAreasResult.data;
+  const areas = data?.stops_database?.areas?.filter(notNullish) ?? [];
+
+  const editedArea = areas.find(
+    (area) => area?.netex_id === selectedStopAreaId,
+  );
+
+  return (
+    <>
+      {areas.map((area) => (
+        <StopArea
+          area={area}
+          selected={area.netex_id === editedArea?.netex_id}
+          key={area.id}
+          onClick={onClick}
+        />
+      ))}
+
+      {editedArea ? (
+        <>
+          <EditStopAreaLayer
+            editedArea={editedArea}
+            onPopupClose={onPopupClose}
+          />
+        </>
+      ) : null}
+    </>
+  );
+};

--- a/ui/src/components/map/stop-areas/StopAreas.tsx
+++ b/ui/src/components/map/stop-areas/StopAreas.tsx
@@ -15,6 +15,7 @@ import {
   notNullish,
 } from '../../../utils';
 import { EditStopAreaLayer } from './EditStopAreaLayer';
+import { MemberStops } from './MemberStops';
 import { StopArea } from './StopArea';
 
 export const StopAreas = () => {
@@ -71,6 +72,8 @@ export const StopAreas = () => {
             editedArea={editedArea}
             onPopupClose={onPopupClose}
           />
+
+          <MemberStops area={editedArea} />
         </>
       ) : null}
     </>

--- a/ui/src/components/map/stop-areas/index.ts
+++ b/ui/src/components/map/stop-areas/index.ts
@@ -1,0 +1,1 @@
+export * from './StopAreas';

--- a/ui/src/components/map/stops/Stops.tsx
+++ b/ui/src/components/map/stops/Stops.tsx
@@ -21,6 +21,7 @@ import {
   selectIsMoveStopModeEnabled,
   selectMapViewport,
   selectSelectedStopId,
+  selectStopAreaEditorIsActive,
   setEditedStopDataAction,
   setIsCreateStopModeEnabledAction,
   setSelectedStopIdAction,
@@ -30,7 +31,6 @@ import {
   buildWithinViewportGqlFilter,
   mapLngLatToGeoJSON,
   mapLngLatToPoint,
-  mapToVariables,
 } from '../../../utils';
 import {
   addLineFromStopToInfraLink,
@@ -50,10 +50,13 @@ const testIds = {
 export const Stops = React.forwardRef((_props, ref) => {
   const { filter } = useFilterStops();
   const { current: map } = useMap();
+
   const selectedStopId = useAppSelector(selectSelectedStopId);
   const editedStopData = useAppSelector(selectEditedStopData);
   const isCreateStopModeEnabled = useAppSelector(selectIsCreateStopModeEnabled);
   const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
+  const stopAreaEditorIsActive = useAppSelector(selectStopAreaEditorIsActive);
+
   const setSelectedStopId = useAppAction(setSelectedStopIdAction);
   const setEditedStopData = useAppAction(setEditedStopDataAction);
   const setIsCreateStopModeEnabled = useAppAction(
@@ -70,11 +73,12 @@ export const Stops = React.forwardRef((_props, ref) => {
 
   const viewport = useAppSelector(selectMapViewport);
 
-  const stopsResult = useGetStopsByLocationQuery(
-    mapToVariables({
+  const stopsResult = useGetStopsByLocationQuery({
+    variables: {
       measured_location_filter: buildWithinViewportGqlFilter(viewport),
-    }),
-  );
+    },
+    skip: stopAreaEditorIsActive,
+  });
 
   useEffect(() => {
     /**
@@ -136,6 +140,10 @@ export const Stops = React.forwardRef((_props, ref) => {
     await stopsResult.refetch();
     setIsLoadingSaveStop(false);
   };
+
+  if (stopAreaEditorIsActive) {
+    return null;
+  }
 
   return (
     <>

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -65401,6 +65401,37 @@ export type MemberStopFieldsFragment = {
   centroid?: GeoJSON.Geometry | null;
 };
 
+export type GetScheduledStopPointByStopPlaceRefQueryVariables = Exact<{
+  stopPlaceRef: Scalars['String'];
+}>;
+
+export type GetScheduledStopPointByStopPlaceRefQuery = {
+  __typename?: 'query_root';
+  service_pattern_scheduled_stop_point: Array<{
+    __typename?: 'service_pattern_scheduled_stop_point';
+    measured_location: GeoJSON.Point;
+    relative_distance_from_infrastructure_link_start: number;
+    closest_point_on_infrastructure_link?: GeoJSON.Point | null;
+    priority: number;
+    direction: InfrastructureNetworkDirectionEnum;
+    scheduled_stop_point_id: UUID;
+    label: string;
+    timing_place_id?: UUID | null;
+    validity_start?: luxon.DateTime | null;
+    validity_end?: luxon.DateTime | null;
+    located_on_infrastructure_link_id: UUID;
+    vehicle_mode_on_scheduled_stop_point: Array<{
+      __typename?: 'service_pattern_vehicle_mode_on_scheduled_stop_point';
+      vehicle_mode: ReusableComponentsVehicleModeEnum;
+    }>;
+    timing_place?: {
+      __typename?: 'timing_pattern_timing_place';
+      timing_place_id: UUID;
+      label: string;
+    } | null;
+  }>;
+};
+
 export type InfrastructureLinkWithStopsFragment = {
   __typename?: 'infrastructure_network_infrastructure_link';
   direction: InfrastructureNetworkDirectionEnum;
@@ -71881,6 +71912,68 @@ export type GetStopAreasByLocationQueryResult = Apollo.QueryResult<
   GetStopAreasByLocationQuery,
   GetStopAreasByLocationQueryVariables
 >;
+export const GetScheduledStopPointByStopPlaceRefDocument = gql`
+  query GetScheduledStopPointByStopPlaceRef($stopPlaceRef: String!) {
+    service_pattern_scheduled_stop_point(
+      where: { stop_place_ref: { _eq: $stopPlaceRef } }
+      limit: 1
+    ) {
+      ...scheduled_stop_point_all_fields
+    }
+  }
+  ${ScheduledStopPointAllFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetScheduledStopPointByStopPlaceRefQuery__
+ *
+ * To run a query within a React component, call `useGetScheduledStopPointByStopPlaceRefQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetScheduledStopPointByStopPlaceRefQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetScheduledStopPointByStopPlaceRefQuery({
+ *   variables: {
+ *      stopPlaceRef: // value for 'stopPlaceRef'
+ *   },
+ * });
+ */
+export function useGetScheduledStopPointByStopPlaceRefQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetScheduledStopPointByStopPlaceRefQuery,
+    GetScheduledStopPointByStopPlaceRefQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetScheduledStopPointByStopPlaceRefQuery,
+    GetScheduledStopPointByStopPlaceRefQueryVariables
+  >(GetScheduledStopPointByStopPlaceRefDocument, options);
+}
+export function useGetScheduledStopPointByStopPlaceRefLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetScheduledStopPointByStopPlaceRefQuery,
+    GetScheduledStopPointByStopPlaceRefQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetScheduledStopPointByStopPlaceRefQuery,
+    GetScheduledStopPointByStopPlaceRefQueryVariables
+  >(GetScheduledStopPointByStopPlaceRefDocument, options);
+}
+export type GetScheduledStopPointByStopPlaceRefQueryHookResult = ReturnType<
+  typeof useGetScheduledStopPointByStopPlaceRefQuery
+>;
+export type GetScheduledStopPointByStopPlaceRefLazyQueryHookResult = ReturnType<
+  typeof useGetScheduledStopPointByStopPlaceRefLazyQuery
+>;
+export type GetScheduledStopPointByStopPlaceRefQueryResult = Apollo.QueryResult<
+  GetScheduledStopPointByStopPlaceRefQuery,
+  GetScheduledStopPointByStopPlaceRefQueryVariables
+>;
 export const GetHighestPriorityLineDetailsWithRoutesDocument = gql`
   query GetHighestPriorityLineDetailsWithRoutes(
     $lineFilters: route_line_bool_exp
@@ -75053,6 +75146,14 @@ export function useGetStopAreasByLocationAsyncQuery() {
 export type GetStopAreasByLocationAsyncQueryHookResult = ReturnType<
   typeof useGetStopAreasByLocationAsyncQuery
 >;
+export function useGetScheduledStopPointByStopPlaceRefAsyncQuery() {
+  return useAsyncQuery<
+    GetScheduledStopPointByStopPlaceRefQuery,
+    GetScheduledStopPointByStopPlaceRefQueryVariables
+  >(GetScheduledStopPointByStopPlaceRefDocument);
+}
+export type GetScheduledStopPointByStopPlaceRefAsyncQueryHookResult =
+  ReturnType<typeof useGetScheduledStopPointByStopPlaceRefAsyncQuery>;
 export function useGetHighestPriorityLineDetailsWithRoutesAsyncQuery() {
   return useAsyncQuery<
     GetHighestPriorityLineDetailsWithRoutesQuery,

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -65316,6 +65316,91 @@ export type GetRoutesBrokenByStopChangeQuery = {
   }>;
 };
 
+export type GetStopAreasByLocationQueryVariables = Exact<{
+  measured_location_filter?: InputMaybe<GeometryComparisonExp>;
+}>;
+
+export type GetStopAreasByLocationQuery = {
+  __typename?: 'query_root';
+  stops_database?: {
+    __typename?: 'stops_database_stops_database_query';
+    areas: Array<{
+      __typename?: 'stops_database_group_of_stop_places';
+      id: any;
+      netex_id?: string | null;
+      centroid?: GeoJSON.Geometry | null;
+      from_date?: any | null;
+      to_date?: any | null;
+      name_lang?: string | null;
+      name_value?: string | null;
+      alternative_names: Array<{
+        __typename?: 'stops_database_group_of_stop_places_alternative_names';
+        group_of_stop_places_id: any;
+        alternative_names_id: any;
+        alternative_name: {
+          __typename?: 'stops_database_alternative_name';
+          id: any;
+          name_value?: string | null;
+          name_lang?: string | null;
+        };
+      }>;
+      members: Array<{
+        __typename?: 'stops_database_group_of_stop_places_members';
+        group_of_stop_places_id: any;
+        ref?: string | null;
+        version?: string | null;
+        stop_place?: {
+          __typename?: 'stops_database_stop_place_newest_version';
+          id?: any | null;
+          netex_id?: string | null;
+          centroid?: GeoJSON.Geometry | null;
+        } | null;
+      }>;
+    }>;
+  } | null;
+};
+
+export type StopAreaMinimalShowOnMapFieldsFragment = {
+  __typename?: 'stops_database_group_of_stop_places';
+  id: any;
+  netex_id?: string | null;
+  centroid?: GeoJSON.Geometry | null;
+  from_date?: any | null;
+  to_date?: any | null;
+  name_lang?: string | null;
+  name_value?: string | null;
+  alternative_names: Array<{
+    __typename?: 'stops_database_group_of_stop_places_alternative_names';
+    group_of_stop_places_id: any;
+    alternative_names_id: any;
+    alternative_name: {
+      __typename?: 'stops_database_alternative_name';
+      id: any;
+      name_value?: string | null;
+      name_lang?: string | null;
+    };
+  }>;
+  members: Array<{
+    __typename?: 'stops_database_group_of_stop_places_members';
+    group_of_stop_places_id: any;
+    ref?: string | null;
+    version?: string | null;
+    stop_place?: {
+      __typename?: 'stops_database_stop_place_newest_version';
+      id?: any | null;
+      netex_id?: string | null;
+      centroid?: GeoJSON.Geometry | null;
+    } | null;
+  }>;
+};
+
+export type MemberStopFieldsFragment = {
+  __typename?: 'stops_database_stop_place_newest_version';
+  id?: any | null;
+  netex_id?: string | null;
+  centroid?: GeoJSON.Geometry | null;
+};
+
 export type InfrastructureLinkWithStopsFragment = {
   __typename?: 'infrastructure_network_infrastructure_link';
   direction: InfrastructureNetworkDirectionEnum;
@@ -68813,6 +68898,42 @@ export const RouteWithInfrastructureLinksFragmentDoc = gql`
   ${RouteAllFieldsFragmentDoc}
   ${LineAllFieldsFragmentDoc}
 `;
+export const MemberStopFieldsFragmentDoc = gql`
+  fragment member_stop_fields on stops_database_stop_place_newest_version {
+    id
+    netex_id
+    centroid
+  }
+`;
+export const StopAreaMinimalShowOnMapFieldsFragmentDoc = gql`
+  fragment stop_area_minimal_show_on_map_fields on stops_database_group_of_stop_places {
+    id
+    netex_id
+    centroid
+    from_date
+    to_date
+    name_lang
+    name_value
+    alternative_names: group_of_stop_places_alternative_names {
+      group_of_stop_places_id
+      alternative_names_id
+      alternative_name {
+        id
+        name_value
+        name_lang
+      }
+    }
+    members: group_of_stop_places_members {
+      group_of_stop_places_id
+      ref
+      version
+      stop_place: stop_place_newest_version {
+        ...member_stop_fields
+      }
+    }
+  }
+  ${MemberStopFieldsFragmentDoc}
+`;
 export const InfrastructureLinkDefaultFieldsFragmentDoc = gql`
   fragment infrastructure_link_default_fields on infrastructure_network_infrastructure_link {
     infrastructure_link_id
@@ -71691,6 +71812,74 @@ export type GetRoutesBrokenByStopChangeLazyQueryHookResult = ReturnType<
 export type GetRoutesBrokenByStopChangeQueryResult = Apollo.QueryResult<
   GetRoutesBrokenByStopChangeQuery,
   GetRoutesBrokenByStopChangeQueryVariables
+>;
+export const GetStopAreasByLocationDocument = gql`
+  query GetStopAreasByLocation(
+    $measured_location_filter: geometry_comparison_exp
+  ) {
+    stops_database {
+      areas: stops_database_group_of_stop_places(
+        where: {
+          centroid: $measured_location_filter
+          netex_id: { _is_null: false }
+        }
+      ) {
+        ...stop_area_minimal_show_on_map_fields
+      }
+    }
+  }
+  ${StopAreaMinimalShowOnMapFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetStopAreasByLocationQuery__
+ *
+ * To run a query within a React component, call `useGetStopAreasByLocationQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStopAreasByLocationQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetStopAreasByLocationQuery({
+ *   variables: {
+ *      measured_location_filter: // value for 'measured_location_filter'
+ *   },
+ * });
+ */
+export function useGetStopAreasByLocationQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetStopAreasByLocationQuery,
+    GetStopAreasByLocationQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetStopAreasByLocationQuery,
+    GetStopAreasByLocationQueryVariables
+  >(GetStopAreasByLocationDocument, options);
+}
+export function useGetStopAreasByLocationLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetStopAreasByLocationQuery,
+    GetStopAreasByLocationQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetStopAreasByLocationQuery,
+    GetStopAreasByLocationQueryVariables
+  >(GetStopAreasByLocationDocument, options);
+}
+export type GetStopAreasByLocationQueryHookResult = ReturnType<
+  typeof useGetStopAreasByLocationQuery
+>;
+export type GetStopAreasByLocationLazyQueryHookResult = ReturnType<
+  typeof useGetStopAreasByLocationLazyQuery
+>;
+export type GetStopAreasByLocationQueryResult = Apollo.QueryResult<
+  GetStopAreasByLocationQuery,
+  GetStopAreasByLocationQueryVariables
 >;
 export const GetHighestPriorityLineDetailsWithRoutesDocument = gql`
   query GetHighestPriorityLineDetailsWithRoutes(
@@ -74854,6 +75043,15 @@ export function useGetRoutesBrokenByStopChangeAsyncQuery() {
 }
 export type GetRoutesBrokenByStopChangeAsyncQueryHookResult = ReturnType<
   typeof useGetRoutesBrokenByStopChangeAsyncQuery
+>;
+export function useGetStopAreasByLocationAsyncQuery() {
+  return useAsyncQuery<
+    GetStopAreasByLocationQuery,
+    GetStopAreasByLocationQueryVariables
+  >(GetStopAreasByLocationDocument);
+}
+export type GetStopAreasByLocationAsyncQueryHookResult = ReturnType<
+  typeof useGetStopAreasByLocationAsyncQuery
 >;
 export function useGetHighestPriorityLineDetailsWithRoutesAsyncQuery() {
   return useAsyncQuery<

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -21293,6 +21293,8 @@ export type StopsDatabaseGroupOfStopPlacesMembers = {
   __typename?: 'stops_database_group_of_stop_places_members';
   group_of_stop_places_id: Scalars['bigint'];
   ref?: Maybe<Scalars['String']>;
+  /** An object relationship */
+  stop_place_newest_version?: Maybe<StopsDatabaseStopPlaceNewestVersion>;
   version?: Maybe<Scalars['String']>;
 };
 
@@ -21365,6 +21367,7 @@ export type StopsDatabaseGroupOfStopPlacesMembersBoolExp = {
   _or?: InputMaybe<Array<StopsDatabaseGroupOfStopPlacesMembersBoolExp>>;
   group_of_stop_places_id?: InputMaybe<BigintComparisonExp>;
   ref?: InputMaybe<StringComparisonExp>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionBoolExp>;
   version?: InputMaybe<StringComparisonExp>;
 };
 
@@ -21377,6 +21380,7 @@ export type StopsDatabaseGroupOfStopPlacesMembersIncInput = {
 export type StopsDatabaseGroupOfStopPlacesMembersInsertInput = {
   group_of_stop_places_id?: InputMaybe<Scalars['bigint']>;
   ref?: InputMaybe<Scalars['String']>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionObjRelInsertInput>;
   version?: InputMaybe<Scalars['String']>;
 };
 
@@ -21423,6 +21427,7 @@ export type StopsDatabaseGroupOfStopPlacesMembersMutationResponse = {
 export type StopsDatabaseGroupOfStopPlacesMembersOrderBy = {
   group_of_stop_places_id?: InputMaybe<OrderBy>;
   ref?: InputMaybe<OrderBy>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionOrderBy>;
   version?: InputMaybe<OrderBy>;
 };
 
@@ -38975,6 +38980,59 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   weighting?: InputMaybe<StringComparisonExp>;
 };
 
+/** input type for inserting data into table "stop_place_newest_version" */
+export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
+  accessibility_assessment_id?: InputMaybe<Scalars['bigint']>;
+  air_submode?: InputMaybe<Scalars['String']>;
+  all_areas_wheelchair_accessible?: InputMaybe<Scalars['Boolean']>;
+  border_crossing?: InputMaybe<Scalars['Boolean']>;
+  bus_submode?: InputMaybe<Scalars['String']>;
+  centroid?: InputMaybe<Scalars['geometry']>;
+  changed?: InputMaybe<Scalars['timestamp']>;
+  changed_by?: InputMaybe<Scalars['String']>;
+  coach_submode?: InputMaybe<Scalars['String']>;
+  covered?: InputMaybe<Scalars['Int']>;
+  created?: InputMaybe<Scalars['timestamp']>;
+  description_lang?: InputMaybe<Scalars['String']>;
+  description_value?: InputMaybe<Scalars['String']>;
+  from_date?: InputMaybe<Scalars['timestamp']>;
+  funicular_submode?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['bigint']>;
+  metro_submode?: InputMaybe<Scalars['String']>;
+  modification_enumeration?: InputMaybe<Scalars['String']>;
+  name_lang?: InputMaybe<Scalars['String']>;
+  name_value?: InputMaybe<Scalars['String']>;
+  netex_id?: InputMaybe<Scalars['String']>;
+  parent_site_ref?: InputMaybe<Scalars['String']>;
+  parent_site_ref_version?: InputMaybe<Scalars['String']>;
+  parent_stop_place?: InputMaybe<Scalars['Boolean']>;
+  place_equipments_id?: InputMaybe<Scalars['bigint']>;
+  polygon_id?: InputMaybe<Scalars['bigint']>;
+  private_code_type?: InputMaybe<Scalars['String']>;
+  private_code_value?: InputMaybe<Scalars['String']>;
+  public_code?: InputMaybe<Scalars['String']>;
+  rail_submode?: InputMaybe<Scalars['String']>;
+  short_name_lang?: InputMaybe<Scalars['String']>;
+  short_name_value?: InputMaybe<Scalars['String']>;
+  stop_place_access_spaces?: InputMaybe<StopsDatabaseStopPlaceAccessSpacesArrRelInsertInput>;
+  stop_place_alternative_names?: InputMaybe<StopsDatabaseStopPlaceAlternativeNamesArrRelInsertInput>;
+  stop_place_children?: InputMaybe<StopsDatabaseStopPlaceChildrenArrRelInsertInput>;
+  stop_place_equipment_places?: InputMaybe<StopsDatabaseStopPlaceEquipmentPlacesArrRelInsertInput>;
+  stop_place_key_values?: InputMaybe<StopsDatabaseStopPlaceKeyValuesArrRelInsertInput>;
+  stop_place_quays?: InputMaybe<StopsDatabaseStopPlaceQuaysArrRelInsertInput>;
+  stop_place_tariff_zones?: InputMaybe<StopsDatabaseStopPlaceTariffZonesArrRelInsertInput>;
+  stop_place_type?: InputMaybe<Scalars['String']>;
+  telecabin_submode?: InputMaybe<Scalars['String']>;
+  to_date?: InputMaybe<Scalars['timestamp']>;
+  topographic_place_id?: InputMaybe<Scalars['bigint']>;
+  tram_submode?: InputMaybe<Scalars['String']>;
+  transport_mode?: InputMaybe<Scalars['String']>;
+  version?: InputMaybe<Scalars['bigint']>;
+  version_comment?: InputMaybe<Scalars['String']>;
+  water_submode?: InputMaybe<Scalars['String']>;
+  weighting?: InputMaybe<Scalars['String']>;
+};
+
 /** aggregate max on columns */
 export type StopsDatabaseStopPlaceNewestVersionMaxFields = {
   __typename?: 'stops_database_stop_place_newest_version_max_fields';
@@ -39059,6 +39117,11 @@ export type StopsDatabaseStopPlaceNewestVersionMinFields = {
   version_comment?: Maybe<Scalars['String']>;
   water_submode?: Maybe<Scalars['String']>;
   weighting?: Maybe<Scalars['String']>;
+};
+
+/** input type for inserting object relation for remote table "stop_place_newest_version" */
+export type StopsDatabaseStopPlaceNewestVersionObjRelInsertInput = {
+  data: StopsDatabaseStopPlaceNewestVersionInsertInput;
 };
 
 /** Ordering options when selecting data from "stop_place_newest_version". */

--- a/ui/src/graphql/client.ts
+++ b/ui/src/graphql/client.ts
@@ -287,6 +287,16 @@ const buildCacheDefinition = () => {
           },
         },
       },
+      // "Nested ROOT QUERY" of stops_database
+      stops_database_stops_database_query: {
+        merge: true,
+      },
+      group_of_stop_places_alternative_names: {
+        keyFields: ['group_of_stop_places_id', 'alternative_names_id'],
+      },
+      group_of_stop_places_members: {
+        keyFields: ['group_of_stop_places_id', 'ref', 'version'],
+      },
     },
   });
 

--- a/ui/src/graphql/stopAreas.ts
+++ b/ui/src/graphql/stopAreas.ts
@@ -1,0 +1,57 @@
+import { gql } from '@apollo/client';
+
+const GQL_QUERY_GET_STOP_AREAS_BY_LOCATION = gql`
+  query GetStopAreasByLocation(
+    $measured_location_filter: geometry_comparison_exp
+  ) {
+    stops_database {
+      areas: stops_database_group_of_stop_places(
+        where: {
+          centroid: $measured_location_filter
+          netex_id: { _is_null: false }
+        }
+      ) {
+        ...stop_area_minimal_show_on_map_fields
+      }
+    }
+  }
+
+  fragment stop_area_minimal_show_on_map_fields on stops_database_group_of_stop_places {
+    id
+    netex_id
+
+    centroid
+
+    from_date
+    to_date
+
+    name_lang
+    name_value
+
+    alternative_names: group_of_stop_places_alternative_names {
+      group_of_stop_places_id
+      alternative_names_id
+      alternative_name {
+        id
+        name_value
+        name_lang
+      }
+    }
+
+    members: group_of_stop_places_members {
+      group_of_stop_places_id
+      ref
+      version
+
+      stop_place: stop_place_newest_version {
+        ...member_stop_fields
+      }
+    }
+  }
+
+  fragment member_stop_fields on stops_database_stop_place_newest_version {
+    id
+    netex_id
+    centroid
+  }
+`;

--- a/ui/src/graphql/stopAreas.ts
+++ b/ui/src/graphql/stopAreas.ts
@@ -55,3 +55,14 @@ const GQL_QUERY_GET_STOP_AREAS_BY_LOCATION = gql`
     centroid
   }
 `;
+
+const GQL_GET_SCHEDULED_STOP_POINT_BY_STOP_PLACE_REF = gql`
+  query GetScheduledStopPointByStopPlaceRef($stopPlaceRef: String!) {
+    service_pattern_scheduled_stop_point(
+      where: { stop_place_ref: { _eq: $stopPlaceRef } }
+      limit: 1 # stop_place_ref is UNIQUE in the DB
+    ) {
+      ...scheduled_stop_point_all_fields
+    }
+  }
+`;

--- a/ui/src/hooks/stop-areas/useResolveScheduledStopPointByStopPlaceRef.ts
+++ b/ui/src/hooks/stop-areas/useResolveScheduledStopPointByStopPlaceRef.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import { useGetScheduledStopPointByStopPlaceRefAsyncQuery } from '../../generated/graphql';
+import { StopWithLocation } from '../../graphql';
+import { Operation } from '../../redux';
+import { useLoader } from '../ui';
+
+type ResolveScheduledStopPointByStopPlaceRefFn = (
+  stopPlaceRef: string,
+) => Promise<StopWithLocation>;
+
+export function useResolveScheduledStopPointByStopPlaceRef() {
+  const [getScheduledStopPointByStopPlaceRef] =
+    useGetScheduledStopPointByStopPlaceRefAsyncQuery();
+  const { setIsLoading } = useLoader(Operation.ResolveScheduledStopPoint);
+
+  return useCallback<ResolveScheduledStopPointByStopPlaceRefFn>(
+    async (stopPlaceRef) => {
+      setIsLoading(true);
+
+      try {
+        const result = await getScheduledStopPointByStopPlaceRef({
+          stopPlaceRef,
+        });
+        const stop = result.data.service_pattern_scheduled_stop_point.at(0);
+
+        if (!stop) {
+          throw new Error(
+            `No scheduled stop found with stopPlaceRef(${stopPlaceRef})`,
+          );
+        }
+
+        return stop as StopWithLocation;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [getScheduledStopPointByStopPlaceRef, setIsLoading],
+  );
+}

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -115,7 +115,10 @@
   },
   "stopArea": {
     "areaWithLabel": "{{areaLabel}} Stop Area ",
-    "delete": "Delete stop area"
+    "delete": "Delete stop area",
+    "errors": {
+      "failedToResolveScheduledStopPoint": "Failed to resolve Scheduled Stop Point! Reason"
+    }
   },
   "stopPlaceTypes": {
     "mainLine": "Main line",

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -113,6 +113,10 @@
     "stopBreaksRoutes": "The stop to be added is not compatible with the following routes: ({{ routeLabels }})",
     "timingPlaceRequired": "The stop is used as timing place on the following routes: {{ routeLabels }}. Attach timing place or stop using as timing point on the routes."
   },
+  "stopArea": {
+    "areaWithLabel": "{{areaLabel}} Stop Area ",
+    "delete": "Delete stop area"
+  },
   "stopPlaceTypes": {
     "mainLine": "Main line",
     "interchange": "Interchange",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -113,6 +113,10 @@
     "stopBreaksRoutes": "Lisättävä pysäkki ei ole yhteensopiva seuraavien reittien kanssa: ({{ routeLabels }})",
     "timingPlaceRequired": "Pysäkkiä käytetään Hastus-paikkana seuraavilla reiteillä: {{ routeLabels }}. Aseta Hastus-paikka tai poista Hastus-paikka käytöstä reiteiltä."
   },
+  "stopArea": {
+    "areaWithLabel": "{{areaLabel}} Pysäkkialue",
+    "delete": "Poista pysäkkialue"
+  },
   "stopPlaceTypes": {
     "mainLine": "Runkolinja",
     "interchange": "Vaihtopysäkki",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -115,7 +115,10 @@
   },
   "stopArea": {
     "areaWithLabel": "{{areaLabel}} Pysäkkialue",
-    "delete": "Poista pysäkkialue"
+    "delete": "Poista pysäkkialue",
+    "errors": {
+      "failedToResolveScheduledStopPoint": "Pysäkin tietojen selvitys epäonnistui! Syy"
+    }
   },
   "stopPlaceTypes": {
     "mainLine": "Runkolinja",

--- a/ui/src/redux/index.ts
+++ b/ui/src/redux/index.ts
@@ -7,6 +7,7 @@ export * from './slices/loader';
 export * from './slices/mapFilter';
 export * from './slices/mapModal';
 export * from './slices/mapRouteEditor';
+export * from './slices/mapStopAreaEditor';
 export * from './slices/mapStopEditor';
 export * from './slices/timetableVersionPanel';
 export * from './slices/modals';

--- a/ui/src/redux/rootReducer.ts
+++ b/ui/src/redux/rootReducer.ts
@@ -5,6 +5,7 @@ import { loaderReducer } from './slices/loader';
 import { mapFilterReducer } from './slices/mapFilter';
 import { mapModalReducer } from './slices/mapModal';
 import { mapRouteEditorReducer } from './slices/mapRouteEditor';
+import { mapStopAreaEditorReducer } from './slices/mapStopAreaEditor';
 import { mapStopEditorReducer } from './slices/mapStopEditor';
 import { modalsReducer } from './slices/modals';
 import { timetableReducer } from './slices/timetable';
@@ -14,6 +15,7 @@ import { loginFailedAction, userReducer } from './slices/user';
 const appReducer = combineReducers({
   export: exportReducer,
   loader: loaderReducer,
+  mapStopAreaEditor: mapStopAreaEditorReducer,
   mapStopEditor: mapStopEditorReducer,
   mapRouteEditor: mapRouteEditorReducer,
   mapFilter: mapFilterReducer,

--- a/ui/src/redux/selectors/index.ts
+++ b/ui/src/redux/selectors/index.ts
@@ -4,6 +4,7 @@ export * from './loader';
 export * from './mapFilter';
 export * from './mapModal';
 export * from './mapRouteEditor';
+export * from './mapStopAreaEditor';
 export * from './mapStopEditor';
 export * from './modals';
 export * from './timetable';

--- a/ui/src/redux/selectors/mapStopAreaEditor.ts
+++ b/ui/src/redux/selectors/mapStopAreaEditor.ts
@@ -10,3 +10,8 @@ export const selectSelectedStopAreaId = createSelector(
   selectMapStopAreaEditor,
   (mapStopAreEditor) => mapStopAreEditor.selectedStopArea,
 );
+
+export const selectStopAreaEditorIsActive = createSelector(
+  selectMapStopAreaEditor,
+  (mapStopAreEditor) => mapStopAreEditor.selectedStopArea !== undefined,
+);

--- a/ui/src/redux/selectors/mapStopAreaEditor.ts
+++ b/ui/src/redux/selectors/mapStopAreaEditor.ts
@@ -1,0 +1,12 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { mapFromStoreType } from '../mappers';
+import { MapStopAreaEditor } from '../slices/mapStopAreaEditor';
+import { RootState } from '../store';
+
+export const selectMapStopAreaEditor = (state: RootState) =>
+  mapFromStoreType<MapStopAreaEditor>(state.mapStopAreaEditor);
+
+export const selectSelectedStopAreaId = createSelector(
+  selectMapStopAreaEditor,
+  (mapStopAreEditor) => mapStopAreEditor.selectedStopArea,
+);

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -16,6 +16,7 @@ export enum Operation {
   AbortImport = 'abortImport',
   FetchRouteTimetables = 'fetchRouteTimetables',
   DeleteTimetable = 'deleteTimetable',
+  ResolveScheduledStopPoint = 'resolveScheduledStopPoint',
 }
 
 export const mapOperations = [
@@ -28,6 +29,7 @@ export const mapOperations = [
   Operation.MatchRoute,
   Operation.CheckBrokenRoutes,
   Operation.SaveTimingPlace,
+  Operation.ResolveScheduledStopPoint,
 ];
 
 export const importOperations = [
@@ -62,6 +64,7 @@ const initialState: IState = {
   [Operation.AbortImport]: false,
   [Operation.FetchRouteTimetables]: false,
   [Operation.DeleteTimetable]: false,
+  [Operation.ResolveScheduledStopPoint]: false,
 };
 
 const slice = createSlice({

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -2,6 +2,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 export enum Operation {
   LoadMap = 'loadMap',
+  FetchStopAreas = 'fetchStopAreas',
   FetchStops = 'fetchStops',
   FetchRoutes = 'fetchRoutes',
   SaveStop = 'saveStop',
@@ -19,6 +20,7 @@ export enum Operation {
 
 export const mapOperations = [
   Operation.LoadMap,
+  Operation.FetchStopAreas,
   Operation.FetchStops,
   Operation.FetchRoutes,
   Operation.SaveStop,
@@ -46,6 +48,7 @@ type IState = {
 
 const initialState: IState = {
   [Operation.LoadMap]: false,
+  [Operation.FetchStopAreas]: false,
   [Operation.FetchStops]: false,
   [Operation.FetchRoutes]: false,
   [Operation.SaveStop]: false,

--- a/ui/src/redux/slices/mapStopAreaEditor.ts
+++ b/ui/src/redux/slices/mapStopAreaEditor.ts
@@ -1,0 +1,33 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { StoreType } from '../mappers';
+
+export type MapStopAreaEditor = {
+  readonly selectedStopArea?: string;
+};
+
+type IState = StoreType<MapStopAreaEditor>;
+
+const initialState: IState = {
+  selectedStopArea: undefined,
+};
+
+const slice = createSlice({
+  name: 'mapStopAreaEditor',
+  initialState,
+  reducers: {
+    setSelectedStopAreaId: (
+      state,
+      action: PayloadAction<string | undefined>,
+    ) => {
+      state.selectedStopArea = action.payload;
+    },
+    reset: () => initialState,
+  },
+});
+
+export const {
+  setSelectedStopAreaId: setSelectedMapStopAreaIdAction,
+  reset: resetMapStopAreaEditorAction,
+} = slice.actions;
+
+export const mapStopAreaEditorReducer = slice.reducer;

--- a/ui/src/redux/thunks/map.ts
+++ b/ui/src/redux/thunks/map.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { resetMapModalAction } from '../slices/mapModal';
 import { resetMapRouteEditorStateAction } from '../slices/mapRouteEditor';
+import { resetMapStopAreaEditorAction } from '../slices/mapStopAreaEditor';
 import { resetMapStopEditorStateAction } from '../slices/mapStopEditor';
 
 export const resetMapState = createAsyncThunk(
@@ -8,6 +9,7 @@ export const resetMapState = createAsyncThunk(
   async (_, thunkAPI) => {
     thunkAPI.dispatch(resetMapModalAction());
     thunkAPI.dispatch(resetMapRouteEditorStateAction());
+    thunkAPI.dispatch(resetMapStopAreaEditorAction());
     thunkAPI.dispatch(resetMapStopEditorStateAction());
   },
 );

--- a/ui/src/utils/gis.ts
+++ b/ui/src/utils/gis.ts
@@ -16,18 +16,17 @@ export const mapPointToGeoJSON = ({
   return geoJsonPoint;
 };
 
-export const mapLngLatToPoint = (lngLat: number[]) => {
+export const mapLngLatToPoint = (lngLat: ReadonlyArray<number>): Point => {
   if (lngLat.length < 2 || lngLat.length > 3) {
     throw new Error(
       `Expected lngLat to be like [number, number] or [number, number, number] but got ${lngLat}`,
     );
   }
-  const point: Point = {
+  return {
     longitude: lngLat[0],
     latitude: lngLat[1],
-    elevation: lngLat[2] || 0,
+    elevation: lngLat[2] ?? 0,
   };
-  return point;
 };
 
 export const mapLngLatToGeoJSON = flow(mapLngLatToPoint, mapPointToGeoJSON);
@@ -55,3 +54,41 @@ export const relativeAlong = (
 
   return along(feature, featureLength * percentage);
 };
+
+export function isGeoJSONPoint(
+  geometry: GeoJSON.Geometry,
+): geometry is GeoJSON.Point {
+  return geometry.type === 'Point';
+}
+
+export function getGeometryPoint(geometry: null | undefined): null;
+export function getGeometryPoint(geometry: GeoJSON.Geometry): Point | null;
+export function getGeometryPoint(
+  geometry: GeoJSON.Geometry | null | undefined,
+): Point | null;
+export function getGeometryPoint(
+  geometry: GeoJSON.Geometry | null | undefined,
+): Point | null {
+  if (geometry && isGeoJSONPoint(geometry)) {
+    return mapLngLatToPoint(geometry.coordinates);
+  }
+
+  return null;
+}
+
+export function getPointPosition(geometry: null | undefined): null;
+export function getPointPosition(
+  geometry: GeoJSON.Geometry,
+): GeoJSON.Position | null;
+export function getPointPosition(
+  geometry: GeoJSON.Geometry | null | undefined,
+): GeoJSON.Position | null;
+export function getPointPosition(
+  geometry: GeoJSON.Geometry | null | undefined,
+): GeoJSON.Position | null {
+  if (geometry && isGeoJSONPoint(geometry)) {
+    return geometry.coordinates;
+  }
+
+  return null;
+}

--- a/ui/src/utils/gql.ts
+++ b/ui/src/utils/gql.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon';
 import {
   GeographyComparisonExp,
+  GeometryComparisonExp,
   ReusableComponentsVehicleModeEnum,
   RouteTypeOfLineEnum,
   StopsDatabaseStopPlaceNewestVersionBoolExp,
@@ -162,6 +163,18 @@ export const buildRouteLineLabelGqlFilter = (label: string) => ({
 export const buildWithinViewportGqlFilter = (
   viewport: Viewport,
 ): GeographyComparisonExp => ({
+  _st_d_within: {
+    from: {
+      type: 'Point',
+      coordinates: [viewport.longitude, viewport.latitude],
+    },
+    distance: viewport.radius,
+  },
+});
+
+export const buildWithinViewportGqlGeometryFilter = (
+  viewport: Viewport,
+): GeometryComparisonExp => ({
   _st_d_within: {
     from: {
       type: 'Point',

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './graphql';
 export * from './journeyPattern';
 export * from './localizedString';
 export * from './logger';
+export * from './misc';
 export * from './object';
 export * from './route';
 export * from './routeShape';

--- a/ui/src/utils/misc.ts
+++ b/ui/src/utils/misc.ts
@@ -1,0 +1,5 @@
+export function notNullish<T>(
+  value: T | null | undefined,
+): value is Exclude<T, 'null' | 'undefined'> {
+  return value !== null && value !== undefined;
+}

--- a/ui/src/utils/stop-registry/alternativeNames.spec.ts
+++ b/ui/src/utils/stop-registry/alternativeNames.spec.ts
@@ -1,0 +1,114 @@
+import i18next from 'i18next';
+import { getNameFromAlternatives } from './alternativeNames';
+
+jest.mock('i18next');
+
+const defaultName = 'finName';
+const defaultLang = 'fin';
+
+const finnishAlternative = { name_lang: defaultLang, name_value: defaultName };
+const swedishAlternative = { name_lang: 'swe', name_value: 'sweName' };
+const englishAlternative = { name_lang: 'eng', name_value: 'engName' };
+const norwegianAlternative = { name_lang: 'nor', name_value: 'norName' };
+
+const alternatives = [
+  swedishAlternative,
+  englishAlternative,
+  norwegianAlternative,
+];
+
+describe('getNameFromAlternatives', () => {
+  beforeEach(() => {
+    i18next.language = defaultLang;
+  });
+
+  describe('Default name given and should return it', () => {
+    it('Only default name given', () => {
+      expect(getNameFromAlternatives(defaultName, null, null)).toBe(
+        defaultName,
+      );
+    });
+
+    it('Only default name and default lang given', () => {
+      expect(getNameFromAlternatives(defaultName, defaultLang, null)).toBe(
+        defaultName,
+      );
+    });
+
+    it('Only default name and other lang given', () => {
+      expect(getNameFromAlternatives(defaultName, 'swe', null)).toBe(
+        defaultName,
+      );
+    });
+
+    it('Default name and default lang given with alternatives', () => {
+      expect(
+        getNameFromAlternatives(defaultName, defaultLang, alternatives),
+      ).toBe(defaultName);
+    });
+  });
+
+  describe('Default name given, but should return alternative', () => {
+    it('Wanted name is in alternatives', () => {
+      i18next.language = 'en-US';
+
+      expect(
+        getNameFromAlternatives(defaultName, defaultLang, alternatives),
+      ).toBe('engName');
+    });
+  });
+
+  describe('No default name given', () => {
+    it('Should return null when there is no default nor alternatives', () => {
+      expect(getNameFromAlternatives(null, null, null)).toBeNull();
+    });
+
+    it('Should return null when there is no default nor a valid alternative', () => {
+      expect(
+        getNameFromAlternatives(null, null, [norwegianAlternative]),
+      ).toBeNull();
+    });
+
+    it('Should return alternative when available', () => {
+      i18next.language = 'en-US';
+
+      expect(getNameFromAlternatives(null, null, alternatives)).toBe('engName');
+    });
+  });
+
+  describe('Should respect fallback order', () => {
+    describe('If language is Finnish', () => {
+      it('Should fallback to Swedish then English', () => {
+        expect(getNameFromAlternatives(null, null, alternatives)).toBe(
+          'sweName',
+        );
+        expect(
+          getNameFromAlternatives(null, null, [
+            norwegianAlternative,
+            englishAlternative,
+          ]),
+        ).toBe('engName');
+      });
+    });
+
+    describe('If language is English', () => {
+      it('Should fallback to Finnish then Swedish', () => {
+        i18next.language = 'en-US';
+
+        expect(
+          getNameFromAlternatives(null, null, [
+            norwegianAlternative,
+            swedishAlternative,
+            finnishAlternative,
+          ]),
+        ).toBe('finName');
+        expect(
+          getNameFromAlternatives(null, null, [
+            norwegianAlternative,
+            swedishAlternative,
+          ]),
+        ).toBe('sweName');
+      });
+    });
+  });
+});

--- a/ui/src/utils/stop-registry/alternativeNames.ts
+++ b/ui/src/utils/stop-registry/alternativeNames.ts
@@ -1,0 +1,53 @@
+import i18next from 'i18next';
+
+type AlternativeName = {
+  readonly name_lang?: string | null;
+  readonly name_value?: string | null;
+};
+
+const i18nLangToMultilingualStringLangOrder = {
+  'fi-FI': ['fin', 'swe', 'eng'],
+  'en-US': ['eng', 'fin', 'swe'],
+} as const;
+
+function getFindOrder(): ReadonlyArray<string> {
+  if (i18next.language in i18nLangToMultilingualStringLangOrder) {
+    return i18nLangToMultilingualStringLangOrder[
+      i18next.language as keyof typeof i18nLangToMultilingualStringLangOrder
+    ];
+  }
+
+  return i18nLangToMultilingualStringLangOrder['fi-FI'];
+}
+
+export function getNameFromAlternatives(
+  defaultName: string,
+  defaultLang: string | undefined,
+  alternatives: ReadonlyArray<AlternativeName> | undefined | null,
+): string;
+export function getNameFromAlternatives(
+  defaultName: string | undefined | null,
+  defaultLang: string | undefined | null,
+  alternatives: ReadonlyArray<AlternativeName> | undefined | null,
+): string | null;
+export function getNameFromAlternatives(
+  defaultName: string | null | undefined,
+  defaultLang: string | null | undefined,
+  alternatives: ReadonlyArray<AlternativeName> | null | undefined,
+): string | null {
+  const findOrder = getFindOrder();
+
+  if (defaultLang !== findOrder.at(0) && alternatives) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const preferredLang of findOrder) {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const alt of alternatives) {
+        if (alt.name_lang === preferredLang && alt.name_value) {
+          return alt.name_value;
+        }
+      }
+    }
+  }
+
+  return defaultName ?? null;
+}

--- a/ui/src/utils/stop-registry/index.ts
+++ b/ui/src/utils/stop-registry/index.ts
@@ -1,1 +1,2 @@
 export * from './stopPlace';
+export * from './alternativeNames';


### PR DESCRIPTION
### Add Hasura join - GroupsOfStopPlace⋄StopPlace

### Add basic Redux bits needed to show Stop Areas on the map

### Add basic StopArea visualization to the map

### Improve LineRenderLayer
* Allow rendering of MultiLineStrings
* Allow overriding paint and layout settings partially

### Visualize StopArea members on the map

### Map: Hide Stops when StopArea is active

### Map: Open Stop details when clicking Area member

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/847)
<!-- Reviewable:end -->
