### PR TITLE
Move MapLoader to MapModal component

### DIFF
--- a/ui/src/components/map/MapModal.tsx
+++ b/ui/src/components/map/MapModal.tsx
@@ -4,6 +4,7 @@ import { useMapQueryParams } from '../../hooks';
 import { Map } from './Map';
 import { MapFooter } from './MapFooter';
 import { MapHeader } from './MapHeader';
+import { MapLoader } from './MapLoader';
 import { RouteEditorRef } from './refTypes';
 
 interface Props {
@@ -53,6 +54,7 @@ export const MapModal: React.FC<Props> = ({ className = '' }) => {
         onCancel={() => mapRef.current?.onCancel()}
         onSave={() => mapRef.current?.onSave()}
       />
+      <MapLoader />
     </Dialog>
   );
 };

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { getUserInfo } from '../api/user';
 import { MainPage } from '../components/main/MainPage';
-import { MapLoader, MapModal } from '../components/map';
+import { MapModal } from '../components/map';
 import { JoreLoader } from '../components/map/JoreLoader';
 import { Navbar } from '../components/navbar';
 import { CreateNewLinePage } from '../components/routes-and-lines/create-line/CreateNewLinePage';
@@ -202,7 +202,6 @@ export const Router: FC = () => {
         ))}
       </Routes>
       <MapModal />
-      <MapLoader />
       <JoreLoader />
       <JoreErrorModal />
     </BrowserRouter>


### PR DESCRIPTION
The map is not it's own page and is in fact a modal/dialog. So if you "click outside of the dialog" it will close, and because the map loader was not inside the map modal component, it is considered as "outside of dialog" and if you click the loader, the map will close.

Don't know or can't remember why map loader was outside of map modal component in the first place, but it probably should be inside anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/897)
<!-- Reviewable:end -->
