### PR TITLE
Edit stop area on details page

### DIFF
--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -102,8 +102,8 @@ describe('Stop area details', () => {
         memberStops
           .getRemoveStopMenuItem()
           .shouldBeVisible()
-          .shouldBeDisabled()
           .shouldHaveText('Poista pysäkki pysäkkialueelta');
+        memberStops.getActionMenu().click();
       });
     }
 

--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -10,36 +10,72 @@ import {
   testInfraLinkExternalIds,
 } from '../../datasets/base';
 import { getClonedBaseStopRegistryData } from '../../datasets/stopRegistry';
-import { StopAreaDetailsPage } from '../../pageObjects';
+import {
+  SelectMemberStopsDropdown,
+  StopAreaDetailsPage,
+  Toast,
+} from '../../pageObjects';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
 import { InsertedStopRegistryIds } from '../utils';
 
+function mapToShortDate(date: DateTime | null) {
+  if (!date) {
+    return '';
+  }
+
+  return date.setLocale('fi').toFormat('d.L.yyyy');
+}
+
+type ExpectedBasicDetails = {
+  readonly name: string;
+  readonly description: string;
+  readonly parentStopPlace: string;
+  readonly areaSize: string;
+  readonly validFrom: DateTime;
+  readonly validTo: DateTime | null;
+  readonly longitude: number;
+  readonly latitude: number;
+};
+
 describe('Stop area details', () => {
   const stopAreaDetailsPage = new StopAreaDetailsPage();
+  const toast = new Toast();
+  const selectMemberStopsDropdown = new SelectMemberStopsDropdown();
 
   let dbResources: SupportedResources;
 
   const baseDbResources = getClonedBaseDbResources();
   const baseStopRegistryData = getClonedBaseStopRegistryData();
 
-  const stopAreaData: Array<StopAreaInput> = [
-    {
-      memberLabels: ['E2E001', 'E2E009'],
-      stopArea: {
-        name: { lang: 'fin', value: 'X0003' },
-        description: { lang: 'fin', value: 'Annankatu 15' },
-        validBetween: {
-          fromDate: DateTime.fromISO('2020-01-01T00:00:00.001'),
-          toDate: DateTime.fromISO('2050-01-01T00:00:00.001'),
-        },
-        geometry: {
-          coordinates: [24.938927, 60.165433],
-          type: StopRegistryGeoJsonType.Point,
-        },
+  const testStopArea = {
+    memberLabels: ['E2E001', 'E2E009'],
+    stopArea: {
+      name: { lang: 'fin', value: 'X0003' },
+      description: { lang: 'fin', value: 'Annankatu 15' },
+      validBetween: {
+        fromDate: DateTime.fromISO('2020-01-01T00:00:00.001'),
+        toDate: DateTime.fromISO('2050-01-01T00:00:00.001'),
+      },
+      geometry: {
+        coordinates: [24.938927, 60.165433],
+        type: StopRegistryGeoJsonType.Point,
       },
     },
-  ];
+  };
+
+  const stopAreaData: Array<StopAreaInput> = [testStopArea];
+
+  const testAreaExpectedBasicDetails: ExpectedBasicDetails = {
+    name: testStopArea.stopArea.name.value,
+    description: testStopArea.stopArea.description.value,
+    validFrom: testStopArea.stopArea.validBetween.fromDate,
+    validTo: testStopArea.stopArea.validBetween.toDate,
+    areaSize: '-',
+    parentStopPlace: '-',
+    longitude: testStopArea.stopArea.geometry.coordinates[0],
+    latitude: testStopArea.stopArea.geometry.coordinates[1],
+  };
 
   before(() => {
     cy.task<UUID[]>(
@@ -58,25 +94,49 @@ describe('Stop area details', () => {
     });
   });
 
-  describe('View basic details', () => {
-    beforeEach(() => {
-      cy.task('resetDbs');
+  beforeEach(() => {
+    cy.task('resetDbs');
 
-      insertToDbHelper(dbResources);
+    insertToDbHelper(dbResources);
 
-      cy.task<InsertedStopRegistryIds>('insertStopRegistryData', {
-        ...baseStopRegistryData,
-        stopAreas: stopAreaData,
-      }).then((data) => {
-        const id = data.stopAreaIdsByName.X0003;
+    cy.task<InsertedStopRegistryIds>('insertStopRegistryData', {
+      ...baseStopRegistryData,
+      stopAreas: stopAreaData,
+    }).then((data) => {
+      const id = data.stopAreaIdsByName.X0003;
 
-        cy.setupTests();
-        cy.mockLogin();
+      cy.setupTests();
+      cy.mockLogin();
 
-        stopAreaDetailsPage.visit(id);
-      });
+      stopAreaDetailsPage.visit(id);
     });
+  });
 
+  function assertBasicDetails(expected: ExpectedBasicDetails) {
+    stopAreaDetailsPage.titleRow.getName().shouldHaveText(expected.name);
+    stopAreaDetailsPage.titleRow
+      .getDescription()
+      .shouldHaveText(expected.description);
+
+    const validity = `${mapToShortDate(expected.validFrom)}-${mapToShortDate(expected.validTo)}`;
+    stopAreaDetailsPage.versioningRow
+      .getValidityPeriod()
+      .shouldHaveText(validity);
+
+    const { details } = stopAreaDetailsPage;
+    details.getName().shouldHaveText(expected.name);
+    details.getDescription().shouldHaveText(expected.description);
+    details.getParentStopPlace().shouldHaveText(expected.parentStopPlace);
+    details.getAreaSize().shouldHaveText(expected.areaSize);
+    details.getValidityPeriod().shouldHaveText(validity);
+
+    stopAreaDetailsPage.minimap
+      .getMarker()
+      .should('have.attr', 'data-longitude', expected.longitude)
+      .should('have.attr', 'data-latitude', expected.latitude);
+  }
+
+  describe('View basic details', () => {
     function testMemberStopRow(label: string) {
       const { memberStops } = stopAreaDetailsPage;
 
@@ -108,24 +168,179 @@ describe('Stop area details', () => {
     }
 
     it('should have basic info', () => {
-      stopAreaDetailsPage.titleRow.getName().shouldHaveText('X0003');
-      stopAreaDetailsPage.titleRow
-        .getDescription()
-        .shouldHaveText('Annankatu 15');
-
-      stopAreaDetailsPage.versioningRow
-        .getValidityPeriod()
-        .shouldHaveText('1.1.2020-1.1.2050');
-
-      const { details } = stopAreaDetailsPage;
-      details.getName().shouldHaveText('X0003');
-      details.getDescription().shouldHaveText('Annankatu 15');
-      details.getParentStopPlace().shouldHaveText('-');
-      details.getAreaSize().shouldHaveText('-');
-      details.getValidityPeriod().shouldHaveText('1.1.2020-1.1.2050');
+      assertBasicDetails(testAreaExpectedBasicDetails);
 
       testMemberStopRow('E2E001');
       testMemberStopRow('E2E009');
+    });
+  });
+
+  describe('Editing', () => {
+    function assertEditButtonsEnabled() {
+      stopAreaDetailsPage.details
+        .getEditButton()
+        .shouldBeVisible()
+        .should('not.be.disabled');
+
+      stopAreaDetailsPage.memberStops
+        .getAddStopButton()
+        .shouldBeVisible()
+        .should('not.be.disabled');
+    }
+
+    function setValidity(from: DateTime, to: DateTime | null) {
+      stopAreaDetailsPage.details.edit.validity.setStartDate(
+        from.toISODate() ?? '',
+      );
+      if (to) {
+        stopAreaDetailsPage.details.edit.validity.setAsIndefinite(false);
+        stopAreaDetailsPage.details.edit.validity.setEndDate(
+          to.toISODate() ?? '',
+        );
+      } else {
+        stopAreaDetailsPage.details.edit.validity.setAsIndefinite(true);
+      }
+    }
+
+    it('should not allow editing multiple sections simultaneously', () => {
+      // Initial state, edit buttons enabled
+      assertEditButtonsEnabled();
+
+      // Start editing details
+      stopAreaDetailsPage.details.getEditButton().click();
+
+      // Details save/edit enabled
+      stopAreaDetailsPage.details.getEditButton().should('not.exist');
+      stopAreaDetailsPage.details.edit.getCancelButton().shouldBeVisible();
+      stopAreaDetailsPage.details.edit.getSaveButton().shouldBeVisible();
+      stopAreaDetailsPage.details.edit.getLabel().shouldBeVisible();
+      stopAreaDetailsPage.details.edit.getName().shouldBeVisible();
+      stopAreaDetailsPage.details.edit
+        .getLongitude()
+        .shouldBeVisible()
+        .shouldBeDisabled();
+      stopAreaDetailsPage.details.edit
+        .getLatitude()
+        .shouldBeVisible()
+        .shouldBeDisabled();
+      stopAreaDetailsPage.details.edit.validity
+        .getStartDateInput()
+        .shouldBeVisible();
+      stopAreaDetailsPage.details.edit.validity
+        .getEndDateInput()
+        .shouldBeVisible();
+      stopAreaDetailsPage.details.edit.validity
+        .getIndefiniteCheckbox()
+        .shouldBeVisible();
+
+      // Member stops no editing available
+      stopAreaDetailsPage.memberStops.getAddStopButton().should('not.exist');
+      stopAreaDetailsPage.memberStops.getCancelButton().should('not.exist');
+      stopAreaDetailsPage.memberStops.getSaveButton().should('not.exist');
+      stopAreaDetailsPage.memberStops
+        .getSelectMemberStops()
+        .should('not.exist');
+
+      // Cancel editing details & Start editing members
+      stopAreaDetailsPage.details.edit.getCancelButton().click();
+      assertEditButtonsEnabled();
+      stopAreaDetailsPage.memberStops.getAddStopButton().click();
+
+      // Member stop editing enabled
+      stopAreaDetailsPage.memberStops.getAddStopButton().should('not.exist');
+      stopAreaDetailsPage.memberStops.getCancelButton().shouldBeVisible();
+      stopAreaDetailsPage.memberStops.getSaveButton().shouldBeVisible();
+      stopAreaDetailsPage.memberStops.getSelectMemberStops().shouldBeVisible();
+
+      // Details editing disabled
+      stopAreaDetailsPage.details.getEditButton().should('not.exist');
+      stopAreaDetailsPage.details.edit.getCancelButton().should('not.exist');
+      stopAreaDetailsPage.details.edit.getSaveButton().should('not.exist');
+
+      // Cancel editing members
+      stopAreaDetailsPage.memberStops.getCancelButton().click();
+      assertEditButtonsEnabled();
+    });
+
+    function waitForSaveToBeFinished() {
+      cy.wait('@gqlUpsertStopArea')
+        .its('response.statusCode')
+        .should('equal', 200);
+      toast.expectSuccessToast('Pysäkkialue muokattu');
+      toast.getSuccessToast().should('not.exist');
+    }
+
+    function inputBasicDetails(inputs: ExpectedBasicDetails) {
+      const { edit } = stopAreaDetailsPage.details;
+
+      edit.getLabel().clearAndType(inputs.name);
+      edit.getName().clearAndType(inputs.description);
+
+      setValidity(inputs.validFrom, inputs.validTo);
+    }
+
+    function testMemberStopEditing() {
+      // Remove stop E2E009
+      stopAreaDetailsPage.memberStops.getAddStopButton().click();
+      // Test remove/add back
+      stopAreaDetailsPage.memberStops.getStopRow('E2E001').within(() => {
+        stopAreaDetailsPage.memberStops.getRemoveButton().click();
+        stopAreaDetailsPage.memberStops.getAddBackButton().click();
+      });
+      stopAreaDetailsPage.memberStops.getStopRow('E2E009').within(() => {
+        stopAreaDetailsPage.memberStops.getRemoveButton().click();
+      });
+      stopAreaDetailsPage.memberStops.getSaveButton().click();
+      waitForSaveToBeFinished();
+      stopAreaDetailsPage.memberStops.getStopRow('E2E009').should('not.exist');
+      assertEditButtonsEnabled();
+
+      // Find and add back stop E2E009
+      stopAreaDetailsPage.memberStops.getAddStopButton().click();
+      stopAreaDetailsPage.memberStops.getSelectMemberStops().within(() => {
+        selectMemberStopsDropdown.dropdownButton().click();
+        selectMemberStopsDropdown.getInput().clearAndType('E2E009');
+        selectMemberStopsDropdown.getMemberOptions().should('have.length', 1);
+        selectMemberStopsDropdown
+          .getMemberOptions()
+          .eq(0)
+          .should('contain.text', 'E2E009')
+          .click();
+      });
+      stopAreaDetailsPage.memberStops.getSaveButton().click();
+      waitForSaveToBeFinished();
+    }
+
+    it('should allow editing details & members', () => {
+      assertBasicDetails(testAreaExpectedBasicDetails);
+
+      const newBasicDetails: ExpectedBasicDetails = {
+        ...testAreaExpectedBasicDetails,
+        name: 'New name',
+        description: 'New description',
+        validFrom: DateTime.now(),
+        validTo: null,
+      };
+
+      // Edit basic details
+      stopAreaDetailsPage.details.getEditButton().click();
+      inputBasicDetails(newBasicDetails);
+      stopAreaDetailsPage.details.edit.getSaveButton().click();
+      waitForSaveToBeFinished();
+
+      // Should have saved the changes and be back at view mode with new details
+      assertEditButtonsEnabled();
+      assertBasicDetails(newBasicDetails);
+
+      // Edit member stops
+      testMemberStopEditing();
+
+      // Both stops should be present in the end
+      stopAreaDetailsPage.memberStops.getStopRow('E2E001').shouldBeVisible();
+      stopAreaDetailsPage.memberStops.getStopRow('E2E009').shouldBeVisible();
+
+      // And the basic details should still match newBasicDetails
+      assertBasicDetails(newBasicDetails);
     });
   });
 });

--- a/cypress/pageObjects/SelectMemberStopsDropdown.ts
+++ b/cypress/pageObjects/SelectMemberStopsDropdown.ts
@@ -1,0 +1,17 @@
+export class SelectMemberStopsDropdown {
+  dropdownButton() {
+    return cy.getByTestId('SelectMemberStopsDropdownButton');
+  }
+
+  getInput() {
+    return cy.getByTestId('SelectMemberStopsDropdown::input');
+  }
+
+  getSelectedMembers() {
+    return cy.getByTestId('SelectedMemberStops::option');
+  }
+
+  getMemberOptions() {
+    return cy.getByTestId('MemberStopOptions::option');
+  }
+}

--- a/cypress/pageObjects/Toast.ts
+++ b/cypress/pageObjects/Toast.ts
@@ -26,4 +26,20 @@ export class Toast {
   checkWarningToastHasMessage(message: string) {
     this.getWarningToast().contains(message);
   }
+
+  expectSuccessToast(message?: string) {
+    // Find any toast
+    cy.get('[data-testElementType="toast"]')
+      // And wait it to become fully visible
+      .should('have.css', 'opacity', '1')
+      // Then assert it is of a right type.
+      .then((toast) => {
+        // eslint-disable-next-line jest/valid-expect
+        expect(toast).have.attr('data-testid', 'success-toast');
+      });
+
+    if (message) {
+      this.checkSuccessToastHasMessage(message);
+    }
+  }
 }

--- a/cypress/pageObjects/index.ts
+++ b/cypress/pageObjects/index.ts
@@ -22,6 +22,7 @@ export * from './RoutePropertiesForm';
 export * from './RouteStopsOverlayRow';
 export * from './RoutesAndLinesPage';
 export * from './SearchResultsPage';
+export * from './SelectMemberStopsDropdown';
 export * from './StopForm';
 export * from './SubstituteDaySettingsPage';
 export * from './TemplateRouteSelector';

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaDetails.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaDetails.ts
@@ -1,4 +1,8 @@
+import { StopAreaDetailsEdit } from './StopAreaDetailsEdit';
+
 export class StopAreaDetails {
+  edit = new StopAreaDetailsEdit();
+
   getEditButton = () => cy.getByTestId('StopAreaDetails::editButton');
 
   getName = () => cy.getByTestId('StopAreaDetails::name');

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaDetailsEdit.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaDetailsEdit.ts
@@ -1,0 +1,17 @@
+import { ValidityPeriodForm } from '../../ValidityPeriodForm';
+
+export class StopAreaDetailsEdit {
+  validity = new ValidityPeriodForm();
+
+  getLabel = () => cy.getByTestId('StopAreaDetailsEdit::label');
+
+  getName = () => cy.getByTestId('StopAreaDetailsEdit::name');
+
+  getLatitude = () => cy.getByTestId('StopAreaDetailsEdit::latitude');
+
+  getLongitude = () => cy.getByTestId('StopAreaDetailsEdit::longitude');
+
+  getCancelButton = () => cy.getByTestId('StopAreaDetailsEdit::cancelButton');
+
+  getSaveButton = () => cy.getByTestId('StopAreaDetailsEdit::saveButton');
+}

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMemberStops.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMemberStops.ts
@@ -17,4 +17,14 @@ export class StopAreaMemberStops {
     cy.getByTestId('StopTableRow::ActionMenu::removeStopMenuItem');
 
   getAddStopButton = () => cy.getByTestId('MemberStops::addStopButton');
+
+  getCancelButton = () => cy.getByTestId('MemberStops::cancelButton');
+
+  getSaveButton = () => cy.getByTestId('MemberStops::saveButton');
+
+  getSelectMemberStops = () => cy.getByTestId('MemberStops::selectMemberStops');
+
+  getRemoveButton = () => cy.getByTestId('StopTableRow::AreaEdit::remove');
+
+  getAddBackButton = () => cy.getByTestId('StopTableRow::AreaEdit::addBack');
 }

--- a/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMinimap.ts
+++ b/cypress/pageObjects/stop-registry/stop-area-details/StopAreaMinimap.ts
@@ -1,3 +1,5 @@
 export class StopAreaMinimap {
   getOpenMapButton = () => cy.getByTestId('StopAreaMinimap::openMapButton');
+
+  getMarker = () => cy.getByTestId('StopAreaMinimap::marker');
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -122,7 +122,10 @@ Cypress.Commands.add('setupTests', () => {
   // label all graphql calls that they can be expected in tests
   // e.g. GetAllLines query can be waited as cy.wait('@gqlGetAllLines')
   cy.intercept('POST', '/api/graphql/**', (req) => {
-    if (req.body && req.body.operationName) {
+    if (
+      typeof req.body === 'object' &&
+      typeof req.body?.operationName === 'string'
+    ) {
       // eslint-disable-next-line no-param-reassign
       req.alias = `gql${req.body.operationName}`;
 
@@ -133,8 +136,9 @@ Cypress.Commands.add('setupTests', () => {
       });
       // eslint-disable-next-line no-param-reassign
       req.headers['X-Environment'] = hasuraEnvironment;
-      req.continue();
     }
+
+    req.continue();
   });
 
   cy.intercept('POST', '/api/hastus/import', (req) => {

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -38,7 +38,7 @@ services:
   jore4-tiamat:
     # Pin tiamat to a compatible version.
     # Note: also update jore4-tiamat-e2e in docker-compose.e2e when changing this.
-    image: "hsldevcom/jore4-tiamat:main--20240918-e524ab5e90e739981b3ed68a08007f39c2604411"
+    image: "hsldevcom/jore4-tiamat:main--20240920-fb94c237e5f9ba67688c65c4d2f19c0b7e744ed6"
 
   jore4-timetablesapi:
     # Pin timetables api to a compatible version.

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -11,7 +11,7 @@ services:
     extends:
       file: docker-compose.base.yml
       service: jore4-tiamat-base
-    image: "hsldevcom/jore4-tiamat:main--20240918-e524ab5e90e739981b3ed68a08007f39c2604411"
+    image: "hsldevcom/jore4-tiamat:main--20240920-fb94c237e5f9ba67688c65c4d2f19c0b7e744ed6"
     container_name: "tiamat-e2e"
     environment:
       - TIAMAT_DB_URL=jdbc:postgresql://jore4-testdb-e2e:5432/stopdb?stringtype=unspecified

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/MemberStopOptions.tsx
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/MemberStopOptions.tsx
@@ -3,6 +3,10 @@ import { FC } from 'react';
 import { MdOutlineAddCircle } from 'react-icons/md';
 import { StopAreaFormMember } from '../stopAreaFormSchema';
 
+const testIds = {
+  option: 'MemberStopOptions::option',
+};
+
 type MemberStopOptionsProps = {
   readonly options: ReadonlyArray<StopAreaFormMember>;
 };
@@ -14,6 +18,7 @@ export const MemberStopOptions: FC<MemberStopOptionsProps> = ({ options }) => {
       key={stop.id}
       value={stop}
       className="flex cursor-pointer items-center border-b p-2 text-left focus:outline-none ui-active:bg-dark-grey ui-active:text-white"
+      data-testid={testIds.option}
     >
       <span>
         <strong>{stop.scheduled_stop_point.label}</strong>{' '}

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
@@ -1,5 +1,6 @@
 import { Combobox as HUICombobox, Transition } from '@headlessui/react';
 import { FC, useMemo, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 import { dropdownTransition } from '../../../../uiComponents';
 import { log } from '../../../../utils';
 import { StopAreaFormMember } from '../stopAreaFormSchema';
@@ -33,6 +34,7 @@ function compareMembersByLabel(
 }
 
 type SelectMemberStopsDropdownProps = {
+  readonly className?: string;
   readonly value: Array<StopAreaFormMember> | undefined;
   readonly editedStopAreaId: string | null | undefined;
   readonly onChange: (selected: Array<StopAreaFormMember>) => void;
@@ -40,6 +42,7 @@ type SelectMemberStopsDropdownProps = {
 };
 
 export const SelectMemberStopsDropdown: FC<SelectMemberStopsDropdownProps> = ({
+  className = '',
   value = [],
   editedStopAreaId,
   onChange,
@@ -94,7 +97,7 @@ export const SelectMemberStopsDropdown: FC<SelectMemberStopsDropdownProps> = ({
     <HUICombobox
       as="div"
       by={stopAreaFormMembersAreSame}
-      className="relative w-full"
+      className={twMerge('relative w-full', className)}
       multiple
       nullable={false}
       onChange={onChangeInternal}

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
@@ -12,6 +12,10 @@ import {
 import { SelectMemberStopsDropdownButton } from './SelectMemberStopsDropdownButton';
 import { useFindStopPlaceByQuery } from './useFindStopPlaceByQuery';
 
+const testIds = {
+  input: 'SelectMemberStopsDropdown::input',
+};
+
 function stopAreaFormMembersAreSame(
   a: StopAreaFormMember,
   b: StopAreaFormMember,
@@ -32,12 +36,14 @@ type SelectMemberStopsDropdownProps = {
   readonly value: Array<StopAreaFormMember> | undefined;
   readonly editedStopAreaId: string | null | undefined;
   readonly onChange: (selected: Array<StopAreaFormMember>) => void;
+  readonly testId?: string;
 };
 
 export const SelectMemberStopsDropdown: FC<SelectMemberStopsDropdownProps> = ({
   value = [],
   editedStopAreaId,
   onChange,
+  testId,
 }: SelectMemberStopsDropdownProps) => {
   const [query, setQuery] = useState('');
   const cleanQuery = query.trim();
@@ -94,12 +100,14 @@ export const SelectMemberStopsDropdown: FC<SelectMemberStopsDropdownProps> = ({
       onChange={onChangeInternal}
       value={value}
       ref={onCloseRef}
+      data-testid={testId}
     >
       <div className="relative w-full">
         <HUICombobox.Input
           className="relative h-full w-full border border-grey bg-white px-2 py-3 ui-open:rounded-b-none ui-not-open:rounded-md"
           onChange={(e) => setQuery(e.target.value)}
           value={query}
+          data-testid={testIds.input}
         />
 
         <SelectMemberStopsDropdownButton selected={value} />

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdownButton.tsx
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdownButton.tsx
@@ -3,6 +3,10 @@ import { FC } from 'react';
 import { MdSearch } from 'react-icons/md';
 import { StopAreaFormMember } from '../stopAreaFormSchema';
 
+const testIds = {
+  button: 'SelectMemberStopsDropdownButton',
+};
+
 type SelectMemberStopsDropdownButtonProps = {
   readonly selected: ReadonlyArray<StopAreaFormMember>;
 };
@@ -11,7 +15,10 @@ export const SelectMemberStopsDropdownButton: FC<
   SelectMemberStopsDropdownButtonProps
 > = ({ selected }) => {
   return (
-    <HUICombobox.Button className="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none">
+    <HUICombobox.Button
+      data-testid={testIds.button}
+      className="absolute inset-y-0 right-0 flex h-full w-full items-center justify-end px-3 text-left focus:outline-none"
+    >
       <span className="hidden ui-not-open:block">
         {selected.map((stop, i) => (
           <span

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectedMemberStops.tsx
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectedMemberStops.tsx
@@ -3,6 +3,10 @@ import { FC } from 'react';
 import { MdOutlineClear } from 'react-icons/md';
 import { StopAreaFormMember } from '../stopAreaFormSchema';
 
+const testIds = {
+  option: 'SelectedMemberStops::option',
+};
+
 type SelectedMemberStopsProps = {
   readonly selected: ReadonlyArray<StopAreaFormMember>;
 };
@@ -22,6 +26,7 @@ export const SelectedMemberStops: FC<SelectedMemberStopsProps> = ({
           value={stop}
           className="flex cursor-pointer flex-row items-center rounded-md bg-brand px-2 py-1 font-bold text-white ui-active:bg-brand-darker"
           title={`${stop.scheduled_stop_point.label}: ${stop.name.value}`}
+          data-testid={testIds.option}
         >
           {stop.scheduled_stop_point.label}
           <MdOutlineClear className="ml-1 text-xl" />

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import { useLoader } from '../../../../hooks';
 import { Container } from '../../../../layoutComponents';
@@ -9,6 +9,7 @@ import {
   StopAreaTitleRow,
   StopAreaVersioningRow,
 } from './components';
+import { StopAreaEditableBlock } from './StopAreaEditableBlock';
 import { useGetStopAreaDetails } from './useGetStopAreaDetails';
 
 const testIds = {
@@ -17,6 +18,10 @@ const testIds = {
 
 export const StopAreaDetailsPage: FC<Record<string, never>> = () => {
   const { id } = useParams();
+
+  const [blockInEdit, setBlockInEdit] = useState<StopAreaEditableBlock | null>(
+    null,
+  );
 
   const { area, loading, refetch } = useGetStopAreaDetails(id ?? '');
   const { setLoadingState } = useLoader(Operation.FetchStopAreaPageDetails, {
@@ -42,8 +47,18 @@ export const StopAreaDetailsPage: FC<Record<string, never>> = () => {
       <StopAreaTitleRow area={area} />
       <hr />
       <StopAreaVersioningRow area={area} />
-      <StopAreaDetailsAndMap area={area} refetch={refetch} />
-      <StopAreaMemberStops area={area} refetch={refetch} />
+      <StopAreaDetailsAndMap
+        area={area}
+        blockInEdit={blockInEdit}
+        onEditBlock={setBlockInEdit}
+        refetch={refetch}
+      />
+      <StopAreaMemberStops
+        area={area}
+        blockInEdit={blockInEdit}
+        onEditBlock={setBlockInEdit}
+        refetch={refetch}
+      />
     </Container>
   );
 };

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage.tsx
@@ -43,7 +43,7 @@ export const StopAreaDetailsPage: FC<Record<string, never>> = () => {
       <hr />
       <StopAreaVersioningRow area={area} />
       <StopAreaDetailsAndMap area={area} refetch={refetch} />
-      <StopAreaMemberStops area={area} />
+      <StopAreaMemberStops area={area} refetch={refetch} />
     </Container>
   );
 };

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage.tsx
@@ -18,7 +18,7 @@ const testIds = {
 export const StopAreaDetailsPage: FC<Record<string, never>> = () => {
   const { id } = useParams();
 
-  const { area, loading } = useGetStopAreaDetails(id ?? '');
+  const { area, loading, refetch } = useGetStopAreaDetails(id ?? '');
   const { setLoadingState } = useLoader(Operation.FetchStopAreaPageDetails, {
     initialState: area ? LoadingState.NotLoading : LoadingState.MediumPriority,
   });
@@ -42,7 +42,7 @@ export const StopAreaDetailsPage: FC<Record<string, never>> = () => {
       <StopAreaTitleRow area={area} />
       <hr />
       <StopAreaVersioningRow area={area} />
-      <StopAreaDetailsAndMap area={area} />
+      <StopAreaDetailsAndMap area={area} refetch={refetch} />
       <StopAreaMemberStops area={area} />
     </Container>
   );

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaEditableBlock.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/StopAreaEditableBlock.ts
@@ -1,0 +1,4 @@
+export enum StopAreaEditableBlock {
+  DETAILS = 'DETAILS',
+  MEMBERS = 'MEMBERS',
+}

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/MemberStopMenuActionButtons/EditModeActionButton.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/MemberStopMenuActionButtons/EditModeActionButton.tsx
@@ -7,8 +7,8 @@ import { IconButton, commonHoverStyle } from '../../../../../../uiComponents';
 import { StopAreaFormMember } from '../../../../../forms/stop-area';
 
 const testIds = {
-  removeButton: '',
-  addBackButton: '',
+  removeButton: 'StopTableRow::AreaEdit::remove',
+  addBackButton: 'StopTableRow::AreaEdit::addBack',
 };
 
 function stopSearchRowToStopAreaFormMember(

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/MemberStopMenuActionButtons/EditModeActionButton.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/MemberStopMenuActionButtons/EditModeActionButton.tsx
@@ -1,0 +1,73 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MdDelete, MdUndo } from 'react-icons/md';
+import { twMerge } from 'tailwind-merge';
+import { StopSearchRow } from '../../../../../../hooks';
+import { IconButton, commonHoverStyle } from '../../../../../../uiComponents';
+import { StopAreaFormMember } from '../../../../../forms/stop-area';
+
+const testIds = {
+  removeButton: '',
+  addBackButton: '',
+};
+
+function stopSearchRowToStopAreaFormMember(
+  stop: StopSearchRow,
+): StopAreaFormMember {
+  return {
+    id: stop.stop_place.netexId as string,
+    name: {
+      lang: 'fin',
+      value: stop.stop_place.nameFin as string,
+    },
+    scheduled_stop_point: {
+      label: stop.label,
+    },
+  };
+}
+
+type EditModeActionButtonProps = {
+  readonly className?: string;
+  readonly onAddBack: (member: StopAreaFormMember) => void;
+  readonly onRemove: (stopId: string) => void;
+  readonly selected: boolean;
+  readonly stop: StopSearchRow;
+};
+
+export const EditModeActionButton: FC<EditModeActionButtonProps> = ({
+  className = '',
+  onAddBack,
+  onRemove,
+  selected,
+  stop,
+}) => {
+  const { t } = useTranslation();
+
+  const allClasses = twMerge(
+    'h-10 w-10 rounded-full border border-grey bg-white text-tweaked-brand',
+    commonHoverStyle,
+    className,
+  );
+
+  if (selected) {
+    return (
+      <IconButton
+        className={allClasses}
+        tooltip={t('stopAreaDetails.memberStops.actionButtons.remove')}
+        onClick={() => onRemove(stop.stop_place.netexId as string)}
+        icon={<MdDelete className="text-2xl" aria-hidden />}
+        testId={testIds.removeButton}
+      />
+    );
+  }
+
+  return (
+    <IconButton
+      className={allClasses}
+      tooltip={t('stopAreaDetails.memberStops.actionButtons.addBack')}
+      onClick={() => onAddBack(stopSearchRowToStopAreaFormMember(stop))}
+      icon={<MdUndo className="text-2xl" aria-hidden />}
+      testId={testIds.addBackButton}
+    />
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/MemberStopMenuItems/RemoveMemberStop.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/MemberStopMenuItems/RemoveMemberStop.tsx
@@ -8,19 +8,25 @@ const testIds = {
   removeStopMenuItem: 'StopTableRow::ActionMenu::removeStopMenuItem',
 };
 
+type RemoveMemberStopProps = StopRowTdProps & {
+  readonly onRemove: (stopId: string) => void;
+};
+
 const RemoveMemberStopImpl: ForwardRefRenderFunction<
   HTMLButtonElement,
-  StopRowTdProps
-> = ({ className }, ref) => {
+  RemoveMemberStopProps
+> = ({ className, onRemove, stop }, ref) => {
   const { t } = useTranslation();
+
+  const id = stop.stop_place.netexId;
 
   return (
     <SimpleDropdownMenuItem
       ref={ref}
-      disabled
       className={className}
+      disabled={!id}
       text={t('stopAreaDetails.memberStops.menuActions.remove')}
-      onClick={noop}
+      onClick={id ? () => onRemove(id) : noop}
       testId={testIds.removeStopMenuItem}
     />
   );

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaComponentProps.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaComponentProps.ts
@@ -4,3 +4,9 @@ export type StopAreaComponentProps = {
   readonly area: StopAreaDetailsFragment;
   readonly className?: string;
 };
+
+export type EditableStopAreaComponentProps = {
+  readonly area: StopAreaDetailsFragment;
+  readonly className?: string;
+  readonly refetch: () => Promise<unknown>;
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaComponentProps.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaComponentProps.ts
@@ -1,4 +1,6 @@
+import { Dispatch, SetStateAction } from 'react';
 import { StopAreaDetailsFragment } from '../../../../../generated/graphql';
+import { StopAreaEditableBlock } from '../StopAreaEditableBlock';
 
 export type StopAreaComponentProps = {
   readonly area: StopAreaDetailsFragment;
@@ -8,5 +10,7 @@ export type StopAreaComponentProps = {
 export type EditableStopAreaComponentProps = {
   readonly area: StopAreaDetailsFragment;
   readonly className?: string;
+  readonly blockInEdit: StopAreaEditableBlock | null;
+  readonly onEditBlock: Dispatch<SetStateAction<StopAreaEditableBlock | null>>;
   readonly refetch: () => Promise<unknown>;
 };

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetails.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetails.tsx
@@ -15,6 +15,7 @@ import { StopAreaDetailsView } from './StopAreaDetailsView';
 
 const testIds = {
   prefix: 'StopAreaDetails',
+  editPrefix: 'StopAreaDetailsEdit',
 };
 
 export const StopAreaDetails: FC<EditableStopAreaComponentProps> = ({
@@ -56,7 +57,9 @@ export const StopAreaDetails: FC<EditableStopAreaComponentProps> = ({
       }}
       controls={infoContainerControls}
       title={t('stopAreaDetails.basicDetails.title')}
-      testIdPrefix={testIds.prefix}
+      testIdPrefix={
+        infoContainerControls.isInEditMode ? testIds.editPrefix : testIds.prefix
+      }
     >
       {infoContainerControls.isInEditMode ? (
         <StopAreaDetailsEdit

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetails.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetails.tsx
@@ -1,9 +1,14 @@
-import { FC, useRef } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';
 import { theme } from '../../../../../generated/theme';
 import { submitFormByRef } from '../../../../../utils';
-import { InfoContainer, useInfoContainerControls } from '../../../../common';
+import {
+  InfoContainer,
+  InfoContainerControls,
+  useInfoContainerControls,
+} from '../../../../common';
+import { StopAreaEditableBlock } from '../StopAreaEditableBlock';
 import { EditableStopAreaComponentProps } from './StopAreaComponentProps';
 import { StopAreaDetailsEdit } from './StopAreaDetailsEdit';
 import { StopAreaDetailsView } from './StopAreaDetailsView';
@@ -15,15 +20,32 @@ const testIds = {
 export const StopAreaDetails: FC<EditableStopAreaComponentProps> = ({
   area,
   className = '',
+  blockInEdit,
+  onEditBlock,
   refetch,
 }) => {
   const { t } = useTranslation();
 
   const formRef = useRef<HTMLFormElement>(null);
-  const infoContainerControls = useInfoContainerControls({
+  const rawInfoContainerControls = useInfoContainerControls({
     isEditable: true,
     onSave: () => submitFormByRef(formRef),
   });
+
+  useEffect(() => {
+    onEditBlock(
+      rawInfoContainerControls.isInEditMode
+        ? StopAreaEditableBlock.DETAILS
+        : null,
+    );
+  }, [rawInfoContainerControls.isInEditMode, onEditBlock]);
+
+  const infoContainerControls: InfoContainerControls = {
+    ...rawInfoContainerControls,
+    isEditable:
+      blockInEdit === StopAreaEditableBlock.DETAILS || blockInEdit === null,
+    isInEditMode: blockInEdit === StopAreaEditableBlock.DETAILS,
+  };
 
   return (
     <InfoContainer

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsAndMap.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsAndMap.tsx
@@ -1,15 +1,16 @@
 import { FC } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { StopAreaComponentProps } from './StopAreaComponentProps';
+import { EditableStopAreaComponentProps } from './StopAreaComponentProps';
 import { StopAreaDetails } from './StopAreaDetails';
 import { StopAreaMinimap } from './StopAreaMinimap';
 
-export const StopAreaDetailsAndMap: FC<StopAreaComponentProps> = ({
+export const StopAreaDetailsAndMap: FC<EditableStopAreaComponentProps> = ({
   area,
   className = '',
+  refetch,
 }) => (
   <div className={twMerge('flex items-stretch gap-2', className)}>
-    <StopAreaDetails area={area} />
+    <StopAreaDetails area={area} refetch={refetch} />
     <StopAreaMinimap area={area} />
   </div>
 );

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsAndMap.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsAndMap.tsx
@@ -7,10 +7,17 @@ import { StopAreaMinimap } from './StopAreaMinimap';
 export const StopAreaDetailsAndMap: FC<EditableStopAreaComponentProps> = ({
   area,
   className = '',
+  blockInEdit,
+  onEditBlock,
   refetch,
 }) => (
   <div className={twMerge('flex items-stretch gap-2', className)}>
-    <StopAreaDetails area={area} refetch={refetch} />
+    <StopAreaDetails
+      area={area}
+      blockInEdit={blockInEdit}
+      onEditBlock={onEditBlock}
+      refetch={refetch}
+    />
     <StopAreaMinimap area={area} />
   </div>
 );

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
@@ -1,0 +1,147 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import React, { ForwardRefRenderFunction, forwardRef, useMemo } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
+import { StopAreaDetailsFragment } from '../../../../../generated/graphql';
+import { useLoader } from '../../../../../hooks';
+import { Column } from '../../../../../layoutComponents';
+import { Operation } from '../../../../../redux';
+import { mapToISODate } from '../../../../../time';
+import { mapLngLatToPoint, showSuccessToast } from '../../../../../utils';
+import {
+  FormColumn,
+  FormRow,
+  InputField,
+  ValidityPeriodForm,
+} from '../../../../forms/common';
+import {
+  StopAreaFormState as FormState,
+  StopAreaFormState,
+  stopAreaFormSchema,
+  stopAreaMemberStopSchema,
+  useUpsertStopArea,
+} from '../../../../forms/stop-area';
+import { EditableStopAreaComponentProps } from './StopAreaComponentProps';
+
+const testIds = {
+  label: 'StopAreaDetailsEdit::label',
+  name: 'StopAreaDetailsEdit::name',
+  latitude: 'StopAreaDetailsEdit::latitude',
+  longitude: 'StopAreaDetailsEdit::longitude',
+};
+
+export const mapStopAreaDataToFormState = (
+  area: StopAreaDetailsFragment,
+): Partial<FormState> => {
+  const { latitude, longitude } = mapLngLatToPoint(
+    area.geometry?.coordinates ?? [],
+  );
+
+  const mappedMembers = area.members
+    ?.map((rawMember) => stopAreaMemberStopSchema.safeParse(rawMember))
+    .filter((parseResult) => parseResult.success)
+    .map((parseResult) => parseResult.data);
+
+  return {
+    label: area.name?.value ?? undefined,
+    name: area.description?.value ?? undefined,
+    latitude,
+    longitude,
+    memberStops: mappedMembers ?? [],
+    validityStart: mapToISODate(area.validBetween?.fromDate),
+    validityEnd: mapToISODate(area.validBetween?.toDate),
+    indefinite: !area.validBetween?.toDate,
+  };
+};
+
+type StopAreaDetailsEditProps = EditableStopAreaComponentProps & {
+  readonly onFinishEditing: () => void;
+};
+
+const StopAreaDetailsEditImpl: ForwardRefRenderFunction<
+  HTMLFormElement,
+  StopAreaDetailsEditProps
+> = ({ area, className = '', onFinishEditing, refetch }, ref) => {
+  const { t } = useTranslation();
+
+  const { upsertStopArea, defaultErrorHandler } = useUpsertStopArea();
+  const { setIsLoading } = useLoader(Operation.ModifyStopArea);
+  const onSubmit = async (state: StopAreaFormState) => {
+    setIsLoading(true);
+    try {
+      await upsertStopArea({ id: area.id, state });
+      await refetch();
+
+      showSuccessToast(t('stopArea.editSuccess'));
+      onFinishEditing();
+    } catch (err) {
+      defaultErrorHandler(err as Error);
+    }
+    setIsLoading(false);
+  };
+
+  const defaultValues = useMemo(() => mapStopAreaDataToFormState(area), [area]);
+  const methods = useForm<FormState>({
+    defaultValues,
+    resolver: zodResolver(stopAreaFormSchema),
+  });
+  const { handleSubmit } = methods;
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <FormProvider {...methods}>
+      <form
+        className={twMerge('space-y-6', className)}
+        onSubmit={handleSubmit(onSubmit)}
+        ref={ref}
+      >
+        <FormColumn>
+          <FormRow lgColumns={4} mdColumns={2}>
+            <Column>
+              <InputField<FormState>
+                type="text"
+                translationPrefix="stopArea"
+                fieldPath="label"
+                testId={testIds.label}
+              />
+            </Column>
+            <Column>
+              <InputField<FormState>
+                type="text"
+                translationPrefix="stopArea"
+                fieldPath="name"
+                testId={testIds.name}
+              />
+            </Column>
+            <Column>
+              <InputField<FormState>
+                type="number"
+                translationPrefix="map"
+                fieldPath="latitude"
+                testId={testIds.latitude}
+                step="any"
+                disabled
+              />
+            </Column>
+            <Column>
+              <InputField<FormState>
+                type="number"
+                translationPrefix="map"
+                fieldPath="longitude"
+                testId={testIds.longitude}
+                step="any"
+                disabled
+              />
+            </Column>
+          </FormRow>
+          <FormRow lgColumns={2} mdColumns={1}>
+            <ValidityPeriodForm />
+          </FormRow>
+        </FormColumn>
+      </form>
+    </FormProvider>
+  );
+};
+
+export const StopAreaDetailsEdit = forwardRef(StopAreaDetailsEditImpl);

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
@@ -22,7 +22,6 @@ import {
   stopAreaMemberStopSchema,
   useUpsertStopArea,
 } from '../../../../forms/stop-area';
-import { EditableStopAreaComponentProps } from './StopAreaComponentProps';
 
 const testIds = {
   label: 'StopAreaDetailsEdit::label',
@@ -55,7 +54,10 @@ export const mapStopAreaDataToFormState = (
   };
 };
 
-type StopAreaDetailsEditProps = EditableStopAreaComponentProps & {
+type StopAreaDetailsEditProps = {
+  readonly area: StopAreaDetailsFragment;
+  readonly className?: string;
+  readonly refetch: () => Promise<unknown>;
   readonly onFinishEditing: () => void;
 };
 

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsView.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsView.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
+import { StopAreaDetailsFragment } from '../../../../../generated/graphql';
+import { mapToShortDate } from '../../../../../time';
+import { DetailRow, LabeledDetail } from '../../../stops/stop-details/layout';
+import { StopAreaComponentProps } from './StopAreaComponentProps';
+
+const testIds = {
+  name: 'StopAreaDetails::name',
+  description: 'StopAreaDetails::description',
+  parentStopPlace: 'StopAreaDetails::parentStopPlace',
+  areaSize: 'StopAreaDetails::areaSize',
+  validityPeriod: 'StopAreaDetails::validityPeriod',
+};
+
+function validityPeriod(area: StopAreaDetailsFragment) {
+  const from = mapToShortDate(area.validBetween?.fromDate);
+  const to = mapToShortDate(area.validBetween?.toDate);
+
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  if (from || to) {
+    return `${from ?? ''}-${to ?? ''}`;
+  }
+
+  return null;
+}
+
+export const StopAreaDetailsView: FC<StopAreaComponentProps> = ({
+  area,
+  className = '',
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <DetailRow className={twMerge('mb-0 flex-grow flex-wrap py-0', className)}>
+      <LabeledDetail
+        title={t('stopAreaDetails.basicDetails.name')}
+        detail={area.name?.value}
+        testId={testIds.name}
+      />
+      <LabeledDetail
+        title={t('stopAreaDetails.basicDetails.description')}
+        detail={area.description?.value}
+        testId={testIds.description}
+      />
+      <LabeledDetail
+        title={t('stopAreaDetails.basicDetails.parentTerminal')}
+        detail={null}
+        testId={testIds.parentStopPlace}
+      />
+      <LabeledDetail
+        title={t('stopAreaDetails.basicDetails.areaSize')}
+        detail={null}
+        testId={testIds.areaSize}
+      />
+      <LabeledDetail
+        title={t('stopAreaDetails.basicDetails.validityPeriod')}
+        detail={validityPeriod(area)}
+        testId={testIds.validityPeriod}
+      />
+    </DetailRow>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopRows.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopRows.tsx
@@ -1,0 +1,201 @@
+import { TFunction } from 'i18next';
+import groupBy from 'lodash/groupBy';
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
+import { StopAreaDetailsFragment } from '../../../../../generated/graphql';
+import { StopSearchRow } from '../../../../../hooks';
+import { StopAreaFormMember } from '../../../../forms/stop-area';
+import { StopTableRow } from '../../../search';
+import { LocatorActionButton } from '../../../search/StopTableRow/ActionButtons/LocatorActionButton';
+import { OpenDetailsPage } from '../../../search/StopTableRow/MenuItems/OpenDetailsPage';
+import { ShowOnMap } from '../../../search/StopTableRow/MenuItems/ShowOnMap';
+import { mapMembersToStopSearchFormat } from '../utils';
+import { EditModeActionButton } from './MemberStopMenuActionButtons/EditModeActionButton';
+import { RemoveMemberStop } from './MemberStopMenuItems/RemoveMemberStop';
+import { StopAreaComponentProps } from './StopAreaComponentProps';
+
+type StopAreaMemberRow = {
+  readonly stop: StopSearchRow;
+  readonly selected: boolean;
+  readonly added: boolean;
+};
+
+function groupBySelectionStatus(
+  existingAreaMembers: ReadonlyArray<StopSearchRow>,
+  selectedIds: ReadonlyArray<string>,
+): Record<'selected' | 'removed', Array<StopSearchRow>> {
+  const grouped = groupBy(existingAreaMembers, (it) =>
+    selectedIds.includes(it.stop_place.netexId as string)
+      ? 'selected'
+      : 'removed',
+  );
+  return {
+    selected: grouped.selected ?? [],
+    removed: grouped.removed ?? [],
+  };
+}
+
+/**
+ * Constructs an imitation of StopSearchRow data
+ * @param member
+ */
+function stopAreaFormMemberToStopSearchRow(
+  member: StopAreaFormMember,
+): StopSearchRow {
+  return {
+    stop_place: {
+      netexId: member.id,
+      nameFin: member.name.value,
+      nameSwe: '',
+    },
+
+    // Incorrect, but unique
+    scheduled_stop_point_id: member.id,
+
+    label: member.scheduled_stop_point.label,
+    measured_location: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+  };
+}
+
+function getStatusText(t: TFunction, row: StopAreaMemberRow): string {
+  if (row.added) {
+    return 'Lisätty';
+  }
+
+  if (!row.selected) {
+    return 'Poistettu';
+  }
+
+  return '';
+}
+
+// A hackish way to add extra info tag to the row in edit mode.
+function tagRowWithStatusText(
+  t: TFunction,
+  row: StopAreaMemberRow,
+): StopAreaMemberRow {
+  return {
+    ...row,
+    stop: {
+      ...row.stop,
+      timing_place: {
+        __typename: 'timing_pattern_timing_place',
+        timing_place_id: '',
+        label: getStatusText(t, row),
+      },
+    },
+  };
+}
+
+function mapRows(
+  t: TFunction,
+  area: StopAreaDetailsFragment,
+  inEditMode: boolean,
+  inEditSelectedStops: ReadonlyArray<StopAreaFormMember>,
+): Array<StopAreaMemberRow> {
+  const existingAreaMembers = mapMembersToStopSearchFormat(area);
+
+  if (!inEditMode) {
+    return existingAreaMembers.map((stop) => ({
+      stop,
+      selected: true,
+      added: false,
+    }));
+  }
+
+  const selectedIds = inEditSelectedStops.map((it) => it.id);
+  const { selected, removed } = groupBySelectionStatus(
+    existingAreaMembers,
+    selectedIds,
+  );
+
+  const existingIds = existingAreaMembers.map((it) => it.stop_place.netexId);
+  const added = inEditSelectedStops
+    .filter((it) => !existingIds.includes(it.id))
+    .map(stopAreaFormMemberToStopSearchRow);
+
+  return [
+    ...selected.map((stop) => ({ stop, selected: true, added: false })),
+    ...removed.map((stop) => ({ stop, selected: false, added: false })),
+    ...added.map((stop) => ({ stop, selected: true, added: true })),
+  ]
+    .map((row) => tagRowWithStatusText(t, row))
+    .sort((a, b) => a.stop.label.localeCompare(b.stop.label));
+}
+
+function getRowBgClassName(added: boolean, selected: boolean) {
+  if (added) {
+    return 'bg-background-hsl-green-10';
+  }
+
+  if (!selected) {
+    return 'bg-background text-grey';
+  }
+
+  return '';
+}
+
+type StopAreaMemberStopRowsProps = StopAreaComponentProps & {
+  readonly onRemove: (stopId: string) => void;
+  readonly onAddBack: (member: StopAreaFormMember) => void;
+  readonly inEditSelectedStops: ReadonlyArray<StopAreaFormMember>;
+  readonly inEditMode: boolean;
+};
+
+export const StopAreaMemberStopRows: FC<StopAreaMemberStopRowsProps> = ({
+  area,
+  className = '',
+  inEditSelectedStops,
+  inEditMode,
+  onAddBack,
+  onRemove,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <table
+      className={twMerge(
+        'mt-4 h-1 w-full border-x border-x-light-grey',
+        className,
+      )}
+    >
+      <tbody>
+        {mapRows(t, area, inEditMode, inEditSelectedStops).map(
+          ({ stop, selected, added }) => (
+            <StopTableRow
+              className={getRowBgClassName(added, selected)}
+              key={stop.scheduled_stop_point_id}
+              inEditMode={inEditMode}
+              stop={stop}
+              actionButtons={
+                inEditMode ? (
+                  <EditModeActionButton
+                    onAddBack={onAddBack}
+                    onRemove={onRemove}
+                    selected={selected}
+                    stop={stop}
+                  />
+                ) : (
+                  <LocatorActionButton stop={stop} />
+                )
+              }
+              menuItems={[
+                <OpenDetailsPage key="OpenDetailsPage" stop={stop} />,
+                <RemoveMemberStop
+                  key="RemoveMemberStop"
+                  stop={stop}
+                  onRemove={onRemove}
+                />,
+                <ShowOnMap key="ShowOnMap" stop={stop} />,
+              ]}
+            />
+          ),
+        )}
+      </tbody>
+    </table>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStops.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStops.tsx
@@ -1,83 +1,222 @@
-import noop from 'lodash/noop';
-import { FC } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { TFunction } from 'i18next';
+import React, {
+  FC,
+  FormEventHandler,
+  ReactNode,
+  useMemo,
+  useState,
+} from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { useLoader } from '../../../../../hooks';
+import { Operation } from '../../../../../redux';
+import { ConfirmationDialog } from '../../../../../uiComponents';
+import { showSuccessToast } from '../../../../../utils';
 import {
-  StopAreaDetailsFragment,
-  StopAreaDetailsMembersFragment,
-} from '../../../../../generated/graphql';
-import { StopSearchRow } from '../../../../../hooks';
-import { getStopPlacesFromQueryResult, notNullish } from '../../../../../utils';
-import { StopTableRow } from '../../../search';
-import { LocatorActionButton } from '../../../search/StopTableRow/ActionButtons/LocatorActionButton';
-import { OpenDetailsPage } from '../../../search/StopTableRow/MenuItems/OpenDetailsPage';
-import { ShowOnMap } from '../../../search/StopTableRow/MenuItems/ShowOnMap';
-import { SlimSimpleButton } from '../../../stops/stop-details/layout';
-import { RemoveMemberStop } from './MemberStopMenuItems/RemoveMemberStop';
+  StopAreaFormState as FormState,
+  StopAreaFormMember,
+  StopAreaFormState,
+  stopAreaFormSchema,
+  useUpsertStopArea,
+} from '../../../../forms/stop-area';
 import { StopAreaComponentProps } from './StopAreaComponentProps';
+import { mapStopAreaDataToFormState } from './StopAreaDetailsEdit';
+import { StopAreaMemberStopRows } from './StopAreaMemberStopRows';
+import { StopAreaMemberStopsEditHeader } from './StopAreaMemberStopsEditHeader';
+import { StopAreaMemberStopsViewHeader } from './StopAreaMemberStopsViewHeader';
 
-const testIds = {
-  addStopButton: 'MemberStops::addStopButton',
+type RootComponentProps = {
+  readonly children: ReactNode;
+  readonly className: string;
+  readonly inEditMode: boolean;
+  readonly onSubmit: FormEventHandler<HTMLFormElement>;
 };
 
-function mapMembersToStopSearchFormat(
-  area: StopAreaDetailsFragment,
-): Array<StopSearchRow> {
-  return getStopPlacesFromQueryResult<StopAreaDetailsMembersFragment>(
-    area.members,
-  )
-    .map((member) => {
-      if (!member.scheduled_stop_point) {
-        return null;
-      }
+const RootComponent: FC<RootComponentProps> = ({
+  children,
+  className,
+  inEditMode,
+  onSubmit,
+}) => {
+  if (inEditMode) {
+    return (
+      <form className={className} onSubmit={onSubmit}>
+        {children}
+      </form>
+    );
+  }
 
-      const stopSearchRow: StopSearchRow = {
-        ...member.scheduled_stop_point,
-        stop_place: {
-          nameFin: member.name?.value,
-          nameSwe: null,
+  return <div className={className}>{children}</div>;
+};
+
+function useMemberStopFormControls(
+  areaId: string | null | undefined,
+  defaultValues: Partial<FormState>,
+  refetch: () => Promise<unknown>,
+  t: TFunction,
+) {
+  const [inEditMode, setInEditMode] = useState(false);
+  const [stopToRemove, setStopToRemove] = useState<string | null>(null);
+
+  const { upsertStopArea, defaultErrorHandler } = useUpsertStopArea();
+  const { setIsLoading } = useLoader(Operation.ModifyStopArea);
+
+  const onSubmit = async (state: StopAreaFormState) => {
+    setIsLoading(true);
+    try {
+      await upsertStopArea({ id: areaId, state });
+      await refetch();
+
+      showSuccessToast(t('stopArea.editSuccess'));
+      setInEditMode(false);
+    } catch (err) {
+      defaultErrorHandler(err as Error);
+    }
+    setIsLoading(false);
+  };
+
+  const removeStop = async (id: string) => {
+    setIsLoading(true);
+    try {
+      // By all means defaultValue should have all needed fields,
+      // but typings says every field could be undefined.
+      // Ensure the data passes the default form validation.
+      const state = stopAreaFormSchema.parse(defaultValues);
+
+      await upsertStopArea({
+        id: areaId,
+        state: {
+          ...state,
+          memberStops: state.memberStops.filter((stop) => stop.id !== id),
         },
-      };
+      });
+      await refetch();
 
-      return stopSearchRow;
-    })
-    .filter(notNullish);
+      setStopToRemove(null);
+      showSuccessToast(t('stopArea.editSuccess'));
+    } catch (err) {
+      defaultErrorHandler(err as Error);
+    }
+    setIsLoading(false);
+  };
+
+  const methods = useForm<FormState>({
+    defaultValues,
+    resolver: zodResolver(stopAreaFormSchema),
+  });
+
+  return {
+    inEditMode,
+    setInEditMode,
+
+    stopToRemove,
+    setStopToRemove,
+
+    submit: methods.handleSubmit(onSubmit),
+    removeStop,
+
+    methods,
+  };
 }
 
-export const StopAreaMemberStops: FC<StopAreaComponentProps> = ({
+type StopAreaMemberStopsProps = StopAreaComponentProps & {
+  readonly refetch: () => Promise<unknown>;
+};
+
+export const StopAreaMemberStops: FC<StopAreaMemberStopsProps> = ({
   area,
   className = '',
+  refetch,
 }) => {
   const { t } = useTranslation();
 
-  return (
-    <div className={className}>
-      <div className="flex items-center justify-between">
-        <h2>{t('stopAreaDetails.memberStops.title')}</h2>
-        <SlimSimpleButton
-          disabled
-          onClick={noop}
-          testId={testIds.addStopButton}
-        >
-          {t('stopAreaDetails.memberStops.addStop')}
-        </SlimSimpleButton>
-      </div>
+  const defaultValues = useMemo(() => mapStopAreaDataToFormState(area), [area]);
+  const {
+    inEditMode,
+    setInEditMode,
 
-      <table className="mt-4 h-1 w-full border-x border-x-light-grey">
-        <tbody>
-          {mapMembersToStopSearchFormat(area).map((stop) => (
-            <StopTableRow
-              key={stop.scheduled_stop_point_id}
-              stop={stop}
-              actionButtons={<LocatorActionButton stop={stop} />}
-              menuItems={[
-                <OpenDetailsPage key="OpenDetailsPage" stop={stop} />,
-                <RemoveMemberStop key="RemoveMemberStop" stop={stop} />,
-                <ShowOnMap key="ShowOnMap" stop={stop} />,
-              ]}
+    stopToRemove,
+    setStopToRemove,
+
+    submit,
+    removeStop,
+
+    methods,
+  } = useMemberStopFormControls(area.id, defaultValues, refetch, t);
+  const { setValue, getValues, watch, reset } = methods;
+
+  const onEditStops = () => {
+    // useForm does not react to changes in defaultValues.
+    // We need to manually apply the new state, in case the area has
+    // already been updated once during the session.
+    reset(defaultValues);
+    setInEditMode(true);
+  };
+
+  const onRemoveWhenEditing = (id: string) => {
+    setValue(
+      'memberStops',
+      getValues('memberStops').filter((it) => it.id !== id),
+    );
+  };
+
+  const onRemoveWhenNotEditing = (id: string) => {
+    setStopToRemove(id);
+  };
+
+  const onAddBack = (member: StopAreaFormMember) => {
+    setValue(
+      'memberStops',
+      getValues('memberStops')
+        .concat(member)
+        .sort((a, b) =>
+          a.scheduled_stop_point.label.localeCompare(
+            b.scheduled_stop_point.label,
+          ),
+        ),
+    );
+  };
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <FormProvider {...methods}>
+      <RootComponent
+        className={className}
+        inEditMode={inEditMode}
+        onSubmit={submit}
+      >
+        <div className="flex items-center gap-4">
+          <h2>{t('stopAreaDetails.memberStops.title')}</h2>
+
+          {inEditMode ? (
+            <StopAreaMemberStopsEditHeader
+              areaId={area.id}
+              setInEditMode={setInEditMode}
             />
-          ))}
-        </tbody>
-      </table>
-    </div>
+          ) : (
+            <StopAreaMemberStopsViewHeader onEditStops={onEditStops} />
+          )}
+        </div>
+
+        <StopAreaMemberStopRows
+          area={area}
+          inEditMode={inEditMode}
+          inEditSelectedStops={watch('memberStops')}
+          onRemove={inEditMode ? onRemoveWhenEditing : onRemoveWhenNotEditing}
+          onAddBack={onAddBack}
+        />
+      </RootComponent>
+
+      <ConfirmationDialog
+        isOpen={stopToRemove !== null}
+        onConfirm={() => removeStop(stopToRemove ?? '')}
+        onCancel={() => setStopToRemove(null)}
+        title={t('stopAreaDetails.memberStops.confirmRemoval.title')}
+        description={t('stopAreaDetails.memberStops.confirmRemoval.body')}
+        confirmText={t('remove')}
+        cancelText={t('cancel')}
+      />
+    </FormProvider>
   );
 };

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsEditHeader.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsEditHeader.tsx
@@ -1,7 +1,6 @@
 import noop from 'lodash/noop';
-import { Dispatch, FC, SetStateAction } from 'react';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StopAreaDetailsFragment } from '../../../../../generated/graphql';
 import { ControlledElement } from '../../../../forms/common/ControlledElement';
 import { SelectMemberStopsDropdown } from '../../../../forms/stop-area';
 import { SlimSimpleButton } from '../../../stops/stop-details/layout';
@@ -14,12 +13,12 @@ const testIds = {
 
 type StopAreaMemberStopsEditHeaderProps = {
   readonly areaId: string | null | undefined;
-  readonly setInEditMode: Dispatch<SetStateAction<boolean>>;
+  readonly onCancel: () => void;
 };
 
 export const StopAreaMemberStopsEditHeader: FC<
   StopAreaMemberStopsEditHeaderProps
-> = ({ areaId, setInEditMode }) => {
+> = ({ areaId, onCancel }) => {
   const { t } = useTranslation();
 
   return (
@@ -55,7 +54,7 @@ export const StopAreaMemberStopsEditHeader: FC<
           containerClassName="w-full"
           className="flex-grow"
           inverted
-          onClick={() => setInEditMode(false)}
+          onClick={onCancel}
           testId={testIds.cancelButton}
         >
           {t('cancel')}

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsEditHeader.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsEditHeader.tsx
@@ -1,0 +1,76 @@
+import noop from 'lodash/noop';
+import { Dispatch, FC, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StopAreaDetailsFragment } from '../../../../../generated/graphql';
+import { ControlledElement } from '../../../../forms/common/ControlledElement';
+import { SelectMemberStopsDropdown } from '../../../../forms/stop-area';
+import { SlimSimpleButton } from '../../../stops/stop-details/layout';
+
+const testIds = {
+  saveButton: 'MemberStops::saveButton',
+  cancelButton: 'MemberStops::cancelButton',
+  selectMemberStops: 'MemberStops::selectMemberStops',
+};
+
+type StopAreaMemberStopsEditHeaderProps = {
+  readonly areaId: string | null | undefined;
+  readonly setInEditMode: Dispatch<SetStateAction<boolean>>;
+};
+
+export const StopAreaMemberStopsEditHeader: FC<
+  StopAreaMemberStopsEditHeaderProps
+> = ({ areaId, setInEditMode }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="flex flex-grow flex-wrap-reverse items-center gap-x-4 gap-y-1 md:justify-center lg:flex-nowrap">
+        <div className="hidden flex-grow lg:block" />
+
+        <p className="text-hsl-red lg:flex-shrink-0">
+          {t('stopArea.sharedNameNotice')}
+        </p>
+
+        <ControlledElement
+          id="memberStops"
+          testId={testIds.selectMemberStops}
+          fieldPath="memberStops"
+          // eslint-disable-next-line react/no-unstable-nested-components
+          inputElementRenderer={({ value, onChange }) => (
+            <SelectMemberStopsDropdown
+              className="lg:w-1/2"
+              editedStopAreaId={areaId}
+              // The form related component typings have been effed up.
+              // Everything is typed as a string.
+              // Cast to Any until the form-typings get fixed (huge rewrite)
+              value={value as ExplicitAny}
+              onChange={onChange}
+            />
+          )}
+        />
+      </div>
+
+      <div className="flex items-stretch gap-2 md:flex-wrap lg:flex-nowrap">
+        <SlimSimpleButton
+          containerClassName="w-full"
+          className="flex-grow"
+          inverted
+          onClick={() => setInEditMode(false)}
+          testId={testIds.cancelButton}
+        >
+          {t('cancel')}
+        </SlimSimpleButton>
+
+        <SlimSimpleButton
+          containerClassName="w-full"
+          className="flex-grow"
+          type="submit"
+          onClick={noop}
+          testId={testIds.saveButton}
+        >
+          {t('save')}
+        </SlimSimpleButton>
+      </div>
+    </>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsEditHeader.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsEditHeader.tsx
@@ -35,7 +35,7 @@ export const StopAreaMemberStopsEditHeader: FC<
           testId={testIds.selectMemberStops}
           fieldPath="memberStops"
           // eslint-disable-next-line react/no-unstable-nested-components
-          inputElementRenderer={({ value, onChange }) => (
+          inputElementRenderer={({ value, onChange, testId }) => (
             <SelectMemberStopsDropdown
               className="lg:w-1/2"
               editedStopAreaId={areaId}
@@ -44,6 +44,7 @@ export const StopAreaMemberStopsEditHeader: FC<
               // Cast to Any until the form-typings get fixed (huge rewrite)
               value={value as ExplicitAny}
               onChange={onChange}
+              testId={testId}
             />
           )}
         />

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsHeader.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsHeader.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react';
+import { StopAreaEditableBlock } from '../StopAreaEditableBlock';
+import { StopAreaMemberStopsEditHeader } from './StopAreaMemberStopsEditHeader';
+import { StopAreaMemberStopsViewHeader } from './StopAreaMemberStopsViewHeader';
+
+type StopAreaMemberStopsHeaderProps = {
+  readonly areaId: string | null | undefined;
+  readonly blockInEdit: StopAreaEditableBlock | null;
+  readonly onCancel: () => void;
+  readonly onEditStops: () => void;
+};
+
+export const StopAreaMemberStopsHeader: FC<StopAreaMemberStopsHeaderProps> = ({
+  areaId,
+  blockInEdit,
+  onCancel,
+  onEditStops,
+}) => {
+  if (blockInEdit === StopAreaEditableBlock.MEMBERS) {
+    return (
+      <StopAreaMemberStopsEditHeader areaId={areaId} onCancel={onCancel} />
+    );
+  }
+
+  if (blockInEdit === null) {
+    return <StopAreaMemberStopsViewHeader onEditStops={onEditStops} />;
+  }
+
+  return null;
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsViewHeader.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsViewHeader.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SlimSimpleButton } from '../../../stops/stop-details/layout';
+
+const testIds = {
+  addStopButton: 'MemberStops::addStopButton',
+};
+
+type StopAreaMemberStopsViewHeaderProps = {
+  readonly onEditStops: () => void;
+};
+
+export const StopAreaMemberStopsViewHeader: FC<
+  StopAreaMemberStopsViewHeaderProps
+> = ({ onEditStops }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="flex-grow" />
+
+      <SlimSimpleButton
+        type="button"
+        onClick={onEditStops}
+        testId={testIds.addStopButton}
+      >
+        {t('stopAreaDetails.memberStops.addStop')}
+      </SlimSimpleButton>
+    </>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMinimap.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMinimap.tsx
@@ -47,6 +47,7 @@ function useShowOnMap() {
 
 const testIds = {
   openMapButton: 'StopAreaMinimap::openMapButton',
+  marker: 'StopAreaMinimap::marker',
 };
 
 export const StopAreaMinimap: FC<StopAreaComponentProps> = ({
@@ -55,6 +56,8 @@ export const StopAreaMinimap: FC<StopAreaComponentProps> = ({
 }) => {
   const { t } = useTranslation();
   const showOnMap = useShowOnMap();
+
+  const point = mapLngLatToPoint(area.geometry?.coordinates ?? []);
 
   return (
     <div
@@ -69,7 +72,13 @@ export const StopAreaMinimap: FC<StopAreaComponentProps> = ({
       <div className="text-center text-2xl font-extrabold">
         <span>🚧 Tähän tulee oikea kartta 🚧</span>
         <br />
-        <span>{area.description?.value}</span>
+        <span
+          data-testid={testIds.marker}
+          data-longitude={point.longitude}
+          data-latitude={point.latitude}
+        >
+          {area.description?.value}
+        </span>
       </div>
 
       <SlimSimpleButton

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/utils.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/utils.ts
@@ -1,0 +1,33 @@
+import {
+  StopAreaDetailsFragment,
+  StopAreaDetailsMembersFragment,
+} from '../../../../generated/graphql';
+import { StopSearchRow } from '../../../../hooks';
+import { getStopPlacesFromQueryResult, notNullish } from '../../../../utils';
+
+export function mapMemberToStopSearchFormat(
+  member: StopAreaDetailsMembersFragment,
+): StopSearchRow | null {
+  if (!member.scheduled_stop_point) {
+    return null;
+  }
+
+  return {
+    ...member.scheduled_stop_point,
+    stop_place: {
+      netexId: member.id,
+      nameFin: member.name?.value,
+      nameSwe: null,
+    },
+  };
+}
+
+export function mapMembersToStopSearchFormat(
+  area: StopAreaDetailsFragment,
+): Array<StopSearchRow> {
+  return getStopPlacesFromQueryResult<StopAreaDetailsMembersFragment>(
+    area.members,
+  )
+    .map(mapMemberToStopSearchFormat)
+    .filter(notNullish);
+}

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -70146,6 +70146,7 @@ export type StopTableRowFragment = {
 export type StopTableRowStopPlaceFragment = {
   __typename?: 'stops_database_stop_place_newest_version';
   id?: any | null;
+  netex_id?: string | null;
   name_value?: string | null;
   stop_place_alternative_names: Array<{
     __typename?: 'stops_database_stop_place_alternative_names';
@@ -70183,6 +70184,7 @@ export type SearchStopsQuery = {
     stops_database_stop_place_newest_version: Array<{
       __typename?: 'stops_database_stop_place_newest_version';
       id?: any | null;
+      netex_id?: string | null;
       name_value?: string | null;
       stop_place_alternative_names: Array<{
         __typename?: 'stops_database_stop_place_alternative_names';
@@ -73009,6 +73011,7 @@ export const RouteMetadataFragmentDoc = gql`
 export const StopTableRowStopPlaceFragmentDoc = gql`
   fragment stop_table_row_stop_place on stops_database_stop_place_newest_version {
     id
+    netex_id
     name_value
     stop_place_alternative_names {
       alternative_name {

--- a/ui/src/hooks/stop-registry/search/useStopSearchResults.ts
+++ b/ui/src/hooks/stop-registry/search/useStopSearchResults.ts
@@ -29,6 +29,7 @@ const GQL_STOP_TABLE_ROW = gql`
 const GQL_STOP_TABLE_ROW_STOP_PLACE = gql`
   fragment stop_table_row_stop_place on stops_database_stop_place_newest_version {
     id
+    netex_id
     name_value
     stop_place_alternative_names {
       alternative_name {
@@ -56,6 +57,7 @@ const GQL_SEARCH_STOPS = gql`
 `;
 
 type StopPlaceSearchRowDetails = {
+  netexId?: string | null;
   nameFin?: string | null;
   nameSwe?: string | null;
 };
@@ -70,6 +72,7 @@ const mapResultRowToStopSearchRow = (
   return {
     ...(stopPlace.scheduled_stop_point_instance as StopTableRowFragment),
     stop_place: {
+      netexId: stopPlace.netex_id,
       nameFin: stopPlace.name_value,
       nameSwe: stopPlace.stop_place_alternative_names.find(
         (alternativeName) =>

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -120,6 +120,7 @@
     "label": "Label",
     "memberStops": "Member stops",
     "sharedNameNotice": "Remember that member stops need to share name with the area.",
+    "editSuccess": "Stop area edited",
     "errors": {
       "failedToResolveScheduledStopPoint": "Failed to resolve Scheduled Stop Point! Reason"
     }

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -144,6 +144,14 @@
       "addStop": "Add a stop",
       "menuActions": {
         "remove": "Remove stop from stop area"
+      },
+      "actionButtons": {
+        "remove": "Remove stop from stop area",
+        "addBack": "Add back to stop area"
+      },
+      "confirmRemoval": {
+        "title": "Removing stop from the stop area",
+        "body": "The Stop will not be deleted, but it will no longer be associated with the stop area."
       }
     }
   },
@@ -838,6 +846,7 @@
   "selected": " {{ count }} selected",
   "yes": "Yes",
   "no": "No",
+  "remove": "Remove",
   "welcomePage": {
     "heading": "JORE4 | Aikataulujen testikäyttö alkaa",
     "subheading1": "Mitä?",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -120,6 +120,7 @@
     "label": "Tunnus",
     "memberStops": "Jäsenpysäkit",
     "sharedNameNotice": "Muista nimetä jäsenpysäkit pysäkkialueen nimellä.",
+    "editSuccess": "Pysäkkialue muokattu",
     "errors": {
       "failedToResolveScheduledStopPoint": "Pysäkin tietojen selvitys epäonnistui! Syy"
     }

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -144,6 +144,14 @@
       "addStop": "Lisää pysäkki",
       "menuActions": {
         "remove": "Poista pysäkki pysäkkialueelta"
+      },
+      "actionButtons": {
+        "remove": "Poista pysäkki pysäkkialueelta",
+        "addBack": "Lisää takaisin pysäkkialueelle"
+      },
+      "confirmRemoval": {
+        "title": "Poistetaan pysäkki pysäkkialueen käytöstä",
+        "body": "Pysäkki jää edelleen jäljelle, se ei ole vain yhdistetty pysäkkialueeseen."
       }
     }
   },
@@ -838,6 +846,7 @@
   "selected": " {{ count }} valittu",
   "yes": "Kyllä",
   "no": "Ei",
+  "remove": "Poista",
   "welcomePage": {
     "heading": "JORE4 | Aikataulujen testikäyttö alkaa",
     "subheading1": "Mitä?",

--- a/ui/src/uiComponents/SimpleButton.tsx
+++ b/ui/src/uiComponents/SimpleButton.tsx
@@ -22,10 +22,12 @@ interface CommonButtonProps {
 
 interface ButtonProps {
   onClick: () => void;
+  type?: 'button' | 'reset' | 'submit' | undefined;
   href?: never;
 }
 interface LinkButtonProps {
   onClick?: never;
+  type?: never;
   href: string;
 }
 
@@ -63,6 +65,7 @@ export const SimpleButton: React.FC<Props> = (props) => {
     ariaSelected,
     role,
     ariaControls,
+    type = 'button',
   } = props;
 
   const colorClassNames = inverted
@@ -83,7 +86,8 @@ export const SimpleButton: React.FC<Props> = (props) => {
           id={id}
           data-selected={selected}
           className={twMerge(`${commonClassNames} ${className}`)}
-          type="button"
+          // eslint-disable-next-line react/button-has-type
+          type={type}
           onClick={(props as ButtonProps).onClick}
           disabled={disabled}
           data-testid={testId}

--- a/ui/src/uiComponents/Toast.tsx
+++ b/ui/src/uiComponents/Toast.tsx
@@ -57,6 +57,7 @@ const ToastImpl: ForwardRefRenderFunction<HTMLDivElement, Props> = (
   return (
     <div
       className={`rounded-md bg-white ${className}`}
+      data-testElementType="toast"
       data-testid={testId}
       ref={ref}
     >

--- a/ui/src/uiComponents/ToastTransition.tsx
+++ b/ui/src/uiComponents/ToastTransition.tsx
@@ -1,5 +1,5 @@
 import { Transition } from '@headlessui/react';
-import React, { FC, ReactNode } from 'react';
+import { FC, Fragment, ReactNode } from 'react';
 
 interface Props {
   show: boolean;
@@ -9,6 +9,14 @@ interface Props {
 export const ToastTransition: FC<Props> = ({ show, children }) => {
   return (
     <Transition
+      // This needs to be a fragment, so that we can match the
+      // toast's animation status in e2e tests.
+      // We must wait for the toast to be fully visible, before we take a
+      // screenshot, or else that will be useless, because we can't see the
+      // actual text in it.
+      // Current matching is based on opacity getting set to 100 (=='1').
+      // See: cypress/pageObjects/Toast.ts
+      as={Fragment}
       appear
       show={show}
       enter="transition-all duration-150"


### PR DESCRIPTION
### Add E2E tests for editing Stop Area on the Details Page


### Only allow editing of a single Stop Area page block at a time

Prevent editing of multiple data blocks simultaneously. Backend does not support partial mutations. If member stops field is left empty it deletes all member stops from the area. Thus on the background, editing the details section also sends in the current list of known member stops as of the time editing started. Editing member stops performs similarly, sending in the known values of the details sections at the time editing started.

Thus we want to limit the user to editing a single block of data at a time.


### Add support for editing Member Stops on Stop Area Page


### Add edit support to `<StopAreaDetails>`


### `<SelectMemberStopsDropdown>`: Add testids
A partial cherry-pick from commit:
"Add e2e tests for stop area map features"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/909)
<!-- Reviewable:end -->
