### PR TITLE
Use dataset in create route

### DIFF
--- a/cypress/e2e/createRoute.cy.ts
+++ b/cypress/e2e/createRoute.cy.ts
@@ -1,224 +1,48 @@
 import {
-  GetInfrastructureLinksByExternalIdsResult,
-  InfraLinkAlongRouteInsertInput,
-  JourneyPatternInsertInput,
-  LineInsertInput,
   Priority,
   ReusableComponentsVehicleModeEnum,
   RouteDirectionEnum,
-  RouteInsertInput,
-  RouteTypeOfLineEnum,
-  StopInJourneyPatternInsertInput,
-  StopInsertInput,
-  buildLine,
-  buildRoute,
-  buildStop,
-  buildStopInJourneyPattern,
-  buildTimingPlace,
-  extractInfrastructureLinkIdsFromResponse,
-  mapToGetInfrastructureLinksByExternalIdsQuery,
 } from '@hsl/jore4-test-db-manager';
-import { DateTime } from 'luxon';
+import {
+  buildInfraLinksAlongRoute,
+  buildStopsOnInfraLinks,
+  getClonedBaseDbResources,
+  testInfraLinkExternalIds,
+} from '../datasets/base';
 import { Tag } from '../enums';
-import { MapModal, RouteEditor } from '../pageObjects';
+import { MapFooter, MapModal, Toast } from '../pageObjects';
 import { FilterPanel } from '../pageObjects/FilterPanel';
 import { RouteStopsOverlay } from '../pageObjects/RouteStopsOverlay';
 import { UUID } from '../types';
 import { SupportedResources, insertToDbHelper } from '../utils';
 
-const testRouteLabels = {
-  label1: 'T-reitti 1',
-  label2: 'T-reitti 2',
-  label3: 'T-reitti 3',
-  label4: 'Indefinite end time route',
-  label5: 'Template route',
-};
-
-// These infralink IDs exist in the 'infraLinks.sql' test data file.
-// These form a straight line on Eerikinkatu in Helsinki.
-// Coordinates are partial since they are needed only for the stop creation.
-
-const testInfraLinks = [
-  {
-    externalId: '445156',
-    coordinates: [24.926699622176628, 60.164181083308065, 10.0969999999943],
-  },
-  {
-    externalId: '442424',
-    coordinates: [24.92904198486008, 60.16490775039894, 0],
-  },
-  {
-    externalId: '442325',
-    coordinates: [24.932072417514647, 60.166003223527824, 0],
-  },
-];
-
-const stopLabels = ['Test stop 1', 'Test stop 2', 'Test stop 3'];
-
-const lines: LineInsertInput[] = [
-  {
-    ...buildLine({ label: '1 Test line 1' }),
-    line_id: '88f8f9fe-058b-49a2-ac8d-42d13488c7fb',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-  },
-  {
-    ...buildLine({ label: '1 Test line 2' }),
-    line_id: 'c0e4e702-60b6-4b90-9313-e463814a9422',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-  },
-  {
-    ...buildLine({ label: '1 Test line 3' }),
-    line_id: '71e19f0a-6eb3-40f2-9818-fb8ea5be135e',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-  },
-  {
-    ...buildLine({ label: '1 Line with indefinite end time' }),
-    line_id: 'ecbd895b-a720-4211-849f-ca380465c838',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-  },
-];
-
-const timingPlaces = [
-  buildTimingPlace('5bd61815-4c60-4f10-9a22-df954c516f5f', '1AACKT'),
-  buildTimingPlace('732eec2e-5728-4494-bec4-3a9718dfdde5', '1AURLA'),
-];
-
-const buildStopsOnInfrastrucureLinks = (
-  infrastructureLinkIds: UUID[],
-): StopInsertInput[] => [
-  {
-    ...buildStop({
-      label: stopLabels[0],
-      located_on_infrastructure_link_id: infrastructureLinkIds[0],
-    }),
-    validity_start: DateTime.fromISO('2020-03-20T22:00:00+00:00'),
-    scheduled_stop_point_id: '3f23a4c5-f527-4395-bd9f-bbc398f837df',
-    timing_place_id: timingPlaces[0].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[0].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[1],
-      located_on_infrastructure_link_id: infrastructureLinkIds[1],
-    }),
-    validity_start: DateTime.fromISO('2020-03-20T22:00:00+00:00'),
-    scheduled_stop_point_id: '431a6791-f1f5-45d4-8c9d-9e154a2531e0',
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[1].coordinates,
-    },
-  },
-  {
-    ...buildStop({
-      label: stopLabels[2],
-      located_on_infrastructure_link_id: infrastructureLinkIds[2],
-    }),
-    validity_start: DateTime.fromISO('2020-03-20T22:00:00+00:00'),
-    scheduled_stop_point_id: '6c09b8d9-5952-4ee3-92b9-a7b4847517d3',
-    timing_place_id: timingPlaces[1].timing_place_id,
-    measured_location: {
-      type: 'Point',
-      coordinates: testInfraLinks[2].coordinates,
-    },
-  },
-];
-
-const routes: RouteInsertInput[] = [
-  {
-    ...buildRoute({ label: testRouteLabels.label1 }),
-    route_id: '7961d12f-26cc-4e0f-b6a7-845bc334df63',
-    on_line_id: lines[0].line_id,
-    validity_start: DateTime.fromISO('2022-08-11T13:08:43.315+03:00'),
-    validity_end: DateTime.fromISO('2032-08-11T13:08:43.315+03:00'),
-  },
-];
-
-const buildInfraLinksAlongRoute = (
-  infrastructureLinkIds: UUID[],
-): InfraLinkAlongRouteInsertInput[] => [
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[0],
-    infrastructure_link_sequence: 0,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[1],
-    infrastructure_link_sequence: 1,
-    is_traversal_forwards: true,
-  },
-  {
-    route_id: routes[0].route_id,
-    infrastructure_link_id: infrastructureLinkIds[2],
-    infrastructure_link_sequence: 2,
-    is_traversal_forwards: true,
-  },
-];
-
-const journeyPatterns: JourneyPatternInsertInput[] = [
-  {
-    journey_pattern_id: '6cae356b-20f4-4e04-a969-097999b351f0',
-    on_route_id: routes[0].route_id,
-  },
-];
-
-const stopsInJourneyPattern: StopInJourneyPatternInsertInput[] = [
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[0],
-    scheduledStopPointSequence: 0,
-    isUsedAsTimingPoint: true,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[1],
-    scheduledStopPointSequence: 1,
-    isUsedAsTimingPoint: false,
-  }),
-  buildStopInJourneyPattern({
-    journeyPatternId: journeyPatterns[0].journey_pattern_id,
-    stopLabel: stopLabels[2],
-    scheduledStopPointSequence: 2,
-    isUsedAsTimingPoint: true,
-  }),
-];
-
-const stopTestIds = {
-  testStop1: `Map::Stops::stopMarker::${stopLabels[0]}_Standard`,
-  testStop2: `Map::Stops::stopMarker::${stopLabels[1]}_Standard`,
-  testStop3: `Map::Stops::stopMarker::${stopLabels[2]}_Standard`,
-};
-
 describe('Route creation', () => {
   let mapModal: MapModal;
   let routeStopsOverlay: RouteStopsOverlay;
-  let routeEditor: RouteEditor;
-  const baseDbResources = {
-    lines,
-    routes,
-    journeyPatterns,
-    stopsInJourneyPattern,
-  };
+  let mapFooter: MapFooter;
+  let filterPanel: FilterPanel;
+  let toast: Toast;
   let dbResources: SupportedResources;
 
-  before(() => {
-    cy.task<GetInfrastructureLinksByExternalIdsResult>(
-      'hasuraAPI',
-      mapToGetInfrastructureLinksByExternalIdsQuery(
-        testInfraLinks.map((infralink) => infralink.externalId),
-      ),
-    ).then((res) => {
-      const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);
+  const baseDbResources = getClonedBaseDbResources();
+  // Location where all test stops and routes are visible.
+  const mapLocation = {
+    lng: 24.929689228090112,
+    lat: 60.16495016651525,
+    zoom: 15,
+  };
 
-      const stops = buildStopsOnInfrastrucureLinks(infraLinkIds);
+  before(() => {
+    cy.task<UUID[]>(
+      'getInfrastructureLinkIdsByExternalIds',
+      testInfraLinkExternalIds,
+    ).then((infraLinkIds) => {
+      const stops = buildStopsOnInfraLinks(infraLinkIds);
+
       const infraLinksAlongRoute = buildInfraLinksAlongRoute(infraLinkIds);
+
       dbResources = {
         ...baseDbResources,
-        timingPlaces,
         stops,
         infraLinksAlongRoute,
       };
@@ -229,26 +53,15 @@ describe('Route creation', () => {
     cy.task('resetDbs');
 
     mapModal = new MapModal();
-    const mapFilterPanel = new FilterPanel();
+
     insertToDbHelper(dbResources);
 
     routeStopsOverlay = new RouteStopsOverlay();
-    routeEditor = new RouteEditor();
+    mapFooter = new MapFooter();
+    filterPanel = new FilterPanel();
+    toast = new Toast();
     cy.setupTests();
     cy.mockLogin();
-
-    // Location where all test stops and routes are visible.
-    const mapLocation = { lng: 24.929689228090112, lat: 60.16495016651525 };
-
-    mapModal.map.visit({
-      zoom: 15,
-      lat: mapLocation.lat,
-      lng: mapLocation.lng,
-    });
-
-    mapFilterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
-
-    mapModal.map.waitForLoadToComplete();
   });
 
   it(
@@ -258,40 +71,73 @@ describe('Route creation', () => {
       scrollBehavior: 'bottom',
     },
     () => {
-      const routeName = 'Testireitti 1';
+      mapModal.map.visit(mapLocation);
 
-      mapModal.createRoute({
-        routeFormInfo: {
-          finnishName: routeName,
-          label: testRouteLabels.label1,
-          variant: '56',
-          direction: RouteDirectionEnum.Outbound,
-          line: String(lines[0].label),
-          validityStartISODate: '2022-01-01',
-          validityEndISODate: '2025-12-01',
-          priority: Priority.Standard,
+      filterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
+      mapModal.map.waitForLoadToComplete();
+
+      mapFooter.getCreateRouteButton().click();
+      mapModal.routePropertiesForm.fillRouteProperties({
+        finnishName: 'Test route',
+        label: '901Y',
+        variant: '56',
+        line: '901',
+        direction: RouteDirectionEnum.Outbound,
+        origin: {
+          finnishName: 'Test origin FIN',
+          finnishShortName: 'Test origin FIN shortName',
+          swedishName: 'Test origin SWE',
+          swedishShortName: 'Test origin SWE shortName',
         },
-        routePoints: [
-          {
-            rightOffset: -10,
-            downOffset: 25,
-            mapMarkerTestId: stopTestIds.testStop1,
-          },
-          {
-            rightOffset: 35,
-            downOffset: -20,
-            mapMarkerTestId: stopTestIds.testStop3,
-          },
-        ],
+        destination: {
+          finnishName: 'Test destination FIN',
+          finnishShortName: 'Test destination FIN shortName',
+          swedishName: 'Test destination SWE',
+          swedishShortName: 'Test destination SWE shortName',
+        },
       });
 
-      routeEditor.gqlRouteShouldBeCreatedSuccessfully();
+      mapModal.routePropertiesForm.changeValidityForm.setPriority(
+        Priority.Standard,
+      );
 
-      routeEditor.checkRouteSubmitSuccessToast();
+      mapModal.routePropertiesForm.changeValidityForm.setStartDate(
+        '2022-01-01',
+      );
+      mapModal.routePropertiesForm.changeValidityForm.setEndDate('2025-12-01');
+      mapModal.editRouteModal.save();
 
+      // Create a geometry for route that includes dataset stops E2E001,
+      // (exclude E2E002) E2E003, E2E004 and E2E005
+      mapModal.map.clickAtPosition(1395, 488);
+      mapModal.map.clickAtPosition(1362, 462);
+      mapModal.map.clickAtPosition(1240, 477);
+      mapModal.map.clickAtPosition(1179, 452);
+      mapModal.map.clickAtPosition(1080, 516);
+      mapModal.map.clickAtPosition(1095, 592);
+      mapModal.map.clickAtPosition(991, 657);
+      // Click the last added node again to finish the route
+      mapModal.map.clickAtPosition(991, 657);
+
+      mapModal.map.getLoader().should('exist');
+      mapModal.map.getLoader().should('not.exist');
+
+      mapFooter.save();
+      toast.checkSuccessToastHasMessage('Reitti tallennettu');
+
+      // Check from routeStopsOverlay that everything is correct
       routeStopsOverlay
-        .getRouteStopListHeader('T-reitti 1', RouteDirectionEnum.Outbound)
+        .getHeader()
+        .should('contain', '901Y 56')
+        .and('contain', 'Test route');
+      routeStopsOverlay
+        .getRouteStopListHeader('901Y', RouteDirectionEnum.Outbound)
         .shouldBeVisible();
+      routeStopsOverlay.getRouteStopsOverlayRows().should('have.length', 4);
+      routeStopsOverlay.getNthRouteStopsOverlayRow(0).shouldHaveText('E2E001');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(1).shouldHaveText('E2E003');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(2).shouldHaveText('E2E004');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(3).shouldHaveText('E2E005');
     },
   );
 
@@ -299,42 +145,74 @@ describe('Route creation', () => {
     'Should create a new route and leave out one stop',
     { tags: [Tag.Map, Tag.Routes, Tag.Network], scrollBehavior: 'bottom' },
     () => {
-      const routeName = 'Testireitti 2';
-      const omittedStopsLabels = [stopLabels[1]];
-      mapModal.createRoute({
-        routeFormInfo: {
-          finnishName: routeName,
-          label: testRouteLabels.label2,
-          direction: RouteDirectionEnum.Inbound,
-          line: String(lines[1].label),
-          validityStartISODate: '2022-01-01',
-          validityEndISODate: '2025-12-01',
-          priority: Priority.Standard,
+      const { routeStopsOverlayRow } = routeStopsOverlay;
+      mapModal.map.visit(mapLocation);
+
+      filterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
+      mapModal.map.waitForLoadToComplete();
+
+      mapFooter.getCreateRouteButton().click();
+      mapModal.routePropertiesForm.fillRouteProperties({
+        finnishName: 'Test route',
+        label: '901X',
+        line: '901',
+        direction: RouteDirectionEnum.Outbound,
+        origin: {
+          finnishName: 'Test origin FIN',
+          finnishShortName: 'Test origin FIN shortName',
+          swedishName: 'Test origin SWE',
+          swedishShortName: 'Test origin SWE shortName',
         },
-        routePoints: [
-          {
-            rightOffset: -10,
-            downOffset: 25,
-            mapMarkerTestId: stopTestIds.testStop1,
-          },
-          {
-            rightOffset: 35,
-            downOffset: -20,
-            mapMarkerTestId: stopTestIds.testStop3,
-          },
-        ],
-        omittedStops: omittedStopsLabels,
+        destination: {
+          finnishName: 'Test destination FIN',
+          finnishShortName: 'Test destination FIN shortName',
+          swedishName: 'Test destination SWE',
+          swedishShortName: 'Test destination SWE shortName',
+        },
       });
 
-      routeEditor.gqlRouteShouldBeCreatedSuccessfully();
+      mapModal.routePropertiesForm.changeValidityForm.setPriority(
+        Priority.Standard,
+      );
+      mapModal.routePropertiesForm.changeValidityForm.setStartDate(
+        '2022-01-01',
+      );
+      mapModal.routePropertiesForm.changeValidityForm.setEndDate('2025-12-01');
+      mapModal.editRouteModal.save();
 
-      routeEditor.checkRouteSubmitSuccessToast();
+      // Create a geometry for route that includes dataset stops E2E001 - E2E004
+      mapModal.map.clickAtPosition(1395, 488);
+      mapModal.map.clickAtPosition(1290, 369);
+      mapModal.map.clickAtPosition(1097, 575);
+      // Click the last added node again to finish the route
+      mapModal.map.clickAtPosition(1097, 575);
+
+      routeStopsOverlay.getRouteStopsOverlayRows().should('have.length', 4);
+      routeStopsOverlay.getNthRouteStopsOverlayRow(0).shouldHaveText('E2E001');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(1).shouldHaveText('E2E002');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(2).shouldHaveText('E2E003');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(3).shouldHaveText('E2E004');
+
+      // Remove one stop from the journey pattern
+      routeStopsOverlay.getNthRouteStopsOverlayRow(2).within(() => {
+        routeStopsOverlayRow.getMenuButton().click();
+        routeStopsOverlayRow
+          .getToggleStopInJourneyPatternButton()
+          .contains('Poista reitin käytöstä')
+          .click();
+      });
+
+      mapFooter.save();
+      toast.checkSuccessToastHasMessage('Reitti tallennettu');
 
       routeStopsOverlay
-        .getRouteStopListHeader('T-reitti 2', RouteDirectionEnum.Inbound)
-        .shouldBeVisible();
-
-      routeStopsOverlay.stopsShouldNotBeIncludedInRoute(omittedStopsLabels);
+        .getHeader()
+        .should('contain', '901X')
+        .and('contain', 'Test route');
+      routeStopsOverlay.getRouteStopsOverlayRows().should('have.length', 3);
+      routeStopsOverlay.getNthRouteStopsOverlayRow(0).shouldHaveText('E2E001');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(1).shouldHaveText('E2E002');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(2).shouldHaveText('E2E004');
     },
   );
 
@@ -342,34 +220,65 @@ describe('Route creation', () => {
     'Should not let the user create a route with only one stop',
     { tags: [Tag.Map, Tag.Routes, Tag.Network], scrollBehavior: 'bottom' },
     () => {
-      const routeName = 'Testireitti 3';
-      const omittedStopsLabels = [stopLabels[1], stopLabels[2]];
-      mapModal.createRoute({
-        routeFormInfo: {
-          finnishName: routeName,
-          label: testRouteLabels.label3,
-          direction: RouteDirectionEnum.Outbound,
-          line: String(lines[2].label),
-          validityStartISODate: '2022-01-01',
-          validityEndISODate: '2025-12-01',
-          priority: Priority.Standard,
+      const { routeStopsOverlayRow } = routeStopsOverlay;
+      mapModal.map.visit(mapLocation);
+
+      filterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
+      mapModal.map.waitForLoadToComplete();
+
+      mapFooter.getCreateRouteButton().click();
+      mapModal.routePropertiesForm.fillRouteProperties({
+        finnishName: 'Erronous route',
+        label: '901F',
+        line: '901',
+        direction: RouteDirectionEnum.Outbound,
+        origin: {
+          finnishName: 'Test origin FIN',
+          finnishShortName: 'Test origin FIN shortName',
+          swedishName: 'Test origin SWE',
+          swedishShortName: 'Test origin SWE shortName',
         },
-        routePoints: [
-          {
-            rightOffset: -10,
-            downOffset: 25,
-            mapMarkerTestId: stopTestIds.testStop1,
-          },
-          {
-            rightOffset: 35,
-            downOffset: -20,
-            mapMarkerTestId: stopTestIds.testStop3,
-          },
-        ],
-        omittedStops: omittedStopsLabels,
+        destination: {
+          finnishName: 'Test destination FIN',
+          finnishShortName: 'Test destination FIN shortName',
+          swedishName: 'Test destination SWE',
+          swedishShortName: 'Test destination SWE shortName',
+        },
       });
 
-      routeEditor.checkRouteSubmitFailureToast();
+      mapModal.routePropertiesForm.changeValidityForm.setPriority(
+        Priority.Standard,
+      );
+
+      mapModal.routePropertiesForm.changeValidityForm.setStartDate(
+        '2022-01-01',
+      );
+      mapModal.routePropertiesForm.changeValidityForm.setEndDate('2025-12-01');
+      mapModal.editRouteModal.save();
+
+      // Create a geometry for route that includes dataset stops E2E001 and E2E002
+      mapModal.map.clickAtPosition(1395, 488);
+      mapModal.map.clickAtPosition(1290, 369);
+      // Click the last added node again to finish the route
+      mapModal.map.clickAtPosition(1290, 369);
+
+      routeStopsOverlay.getRouteStopsOverlayRows().should('have.length', 2);
+      routeStopsOverlay.getNthRouteStopsOverlayRow(0).shouldHaveText('E2E001');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(1).shouldHaveText('E2E002');
+
+      // Remove the other stop from the journey pattern
+      routeStopsOverlay.getNthRouteStopsOverlayRow(1).within(() => {
+        routeStopsOverlayRow.getMenuButton().click();
+        routeStopsOverlayRow
+          .getToggleStopInJourneyPatternButton()
+          .contains('Poista reitin käytöstä')
+          .click();
+      });
+
+      mapFooter.save();
+      toast.checkDangerToastHasMessage(
+        'Tallennus epäonnistui: Reitillä on oltava ainakin kaksi pysäkkiä.',
+      );
     },
   );
 
@@ -377,41 +286,54 @@ describe('Route creation', () => {
     'Should create new route with an indefinite validity end date',
     { tags: [Tag.Map, Tag.Routes, Tag.Network], scrollBehavior: 'bottom' },
     () => {
-      const routeName = 'Testireitti 4';
+      mapModal.map.visit(mapLocation);
 
-      mapModal.createRoute({
-        routeFormInfo: {
-          finnishName: routeName,
-          label: testRouteLabels.label4,
-          direction: RouteDirectionEnum.Outbound,
-          line: String(lines[3].label),
-          validityStartISODate: '2022-01-01',
-          priority: Priority.Standard,
+      filterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
+      mapModal.map.waitForLoadToComplete();
+
+      mapFooter.getCreateRouteButton().click();
+      mapModal.routePropertiesForm.fillRouteProperties({
+        finnishName: 'Indefinite end time route',
+        label: '901I',
+        line: '901',
+        direction: RouteDirectionEnum.Outbound,
+        origin: {
+          finnishName: 'Test origin FIN',
+          finnishShortName: 'Test origin FIN shortName',
+          swedishName: 'Test origin SWE',
+          swedishShortName: 'Test origin SWE shortName',
         },
-        routePoints: [
-          {
-            rightOffset: -10,
-            downOffset: 30,
-            mapMarkerTestId: stopTestIds.testStop1,
-          },
-          {
-            rightOffset: 35,
-            downOffset: -10,
-            mapMarkerTestId: stopTestIds.testStop3,
-          },
-        ],
+        destination: {
+          finnishName: 'Test destination FIN',
+          finnishShortName: 'Test destination FIN shortName',
+          swedishName: 'Test destination SWE',
+          swedishShortName: 'Test destination SWE shortName',
+        },
       });
 
-      routeEditor.gqlRouteShouldBeCreatedSuccessfully();
+      mapModal.routePropertiesForm.changeValidityForm.setPriority(
+        Priority.Standard,
+      );
+      mapModal.routePropertiesForm.changeValidityForm.setStartDate(
+        '2022-01-01',
+      );
+      mapModal.routePropertiesForm.changeValidityForm
+        .getIndefiniteCheckbox()
+        .click();
+      mapModal.editRouteModal.save();
 
-      routeEditor.checkRouteSubmitSuccessToast();
+      // Create a geometry for route that includes dataset stops E2E001
+      // and E2E002
+      mapModal.map.clickAtPosition(1395, 488);
+      mapModal.map.clickAtPosition(1290, 369);
+      // Click the last added node again to finish the route
+      mapModal.map.clickAtPosition(1290, 369);
 
-      routeStopsOverlay
-        .getRouteStopListHeader(
-          'Indefinite end time route',
-          RouteDirectionEnum.Outbound,
-        )
-        .shouldBeVisible();
+      mapModal.map.getLoader().should('exist');
+      mapModal.map.getLoader().should('not.exist');
+
+      mapFooter.save();
+      toast.checkSuccessToastHasMessage('Reitti tallennettu');
     },
   );
 
@@ -419,37 +341,63 @@ describe('Route creation', () => {
     'Should create a new route using an existing route as a template',
     { tags: [Tag.Map, Tag.Routes, Tag.Network], scrollBehavior: 'bottom' },
     () => {
-      mapModal.createRoute({
-        routeFormInfo: {
-          finnishName: 'Reitin pohjalta luotu reitti',
-          label: testRouteLabels.label5,
-          direction: RouteDirectionEnum.Outbound,
-          line: String(lines[0].label),
-          templateRoute: {
-            templateRouteSelectorInfo: {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              priority: routes[0].priority!,
-              label: routes[0].label,
-            },
-          },
-          validityStartISODate: String(routes[0].validity_start),
-          validityEndISODate: String(routes[0].validity_end),
-          priority: Priority.Standard,
+      mapModal.map.visit(mapLocation);
+
+      filterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
+      mapModal.map.waitForLoadToComplete();
+
+      mapFooter.getCreateRouteButton().click();
+      mapModal.routePropertiesForm.fillRouteProperties({
+        finnishName: 'Based on template test route',
+        label: '901T',
+        line: '901',
+        direction: RouteDirectionEnum.Outbound,
+        origin: {
+          finnishName: 'Test origin FIN',
+          finnishShortName: 'Test origin FIN shortName',
+          swedishName: 'Test origin SWE',
+          swedishShortName: 'Test origin SWE shortName',
+        },
+        destination: {
+          finnishName: 'Test destination FIN',
+          finnishShortName: 'Test destination FIN shortName',
+          swedishName: 'Test destination SWE',
+          swedishShortName: 'Test destination SWE shortName',
         },
       });
 
-      routeEditor.gqlRouteShouldBeCreatedSuccessfully();
+      // Use standard route 901 from dataset as template
+      mapModal.routePropertiesForm.getUseTemplateRouteButton().click();
+      mapModal.routePropertiesForm.templateRouteSelector.fillForm({
+        priority: Priority.Standard,
+        label: '901',
+      });
 
-      routeEditor.checkRouteSubmitSuccessToast();
+      mapModal.routePropertiesForm.changeValidityForm.setPriority(
+        Priority.Standard,
+      );
+      mapModal.routePropertiesForm.changeValidityForm.setStartDate(
+        '2022-01-01',
+      );
+      mapModal.routePropertiesForm.changeValidityForm.setEndDate('2025-12-01');
+
+      mapModal.editRouteModal.save();
+
+      mapModal.map.getLoader().should('exist');
+      mapModal.map.getLoader().should('not.exist');
+
+      mapFooter.save();
 
       routeStopsOverlay
-        .getRouteStopListHeader('Template route', RouteDirectionEnum.Outbound)
-        .shouldBeVisible();
-
-      // Verify that the stops from the template route are included in the new route
-      // and that the stop count is correct
-      routeStopsOverlay.stopsShouldBeIncludedInRoute(stopLabels);
-      routeStopsOverlay.assertRouteStopCount(3);
+        .getHeader()
+        .should('contain', '901T')
+        .and('contain', 'Based on template test route');
+      routeStopsOverlay.getRouteStopsOverlayRows().should('have.length', 5);
+      routeStopsOverlay.getNthRouteStopsOverlayRow(0).shouldHaveText('E2E001');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(1).shouldHaveText('E2E002');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(2).shouldHaveText('E2E003');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(3).shouldHaveText('E2E004');
+      routeStopsOverlay.getNthRouteStopsOverlayRow(4).shouldHaveText('E2E005');
     },
   );
 });

--- a/cypress/pageObjects/BlockVehicleJourneysTable.ts
+++ b/cypress/pageObjects/BlockVehicleJourneysTable.ts
@@ -8,11 +8,7 @@ export class BlockVehicleJourneysTable {
   }
 
   getTableRows() {
-    // TODO: This is just temp solution and will be changed to normal data-testid
-    // after all vehiclejourneyRow::label::direction usages have been removed.
-    // label and direction is not enough to identify one row anyway, because there
-    // always is more than one journey per direction
-    return cy.get('[data-testidtemp="VehicleJourneyRow"]');
+    return cy.getByTestId('VehicleJourneyRow');
   }
 
   getNthTableRow(nth: number) {
@@ -25,12 +21,6 @@ export class BlockVehicleJourneysTable {
 
   getTable() {
     return cy.getByTestId('BlockVehicleJourneysTable::table');
-  }
-
-  getVehicleJourneyRow(routeLabel: string, routeDirection: string) {
-    return cy.getByTestId(
-      `VehicleJourneyRow::${routeLabel}::${routeDirection}`,
-    );
   }
 
   clickAllTableToggles() {

--- a/cypress/pageObjects/MapModal.ts
+++ b/cypress/pageObjects/MapModal.ts
@@ -1,8 +1,8 @@
 import { EditRouteModal } from './EditRouteModal';
-import { ClickPointNearMapMarker, Map } from './Map';
+import { Map } from './Map';
 import { MapFooter } from './MapFooter';
 import { RouteEditor } from './RouteEditor';
-import { RouteFormInfo, RoutePropertiesForm } from './RoutePropertiesForm';
+import { RoutePropertiesForm } from './RoutePropertiesForm';
 import { RouteStopsOverlay } from './RouteStopsOverlay';
 import { StopForm, StopFormInfo } from './StopForm';
 import { Toast } from './Toast';
@@ -23,28 +23,6 @@ export class MapModal {
   toast = new Toast();
 
   routeEditor = new RouteEditor();
-
-  /**
-   * Creates stop using ClickPointNear stop.
-   * This means that you give a stop testId as the origin of the click
-   * and then 'right' and 'down' values of where you want to click
-   * related to that stop.
-   */
-  createStopNextToAnotherStop = ({
-    stopFormInfo,
-    stopPoint,
-  }: {
-    stopFormInfo: StopFormInfo;
-    stopPoint: ClickPointNearMapMarker;
-  }) => {
-    this.mapFooter.addStop();
-
-    this.map.clickAtPositionFromMapMarkerByTestId(stopPoint);
-
-    this.stopForm.fillForm(stopFormInfo);
-
-    this.stopForm.save();
-  };
 
   /**
    * This creates stop at a location that is specified by percentages of the viewport'sg width and height.
@@ -68,71 +46,8 @@ export class MapModal {
     this.stopForm.save();
   };
 
-  /**
-   * Create route with UI by giving the necessary information for route creation. This
-   * uses ClickPointNearStop array for the route points. This means that you give a stop
-   * testId as the origin of the click and then 'right' and 'down' values of where you want
-   * to click related to that stop.
-   */
-  createRoute = ({
-    routeFormInfo,
-    routePoints,
-    omittedStops,
-  }: {
-    routeFormInfo: RouteFormInfo;
-    routePoints?: ClickPointNearMapMarker[];
-    omittedStops?: string[];
-  }) => {
-    this.map.waitForLoadToComplete();
-
-    this.mapFooter.createRoute();
-
-    this.routePropertiesForm.fillRouteProperties(routeFormInfo);
-
-    this.editRouteModal.save();
-
-    this.map.getLoader().should('not.exist');
-
-    if (routeFormInfo.templateRoute?.moveRouteEditHandleInfo) {
-      this.map.getLoader().should('not.exist');
-      this.mapFooter.editRoute();
-      this.routeEditor.editOneRoutePoint(
-        routeFormInfo.templateRoute.moveRouteEditHandleInfo,
-      );
-      // Using a route as a template seems to fail without these waits
-      cy.wait('@gqlGetLinksWithStopsByExternalLinkIds');
-      cy.wait('@gqlGetStopsAlongInfrastructureLinks');
-      cy.wait('@gqlGetRouteWithInfrastructureLinksWithStops');
-      cy.wait('@gqlGetStopsAlongInfrastructureLinks');
-    }
-
-    if (routePoints) {
-      this.map.getLoader().should('not.exist');
-      routePoints.forEach((routePoint) => {
-        this.map.clickAtPositionFromMapMarkerByTestId(routePoint);
-      });
-
-      this.map.clickAtPositionFromMapMarkerByTestId(
-        routePoints[routePoints.length - 1],
-      );
-    }
-
-    cy.wait('@mapMatching');
-
-    if (omittedStops) {
-      this.map.getLoader().should('not.exist');
-      this.routeStopsOverlay.removeStopsFromRoute(omittedStops);
-    }
-
-    this.mapFooter.save();
-  };
-
   checkStopSubmitSuccessToast() {
     this.toast.checkSuccessToastHasMessage('Pysäkki luotu');
-  }
-
-  checkStopSubmitFailureToast() {
-    this.toast.checkDangerToastHasMessage('Tallennus epäonnistui');
   }
 
   gqlStopShouldBeCreatedSuccessfully() {

--- a/cypress/pageObjects/RouteEditor.ts
+++ b/cypress/pageObjects/RouteEditor.ts
@@ -28,35 +28,4 @@ export class RouteEditor {
   checkRouteSubmitSuccessToast() {
     this.toast.checkSuccessToastHasMessage('Reitti tallennettu');
   }
-
-  checkRouteSubmitFailureToast() {
-    this.toast.checkDangerToastHasMessage('Tallennus epäonnistui');
-  }
-
-  getRouteDashedLine() {
-    // Locator matches multiple elements, but we need only one of them to be able to click the route.
-    return cy.get('[data-type="feature"]').eq(1);
-  }
-
-  moveRouteEditHandle(values: MoveRouteEditHandleInfo) {
-    this.map.getNthSnappingPointHandle(values.handleIndex).move(values);
-  }
-
-  /**
-   * Starts the route editing process, moves one editHandle by the given offset
-   * and saves the route.
-   * @example const moveHandleInfo: MoveRouteEditHandleInfo =
-   * { handleIndex: 2, deltaX: 10, deltaY: -90}
-   * editOneRoutePoint(moveHandleInfo)
-   */
-  editOneRoutePoint(values: MoveRouteEditHandleInfo) {
-    this.mapFooter.editRoute();
-    this.map.waitForLoadToComplete();
-    // Force click because element might be covered by some other element, like a stop circle
-    this.getRouteDashedLine().click('topLeft', { force: true });
-    this.moveRouteEditHandle(values);
-    cy.wait('@mapMatching');
-    cy.wait('@gqlGetLinksWithStopsByExternalLinkIds');
-    cy.wait('@gqlGetStopsByLocation');
-  }
 }

--- a/cypress/pageObjects/RouteStopsOverlay.ts
+++ b/cypress/pageObjects/RouteStopsOverlay.ts
@@ -1,6 +1,9 @@
 import { RouteDirectionEnum } from '@hsl/jore4-test-db-manager';
+import { RouteStopsOverlayRow } from './RouteStopsOverlayRow';
 
 export class RouteStopsOverlay {
+  routeStopsOverlayRow = new RouteStopsOverlayRow();
+
   getRouteStopRow(stopLabel: string) {
     return cy.getByTestId(`RouteStopsOverlayRow::label::${stopLabel}`);
   }
@@ -9,29 +12,22 @@ export class RouteStopsOverlay {
     return cy.getByTestId('RouteStopsOverlay::mapOverlayHeader');
   }
 
-  getRouteStopRowMenu(stopLabel: string) {
-    return cy.getByTestId(`RouteStopsOverlayRow::${stopLabel}::menu`);
+  getRouteStopsOverlayRows() {
+    return cy.getByTestId('RouteStopsOverlayRow');
   }
 
-  getAddToJourneyPatternButton(stopLabel: string) {
-    return cy.getByTestId(
-      `RouteStopsOverlayRow::${stopLabel}::menu::addToJourneyPatternButton`,
-    );
+  getNthRouteStopsOverlayRow(nth: number) {
+    return this.getRouteStopsOverlayRows().eq(nth);
+  }
+
+  getRouteStopRowMenu(stopLabel: string) {
+    return cy.getByTestId(`RouteStopsOverlayRow::${stopLabel}::menu`);
   }
 
   getRouteStopListHeader(label: string, direction: RouteDirectionEnum) {
     return cy.getByTestId(
       `RouteStopsOverlay::routeStopListHeader::${label}-${direction}`,
     );
-  }
-
-  removeStopsFromRoute(stopLabels: string[]) {
-    stopLabels.forEach((label) => {
-      this.getRouteStopRowMenu(label).should('be.visible');
-      this.getRouteStopRowMenu(label).click();
-      this.getAddToJourneyPatternButton(label).should('be.visible');
-      this.getAddToJourneyPatternButton(label).click({ force: true });
-    });
   }
 
   stopsShouldNotBeIncludedInRoute(stopLabels: string[]) {

--- a/cypress/pageObjects/RouteStopsOverlayRow.ts
+++ b/cypress/pageObjects/RouteStopsOverlayRow.ts
@@ -1,0 +1,11 @@
+export class RouteStopsOverlayRow {
+  getMenuButton() {
+    return cy.getByTestId(`RouteStopsOverlayRow::menu`);
+  }
+
+  getToggleStopInJourneyPatternButton() {
+    return cy.getByTestId(
+      `RouteStopsOverlayRow::menu::toggleStopInJourneyPatternButton`,
+    );
+  }
+}

--- a/cypress/pageObjects/index.ts
+++ b/cypress/pageObjects/index.ts
@@ -19,6 +19,7 @@ export * from './PreviewTimetablesPage';
 export * from './RouteEditor';
 export * from './RoutePropertiesForm';
 export * from './RouteStopsTable';
+export * from './RouteStopsOverlayRow';
 export * from './RoutesAndLinesPage';
 export * from './SearchResultsPage';
 export * from './StopForm';

--- a/ui/src/components/map/RouteStopsOverlayRow.tsx
+++ b/ui/src/components/map/RouteStopsOverlayRow.tsx
@@ -15,10 +15,11 @@ interface Props {
 }
 
 const testIds = {
+  row: 'RouteStopsOverlayRow',
   rowLabel: (label: string) => `RouteStopsOverlayRow::label::${label}`,
-  menuButton: (label: string) => `RouteStopsOverlayRow::${label}::menu`,
-  addToJourneyPatternButton: (label: string) =>
-    `RouteStopsOverlayRow::${label}::menu::addToJourneyPatternButton`,
+  menuButton: 'RouteStopsOverlayRow::menu',
+  toggleStopInJourneyPatternButton:
+    'RouteStopsOverlayRow::menu::toggleStopInJourneyPatternButton',
 };
 
 export const RouteStopsOverlayRow = ({
@@ -39,7 +40,10 @@ export const RouteStopsOverlayRow = ({
   };
 
   return (
-    <div className="flex h-10 items-center justify-between border-b p-2">
+    <div
+      data-testid={testIds.row}
+      className="flex h-10 items-center justify-between border-b p-2"
+    >
       <div className="flex items-center">
         <div className="w-10">
           <PriorityBadge
@@ -61,7 +65,7 @@ export const RouteStopsOverlayRow = ({
         <div className="text-tweaked-brand">
           <SimpleDropdownMenu
             alignItems={AlignDirection.Left}
-            testId={testIds.menuButton(stop.label)}
+            testId={testIds.menuButton}
             tooltip={t('accessibility:map.routeStopsOverlayRowActions', {
               stopLabel: stop.label,
             })}
@@ -71,7 +75,7 @@ export const RouteStopsOverlayRow = ({
               onClick={() =>
                 setBelongsToJourneyPattern(!belongsToJourneyPattern)
               }
-              data-testid={testIds.addToJourneyPatternButton(stop.label)}
+              data-testid={testIds.toggleStopInJourneyPatternButton}
             >
               {belongsToJourneyPattern
                 ? t('stops.removeFromRoute')

--- a/ui/src/components/timetables/import/contents-view/ImportContentsView.spec.tsx
+++ b/ui/src/components/timetables/import/contents-view/ImportContentsView.spec.tsx
@@ -212,7 +212,7 @@ describe('<ImportContentsView />', () => {
     // Expand the block.
     fireEvent.click(toggleShowFirstBlock);
     const vehicleJourneyRowOutbound = within(block).getAllByTestId(
-      vehicleJourneyRowTestIds.vehicleJourneyRow('35', 'outbound'),
+      vehicleJourneyRowTestIds.vehicleJourneyRow,
     )[0];
     expect(vehicleJourneyRowOutbound).toBeVisible();
 
@@ -271,11 +271,11 @@ describe('<ImportContentsView />', () => {
     // Toggle open.
     fireEvent.click(toggleShowFirstBlock);
     const vehicleJourneyRowOutbound = within(block).getAllByTestId(
-      vehicleJourneyRowTestIds.vehicleJourneyRow('35', 'outbound'),
+      vehicleJourneyRowTestIds.vehicleJourneyRow,
     )[0];
     const vehicleJourneyRowInbound = within(block).getAllByTestId(
-      vehicleJourneyRowTestIds.vehicleJourneyRow('35', 'inbound'),
-    )[0];
+      vehicleJourneyRowTestIds.vehicleJourneyRow,
+    )[1];
     expect(vehicleJourneyRowOutbound).toBeVisible();
 
     const queryFromOutboundRow = within(
@@ -351,7 +351,7 @@ describe('<ImportContentsView />', () => {
 
     const queryJourneyRow = (block: HTMLElement) =>
       within(block).queryAllByTestId(
-        vehicleJourneyRowTestIds.vehicleJourneyRow('35', 'outbound'),
+        vehicleJourneyRowTestIds.vehicleJourneyRow,
       );
 
     // Initially hidden.

--- a/ui/src/components/timetables/import/contents-view/VehicleJourneyRow.tsx
+++ b/ui/src/components/timetables/import/contents-view/VehicleJourneyRow.tsx
@@ -9,9 +9,7 @@ import { getRouteLabelVariantText } from '../../../../utils';
 import { DirectionBadge } from '../../../routes-and-lines/line-details/DirectionBadge';
 
 const testIds = {
-  vehicleJourneyRow: (routeLabel: string, routeDirection: string) =>
-    `VehicleJourneyRow::${routeLabel}::${routeDirection}`,
-  vehicleJourneyRowTemp: 'VehicleJourneyRow',
+  vehicleJourneyRow: 'VehicleJourneyRow',
   label: 'VehicleJourneyRow::label',
   dayTypeName: 'VehicleJourneyRow::dayTypeName',
   startTime: 'VehicleJourneyRow::startTime',
@@ -42,8 +40,7 @@ export const VehicleJourneyRow = ({
   return (
     <tr
       className="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
-      data-testid={testIds.vehicleJourneyRow(route.label, route.direction)}
-      data-testidtemp={testIds.vehicleJourneyRowTemp}
+      data-testid={testIds.vehicleJourneyRow}
     >
       <td>
         <Row className="items-center font-bold">

--- a/ui/src/components/timetables/import/contents-view/__snapshots__/ImportContentsView.spec.tsx.snap
+++ b/ui/src/components/timetables/import/contents-view/__snapshots__/ImportContentsView.spec.tsx.snap
@@ -86,8 +86,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
   <tbody>
     <tr
       class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
-      data-testid="VehicleJourneyRow::35::outbound"
-      data-testidtemp="VehicleJourneyRow"
+      data-testid="VehicleJourneyRow"
     >
       <td>
         <div
@@ -135,8 +134,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
     </tr>
     <tr
       class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
-      data-testid="VehicleJourneyRow::35::inbound"
-      data-testidtemp="VehicleJourneyRow"
+      data-testid="VehicleJourneyRow"
     >
       <td>
         <div
@@ -184,8 +182,7 @@ exports[`<ImportContentsView /> should render an expanded block correctly 1`] = 
     </tr>
     <tr
       class="even:bg-white [&>td]:border [&>td]:border-light-grey [&>td]:px-5 [&>td]:py-2"
-      data-testid="VehicleJourneyRow::35::outbound"
-      data-testidtemp="VehicleJourneyRow"
+      data-testid="VehicleJourneyRow"
     >
       <td>
         <div


### PR DESCRIPTION
The first commit was supposed to be in the earlier PR already, but forgot so adding it here.

**Remove temporary test id from VehicleJourneyRow**
After we removed the `getVehicleJourneyRow(routeLabel: string, routeDirection: string)` usage from e2e tests,
we can remove it from the component test and remove it completely and replace it with the data-testidtemp, which
doesn't have any identifying parameters. For context: the route label and direction was not enough to identify one row anyway,
because there could be many rows with the same label and direction. Also we have been refactoring these usages towards
a guideline that we get all rows from a list and then pick the nth row. With this approach we also can be sure that the lists are
in correct order

**Use dataset in createRoute and refactor**
- Replaced dynamic testIds with static ones (dynamic testIds are a bit problematic and e.g. using dynamic testIds in lists
ignore the order of the list completely)
- Added pageObject RouteStopsOverlayRow
- Renamed `addToJourneyPatternButton` testId to `toggleInJourneyPatternButton` since the button has two different functionalities depending
on whether the stop belongs to the journey pattern or not.
- Removed mapModal pageObject's `createRoute` method completely. It supported very narrow usage and we should not hide that much UI test logic
behind very complex and long methods. Also removed `createStopNextToAnotherStop` method as unused and also if in the future we merge the stopMarkers
as the map's `feature`, we can't use the mapMarkers in the tests at all.
- Removed removeStopsFromRoute method from RouteStopsOverlay for many reasons. We should have this functionality in the tests, not in method. Also this
was named `removeStopsFromRoute`, even though it would just as well add a stop to a route if the chosen stop was not used on the route.
- Removed some unused methods from RouteEditor, some of these wouldn't even work anymore since the map update (snapping line & edit handles
are not working the same way) and also
- End note: As iterative approach I did not change/fix everything at once, so there are still things to enhance here, probably some methods might be unused, but
small parts at a time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/872)
<!-- Reviewable:end -->
