### PR TITLE
Fix local timetables-api-e2e database connection

### DIFF
--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -30,7 +30,9 @@ services:
     container_name: "timetablesapi-e2e"
     environment:
       - SKIP_SET_VARIABLE_SECRET_OVERRIDE=true
-      - JORE4_DB_HOSTNAME=jore4-testdb-e2e
+      # Set the URL to e2e database, because for some reason giving the JORE4_DB_HOSTNAME and
+      # JORE4_DB_PORT and JORE4_DB_DATABASE does not work properly and using them points to dev database.
+      - JORE4_DB_URL=jdbc:postgresql://jore4-testdb-e2e:5432/timetablesdb?stringtype=unspecified
     ports:
       - "127.0.0.1:3109:8080"
     depends_on:


### PR DESCRIPTION
For some reason (I was unable to figure out why) using the HOSTNAME, DATABASE and PORT environment variables did not work, and timetables api always tried to do imports to dev environment database instead of e2e. By reading the README from timetables api and quick skim through code, those should have done the same thing, but just did not work. But setting the exact database url JORE4_DB_URL works. So for now we can use that and with that our e2e import tests will also work in local environment. (This has no effect to CI)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/863)
<!-- Reviewable:end -->
