### PR TITLE
Show a loader when refetching stop details after form submits

### DIFF
--- a/ui/src/hooks/stop-registry/useGetStopDetails.ts
+++ b/ui/src/hooks/stop-registry/useGetStopDetails.ts
@@ -270,6 +270,7 @@ export const useGetStopDetails = (): {
 
   const result = useGetHighestPriorityStopDetailsByLabelAndDateQuery({
     variables: { label, observationDate },
+    notifyOnNetworkStatusChange: true, // Required so that `loading` updates on refetches.
   });
 
   const stopDetails = result.data?.service_pattern_scheduled_stop_point[0];


### PR DESCRIPTION
So old values don't briefly show in the UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/851)
<!-- Reviewable:end -->
