### PR TITLE
Change cypress intercept config to speed up the tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -55,11 +55,16 @@ Cypress.Commands.add('mockLogin', () => {
       body: userInfo,
     }).as('userInfo');
 
-    // intercept calls to hasura and log in as admin (to avoid it going to auth backend)
-    // TODO: we should match only '/api/graphql' requests, but for some
-    // reason that doesn't seem to work. (Could be because our graphql
-    // requests use ws:// protocol?)
-    cy.intercept('**', (req) => {
+    // intercept calls to hastus service
+    // and log in as admin (to avoid it going to auth backend)
+    cy.intercept('/api/hastus/**', (req) => {
+      // eslint-disable-next-line no-param-reassign
+      req.headers['x-hasura-admin-secret'] = 'hasura';
+    }).as('hastusAuth');
+
+    // intercept calls to hasura
+    // and log in as admin (to avoid it going to auth backend)
+    cy.intercept('/api/graphql/**', (req) => {
       // eslint-disable-next-line no-param-reassign
       req.headers['x-hasura-admin-secret'] = 'hasura';
     }).as('hasuraAuth');


### PR DESCRIPTION
When running cypress on local machine it takes 10-15s per test (.visit() command) to load up before the test actually starts. This seems to be mostly because of cypress was intercepting every single call made. There was a comment about "we should only intercept the hasura calls, but it doesnt work". But at least now it seems to work just fine. And also this sped up the tests majorly which feels amazing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/855)
<!-- Reviewable:end -->
