### PR TITLE
E2E: Properly check GGL network requests succeed

### DIFF
--- a/cypress/e2e/editRoute.cy.ts
+++ b/cypress/e2e/editRoute.cy.ts
@@ -14,6 +14,7 @@ import {
 } from '../pageObjects';
 import { UUID } from '../types';
 import { SupportedResources, insertToDbHelper } from '../utils';
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
 
 describe('Route editing', () => {
   let editRoutePage: EditRoutePage;
@@ -136,9 +137,7 @@ describe('Route editing', () => {
       editRoutePage.getDeleteRouteButton().click();
 
       editRoutePage.confirmationDialog.getConfirmButton().click();
-      cy.wait('@gqlDeleteRoute')
-        .its('response.statusCode')
-        .should('equal', 200);
+      expectGraphQLCallToSucceed('@gqlDeleteRoute');
       toast.checkSuccessToastHasMessage('Reitti poistettu');
 
       routeRow

--- a/cypress/e2e/editStop.cy.ts
+++ b/cypress/e2e/editStop.cy.ts
@@ -20,6 +20,7 @@ import {
 } from '../pageObjects';
 import { UUID } from '../types';
 import { SupportedResources, insertToDbHelper } from '../utils';
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
 
 // Stops are created on these infralinks via insertToDbHelper or the map view.
 
@@ -129,7 +130,7 @@ describe('Stop editing tests', () => {
 
       confirmationDialog.getConfirmButton().click();
 
-      cy.wait('@gqlEditStop').its('response.statusCode').should('equal', 200);
+      expectGraphQLCallToSucceed('@gqlEditStop');
 
       toast.checkSuccessToastHasMessage('Pysäkki muokattu');
 
@@ -162,7 +163,7 @@ describe('Stop editing tests', () => {
 
       confirmationDialog.getConfirmButton().click();
 
-      cy.wait('@gqlRemoveStop').its('response.statusCode').should('equal', 200);
+      expectGraphQLCallToSucceed('@gqlRemoveStop');
 
       toast.checkSuccessToastHasMessage('Pysäkki poistettu');
 
@@ -208,7 +209,7 @@ describe('Stop editing tests', () => {
 
       confirmationDialog.getConfirmButton().click();
 
-      cy.wait('@gqlEditStop').its('response.statusCode').should('equal', 200);
+      expectGraphQLCallToSucceed('@gqlEditStop');
 
       toast.checkSuccessToastHasMessage('Pysäkki muokattu');
 
@@ -266,7 +267,7 @@ describe('Stop editing tests', () => {
 
       toast.checkSuccessToastHasMessage('Hastus-paikka luotu');
 
-      cy.wait('@gqlEditStop').its('response.statusCode').should('equal', 200);
+      expectGraphQLCallToSucceed('@gqlEditStop');
 
       map
         .getStopByStopLabelAndPriority(stops[0].label, stops[0].priority)
@@ -276,9 +277,7 @@ describe('Stop editing tests', () => {
       stopForm.getTimingPlaceDropdown().type(testTimingPlaceLabels.label1);
 
       // Wait for the search results before trying to find the result list item
-      cy.wait('@gqlGetTimingPlacesForCombobox')
-        .its('response.statusCode')
-        .should('equal', 200);
+      expectGraphQLCallToSucceed('@gqlGetTimingPlacesForCombobox');
 
       stopForm
         .getTimingPlaceDropdown()

--- a/cypress/e2e/searchRoutesAndLines.cy.ts
+++ b/cypress/e2e/searchRoutesAndLines.cy.ts
@@ -9,6 +9,7 @@ import { DateTime } from 'luxon';
 import { Tag } from '../enums';
 import { RoutesAndLinesPage, SearchResultsPage } from '../pageObjects';
 import { insertToDbHelper } from '../utils';
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
 
 const lines: LineInsertInput[] = [
   // Valid in 2022
@@ -133,7 +134,7 @@ describe('Verify that route and line search works', () => {
     { tags: [Tag.Lines, Tag.Smoke] },
     () => {
       routesAndLinesPage.searchContainer.getSearchInput().type(`9999{enter}`);
-      cy.wait('@gqlSearchLinesAndRoutes');
+      expectGraphQLCallToSucceed('@gqlSearchLinesAndRoutes');
 
       searchResultsPage
         .getSearchResultsContainer()
@@ -147,7 +148,7 @@ describe('Verify that route and line search works', () => {
 
   it('Searches for lines with an asterisk', { tags: Tag.Lines }, () => {
     routesAndLinesPage.searchContainer.getSearchInput().type('9*{enter}');
-    cy.wait('@gqlSearchLinesAndRoutes');
+    expectGraphQLCallToSucceed('@gqlSearchLinesAndRoutes');
 
     searchResultsPage
       .getSearchResultsContainer()
@@ -164,7 +165,7 @@ describe('Verify that route and line search works', () => {
 
   it('Searches for a route with an exact label', { tags: Tag.Routes }, () => {
     routesAndLinesPage.searchContainer.getSearchInput().type(`1999{enter}`);
-    cy.wait('@gqlSearchLinesAndRoutes');
+    expectGraphQLCallToSucceed('@gqlSearchLinesAndRoutes');
 
     searchResultsPage.getRoutesResultsButton().click();
     searchResultsPage
@@ -178,7 +179,7 @@ describe('Verify that route and line search works', () => {
 
   it('Searches for routes with an asterisk', { tags: Tag.Routes }, () => {
     routesAndLinesPage.searchContainer.getSearchInput().type('1*{enter}');
-    cy.wait('@gqlSearchLinesAndRoutes');
+    expectGraphQLCallToSucceed('@gqlSearchLinesAndRoutes');
 
     searchResultsPage.getRoutesResultsButton().click();
     searchResultsPage
@@ -198,7 +199,7 @@ describe('Verify that route and line search works', () => {
       routesAndLinesPage.searchContainer.getChevron().click();
       routesAndLinesPage.searchContainer.setObservationDate('2024-04-01');
       routesAndLinesPage.searchContainer.getSearchButton().click();
-      cy.wait('@gqlSearchLinesAndRoutes');
+      expectGraphQLCallToSucceed('@gqlSearchLinesAndRoutes');
 
       searchResultsPage.getLinesResultsButton().click();
       searchResultsPage

--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -17,6 +17,7 @@ import {
 } from '../../pageObjects';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
+import { expectGraphQLCallToSucceed } from '../../utils/assertions';
 import { InsertedStopRegistryIds } from '../utils';
 
 function mapToShortDate(date: DateTime | null) {
@@ -263,9 +264,7 @@ describe('Stop area details', () => {
     });
 
     function waitForSaveToBeFinished() {
-      cy.wait('@gqlUpsertStopArea')
-        .its('response.statusCode')
-        .should('equal', 200);
+      expectGraphQLCallToSucceed('@gqlUpsertStopArea');
       toast.expectSuccessToast('Pysäkkialue muokattu');
       toast.getSuccessToast().should('not.exist');
     }

--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -30,6 +30,7 @@ import {
 } from '../../pageObjects';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
+import { expectGraphQLCallToSucceed } from '../../utils/assertions';
 import { InsertedStopRegistryIds } from '../utils';
 
 // These infralink IDs exist in the 'infraLinks.sql' test data file.
@@ -779,7 +780,7 @@ describe('Stop details', () => {
           view.getFasciaBoardTaping().should('have.text', 'Ei');
 
           // "enclosed" is not visible anywhere in UI, check from request that it got sent.
-          cy.wait('@gqlUpdateStopPlace')
+          expectGraphQLCallToSucceed('@gqlUpdateStopPlace')
             .its(
               'request.body.variables.input.quays.0.placeEquipments.shelterEquipment.0.enclosed',
             )

--- a/cypress/e2e/stop-registry/stopSearch.cy.ts
+++ b/cypress/e2e/stop-registry/stopSearch.cy.ts
@@ -16,6 +16,7 @@ import { StopSearchBar } from '../../pageObjects/stop-registry/StopSearchBar';
 import { StopSearchResultsPage } from '../../pageObjects/stop-registry/StopSearchResultsPage';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
+import { expectGraphQLCallToSucceed } from '../../utils/assertions';
 import { InsertedStopRegistryIds } from '../utils';
 
 // These infralink IDs exist in the 'infraLinks.sql' test data file.
@@ -227,7 +228,7 @@ describe('Stop search', () => {
           .getLabelRadioButton()
           .should('be.checked');
         stopSearchBar.getSearchInput().type(`H1234{enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -240,7 +241,7 @@ describe('Stop search', () => {
       { tags: [Tag.StopRegistry, Tag.Smoke] },
       () => {
         stopSearchBar.getSearchInput().type(`H1*{enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 2);
@@ -256,7 +257,7 @@ describe('Stop search', () => {
       { tags: Tag.StopRegistry },
       () => {
         stopSearchBar.getSearchInput().type(`*404*{enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('not.exist');
@@ -273,7 +274,7 @@ describe('Stop search', () => {
         stopSearchBar.getElyInput().type(`123456`);
         stopSearchBar.getSearchButton().click();
 
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -289,7 +290,7 @@ describe('Stop search', () => {
         stopSearchBar.getElyInput().type(`1234*`);
         stopSearchBar.getSearchButton().click();
 
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 2);
@@ -306,7 +307,7 @@ describe('Stop search', () => {
         stopSearchBar.getElyInput().type(`not-an-ELY-number`);
         stopSearchBar.getSearchButton().click();
 
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('not.exist');
@@ -324,7 +325,7 @@ describe('Stop search', () => {
           .click();
         stopSearchBar.getSearchInput().type(`Tuusulanväylä 10-16{enter}`);
 
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -341,7 +342,7 @@ describe('Stop search', () => {
           .click();
         stopSearchBar.getSearchInput().type(`Tuusul*{enter}`);
 
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -358,7 +359,7 @@ describe('Stop search', () => {
           .click();
         stopSearchBar.getSearchInput().type(`no address 22{enter}`);
 
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('not.exist');
@@ -375,7 +376,7 @@ describe('Stop search', () => {
         stopSearchBar.searchCriteriaRadioButtons
           .getAddressRadioButton()
           .click();
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -388,7 +389,7 @@ describe('Stop search', () => {
       { tags: Tag.StopRegistry },
       () => {
         stopSearchBar.getSearchInput().type(`H2233{enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
         stopSearchResultsPage.getResultRows().should('contain', 'H2233');
@@ -415,7 +416,7 @@ describe('Stop search', () => {
         stopSearchBar.openMunicipalityDropdown();
         stopSearchBar.isMunicipalitySelected('Kaikki');
         stopSearchBar.getSearchButton().click();
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 3);
       },
@@ -431,7 +432,7 @@ describe('Stop search', () => {
         stopSearchBar.toggleMunicipality('Kaikki');
         stopSearchBar.toggleMunicipality('Vantaa');
         stopSearchBar.getSearchButton().click();
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 2);
@@ -450,7 +451,7 @@ describe('Stop search', () => {
           .getLabelRadioButton()
           .should('be.checked');
         stopSearchBar.getSearchInput().type(`Lapinrinne{enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -466,7 +467,7 @@ describe('Stop search', () => {
           .getLabelRadioButton()
           .should('be.checked');
         stopSearchBar.getSearchInput().type(`Lappbrinken{enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -482,7 +483,7 @@ describe('Stop search', () => {
           .getLabelRadioButton()
           .should('be.checked');
         stopSearchBar.getSearchInput().type(`Lapinrinne (pitkä){enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);
@@ -497,7 +498,7 @@ describe('Stop search', () => {
           .getLabelRadioButton()
           .should('be.checked');
         stopSearchBar.getSearchInput().type(`Lappbrinken (lång){enter}`);
-        cy.wait('@gqlSearchStops');
+        expectGraphQLCallToSucceed('@gqlSearchStops');
 
         stopSearchResultsPage.getContainer().should('be.visible');
         stopSearchResultsPage.getResultRows().should('have.length', 1);

--- a/cypress/pageObjects/Map.ts
+++ b/cypress/pageObjects/Map.ts
@@ -1,5 +1,6 @@
 import { Priority } from '@hsl/jore4-test-db-manager';
 import qs from 'qs';
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
 import { StopPopUp } from './StopPopUp';
 
 export interface ClickPointNearMapMarker {
@@ -26,7 +27,7 @@ export class Map {
       }
     });
     this.waitForLoadToComplete();
-    cy.wait('@gqlGetStopsByLocation');
+    expectGraphQLCallToSucceed('@gqlGetStopsByLocation');
   }
 
   getNthMarker(markerNumber: number, options?: Partial<Cypress.Timeoutable>) {

--- a/cypress/pageObjects/MapModal.ts
+++ b/cypress/pageObjects/MapModal.ts
@@ -1,3 +1,4 @@
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
 import { EditRouteModal } from './EditRouteModal';
 import { Map } from './Map';
 import { MapFooter } from './MapFooter';
@@ -51,10 +52,7 @@ export class MapModal {
   }
 
   gqlStopShouldBeCreatedSuccessfully() {
-    return cy
-      .wait('@gqlInsertStop')
-      .its('response.statusCode')
-      .should('equal', 200);
+    return expectGraphQLCallToSucceed('@gqlInsertStop');
   }
 
   getCloseButton() {

--- a/cypress/pageObjects/RouteEditor.ts
+++ b/cypress/pageObjects/RouteEditor.ts
@@ -1,4 +1,5 @@
 import '@4tw/cypress-drag-drop';
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
 import { Map } from './Map';
 import { MapFooter } from './MapFooter';
 import { Toast } from './Toast';
@@ -19,10 +20,7 @@ export class RouteEditor {
   toast = new Toast();
 
   gqlRouteShouldBeCreatedSuccessfully() {
-    return cy
-      .wait('@gqlInsertRouteOne')
-      .its('response.statusCode')
-      .should('equal', 200);
+    return expectGraphQLCallToSucceed('@gqlInsertRouteOne');
   }
 
   checkRouteSubmitSuccessToast() {

--- a/cypress/pageObjects/StopForm.ts
+++ b/cypress/pageObjects/StopForm.ts
@@ -1,3 +1,4 @@
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
 import { ChangeValidityForm } from './ChangeValidityForm';
 import { CreateTimingPlaceForm } from './CreateTimingPlaceForm';
 import { PriorityForm, PriorityFormInfo } from './PriorityForm';
@@ -41,9 +42,7 @@ export class StopForm {
     // type to form to make sure that desired timing place is visible
     this.getTimingPlaceDropdown().type(timingPlaceName);
     // Wait for the search results before trying to find the result list item
-    cy.wait('@gqlGetTimingPlacesForCombobox')
-      .its('response.statusCode')
-      .should('equal', 200);
+    expectGraphQLCallToSucceed('@gqlGetTimingPlacesForCombobox');
     this.getTimingPlaceDropdown()
       .find('[role="option"]')
       .contains(timingPlaceName)

--- a/cypress/pageObjects/TimingSettingsForm.ts
+++ b/cypress/pageObjects/TimingSettingsForm.ts
@@ -1,3 +1,5 @@
+import { expectGraphQLCallToSucceed } from '../utils/assertions';
+
 export class TimingSettingsForm {
   getIsUsedAsTimingPointCheckbox() {
     return cy.getByTestId('TimingSettingsForm::isUsedAsTimingPoint');
@@ -31,9 +33,7 @@ export class TimingSettingsForm {
     // type to form to make sure that desired timing place is visible
     this.getTimingPlaceDropdownButton().type(timingPlaceName);
     // Wait for the search results before trying to find the result list item
-    cy.wait('@gqlGetTimingPlacesForCombobox')
-      .its('response.statusCode')
-      .should('equal', 200);
+    expectGraphQLCallToSucceed('@gqlGetTimingPlacesForCombobox');
     this.getTimingPlaceDropdown()
       .find('[role="option"]')
       .contains(timingPlaceName)

--- a/cypress/utils/assertions.ts
+++ b/cypress/utils/assertions.ts
@@ -1,0 +1,54 @@
+/* eslint-disable jest/valid-expect,no-unused-expressions */
+
+import type { CyHttpMessages } from 'cypress/types/net-stubbing';
+
+function assertResponseIsDefined<TBody>(
+  alias: string,
+  response: CyHttpMessages.IncomingResponse<TBody> | undefined | null,
+): asserts response is CyHttpMessages.IncomingResponse<TBody> {
+  expect(response).to.be.an('object', `${alias}: Response should be defined!`);
+}
+
+function assertBodyIsObject(
+  alias: string,
+  body: unknown,
+): asserts body is object {
+  expect(body).to.be.an(
+    'object',
+    `${alias}: Response body should be an Object!`,
+  );
+}
+
+function assertBodyIsAnErrorFreeGraphQlResponse(alias: string, body: object) {
+  if ('errors' in body) {
+    const bodyAsJson = JSON.stringify(body, null, 2);
+
+    expect(
+      body.errors,
+      `${alias}: There should be no errors in the response! Body:\n${bodyAsJson}\n`,
+    ).to.be.an('array').that.is.empty;
+  }
+}
+
+export function expectGraphQLCallToSucceed(alias: string) {
+  return cy.wait(alias).then((interceptedCall) => {
+    const { error, response } = interceptedCall;
+
+    expect(error).to.be.an(
+      'undefined',
+      `${alias}: Intercepted call should not have raw network error!`,
+    );
+
+    assertResponseIsDefined(alias, response);
+
+    const { body, statusCode } = response;
+    expect(statusCode).to.eq(
+      200,
+      `${alias}: A successful response should have status code of 200!`,
+    );
+    assertBodyIsObject(alias, body);
+    assertBodyIsAnErrorFreeGraphQlResponse(alias, body);
+
+    return interceptedCall;
+  });
+}


### PR DESCRIPTION
Unless there is something wrong with he GraphQL server or an error occurs on a proxy/gateway level, the network response's status code will always be 200.

So:
```
  cy.wait('@gqlSaveMyThing')
    .its('response.statusCode)'
    .should('equal', 200)
```
Does not actually check that `myThing` was properly saved, the saving could have actually failed. Instead the correct thing to do, is to check that the Body of the Response does not contain any values in the `errors` field.

Also, the example above has the added problem, that `should` simply implies a retry check. So even if a lower level network error was to occur and `statusCode` was set to 500, cypress would just continue to monitor for another call for the same Query, until it finds one that succeeds. Normally there will ever be only a single network call, and thus Cypress will simply timeout and say that it newer saw any network requests with status of 200.

With this change Cypress will capture the 1st instance of the requested network call, and then continues to check that it was a truly successful call, without any low level errors nor any GraphQL level errors in it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/913)
<!-- Reviewable:end -->
