### PR TITLE
Fix excessive data loading bug on OpenMap -type buttons

### DIFF
--- a/ui/src/components/common/OpenDefaultMapButton.tsx
+++ b/ui/src/components/common/OpenDefaultMapButton.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { useAppDispatch, useFilterStops, useMapQueryParams } from '../../hooks';
-import { FilterType, resetMapState } from '../../redux';
+import { useAppDispatch, useMapQueryParams } from '../../hooks';
+import { FilterType, resetMapState, setStopFilterAction } from '../../redux';
 import { SimpleButton } from '../../uiComponents';
 
 type OpenDefaultMapButtonProps = {
@@ -15,8 +15,6 @@ export const OpenDefaultMapButton = ({
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const { addMapOpenQueryParameter } = useMapQueryParams();
-  const { toggleFunction } = useFilterStops();
-  const toggleShowAllStops = toggleFunction(FilterType.ShowAllBusStops);
 
   const onOpenMapModal = () => {
     dispatch(resetMapState());
@@ -24,7 +22,12 @@ export const OpenDefaultMapButton = ({
      * By default only stops that belong to displayed route are shown on map.
      * Now that no routes are shown on map, show all stops by default.
      */
-    toggleShowAllStops(true);
+    dispatch(
+      setStopFilterAction({
+        filterType: FilterType.ShowAllBusStops,
+        isActive: true,
+      }),
+    );
 
     addMapOpenQueryParameter();
   };

--- a/ui/src/components/stop-registry/search/StopTableRow/utils.ts
+++ b/ui/src/components/stop-registry/search/StopTableRow/utils.ts
@@ -1,7 +1,6 @@
 import {
   StopSearchRow,
   useAppDispatch,
-  useFilterStops,
   useMapQueryParams,
   useObservationDateQueryParam,
 } from '../../../../hooks';
@@ -9,6 +8,7 @@ import {
   FilterType,
   resetMapState,
   setSelectedStopIdAction,
+  setStopFilterAction,
 } from '../../../../redux';
 import { mapLngLatToPoint } from '../../../../utils';
 
@@ -16,15 +16,18 @@ export function useOpenStopOnMap() {
   const dispatch = useAppDispatch();
   const { observationDate } = useObservationDateQueryParam();
   const { openMapWithParameters } = useMapQueryParams();
-  const { toggleFunction } = useFilterStops();
-  const toggleShowAllStops = toggleFunction(FilterType.ShowAllBusStops);
 
   return (stop: StopSearchRow) => {
     dispatch(resetMapState()).then(() => {
       dispatch(
         setSelectedStopIdAction(stop.scheduled_stop_point_id ?? undefined),
       );
-      toggleShowAllStops(true);
+      dispatch(
+        setStopFilterAction({
+          filterType: FilterType.ShowAllBusStops,
+          isActive: true,
+        }),
+      );
 
       const point = mapLngLatToPoint(stop.measured_location.coordinates);
       openMapWithParameters({


### PR DESCRIPTION
`<OpenDefaultMapButton>` and `useOpenStopOnMap()` hooks were calling `useFilterStops()` -hook which was triggering a fetch operation of stop labels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/923)
<!-- Reviewable:end -->
