### PR TITLE
Fix url pathname from disappearing when opening the map

### DIFF
--- a/ui/src/hooks/urlQuery/useUrlQuery.ts
+++ b/ui/src/hooks/urlQuery/useUrlQuery.ts
@@ -141,7 +141,7 @@ export const useUrlQuery = () => {
     ({
       parameters,
       replace = false,
-      pathname = '',
+      pathname = undefined,
     }: {
       parameters: QueryParameter<QueryParameterTypes>[];
       replace?: boolean;


### PR DESCRIPTION
useUrlQuery's setMultipleParametersToUrlQuery's pathname was defaulted to a an empty string when it should've been undefined. Under the hood it uses useNavigate hook and an empty value is a valid value for the navigate function and it will empty the pathname.
So we change the default value to undefined, which results in no changes to pathname.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/898)
<!-- Reviewable:end -->
