### PR TITLE
Improve Map LoadingOverlay

### DIFF
--- a/cypress/pageObjects/Map.ts
+++ b/cypress/pageObjects/Map.ts
@@ -12,8 +12,19 @@ export class Map {
   stopPopUp = new StopPopUp();
 
   zoomIn(n = 1) {
-    cy.get('*[class^="maplibregl-canvas"]').last().focus();
-    Cypress._.times(n, () => cy.getByTestId('mapModal').type('+'));
+    Cypress._.times(n, (iteration) => {
+      cy.get('button[class*="maplibregl-ctrl-zoom-in"]').click();
+
+      if (iteration < n) {
+        // The zoom in action takes some time to settle down.
+        // The Map component ignores zoom actions if they are triggered
+        // while the map is still displaying the animation from the previous
+        // action.
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(1000);
+      }
+    });
     this.waitForLoadToComplete();
     cy.wait('@gqlGetStopsByLocation');
   }

--- a/ui/src/components/map/JoreLoader.tsx
+++ b/ui/src/components/map/JoreLoader.tsx
@@ -9,5 +9,5 @@ const testIds = {
 export const JoreLoader = (): React.ReactElement => {
   const isLoading = useAppSelector(selectIsJoreOperationLoading);
 
-  return <LoadingOverlay testId={testIds.loader} visible={isLoading} />;
+  return <LoadingOverlay testId={testIds.loader} isLoading={isLoading} />;
 };

--- a/ui/src/components/map/MapLoader.tsx
+++ b/ui/src/components/map/MapLoader.tsx
@@ -1,5 +1,5 @@
 import { useAppSelector, useMapQueryParams } from '../../hooks';
-import { selectIsMapOperationLoading } from '../../redux';
+import { LoadingState, selectMapOperationLoadingState } from '../../redux';
 import { LoadingOverlay } from '../../uiComponents';
 
 const testIds = {
@@ -8,9 +8,12 @@ const testIds = {
 
 export const MapLoader = (): React.ReactElement => {
   const { isMapOpen } = useMapQueryParams();
-  const isLoading = useAppSelector(selectIsMapOperationLoading);
+  const loadingState = useAppSelector(selectMapOperationLoadingState);
 
   return (
-    <LoadingOverlay testId={testIds.loader} visible={isMapOpen && isLoading} />
+    <LoadingOverlay
+      loadingState={isMapOpen ? loadingState : LoadingState.NotLoading}
+      testId={testIds.loader}
+    />
   );
 };

--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -9,7 +9,7 @@ import MapGL, {
   NavigationControl,
 } from 'react-map-gl/maplibre';
 import { useAppDispatch, useLoader, useMapQueryParams } from '../../hooks';
-import { Operation, setViewPortAction } from '../../redux';
+import { LoadingState, Operation, setViewPortAction } from '../../redux';
 import { getInteractiveLayerIds, loadMapAssets } from '../../utils/map';
 
 interface Props {
@@ -64,7 +64,9 @@ export const Maplibre: FC<Props> = ({
   });
 
   const dispatch = useAppDispatch();
-  const { setIsLoading } = useLoader(Operation.LoadMap);
+  const { setLoadingState } = useLoader(Operation.LoadMap, {
+    initialState: LoadingState.HighPriority,
+  });
 
   const updateMapDetailsDebounced = useMemo(
     () =>
@@ -135,7 +137,7 @@ export const Maplibre: FC<Props> = ({
   };
 
   const onLoad = () => {
-    setIsLoading(false);
+    setLoadingState(LoadingState.NotLoading);
     onViewportChange(viewport);
   };
 

--- a/ui/src/components/map/stop-areas/StopAreas.tsx
+++ b/ui/src/components/map/stop-areas/StopAreas.tsx
@@ -19,6 +19,7 @@ import {
   useUpsertStopArea,
 } from '../../../hooks';
 import {
+  LoadingState,
   Operation,
   selectEditedStopAreaData,
   selectIsCreateStopAreaModeEnabled,
@@ -59,7 +60,7 @@ export const StopAreas = React.forwardRef((_props, ref) => {
   );
 
   const { defaultErrorHandler, initializeStopArea } = useUpsertStopArea();
-  const { setIsLoading } = useLoader(Operation.FetchStopAreas);
+  const { setLoadingState, setIsLoading } = useLoader(Operation.FetchStopAreas);
 
   const viewport = useAppSelector(selectMapViewport);
   const stopAreasResult = useGetStopAreasByLocationQuery({
@@ -90,8 +91,12 @@ export const StopAreas = React.forwardRef((_props, ref) => {
      * We could also use useLoader's immediatelyOn option instead of useEffect,
      * but using options to dynamically control loading state feels semantically wrong.
      */
-    setIsLoading(stopAreasResult.loading);
-  }, [setIsLoading, stopAreasResult.loading]);
+    setLoadingState(
+      stopAreasResult.loading
+        ? LoadingState.LowPriority
+        : LoadingState.NotLoading,
+    );
+  }, [setLoadingState, stopAreasResult.loading]);
 
   const onEditStopArea = (stopArea: StopAreaByIdResult) => {
     setEditedStopAreaData(stopArea);

--- a/ui/src/components/map/stop-areas/StopAreas.tsx
+++ b/ui/src/components/map/stop-areas/StopAreas.tsx
@@ -10,6 +10,7 @@ import {
   useAppSelector,
   useGetStopAreaById,
   useLoader,
+  useMapDataLayerSimpleQueryLoader,
   useUpsertStopArea,
 } from '../../../hooks';
 import {
@@ -59,15 +60,16 @@ export const StopAreas = React.forwardRef((_props, ref) => {
 
   const { defaultErrorHandler, initializeStopArea } = useUpsertStopArea();
 
-  const { setLoadingState: setFetchAreasLoadingState } = useLoader(
-    Operation.FetchStopAreas,
-  );
   const viewport = useAppSelector(selectMapViewport);
   const stopAreasResult = useGetStopAreasByLocationQuery({
     variables: {
       measured_location_filter: buildWithinViewportGqlGeometryFilter(viewport),
     },
+    // Skip initial 0 radius fetch and wait for the map to get loaded,
+    // so that we have a proper viewport.
+    skip: viewport.radius <= 0,
   });
+  useMapDataLayerSimpleQueryLoader(Operation.FetchStopAreas, stopAreasResult);
 
   const { setLoadingState: setFetchStopAreaDetailsLoadingState } = useLoader(
     Operation.FetchStopAreaDetails,
@@ -101,20 +103,6 @@ export const StopAreas = React.forwardRef((_props, ref) => {
     setFetchStopAreaDetailsLoadingState,
     defaultErrorHandler,
   ]);
-
-  useEffect(() => {
-    /**
-     * Here we sync getStopAreasByLocationQuery query loading state with useLoader hook state.
-     *
-     * We could also use useLoader's immediatelyOn option instead of useEffect,
-     * but using options to dynamically control loading state feels semantically wrong.
-     */
-    setFetchAreasLoadingState(
-      stopAreasResult.loading
-        ? LoadingState.LowPriority
-        : LoadingState.NotLoading,
-    );
-  }, [setFetchAreasLoadingState, stopAreasResult.loading]);
 
   useImperativeHandle(ref, () => ({
     onCreateStopArea: (e: MapLayerMouseEvent) => {

--- a/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
+++ b/ui/src/components/routes-and-lines/search/ExportToolbar.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../hooks';
 import { Row, Visible } from '../../../layoutComponents';
 import {
+  LoadingState,
   resetSelectedRowsAction,
   selectExport,
   selectLoader,
@@ -37,7 +38,7 @@ export const ExportToolbar = (): React.ReactElement => {
     useAppSelector(selectExport);
   const { canExport, exportRoutesToHastus, findNotEligibleRoutesForExport } =
     useExportRoutes();
-  const { exportRoute: isExportRouteLoading } = useAppSelector(selectLoader);
+  const { exportRoute: exportRouteLoadingState } = useAppSelector(selectLoader);
 
   const linesWithRoutes = lines.filter((line) => !!line.line_routes.length);
 
@@ -128,7 +129,11 @@ export const ExportToolbar = (): React.ReactElement => {
       <Visible visible={isSelectingRoutesForExport}>
         <SimpleSmallButton
           inverted
-          disabled={!canExport || !selectedRows.length || isExportRouteLoading}
+          disabled={
+            !canExport ||
+            !selectedRows.length ||
+            exportRouteLoadingState !== LoadingState.NotLoading
+          }
           onClick={exportRoutes}
           label={t('export.exportSelected')}
           className="!rounded-full"

--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../hooks';
 import { parseI18nField } from '../../../i18n/utils';
 import { Row, Visible } from '../../../layoutComponents';
-import { selectLoader, selectTimetable } from '../../../redux';
+import { LoadingState, selectLoader, selectTimetable } from '../../../redux';
 import { DayType } from '../../../types/enums';
 import { AccordionButton } from '../../../uiComponents';
 import { LoadingWrapper } from '../../../uiComponents/LoadingWrapper';
@@ -105,7 +105,7 @@ export const RouteTimetablesSection = ({
       </Row>
       <LoadingWrapper
         className="flex justify-center p-5"
-        loading={fetchRouteTimetables}
+        loading={fetchRouteTimetables !== LoadingState.NotLoading}
         testId={testIds.loadingRouteTimetables}
       >
         <Visible visible={isOpen}>

--- a/ui/src/hooks/map/useFetchInfraLinksWithStops.ts
+++ b/ui/src/hooks/map/useFetchInfraLinksWithStops.ts
@@ -5,7 +5,7 @@ import { Operation } from '../../redux';
 import { MapMatchingNoSegmentError, showDangerToast } from '../../utils';
 
 export const useFetchInfraLinksWithStops = () => {
-  const { setIsLoading } = useLoader(Operation.LoadMap);
+  const { setIsLoading } = useLoader(Operation.FetchInfraLinksWithStops);
   const { t } = useTranslation();
   const { getInfraLinksWithStopsForGeometry } = useExtractRouteFromFeature();
 
@@ -13,8 +13,7 @@ export const useFetchInfraLinksWithStops = () => {
     async (geometry: GeoJSON.LineString) => {
       setIsLoading(true);
       try {
-        const response = await getInfraLinksWithStopsForGeometry(geometry);
-        return response;
+        return await getInfraLinksWithStopsForGeometry(geometry);
       } catch (err) {
         if (err instanceof MapMatchingNoSegmentError) {
           showDangerToast(t('errors.tooFarFromInfrastructureLink'));

--- a/ui/src/hooks/stop-areas/useResolveScheduledStopPointByStopPlaceRef.ts
+++ b/ui/src/hooks/stop-areas/useResolveScheduledStopPointByStopPlaceRef.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useGetScheduledStopPointByStopPlaceRefLazyQuery } from '../../generated/graphql';
 import { StopWithLocation } from '../../graphql';
-import { Operation } from '../../redux';
+import { LoadingState, Operation } from '../../redux';
 import { useLoader } from '../ui';
 
 type ResolveScheduledStopPointByStopPlaceRefFn = (
@@ -11,11 +11,11 @@ type ResolveScheduledStopPointByStopPlaceRefFn = (
 export function useResolveScheduledStopPointByStopPlaceRef() {
   const [getScheduledStopPointByStopPlaceRef] =
     useGetScheduledStopPointByStopPlaceRefLazyQuery();
-  const { setIsLoading } = useLoader(Operation.ResolveScheduledStopPoint);
+  const { setLoadingState } = useLoader(Operation.ResolveScheduledStopPoint);
 
   return useCallback<ResolveScheduledStopPointByStopPlaceRefFn>(
     async (stopPlaceRef) => {
-      setIsLoading(true);
+      setLoadingState(LoadingState.MediumPriority);
 
       try {
         const result = await getScheduledStopPointByStopPlaceRef({
@@ -33,9 +33,9 @@ export function useResolveScheduledStopPointByStopPlaceRef() {
 
         return stop as StopWithLocation;
       } finally {
-        setIsLoading(false);
+        setLoadingState(LoadingState.NotLoading);
       }
     },
-    [getScheduledStopPointByStopPlaceRef, setIsLoading],
+    [getScheduledStopPointByStopPlaceRef, setLoadingState],
   );
 }

--- a/ui/src/hooks/ui/useLoader.ts
+++ b/ui/src/hooks/ui/useLoader.ts
@@ -1,3 +1,4 @@
+import { QueryResult } from '@apollo/client';
 import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import {
@@ -37,4 +38,32 @@ export function useLoader(operation: Operation, options?: LoaderOptions) {
   }, []);
 
   return { setIsLoading, setLoadingState };
+}
+
+export function useMapDataLayerLoader(
+  operation: Operation,
+  initialLoadDone: boolean,
+  loading: boolean,
+) {
+  const { setLoadingState } = useLoader(operation);
+
+  useEffect(() => {
+    if (!initialLoadDone) {
+      setLoadingState(LoadingState.HighPriority);
+    } else {
+      setLoadingState(
+        loading ? LoadingState.LowPriority : LoadingState.NotLoading,
+      );
+    }
+  }, [loading, initialLoadDone, setLoadingState]);
+
+  return setLoadingState;
+}
+
+export function useMapDataLayerSimpleQueryLoader<T>(
+  operation: Operation,
+  { data, loading, previousData }: QueryResult<T>,
+) {
+  const initialLoadDone = !!(previousData ?? data);
+  return useMapDataLayerLoader(operation, initialLoadDone, loading);
 }

--- a/ui/src/hooks/ui/useLoader.ts
+++ b/ui/src/hooks/ui/useLoader.ts
@@ -1,12 +1,17 @@
 import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { Operation, setLoadingAction } from '../../redux';
+import {
+  LoadingState,
+  Operation,
+  setLoadingAction,
+  setLoadingStateAction,
+} from '../../redux';
 
 interface LoaderOptions {
-  immediatelyOn?: boolean;
+  initialState?: LoadingState;
 }
 
-export const useLoader = (operation: Operation, options?: LoaderOptions) => {
+export function useLoader(operation: Operation, options?: LoaderOptions) {
   const dispatch = useDispatch();
 
   const setIsLoading = useCallback(
@@ -15,10 +20,21 @@ export const useLoader = (operation: Operation, options?: LoaderOptions) => {
     [dispatch, operation],
   );
 
+  const setLoadingState = useCallback(
+    (state: LoadingState) =>
+      dispatch(setLoadingStateAction({ operation, state })),
+    [dispatch, operation],
+  );
+
   useEffect(() => {
-    setIsLoading(!!options?.immediatelyOn);
+    const initialState = options?.initialState;
+
+    if (initialState) {
+      setLoadingState(initialState);
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { setIsLoading };
-};
+  return { setIsLoading, setLoadingState };
+}

--- a/ui/src/redux/selectors/loader.ts
+++ b/ui/src/redux/selectors/loader.ts
@@ -1,5 +1,11 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { Operation, joreOperations, mapOperations } from '../slices/loader';
+import {
+  LoadingState,
+  Operation,
+  getHighestLoadingState,
+  joreOperations,
+  mapOperations,
+} from '../slices/loader';
 import { RootState } from '../store';
 
 export const selectLoader = (state: RootState) => state.loader;
@@ -9,7 +15,17 @@ export const selectIsMapOperationLoading = createSelector(
   (loaders) =>
     Object.entries(loaders)
       .filter(([operation]) => mapOperations.includes(operation as Operation))
-      .some(([, isLoading]) => isLoading),
+      .some(([, state]) => state !== LoadingState.NotLoading),
+);
+
+export const selectMapOperationLoadingState = createSelector(
+  selectLoader,
+  (loaders) => {
+    const mapStates = Object.entries(loaders)
+      .filter(([operation]) => mapOperations.includes(operation as Operation))
+      .map(([, state]) => state);
+    return getHighestLoadingState(mapStates);
+  },
 );
 
 export const selectIsJoreOperationLoading = createSelector(
@@ -17,5 +33,5 @@ export const selectIsJoreOperationLoading = createSelector(
   (loaders) =>
     Object.entries(loaders)
       .filter(([operation]) => joreOperations.includes(operation as Operation))
-      .some(([, isLoading]) => isLoading),
+      .some(([, state]) => state !== LoadingState.NotLoading),
 );

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -3,6 +3,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 export enum Operation {
   LoadMap = 'loadMap',
   FetchInfraLinksWithStops = 'fetchInfraLinksWithStops',
+  FetchStopAreaDetails = 'fetchStopAreaDetails',
   FetchStopAreas = 'fetchStopAreas',
   FetchStops = 'fetchStops',
   FetchRoutes = 'fetchRoutes',
@@ -67,6 +68,7 @@ export function getHighestLoadingState(
 export const mapOperations = [
   Operation.LoadMap,
   Operation.FetchInfraLinksWithStops,
+  Operation.FetchStopAreaDetails,
   Operation.FetchStopAreas,
   Operation.FetchStops,
   Operation.FetchRoutes,

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -20,6 +20,49 @@ export enum Operation {
   ResolveScheduledStopPoint = 'resolveScheduledStopPoint',
 }
 
+/**
+ * Alternatively LoadingPriority.
+ * Should the spinner for the {@link Operation} be hidden, or should be shown
+ * based on the set priority.
+ */
+export enum LoadingState {
+  /** No spinner should be visible */
+  NotLoading = 'notLoading',
+
+  /** Spinner would be a distraction to the user.
+   *  Prefer to silently load data on the background.
+   *  Only show spinner if loading takes a real long time.
+   * */
+  LowPriority = 'lowPriority',
+
+  /** Network operation should complete quickly,
+   * but if it doesn't it would confuse the user.
+   * Thus spinner should be shown soonish.
+   * */
+  MediumPriority = 'mediumPriority',
+
+  /** Block further user action immediately, until network operation is done. */
+  HighPriority = 'highPriority',
+}
+
+export function getHighestLoadingState(
+  loadingStates: ReadonlyArray<LoadingState>,
+): LoadingState {
+  if (loadingStates.includes(LoadingState.HighPriority)) {
+    return LoadingState.HighPriority;
+  }
+
+  if (loadingStates.includes(LoadingState.MediumPriority)) {
+    return LoadingState.MediumPriority;
+  }
+
+  if (loadingStates.includes(LoadingState.LowPriority)) {
+    return LoadingState.LowPriority;
+  }
+
+  return LoadingState.NotLoading;
+}
+
 export const mapOperations = [
   Operation.LoadMap,
   Operation.FetchStopAreas,
@@ -47,28 +90,16 @@ export const joreOperations = [
 ];
 
 type IState = {
-  [key in Operation]: boolean;
+  [key in Operation]: LoadingState;
 };
 
-const initialState: IState = {
-  [Operation.LoadMap]: false,
-  [Operation.FetchStopAreas]: false,
-  [Operation.FetchStops]: false,
-  [Operation.FetchRoutes]: false,
-  [Operation.SaveStop]: false,
-  [Operation.ModifyStopArea]: false,
-  [Operation.SaveRoute]: false,
-  [Operation.MatchRoute]: false,
-  [Operation.CheckBrokenRoutes]: false,
-  [Operation.SaveTimingPlace]: false,
-  [Operation.ExportRoute]: false,
-  [Operation.ConfirmTimetablesImport]: false,
-  [Operation.UploadFilesToHastusImport]: false,
-  [Operation.AbortImport]: false,
-  [Operation.FetchRouteTimetables]: false,
-  [Operation.DeleteTimetable]: false,
-  [Operation.ResolveScheduledStopPoint]: false,
-};
+const initialState: IState = Object.values(Operation).reduce(
+  (state: IState, operation) => ({
+    ...state,
+    [operation]: LoadingState.NotLoading,
+  }),
+  {} as IState,
+);
 
 const slice = createSlice({
   name: 'loader',
@@ -78,11 +109,22 @@ const slice = createSlice({
       state: IState,
       action: PayloadAction<{ operation: Operation; isLoading: boolean }>,
     ) => {
-      state[action.payload.operation] = action.payload.isLoading;
+      state[action.payload.operation] = action.payload.isLoading
+        ? LoadingState.HighPriority
+        : LoadingState.NotLoading;
+    },
+    setLoadingState: (
+      state: IState,
+      action: PayloadAction<{ operation: Operation; state: LoadingState }>,
+    ) => {
+      state[action.payload.operation] = action.payload.state;
     },
   },
 });
 
-export const { setLoading: setLoadingAction } = slice.actions;
+export const {
+  setLoading: setLoadingAction,
+  setLoadingState: setLoadingStateAction,
+} = slice.actions;
 
 export const loaderReducer = slice.reducer;

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -2,6 +2,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 export enum Operation {
   LoadMap = 'loadMap',
+  FetchInfraLinksWithStops = 'fetchInfraLinksWithStops',
   FetchStopAreas = 'fetchStopAreas',
   FetchStops = 'fetchStops',
   FetchRoutes = 'fetchRoutes',
@@ -65,6 +66,7 @@ export function getHighestLoadingState(
 
 export const mapOperations = [
   Operation.LoadMap,
+  Operation.FetchInfraLinksWithStops,
   Operation.FetchStopAreas,
   Operation.FetchStops,
   Operation.FetchRoutes,

--- a/ui/src/uiComponents/LoadingOverlay.tsx
+++ b/ui/src/uiComponents/LoadingOverlay.tsx
@@ -1,13 +1,100 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PulseLoader from 'react-spinners/PulseLoader';
 import { theme } from '../generated/theme';
+// The index.ts can, and do here, cause a massive cyclic dependency loop.
+// Use direct import
+import { LoadingState } from '../redux/slices/loader';
 
-interface Props {
-  visible: boolean;
-  testId?: string;
+// Make sure the loader doesn't simply flash on the screen for 1 frame.
+// See also resolveTransitionTimeout fn down below
+const HIDE_LOADER_DELAY = 200;
+const MEDIUM_PRIO_LOADER_DELAY = 300;
+const LOW_PRIO_LOADER_DELAY = 500;
+
+type BaseProps = { testId?: string };
+type IsLoadingProps = { isLoading: boolean; loadingState?: never };
+type LoadingStateProps = { isLoading?: never; loadingState: LoadingState };
+
+type Props = BaseProps & (IsLoadingProps | LoadingStateProps);
+
+function resolveLoadingState(
+  loadingState: LoadingState | undefined,
+  isLoading: boolean | undefined,
+): LoadingState {
+  if (loadingState) {
+    return loadingState;
+  }
+
+  return isLoading ? LoadingState.HighPriority : LoadingState.NotLoading;
 }
 
-export const LoadingOverlay: React.FC<Props> = ({ visible, testId = '' }) => {
+function getBaseDelay(loadingState: LoadingState): number {
+  switch (loadingState) {
+    case LoadingState.NotLoading:
+      return HIDE_LOADER_DELAY;
+
+    case LoadingState.LowPriority:
+      return LOW_PRIO_LOADER_DELAY;
+
+    case LoadingState.MediumPriority:
+      return MEDIUM_PRIO_LOADER_DELAY;
+
+    default:
+      return 0;
+  }
+}
+
+function resolveTransitionTimeout(
+  lastShown: number,
+  loadingState: LoadingState,
+): number {
+  const baseDelay = getBaseDelay(loadingState);
+
+  if (loadingState === LoadingState.NotLoading) {
+    // No need for delay if the loader has already been on the screen for long enough.
+    const onScreen = Date.now() - lastShown;
+    return Math.max(0, baseDelay - onScreen);
+  }
+
+  return baseDelay;
+}
+
+function useIsVisible(
+  loadingState: LoadingState | undefined,
+  isLoading: boolean | undefined,
+): boolean {
+  const resolvedLoadingState = resolveLoadingState(loadingState, isLoading);
+
+  const [visible, setVisible] = useState(
+    resolvedLoadingState !== LoadingState.NotLoading,
+  );
+  const shownAt = useRef(visible ? Date.now() : 0);
+
+  useEffect(() => {
+    const timeout = setTimeout(
+      () => {
+        const nextIsVisible = resolvedLoadingState !== LoadingState.NotLoading;
+        setVisible(nextIsVisible);
+        if (nextIsVisible) {
+          shownAt.current = Date.now();
+        }
+      },
+      resolveTransitionTimeout(shownAt.current, resolvedLoadingState),
+    );
+
+    return () => clearTimeout(timeout);
+  }, [resolvedLoadingState]);
+
+  return visible;
+}
+
+export const LoadingOverlay: React.FC<Props> = ({
+  isLoading,
+  loadingState,
+  testId = '',
+}) => {
+  const visible = useIsVisible(loadingState, isLoading);
+
   if (!visible) {
     return null;
   }

--- a/ui/src/utils/makePromiseCleanupHelper.ts
+++ b/ui/src/utils/makePromiseCleanupHelper.ts
@@ -1,0 +1,99 @@
+export class PromiseCanceledError extends Error {}
+
+export function filterCancellationError<T>(
+  handler: (error: unknown) => T | undefined,
+): (error: unknown) => T | undefined {
+  return (error) => {
+    if (error instanceof PromiseCanceledError) {
+      return undefined;
+    }
+
+    return handler(error);
+  };
+}
+
+type PromiseCleanupHelper = {
+  /**
+   * Function to be inserted in middle of a then-chain
+   * to skip the rest of the chain.
+   */
+  readonly blockOnCleanup: <T>(value: T) => T;
+
+  /**
+   * Function that sets the helper into canceled state,
+   * thus triggering blockOnCleanup to throw cancellation errors.
+   */
+  readonly cleanup: () => void;
+
+  /** Allows one to check the current state of the helper */
+  readonly cleanedUp: boolean;
+};
+
+/**
+ * A helper to ease working with Promises in useEffect.
+ *
+ * Promises cannot be canceled and thus can lead to problems when used in
+ * useEffect hooks, if the end action of the Promise chain should not be
+ * performed in case the useEffect hook has been executed again, with other
+ * parameters.
+ *
+ * Usage example:
+ * <code>
+ *   <pre>
+ *     const [id, setId] = useState(null);
+ *     const [areaToEdit, setAreaToEdit] = useReduxMagic();
+ *     const asyncLoadData = useAsyncLoadArea();
+ *
+ *     useEffect(() => {
+ *       const cleanupHelper = makePromiseCleanupHelper();
+ *
+ *       setAreaToEdit(null);
+ *       asyncLoadData(id)
+ *         // If current useEffect cycle has been marked as cleaned up when the
+ *         // actual data loading promise fulfills, throw an Error instead of
+ *         // continuing the then-chain. Else just pass through the data, and
+ *         // continue with the then-chain.
+ *         .then(cleanupHelper.blockOnCleanup)
+ *
+ *         // If id was to change again before the previous item was loaded
+ *         // it could cause a race condition where bot id and areaToEdit are
+ *         // set, but have conflicting data.
+ *
+ *         // In worse case scenario the second fetch might complete before
+ *         // the 1st one, thus for a moment setting in correct data, just for
+ *         // it to get overridden by data-1 moments after.
+ *         // Thus it is important to clean up and cancel old promises in
+ *         // useEffect hooks.
+ *         .then(setAreaToEdit)
+ *         .catch(handleErrorAndOrPromiseCancellation);
+ *
+ *       return cleanupHelper.cleanup;
+ *     }, [id, asyncLoadData]);
+ *   </pre>
+ * </code>
+ *
+ * @returns {PromiseCleanupHelper}
+ */
+export function makePromiseCleanupHelper(): PromiseCleanupHelper {
+  let cleanedUp = false;
+
+  return {
+    blockOnCleanup: <T>(value: T): T => {
+      if (cleanedUp) {
+        throw new PromiseCanceledError(
+          'Promise then-chain blocked due to cleanup!',
+        );
+      }
+
+      return value;
+    },
+
+    cleanup: () => {
+      cleanedUp = true;
+    },
+
+    get cleanedUp() {
+      return cleanedUp;
+    },
+  };
+}


### PR DESCRIPTION
### Rework Loader: Add Priority & allow LoadingOverlay to make use of them

* Instead of having booleans for the different Loader Operators, use a
  priority system for them:
  - NotLoading:Don't show LoadingOverlay
  - LowPriority: Not important & prefer not to show LoadingOverlay at all.
  - MediumPriority: No need to block further user input, but might confuse user of the network request is not immediate.
  - HighPriority: Immediately show LoadingOverlay

* Old Boolean based API kept in place with mapping:
  - false: NotLoading
  - true: HighPriority

* Update Map data features to use the new priority API.

* Updated LoadingOverlay to work with the Priority system.
  - Avoid Loader flashing the screen by always making sure that the loader is never just spawned in then hidden again on next frame.
  - If the loader is on screen, hiding it will happen on a timeout, making sure the loader stays on screen for at least 200ms.
  - Timeout for showing the loader on Medium prio is 300m.
  - Timeout for showing the loader on Low prio is 500ms.

* MapLoader:
  - Works with the new prio API.
  - Uses highest prio Map Operation as the prio.

* JoreLoader: Works with the old Boolean API.


### Add custom loader Operation for Infra Link fetching

Previously the Infra Link fetch was using the same loader Operation with the base Map, creating a potential conflict between them.


### Show single consistent loader when opening the map

Make sure all data fetches are synchronized and that we don't get multiple flashy loaders, from the multiple data layer fetch operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/868)
<!-- Reviewable:end -->
