### PR TITLE
Make newer versions of docker compose happy with our config

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -34,8 +34,6 @@ services:
       # use the same Hasura URL that the UI uses to enable routing requests to correct Hasura instances
       # when running e2e tests locally
       HASURA_URL: "http://host.docker.internal:3300/api/graphql/v1/graphql"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
 
   jore4-tiamat:
     # Pin tiamat to a compatible version.


### PR DESCRIPTION
`docker-compose.custom.yml` specified `host.docker.internal:host-gateway` as `extra_hosts`. But that is already declared in the base `docker-compose.yml` file. Newer versions of docker don't like it when you double declare a array based setting, when using multiple compose files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/912)
<!-- Reviewable:end -->
