### PR TITLE
E2E: Unify seed data

### DIFF
--- a/cypress/datasets/base.ts
+++ b/cypress/datasets/base.ts
@@ -13,7 +13,7 @@ import {
   buildStopInJourneyPattern,
   buildTimingPlace,
 } from '@hsl/jore4-test-db-manager';
-import cloneDeep from 'lodash/cloneDeep';
+import cloneDeepWith from 'lodash/cloneDeepWith';
 import { DateTime } from 'luxon';
 import { UUID } from '../types';
 
@@ -45,6 +45,7 @@ export const stopCoordinatesByLabel = {
   E2E007: [24.935714344053142, 60.16644692066976, 0],
   E2E008: [24.937281651830318, 60.16645331474371, 0],
   E2E009: [24.93877038021971, 60.1653765292378, 0],
+  E2E010: [24.706945, 60.157696, 0],
 };
 
 export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
@@ -172,17 +173,85 @@ export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
       coordinates: stopCoordinatesByLabel.E2E009,
     },
   },
+  {
+    ...buildStop({
+      label: 'E2E010',
+      located_on_infrastructure_link_id: testInfraLinkIds[0],
+    }),
+    validity_start: DateTime.fromISO('2020-03-20'),
+    direction: InfrastructureNetworkDirectionEnum.Backward,
+    scheduled_stop_point_id: '75afcec1-68a3-4411-bad2-f4f235c37215',
+    timing_place_id: timingPlaces[0].timing_place_id,
+    measured_location: {
+      type: 'Point',
+      coordinates: stopCoordinatesByLabel.E2E010,
+    },
+  },
 ];
 
 const lines: LineInsertInput[] = [
+  // Proper line with stops
   {
     ...buildLine({ label: '901' }),
     line_id: '08d1fa6b-440c-421e-ad4d-0778d65afe60',
     type_of_line: RouteTypeOfLineEnum.StoppingBusService,
   },
+
+  // Raw lines
+  // Valid in 2022
+  {
+    ...buildLine({ label: '1666' }),
+    line_id: '5dfa82f1-b3f7-4e26-b31d-0d7bd78da0be',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
+    validity_start: DateTime.fromISO('2022-01-02'),
+    validity_end: DateTime.fromISO('2022-12-24'),
+  },
+  // Valid in 2023
+  {
+    ...buildLine({ label: '2666' }),
+    line_id: '61e4d95e-34e5-11ed-a261-0242ac120002',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
+    validity_start: DateTime.fromISO('2023-01-02'),
+    validity_end: DateTime.fromISO('2023-12-24'),
+  },
+  // Valid in 2024
+  {
+    ...buildLine({ label: '1777' }),
+    line_id: '47c5fe92-e630-430b-a2da-2c6739acbb2b',
+    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
+    validity_start: DateTime.fromISO('2024-01-02'),
+    validity_end: DateTime.fromISO('2024-12-24'),
+  },
+  // Valid between 2000 and 2054
+  {
+    ...buildLine({ label: '9999' }),
+    line_id: '7f5aa870-891a-433e-bd9b-f864162a2adf',
+    validity_start: DateTime.fromISO('2000-01-02'),
+    validity_end: DateTime.fromISO('2054-12-24'),
+  },
+  {
+    ...buildLine({ label: '9888' }),
+    line_id: 'a627dfbf-8db6-4519-b968-56b4a4988d91',
+    validity_start: DateTime.fromISO('2000-01-02'),
+    validity_end: DateTime.fromISO('2054-12-24'),
+  },
+  {
+    ...buildLine({ label: '8888' }),
+    line_id: '69141b10-98cb-4319-9fe9-95cddbd46987',
+    validity_start: DateTime.fromISO('2000-01-02'),
+    validity_end: DateTime.fromISO('2054-12-24'),
+  },
+  // Always valid.
+  {
+    ...buildLine({ label: '8889' }),
+    line_id: '429413b0-a3b7-4b12-a3a1-5c26268066c1',
+    validity_start: null,
+    validity_end: null,
+  },
 ];
 
 export const routes: RouteInsertInput[] = [
+  // Proper routes with stops
   {
     ...buildRoute({ label: '901' }),
     route_id: '994a7d79-4991-423b-9c1a-0ca621a6d9ed',
@@ -198,6 +267,47 @@ export const routes: RouteInsertInput[] = [
     on_line_id: lines[0].line_id,
     validity_start: DateTime.fromISO('2022-08-11'),
     validity_end: DateTime.fromISO('2032-08-11'),
+  },
+
+  // Raw routes
+  // Valid in 2022
+  {
+    ...buildRoute({ label: '1111' }),
+    route_id: '48490721-3346-493a-80c8-3edd07c2d5d6',
+    on_line_id: lines[1].line_id,
+    validity_start: lines[1].validity_start,
+    validity_end: lines[1].validity_end,
+  },
+  // Valid in 2023
+  {
+    ...buildRoute({ label: '1222' }),
+    route_id: 'd82ebf21-5adb-419c-b057-c6e3b0f7480c',
+    on_line_id: lines[2].line_id,
+    validity_start: lines[2].validity_start,
+    validity_end: lines[2].validity_end,
+  },
+  // Valid in 2024
+  {
+    ...buildRoute({ label: '2333' }),
+    route_id: 'fa6196fa-ce61-4808-84bf-f4fc60bf1162',
+    on_line_id: lines[3].line_id,
+    validity_start: lines[3].validity_start,
+    validity_end: lines[3].validity_end,
+  },
+  // The rest are valid between 2000 and 2054
+  {
+    ...buildRoute({ label: '1999' }),
+    route_id: 'eec15aaf-3cf3-4fc8-86a1-7849ea4d88e0',
+    on_line_id: lines[4].line_id,
+    validity_start: lines[4].validity_start,
+    validity_end: lines[4].validity_end,
+  },
+  {
+    ...buildRoute({ label: '1888' }),
+    route_id: '88f2bb05-8438-41ab-ba26-27983250a78e',
+    on_line_id: lines[4].line_id,
+    validity_start: lines[4].validity_start,
+    validity_end: lines[4].validity_end,
   },
 ];
 
@@ -378,4 +488,11 @@ const baseDbResources = {
  * Returns a clone of baseDbResources so that the caller can
  * modify the data freely without side effects
  */
-export const getClonedBaseDbResources = () => cloneDeep(baseDbResources);
+export const getClonedBaseDbResources = () =>
+  cloneDeepWith(baseDbResources, (value) => {
+    if (value instanceof DateTime) {
+      return value;
+    }
+
+    return undefined;
+  });

--- a/cypress/datasets/stopRegistry.ts
+++ b/cypress/datasets/stopRegistry.ts
@@ -2,6 +2,7 @@ import {
   StopPlaceInput,
   StopRegistryGeoJson,
   StopRegistryGeoJsonType,
+  StopRegistryNameType,
 } from '@hsl/jore4-test-db-manager';
 import cloneDeep from 'lodash/cloneDeep';
 import { stopCoordinatesByLabel } from './base';
@@ -22,6 +23,8 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Annankatu 15' },
       quays: [{ publicCode: 'E2E001' }],
+      privateCode: { value: 'E2E001', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Annankatu 15'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E001),
     },
   },
@@ -30,6 +33,8 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Annankatu 20' },
       quays: [{ publicCode: 'E2E002' }],
+      privateCode: { value: 'E2E002', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Annankatu 20'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E002),
     },
   },
@@ -38,6 +43,8 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Kalevankatu 32' },
       quays: [{ publicCode: 'E2E003' }],
+      privateCode: { value: 'E2E003', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Kalevankatu 32'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E003),
     },
   },
@@ -45,7 +52,23 @@ const stopPlaceData: Array<StopPlaceInput> = [
     label: 'E2E004',
     stopPlace: {
       name: { lang: 'fin', value: 'Albertinkatu 38' },
+      alternativeNames: [
+        {
+          nameType: StopRegistryNameType.Translation,
+          name: { lang: 'swe', value: 'Albertsgatan 38' },
+        },
+        {
+          nameType: StopRegistryNameType.Alias,
+          name: { lang: 'swe', value: 'Albertsgatan 38 (lång)' },
+        },
+        {
+          nameType: StopRegistryNameType.Alias,
+          name: { lang: 'swe', value: 'Albertinkatu 38 (pitkä)' },
+        },
+      ],
       quays: [{ publicCode: 'E2E004' }],
+      privateCode: { value: 'E2E004', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Albertinkatu 38'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E004),
     },
   },
@@ -54,6 +77,8 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Lönnrotinkatu 32' },
       quays: [{ publicCode: 'E2E005' }],
+      privateCode: { value: 'E2E005', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Lönnrotinkatu 32'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E005),
     },
   },
@@ -62,6 +87,8 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Kalevankatu 32' },
       quays: [{ publicCode: 'E2E006' }],
+      privateCode: { value: 'E2E006', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Kalevankatu 32'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E006),
     },
   },
@@ -70,6 +97,8 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Kalevankatu 18' },
       quays: [{ publicCode: 'E2E007' }],
+      privateCode: { value: 'E2E007', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Kalevankatu 18'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E007),
     },
   },
@@ -78,6 +107,8 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Annankatu 20' },
       quays: [{ publicCode: 'E2E008' }],
+      privateCode: { value: 'E2E008', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Annankatu 20'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E008),
     },
   },
@@ -86,7 +117,19 @@ const stopPlaceData: Array<StopPlaceInput> = [
     stopPlace: {
       name: { lang: 'fin', value: 'Annankatu 15' },
       quays: [{ publicCode: 'E2E009' }],
+      privateCode: { value: 'E2E009', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Annankatu 15'] }],
       geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E009),
+    },
+  },
+  {
+    label: 'E2E010',
+    stopPlace: {
+      name: { lang: 'fin', value: 'Finnoonkartano' },
+      quays: [{ publicCode: 'E2E010' }],
+      privateCode: { value: 'E2E010', type: 'ELY' },
+      keyValues: [{ key: 'streetAddress', values: ['Finnoonkartano'] }],
+      geometry: coordinatesToStopRegistryGeoJSON(stopCoordinatesByLabel.E2E010),
     },
   },
 ];

--- a/cypress/e2e/searchRoutesAndLines.cy.ts
+++ b/cypress/e2e/searchRoutesAndLines.cy.ts
@@ -1,115 +1,11 @@
-import {
-  LineInsertInput,
-  RouteInsertInput,
-  RouteTypeOfLineEnum,
-  buildLine,
-  buildRoute,
-} from '@hsl/jore4-test-db-manager';
-import { DateTime } from 'luxon';
+import pick from 'lodash/pick';
+import { getClonedBaseDbResources } from '../datasets/base';
 import { Tag } from '../enums';
 import { RoutesAndLinesPage, SearchResultsPage } from '../pageObjects';
 import { insertToDbHelper } from '../utils';
 import { expectGraphQLCallToSucceed } from '../utils/assertions';
 
-const lines: LineInsertInput[] = [
-  // Valid in 2022
-  {
-    ...buildLine({ label: '1666' }),
-    line_id: '5dfa82f1-b3f7-4e26-b31d-0d7bd78da0be',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-    validity_start: DateTime.fromISO('2022-01-02'),
-    validity_end: DateTime.fromISO('2022-12-24'),
-  },
-  // Valid in 2023
-  {
-    ...buildLine({ label: '2666' }),
-    line_id: '61e4d95e-34e5-11ed-a261-0242ac120002',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-    validity_start: DateTime.fromISO('2023-01-02'),
-    validity_end: DateTime.fromISO('2023-12-24'),
-  },
-  // Valid in 2024
-  {
-    ...buildLine({ label: '1777' }),
-    line_id: '47c5fe92-e630-430b-a2da-2c6739acbb2b',
-    type_of_line: RouteTypeOfLineEnum.StoppingBusService,
-    validity_start: DateTime.fromISO('2024-01-02'),
-    validity_end: DateTime.fromISO('2024-12-24'),
-  },
-  // Valid between 2000 and 2054
-  {
-    ...buildLine({ label: '9999' }),
-    line_id: '7f5aa870-891a-433e-bd9b-f864162a2adf',
-    validity_start: DateTime.fromISO('2000-01-02'),
-    validity_end: DateTime.fromISO('2054-12-24'),
-  },
-  {
-    ...buildLine({ label: '9888' }),
-    line_id: 'a627dfbf-8db6-4519-b968-56b4a4988d91',
-    validity_start: DateTime.fromISO('2000-01-02'),
-    validity_end: DateTime.fromISO('2054-12-24'),
-  },
-  {
-    ...buildLine({ label: '8888' }),
-    line_id: '69141b10-98cb-4319-9fe9-95cddbd46987',
-    validity_start: DateTime.fromISO('2000-01-02'),
-    validity_end: DateTime.fromISO('2054-12-24'),
-  },
-  // Always valid.
-  {
-    ...buildLine({ label: '8889' }),
-    line_id: '429413b0-a3b7-4b12-a3a1-5c26268066c1',
-    validity_start: null,
-    validity_end: null,
-  },
-];
-
-const routes: RouteInsertInput[] = [
-  // Valid in 2022
-  {
-    ...buildRoute({ label: '1111' }),
-    route_id: '48490721-3346-493a-80c8-3edd07c2d5d6',
-    on_line_id: lines[0].line_id,
-    validity_start: lines[0].validity_start,
-    validity_end: lines[0].validity_end,
-  },
-  // Valid in 2023
-  {
-    ...buildRoute({ label: '1222' }),
-    route_id: 'd82ebf21-5adb-419c-b057-c6e3b0f7480c',
-    on_line_id: lines[1].line_id,
-    validity_start: lines[1].validity_start,
-    validity_end: lines[1].validity_end,
-  },
-  // Valid in 2024
-  {
-    ...buildRoute({ label: '2333' }),
-    route_id: 'fa6196fa-ce61-4808-84bf-f4fc60bf1162',
-    on_line_id: lines[2].line_id,
-    validity_start: lines[2].validity_start,
-    validity_end: lines[2].validity_end,
-  },
-  // The rest are valid between 2000 and 2054
-  {
-    ...buildRoute({ label: '1999' }),
-    route_id: 'eec15aaf-3cf3-4fc8-86a1-7849ea4d88e0',
-    on_line_id: lines[3].line_id,
-    validity_start: lines[3].validity_start,
-    validity_end: lines[3].validity_end,
-  },
-  {
-    ...buildRoute({ label: '1888' }),
-    route_id: '88f2bb05-8438-41ab-ba26-27983250a78e',
-    on_line_id: lines[3].line_id,
-    validity_start: lines[3].validity_start,
-    validity_end: lines[3].validity_end,
-  },
-];
-
-const dbResources = {
-  lines,
-  routes,
-};
+const dbResources = pick(getClonedBaseDbResources(), 'lines', 'routes');
 
 describe('Verify that route and line search works', () => {
   let searchResultsPage: SearchResultsPage;
@@ -152,11 +48,12 @@ describe('Verify that route and line search works', () => {
 
     searchResultsPage
       .getSearchResultsContainer()
-      .should('contain', '2 hakutulosta');
+      .should('contain', '3 hakutulosta');
     searchResultsPage
       .getLinesSearchResultTable()
       .should('contain', '9999')
-      .and('contain', '9888');
+      .and('contain', '9888')
+      .and('contain', '901');
     searchResultsPage
       .getLinesSearchResultTable()
       .should('not.contain', '8888')


### PR DESCRIPTION
* Move lines and routes into datasets/base.ts so that they can be used in the tests for "Search stops by line" feature.

* Augment datasets/stopRegistry.ts data with more info.

* Swtich stop-registry/stopSearch tests to use datasets/* data, instead of custom data defined on the test file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/924)
<!-- Reviewable:end -->
