### PR TITLE
Stop area details page test

### DIFF
--- a/cypress/datasets/base.ts
+++ b/cypress/datasets/base.ts
@@ -35,6 +35,18 @@ const timingPlaces = [
   buildTimingPlace('763b275a-bd51-4310-93ff-0bd666c67849', '1ALKU'),
 ];
 
+export const stopCoordinatesByLabel = {
+  E2E001: [24.9390091244705, 60.16551299383615, 0],
+  E2E002: [24.937610671343663, 60.16648629862467, 0],
+  E2E003: [24.93286261070354, 60.165644561954316, 0],
+  E2E004: [24.932290135584754, 60.16486923767877, 0],
+  E2E005: [24.9314028056389, 60.163980768982995, 0],
+  E2E006: [24.93296734706376, 60.16543343120806, 0],
+  E2E007: [24.935714344053142, 60.16644692066976, 0],
+  E2E008: [24.937281651830318, 60.16645331474371, 0],
+  E2E009: [24.93877038021971, 60.1653765292378, 0],
+};
+
 export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
   // Stops along test route 901 Outbound
   {
@@ -48,7 +60,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: [24.9390091244705, 60.16551299383615, 0],
+      coordinates: stopCoordinatesByLabel.E2E001,
     },
   },
   {
@@ -61,7 +73,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     scheduled_stop_point_id: 'a92c7c8f-352b-432d-a6f6-a91a894dbb83',
     measured_location: {
       type: 'Point',
-      coordinates: [24.937610671343663, 60.16648629862467, 0],
+      coordinates: stopCoordinatesByLabel.E2E002,
     },
   },
   {
@@ -75,7 +87,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: [24.93286261070354, 60.165644561954316, 0],
+      coordinates: stopCoordinatesByLabel.E2E003,
     },
   },
   {
@@ -88,7 +100,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     scheduled_stop_point_id: '31d84532-43e4-47d2-b7fd-ba8184ae9e70',
     measured_location: {
       type: 'Point',
-      coordinates: [24.932290135584754, 60.16486923767877, 0],
+      coordinates: stopCoordinatesByLabel.E2E004,
     },
   },
   {
@@ -102,7 +114,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     timing_place_id: timingPlaces[2].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: [24.9314028056389, 60.163980768982995, 0],
+      coordinates: stopCoordinatesByLabel.E2E005,
     },
   },
   // Stops along test route 901 Inbound
@@ -117,7 +129,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     timing_place_id: timingPlaces[1].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: [24.93296734706376, 60.16543343120806, 0],
+      coordinates: stopCoordinatesByLabel.E2E006,
     },
   },
   {
@@ -130,7 +142,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     scheduled_stop_point_id: '43dc3fd1-2cfe-40fe-9431-dd8d85c124f2',
     measured_location: {
       type: 'Point',
-      coordinates: [24.935714344053142, 60.16644692066976, 0],
+      coordinates: stopCoordinatesByLabel.E2E007,
     },
   },
   {
@@ -143,7 +155,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     scheduled_stop_point_id: '8d60a644-fce6-460b-ad1c-30b5a39dee17',
     measured_location: {
       type: 'Point',
-      coordinates: [24.937281651830318, 60.16645331474371, 0],
+      coordinates: stopCoordinatesByLabel.E2E008,
     },
   },
   {
@@ -157,7 +169,7 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
     timing_place_id: timingPlaces[0].timing_place_id,
     measured_location: {
       type: 'Point',
-      coordinates: [24.93877038021971, 60.1653765292378, 0],
+      coordinates: stopCoordinatesByLabel.E2E009,
     },
   },
 ];

--- a/cypress/datasets/stopRegistry.ts
+++ b/cypress/datasets/stopRegistry.ts
@@ -1,0 +1,101 @@
+import {
+  StopPlaceInput,
+  StopRegistryGeoJson,
+  StopRegistryGeoJsonType,
+} from '@hsl/jore4-test-db-manager';
+import cloneDeep from 'lodash/cloneDeep';
+import { stopCoordinatesByLabel } from './base';
+
+const coordinatesToStopRegistryGeoJSON = (
+  coordinates: number[],
+): StopRegistryGeoJson => {
+  return {
+    coordinates: coordinates.slice(0, 2),
+    type: StopRegistryGeoJsonType.Point,
+  };
+};
+
+// Stop registry stopPlace data for each scheduled stop point in the base dataset.
+const stopPlaceData: Array<StopPlaceInput> = [
+  {
+    label: 'E2E001',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Annankatu 15' },
+      quays: [{ publicCode: 'E2E001' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E001),
+    },
+  },
+  {
+    label: 'E2E002',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Annankatu 20' },
+      quays: [{ publicCode: 'E2E002' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E002),
+    },
+  },
+  {
+    label: 'E2E003',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Kalevankatu 32' },
+      quays: [{ publicCode: 'E2E003' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E003),
+    },
+  },
+  {
+    label: 'E2E004',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Albertinkatu 38' },
+      quays: [{ publicCode: 'E2E004' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E004),
+    },
+  },
+  {
+    label: 'E2E005',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Lönnrotinkatu 32' },
+      quays: [{ publicCode: 'E2E005' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E005),
+    },
+  },
+  {
+    label: 'E2E006',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Kalevankatu 32' },
+      quays: [{ publicCode: 'E2E006' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E006),
+    },
+  },
+  {
+    label: 'E2E007',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Kalevankatu 18' },
+      quays: [{ publicCode: 'E2E007' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E007),
+    },
+  },
+  {
+    label: 'E2E008',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Annankatu 20' },
+      quays: [{ publicCode: 'E2E008' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E008),
+    },
+  },
+  {
+    label: 'E2E009',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Annankatu 15' },
+      quays: [{ publicCode: 'E2E009' }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E009),
+    },
+  },
+];
+
+const baseStopRegistryData = {
+  organisations: [],
+  stopAreas: [],
+  stopPlaces: stopPlaceData,
+};
+
+export const getClonedBaseStopRegistryData = () =>
+  cloneDeep(baseStopRegistryData);

--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -1,0 +1,131 @@
+import {
+  StopAreaInput,
+  StopRegistryGeoJsonType,
+} from '@hsl/jore4-test-db-manager';
+import { DateTime } from 'luxon';
+import {
+  buildInfraLinksAlongRoute,
+  buildStopsOnInfraLinks,
+  getClonedBaseDbResources,
+  testInfraLinkExternalIds,
+} from '../../datasets/base';
+import { getClonedBaseStopRegistryData } from '../../datasets/stopRegistry';
+import { StopAreaDetailsPage } from '../../pageObjects';
+import { UUID } from '../../types';
+import { SupportedResources, insertToDbHelper } from '../../utils';
+import { InsertedStopRegistryIds } from '../utils';
+
+describe('Stop area details', () => {
+  const stopAreaDetailsPage = new StopAreaDetailsPage();
+
+  let dbResources: SupportedResources;
+
+  const baseDbResources = getClonedBaseDbResources();
+  const baseStopRegistryData = getClonedBaseStopRegistryData();
+
+  const stopAreaData: Array<StopAreaInput> = [
+    {
+      memberLabels: ['E2E001', 'E2E009'],
+      stopArea: {
+        name: { lang: 'fin', value: 'X0003' },
+        description: { lang: 'fin', value: 'Annankatu 15' },
+        validBetween: {
+          fromDate: DateTime.fromISO('2020-01-01T00:00:00.001'),
+          toDate: DateTime.fromISO('2050-01-01T00:00:00.001'),
+        },
+        geometry: {
+          coordinates: [24.938927, 60.165433],
+          type: StopRegistryGeoJsonType.Point,
+        },
+      },
+    },
+  ];
+
+  before(() => {
+    cy.task<UUID[]>(
+      'getInfrastructureLinkIdsByExternalIds',
+      testInfraLinkExternalIds,
+    ).then((infraLinkIds) => {
+      const stops = buildStopsOnInfraLinks(infraLinkIds);
+
+      const infraLinksAlongRoute = buildInfraLinksAlongRoute(infraLinkIds);
+
+      dbResources = {
+        ...baseDbResources,
+        stops,
+        infraLinksAlongRoute,
+      };
+    });
+  });
+
+  describe('View basic details', () => {
+    beforeEach(() => {
+      cy.task('resetDbs');
+
+      insertToDbHelper(dbResources);
+
+      cy.task<InsertedStopRegistryIds>('insertStopRegistryData', {
+        ...baseStopRegistryData,
+        stopAreas: stopAreaData,
+      }).then((data) => {
+        const id = data.stopAreaIdsByName.X0003;
+
+        cy.setupTests();
+        cy.mockLogin();
+
+        stopAreaDetailsPage.visit(id);
+      });
+    });
+
+    function testMemberStopRow(label: string) {
+      const { memberStops } = stopAreaDetailsPage;
+
+      memberStops.getStopRow(label).shouldBeVisible();
+
+      memberStops.getStopRow(label).within(() => {
+        memberStops
+          .getLink()
+          .shouldBeVisible()
+          .should('have.attr', 'href', `/stop-registry/stops/${label}`);
+
+        memberStops.getShowOnMapButton().shouldBeVisible();
+
+        memberStops.getActionMenu().click();
+        memberStops
+          .getShowStopDetailsMenuItem()
+          .shouldBeVisible()
+          .shouldHaveText('Näytä pysäkin tiedot');
+        memberStops
+          .getShowOnMapMenuItem()
+          .shouldBeVisible()
+          .shouldHaveText('Näytä pysäkki kartalla');
+        memberStops
+          .getRemoveStopMenuItem()
+          .shouldBeVisible()
+          .shouldBeDisabled()
+          .shouldHaveText('Poista pysäkki pysäkkialueelta');
+      });
+    }
+
+    it('should have basic info', () => {
+      stopAreaDetailsPage.titleRow.getName().shouldHaveText('X0003');
+      stopAreaDetailsPage.titleRow
+        .getDescription()
+        .shouldHaveText('Annankatu 15');
+
+      stopAreaDetailsPage.versioningRow
+        .getValidityPeriod()
+        .shouldHaveText('1.1.2020-1.1.2050');
+
+      const { details } = stopAreaDetailsPage;
+      details.getName().shouldHaveText('X0003');
+      details.getDescription().shouldHaveText('Annankatu 15');
+      details.getParentStopPlace().shouldHaveText('-');
+      details.getAreaSize().shouldHaveText('-');
+      details.getValidityPeriod().shouldHaveText('1.1.2020-1.1.2050');
+
+      testMemberStopRow('E2E001');
+      testMemberStopRow('E2E009');
+    });
+  });
+});

--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -30,6 +30,7 @@ import {
 } from '../../pageObjects';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
+import { InsertedStopRegistryIds } from '../utils';
 
 // These infralink IDs exist in the 'infraLinks.sql' test data file.
 // These form a straight line on Eerikinkatu in Helsinki.
@@ -127,7 +128,7 @@ describe('Stop details', () => {
 
     insertToDbHelper(dbResources);
     toast = new Toast();
-    cy.task<string[]>('insertStopRegistryData', {
+    cy.task<InsertedStopRegistryIds>('insertStopRegistryData', {
       stopPlaces: stopPlaceData,
       organisations: seedOrganisations,
     });

--- a/cypress/e2e/stop-registry/stopSearch.cy.ts
+++ b/cypress/e2e/stop-registry/stopSearch.cy.ts
@@ -16,6 +16,7 @@ import { StopSearchBar } from '../../pageObjects/stop-registry/StopSearchBar';
 import { StopSearchResultsPage } from '../../pageObjects/stop-registry/StopSearchResultsPage';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
+import { InsertedStopRegistryIds } from '../utils';
 
 // These infralink IDs exist in the 'infraLinks.sql' test data file.
 // These form a straight line on Eerikinkatu in Helsinki.
@@ -201,7 +202,7 @@ describe('Stop search', () => {
     cy.task('resetDbs');
     insertToDbHelper(dbResources);
 
-    cy.task<string[]>('insertStopRegistryData', {
+    cy.task<InsertedStopRegistryIds>('insertStopRegistryData', {
       stopPlaces: stopPlaceData,
     });
 

--- a/cypress/e2e/utils/tasks.ts
+++ b/cypress/e2e/utils/tasks.ts
@@ -3,7 +3,10 @@ import {
   GetAllStopAreaIdsResult,
   GetAllStopPlaceIdsResult,
   GetInfrastructureLinksByExternalIdsResult,
+  OrganisationIdsByName,
+  StopAreaIdsByName,
   StopAreaInput,
+  StopPlaceIdsByLabel,
   StopPlaceInput,
   StopRegistryOrganisationInput,
   e2eDatabaseConfig,
@@ -100,6 +103,12 @@ export const getInfrastructureLinkIdsByExternalIds = (
     });
   });
 
+export type InsertedStopRegistryIds = {
+  stopAreaIdsByName: StopAreaIdsByName;
+  stopPlaceIdsByLabel: StopPlaceIdsByLabel;
+  organisationIdsByName: OrganisationIdsByName;
+};
+
 export const insertStopRegistryData = async ({
   organisations = [],
   stopAreas = [],
@@ -108,7 +117,7 @@ export const insertStopRegistryData = async ({
   organisations?: Array<StopRegistryOrganisationInput>;
   stopAreas?: Array<StopAreaInput>;
   stopPlaces?: Array<StopPlaceInput>;
-}) => {
+}): Promise<InsertedStopRegistryIds> => {
   const organisationIdsByName =
     await insertStopRegistryOrganisations(organisations);
 
@@ -124,9 +133,9 @@ export const insertStopRegistryData = async ({
   const stopAreaInputs = stopAreas.map((area) =>
     setStopAreaRelations(area, stopPlaceIdsByLabel),
   );
-  await insertStopRegistryStopAreas(stopAreaInputs);
+  const stopAreaIdsByName = await insertStopRegistryStopAreas(stopAreaInputs);
 
-  return { stopPlaceIdsByLabel, organisationIdsByName };
+  return { stopAreaIdsByName, stopPlaceIdsByLabel, organisationIdsByName };
 };
 
 export const truncateTimetablesDatabase = () => {

--- a/cypress/pageObjects/stop-registry/StopAreaDetailsPage.ts
+++ b/cypress/pageObjects/stop-registry/StopAreaDetailsPage.ts
@@ -1,0 +1,23 @@
+import {
+  StopAreaDetails,
+  StopAreaMemberStops,
+  StopAreaMinimap,
+  StopAreaTitleRow,
+  StopAreaVersioningRow,
+} from './stop-area-details';
+
+export class StopAreaDetailsPage {
+  details = new StopAreaDetails();
+
+  memberStops = new StopAreaMemberStops();
+
+  minimap = new StopAreaMinimap();
+
+  titleRow = new StopAreaTitleRow();
+
+  versioningRow = new StopAreaVersioningRow();
+
+  visit(netexId: string) {
+    cy.visit(`/stop-registry/stop-areas/${netexId}`);
+  }
+}

--- a/cypress/pageObjects/stop-registry/index.ts
+++ b/cypress/pageObjects/stop-registry/index.ts
@@ -1,3 +1,4 @@
+export * from './StopAreaDetailsPage';
 export * from './stop-details';
 export * from './StopDetailsPage';
 export * from './StopSearchBar';

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaDetails.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaDetails.ts
@@ -1,0 +1,13 @@
+export class StopAreaDetails {
+  getEditButton = () => cy.getByTestId('StopAreaDetails::editButton');
+
+  getName = () => cy.getByTestId('StopAreaDetails::name');
+
+  getDescription = () => cy.getByTestId('StopAreaDetails::description');
+
+  getParentStopPlace = () => cy.getByTestId('StopAreaDetails::parentStopPlace');
+
+  getAreaSize = () => cy.getByTestId('StopAreaDetails::areaSize');
+
+  getValidityPeriod = () => cy.getByTestId('StopAreaDetails::validityPeriod');
+}

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMemberStops.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMemberStops.ts
@@ -1,0 +1,20 @@
+export class StopAreaMemberStops {
+  getStopRow = (label: string) => cy.getByTestId(`StopTableRow::row::${label}`);
+
+  getLink = () => cy.getByTestId('StopTableRow::link');
+
+  getShowOnMapButton = () => cy.getByTestId('LocatorButton::button');
+
+  getActionMenu = () => cy.getByTestId('StopTableRow::actionMenu');
+
+  getShowStopDetailsMenuItem = () =>
+    cy.getByTestId('StopTableRow::ActionMenu::ShowStopDetails');
+
+  getShowOnMapMenuItem = () =>
+    cy.getByTestId('StopTableRow::ActionMenu::ShowOnMap');
+
+  getRemoveStopMenuItem = () =>
+    cy.getByTestId('StopTableRow::ActionMenu::removeStopMenuItem');
+
+  getAddStopButton = () => cy.getByTestId('MemberStops::addStopButton');
+}

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMinimap.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMinimap.ts
@@ -1,0 +1,3 @@
+export class StopAreaMinimap {
+  getOpenMapButton = () => cy.getByTestId('StopAreaMinimap::openMapButton');
+}

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaTitleRow.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaTitleRow.ts
@@ -1,0 +1,5 @@
+export class StopAreaTitleRow {
+  getDescription = () => cy.getByTestId('StopAreaTitleRow::description');
+
+  getName = () => cy.getByTestId('StopAreaTitleRow::name');
+}

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaVersioningRow.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaVersioningRow.ts
@@ -1,0 +1,4 @@
+export class StopAreaVersioningRow {
+  getValidityPeriod = () =>
+    cy.getByTestId('StopAreaVersioningRow::validityPeriod');
+}

--- a/cypress/pageObjects/stop-registry/stop-area-details/index.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/index.ts
@@ -1,0 +1,5 @@
+export * from './StopAreaDetails';
+export * from './StopAreaMemberStops';
+export * from './StopAreaMinimap';
+export * from './StopAreaTitleRow';
+export * from './StopAreaVersioningRow';

--- a/test-db-manager/src/datasets/stopRegistry/mappers.ts
+++ b/test-db-manager/src/datasets/stopRegistry/mappers.ts
@@ -9,8 +9,9 @@ import { isNotNullish } from '../../utils';
 import { StopAreaInput } from './stopArea';
 import { StopPlaceInput, StopPlaceMaintenance } from './stopPlaces';
 
-export type StopPlaceIdsByLabel = Map<string, string>;
-export type OrganisationIdsByName = Map<string, string>;
+export type StopAreaIdsByName = Record<string, string>;
+export type StopPlaceIdsByLabel = Record<string, string>;
+export type OrganisationIdsByName = Record<string, string>;
 
 const mapStopPlaceMaintenanceToInput = (
   maintenance: StopPlaceMaintenance | undefined | null,
@@ -28,7 +29,7 @@ const mapStopPlaceMaintenanceToInput = (
         }
 
         const maintenanceOrganisationId =
-          organisationIdsByName.get(organisationName);
+          organisationIdsByName[organisationName];
         if (!maintenanceOrganisationId) {
           throw new Error(
             `Could not find organisation with name ${organisationName}`,
@@ -72,7 +73,7 @@ export const setStopAreaRelations = (
     members: input.memberLabels.map(
       (label) =>
         ({
-          ref: stopPlaceIdsByLabel.get(label),
+          ref: stopPlaceIdsByLabel[label],
         }) as StopRegistryVersionLessEntityRefInput,
     ),
   };

--- a/ui/src/components/stop-registry/search/StopTableRow/ActionMenuTd.tsx
+++ b/ui/src/components/stop-registry/search/StopTableRow/ActionMenuTd.tsx
@@ -2,6 +2,10 @@ import { FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlignDirection, SimpleDropdownMenu } from '../../../../uiComponents';
 
+const testIds = {
+  actionMenu: 'StopTableRow::actionMenu',
+};
+
 type ActionMenuTdProps = {
   readonly className?: string;
   readonly menuItems: ReactNode;
@@ -18,6 +22,7 @@ export const ActionMenuTd: FC<ActionMenuTdProps> = ({
       <SimpleDropdownMenu
         tooltip={t('accessibility:common.actionMenu')}
         alignItems={AlignDirection.Left}
+        testId={testIds.actionMenu}
       >
         {menuItems}
       </SimpleDropdownMenu>


### PR DESCRIPTION
### E2E: Updated datasets
Cherry-plucked out of Stop Area Map E2E test pr.

### E2E: Improve insertStopRegistryData Cypress task
* Return IDs for Stop Areas too
* Store Label/Name → ID mapping in raw objects instead of Maps. Maps seem to get serialized into empty objects after being return from the task.
* Use correct type on call sites.

### E2E: Add initial tests for StopAreaDetailsPage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/903)
<!-- Reviewable:end -->
