### PR TITLE
Update map-matching pinned image and fix post request url

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -25,7 +25,7 @@ services:
 
   jore4-mapmatching:
     # pinning map-matching API to compatible version
-    image: "hsldevcom/jore4-map-matching:main--20230922-d1608c25525ce4ef250b8a61abaa01a64451538b"
+    image: "hsldevcom/jore4-map-matching:main--20240820-f3a4b33f20a3c3c409205b52c35e6a3cb909153e"
 
   jore4-hastus:
     # pinning hastus import-export-microservice version

--- a/ui/src/api/routing.ts
+++ b/ui/src/api/routing.ts
@@ -19,7 +19,7 @@ const apiClient = axios.create({
   baseURL: '/api/mapmatching/api/route/v1',
 });
 
-const getBus = (coordinates: RouteBody) => apiClient.post('/bus/', coordinates);
+const getBus = (coordinates: RouteBody) => apiClient.post('/bus', coordinates);
 
 export interface BusRouteResponse {
   code: 'Ok';


### PR DESCRIPTION
Map-matching service was recently updated and this POST request stopped working.
It seems that the trailing `/` in the url end `/bus/` was now extra and
resulted in 403 forbidden status response.
So it seems that the url path is now more strict. (and we do not have the trailing version defined in the API)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/890)
<!-- Reviewable:end -->
