### PR TITLE
Add yarn build to setup dependencies

### DIFF
--- a/scripts/setup-dependencies-and-seed.sh
+++ b/scripts/setup-dependencies-and-seed.sh
@@ -29,6 +29,7 @@ echo "y" | ./scripts/development.sh dump:import
 
 # Seed timetables and stop registry
 cd ./test-db-manager
+yarn build
 yarn seed
 
 echo "All done! Happy coding! :)"


### PR DESCRIPTION
Add yarn build to setup dependencies to make sure yarn seed is ready to be run.
Running `yarn seed` might fail if build is not up to date, so added `yarn build` to scripts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/856)
<!-- Reviewable:end -->
