### PR TITLE
Fix RouteRowLoader elements

### DIFF
--- a/ui/src/components/routes-and-lines/line-details/RouteRowLoader.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteRowLoader.tsx
@@ -7,16 +7,10 @@ interface Props {
 
 export const RouteRowLoader = ({ className = '' }: Props): JSX.Element => {
   return (
-    <tr className={`border border-white bg-lighter-grey ${className} p-4`}>
-      <td className="p-4" colSpan={6}>
-        <div className="mt-1 inline-flex w-full flex-col items-center">
-          <PulseLoader
-            size={15}
-            color={theme.colors.brand}
-            speedMultiplier={0.7}
-          />
-        </div>
-      </td>
-    </tr>
+    <div
+      className={`mt-1 inline-flex min-h-16 w-full flex-col items-center justify-center bg-lighter-grey ${className}`}
+    >
+      <PulseLoader size={15} color={theme.colors.brand} speedMultiplier={0.7} />
+    </div>
   );
 };


### PR DESCRIPTION
LineRouteRow component was refactored to list item from table element, but this RouteRowLoader was left untouched. This resulted in invalid HTML (`<tr>` inside `<li>`). So lets remove the table elements from this Loader component as well. Also changed min height to match
the resulting row (p-4 -> min-h-16).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/883)
<!-- Reviewable:end -->
