### PR TITLE
Fix map bugs

### DIFF
--- a/ui/src/components/map/MapModal.tsx
+++ b/ui/src/components/map/MapModal.tsx
@@ -4,6 +4,7 @@ import { useMapQueryParams } from '../../hooks';
 import { Map } from './Map';
 import { MapFooter } from './MapFooter';
 import { MapHeader } from './MapHeader';
+import { MapLoader } from './MapLoader';
 import { RouteEditorRef } from './refTypes';
 
 interface Props {
@@ -53,6 +54,7 @@ export const MapModal: React.FC<Props> = ({ className = '' }) => {
         onCancel={() => mapRef.current?.onCancel()}
         onSave={() => mapRef.current?.onSave()}
       />
+      <MapLoader />
     </Dialog>
   );
 };

--- a/ui/src/hooks/urlQuery/useUrlQuery.ts
+++ b/ui/src/hooks/urlQuery/useUrlQuery.ts
@@ -141,7 +141,7 @@ export const useUrlQuery = () => {
     ({
       parameters,
       replace = false,
-      pathname = '',
+      pathname = undefined,
     }: {
       parameters: QueryParameter<QueryParameterTypes>[];
       replace?: boolean;

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { getUserInfo } from '../api/user';
 import { MainPage } from '../components/main/MainPage';
-import { MapLoader, MapModal } from '../components/map';
+import { MapModal } from '../components/map';
 import { JoreLoader } from '../components/map/JoreLoader';
 import { Navbar } from '../components/navbar';
 import { CreateNewLinePage } from '../components/routes-and-lines/create-line/CreateNewLinePage';
@@ -204,7 +204,6 @@ export const Router: FC = () => {
       <ProtectedRoute>
         <MapModal />
       </ProtectedRoute>
-      <MapLoader />
       <JoreLoader />
       <JoreErrorModal />
     </BrowserRouter>

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -201,7 +201,9 @@ export const Router: FC = () => {
           />
         ))}
       </Routes>
-      <MapModal />
+      <ProtectedRoute>
+        <MapModal />
+      </ProtectedRoute>
       <MapLoader />
       <JoreLoader />
       <JoreErrorModal />


### PR DESCRIPTION
Commits:
**Fix unauthorized map login loop**

The login loop issue is actually a two fold:
We have protected routes from unauthorized users by redirecting them to front page for login,
in case the userInfo can't be retrieved. But we also have a "temporary quality of life" addition so
that if a GQL request fails, we reload the page, which is added so that when developers are stopping
and starting the dependencies, they lose the authorisation from the auth service, but the userInfo
is still there, so the pages are accessible, but the GQL's return nothing, and with the reload it actually
fetches the userInfo again -> not authorized -> redirect to front page.

But since mapModal is not an individual page and is in fact a modal and visible anywhere if the queryString
'mapOpen=true' is present, and if the map is open on top of the root page so localhost:3300?mapOpen=true
we were not redirecting the user to front page, because front page does not require auth. But the temp QoL
causes the page to reload -> So in the end the page reloads -> sends GQLs -> gets unauthed -> reloads..

The second part is that even if we removed the "reload QoL addition" in client.ts which would fix the loop,
it would still mean that the map can be opened on top of front page, it would just have an infinite loader spinning
and no data. So probably best to "protect" it as well for now, before we get some better solutions.

**Move MapLoader to MapModal component**

The map is not it's own page and is in fact a modal/dialog. So if you "click outside of the dialog" it will close,
and because the map loader was not inside the map modal component, it is considered as "outside of dialog" and
if you click the loader, the map will close.

Don't know or can't remember why map loader was outside of map modal component in the first place, but it probably
should be inside anyway.

**Fix url pathname from disappearing when opening the map**

useUrlQuery's setMultipleParametersToUrlQuery's pathname was defaulted
to a an empty string when it should've been undefined. Under the hood it uses
useNavigate hook and an empty value is a valid value for the navigate function
and it will empty the pathname.
So we change the default value to undefined, which results in no changes to
pathname.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/894)
<!-- Reviewable:end -->
