### PR TITLE
Don't mutate useInfoContainerControls defaultOptions

### DIFF
--- a/ui/src/components/common/info-container/useInfoContainerControls.ts
+++ b/ui/src/components/common/info-container/useInfoContainerControls.ts
@@ -11,19 +11,19 @@ type InfoContainerControlOptions = {
   readonly onCancel: () => void;
 };
 
-const defaultOptions: InfoContainerControlOptions = {
+const defaultOptions: InfoContainerControlOptions = Object.freeze({
   isExpandable: false,
   isEditable: false,
   expandedByDefault: true,
   onSave: noop,
   onCancel: noop,
-};
+});
 
 function getAllOptions(
   options: Partial<InfoContainerControlOptions> | undefined,
 ): InfoContainerControlOptions {
   if (options) {
-    return merge(defaultOptions, options);
+    return merge({}, defaultOptions, options);
   }
 
   return defaultOptions;


### PR DESCRIPTION
Lodash `merge` is not properly functional, and mutates the 1st parameter passed in.
Fix: Pass in an empty object as the "target" `merge({}, fromA, fromB)` Extra: Protect `defaultOptions` from further possible mutation bugs, by freezing it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/915)
<!-- Reviewable:end -->
