### PR TITLE
43662 - Added error handling hook to StopAreaDetailsEdit

### DIFF
--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -1,3 +1,7 @@
+import {
+  StopAreaInput,
+  StopRegistryGeoJsonType,
+} from '@hsl/jore4-test-db-manager';
 import { DateTime } from 'luxon';
 import {
   buildInfraLinksAlongRoute,
@@ -16,7 +20,10 @@ import {
 } from '../../pageObjects';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
-import { expectGraphQLCallToSucceed } from '../../utils/assertions';
+import {
+  expectGraphQLCallToReturnError,
+  expectGraphQLCallToSucceed,
+} from '../../utils/assertions';
 import { InsertedStopRegistryIds } from '../utils';
 
 function mapToShortDate(date: DateTime | null) {
@@ -49,6 +56,24 @@ describe('Stop area details', () => {
   const baseStopRegistryData = getClonedBaseStopRegistryData();
 
   const testStopArea = { ...stopAreaX0003 };
+  const stopAreaData: Array<StopAreaInput> = [
+    testStopArea,
+    {
+      memberLabels: ['E2E002', 'E2E008'],
+      stopArea: {
+        name: { lang: 'fin', value: 'X0004' },
+        description: { lang: 'fin', value: 'Annankatu 16' },
+        validBetween: {
+          fromDate: DateTime.fromISO('2020-01-01T00:00:00.001'),
+          toDate: DateTime.fromISO('2050-01-01T00:00:00.001'),
+        },
+        geometry: {
+          coordinates: [24.838928, 60.165434],
+          type: StopRegistryGeoJsonType.Point,
+        },
+      },
+    },
+  ];
 
   const testAreaExpectedBasicDetails: ExpectedBasicDetails = {
     name: testStopArea.stopArea.name.value,
@@ -82,11 +107,10 @@ describe('Stop area details', () => {
     cy.task('resetDbs');
 
     insertToDbHelper(dbResources);
-
-    cy.task<InsertedStopRegistryIds>(
-      'insertStopRegistryData',
-      baseStopRegistryData,
-    ).then((data) => {
+    cy.task<InsertedStopRegistryIds>('insertStopRegistryData', {
+      ...baseStopRegistryData,
+      stopAreas: stopAreaData,
+    }).then((data) => {
       const id = data.stopAreaIdsByName.X0003;
 
       cy.setupTests();
@@ -323,6 +347,42 @@ describe('Stop area details', () => {
 
       // And the basic details should still match newBasicDetails
       assertBasicDetails(newBasicDetails);
+    });
+
+    it('should handle unique name exception', () => {
+      const existingLabel =
+        stopAreaData?.at(1)?.stopArea?.name?.value ?? 'noop';
+      const newBasicDetails: ExpectedBasicDetails = {
+        ...testAreaExpectedBasicDetails,
+        name: existingLabel,
+      };
+
+      assertBasicDetails(testAreaExpectedBasicDetails);
+      stopAreaDetailsPage.details.getEditButton().click();
+      inputBasicDetails(newBasicDetails);
+      stopAreaDetailsPage.details.edit.getSaveButton().click();
+      toast.checkDangerToastHasMessage(
+        'Pysäkkialueella tulee olla uniikki tunnus, mutta tunnus X0004 on jo jonkin toisen alueen käytössä!',
+      );
+      expectGraphQLCallToReturnError('@gqlUpsertStopArea');
+    });
+
+    it('should handle unique description exception', () => {
+      const existingDescription =
+        stopAreaData?.at(1)?.stopArea?.description?.value ?? 'noop';
+      const newBasicDetails: ExpectedBasicDetails = {
+        ...testAreaExpectedBasicDetails,
+        description: existingDescription,
+      };
+
+      assertBasicDetails(testAreaExpectedBasicDetails);
+      stopAreaDetailsPage.details.getEditButton().click();
+      inputBasicDetails(newBasicDetails);
+      stopAreaDetailsPage.details.edit.getSaveButton().click();
+      toast.checkDangerToastHasMessage(
+        'Pysäkkialueella tulee olla uniikki nimi, mutta nimi Annankatu 16 on jo jonkin toisen alueen käytössä!',
+      );
+      expectGraphQLCallToReturnError('@gqlUpsertStopArea');
     });
   });
 });

--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -351,7 +351,10 @@ describe('Stop area details', () => {
 
     it('should handle unique name exception', () => {
       const existingLabel =
-        stopAreaData?.at(1)?.stopArea?.name?.value ?? 'noop';
+        stopAreaData?.find(
+          (d) => d.stopArea?.name?.value !== testStopArea.stopArea.name.value,
+        )?.stopArea?.name?.value ?? 'noop';
+
       const newBasicDetails: ExpectedBasicDetails = {
         ...testAreaExpectedBasicDetails,
         name: existingLabel,
@@ -361,7 +364,7 @@ describe('Stop area details', () => {
       stopAreaDetailsPage.details.getEditButton().click();
       inputBasicDetails(newBasicDetails);
       stopAreaDetailsPage.details.edit.getSaveButton().click();
-      toast.checkDangerToastHasMessage(
+      toast.expectDangerToast(
         'Pysäkkialueella tulee olla uniikki tunnus, mutta tunnus X0004 on jo jonkin toisen alueen käytössä!',
       );
       expectGraphQLCallToReturnError('@gqlUpsertStopArea');
@@ -369,7 +372,11 @@ describe('Stop area details', () => {
 
     it('should handle unique description exception', () => {
       const existingDescription =
-        stopAreaData?.at(1)?.stopArea?.description?.value ?? 'noop';
+        stopAreaData?.find(
+          (d) =>
+            d.stopArea?.description?.value !==
+            testStopArea.stopArea.description.value,
+        )?.stopArea?.description?.value ?? 'noop';
       const newBasicDetails: ExpectedBasicDetails = {
         ...testAreaExpectedBasicDetails,
         description: existingDescription,
@@ -379,7 +386,7 @@ describe('Stop area details', () => {
       stopAreaDetailsPage.details.getEditButton().click();
       inputBasicDetails(newBasicDetails);
       stopAreaDetailsPage.details.edit.getSaveButton().click();
-      toast.checkDangerToastHasMessage(
+      toast.expectDangerToast(
         'Pysäkkialueella tulee olla uniikki nimi, mutta nimi Annankatu 16 on jo jonkin toisen alueen käytössä!',
       );
       expectGraphQLCallToReturnError('@gqlUpsertStopArea');

--- a/cypress/pageObjects/Toast.ts
+++ b/cypress/pageObjects/Toast.ts
@@ -1,18 +1,33 @@
+export enum ToastType {
+  PRIMARY = 'primary-toast',
+  SUCCESS = 'success-toast',
+  WARNING = 'warning-toast',
+  DANGER = 'danger-toast',
+}
+
 export class Toast {
+  getToastByType(toastType: ToastType) {
+    return cy.getByTestId(toastType);
+  }
+
   getPrimaryToast() {
-    return cy.getByTestId('primary-toast');
+    return this.getToastByType(ToastType.PRIMARY);
   }
 
   getSuccessToast() {
-    return cy.getByTestId('success-toast');
+    return this.getToastByType(ToastType.SUCCESS);
   }
 
   getDangerToast() {
-    return cy.getByTestId('danger-toast');
+    return this.getToastByType(ToastType.DANGER);
   }
 
   getWarningToast() {
-    return cy.getByTestId('warning-toast');
+    return this.getToastByType(ToastType.WARNING);
+  }
+
+  checkToastHasMessage(message: string, toastType: ToastType) {
+    this.getToastByType(toastType).contains(message);
   }
 
   checkDangerToastHasMessage(message: string) {
@@ -27,7 +42,7 @@ export class Toast {
     this.getWarningToast().contains(message);
   }
 
-  expectSuccessToast(message?: string) {
+  expectToast(toastType: ToastType, message?: string) {
     // Find any toast
     cy.get('[data-testElementType="toast"]')
       // And wait it to become fully visible
@@ -35,11 +50,27 @@ export class Toast {
       // Then assert it is of a right type.
       .then((toast) => {
         // eslint-disable-next-line jest/valid-expect
-        expect(toast).have.attr('data-testid', 'success-toast');
+        expect(toast).have.attr('data-testid', toastType);
       });
 
     if (message) {
-      this.checkSuccessToastHasMessage(message);
+      this.checkToastHasMessage(message, toastType);
     }
+  }
+
+  expectPrimaryToast(message?: string) {
+    this.expectToast(ToastType.PRIMARY, message);
+  }
+
+  expectSuccessToast(message?: string) {
+    this.expectToast(ToastType.SUCCESS, message);
+  }
+
+  expectDangerToast(message?: string) {
+    this.expectToast(ToastType.DANGER, message);
+  }
+
+  expectWarningToast(message?: string) {
+    this.expectToast(ToastType.WARNING, message);
   }
 }

--- a/scripts/replace-old-image-versions.sh
+++ b/scripts/replace-old-image-versions.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+compose_folder="../docker/"
+compose_file_prefix="docker-compose."
+compose_custom_file="${compose_folder}${compose_file_prefix}custom.yml"
+
+# Capture the entire output of the script, stripping ANSI color codes
+output=$(./check-for-new-image-versions.sh | sed "s/\x1B\[[0-9;]*[a-zA-Z]//g")
+
+# Define the regex to match the lines
+regex="^hsldevcom\/([^[:space:]]+) does not use newest image in ([a-zA-Z0-9._-]+(\.[a-zA-Z0-9]+)?), uses\s+([A-Za-z0-9_-]+)\s+newest is ([A-Za-z0-9_-]+)$"
+
+# Split the output into lines and process each line
+while IFS= read -r line; do
+  echo "Processing line: $line"
+
+  # Apply the regex to capture the groups
+  if [[ $line =~ $regex ]]; then
+      image_prefix="${BASH_REMATCH[1]}"
+      file_name="${BASH_REMATCH[2]}"
+      old_version="${BASH_REMATCH[4]}"
+      newest_version="${BASH_REMATCH[5]}"
+
+      # Output the captured groups
+      echo "Captured image_prefix: $image_prefix"
+      echo "Captured file_name: $file_name"
+      echo "Captured old_version: $old_version"
+      echo "Captured newest_version: $newest_version"
+
+      # Construct the path to the docker-compose file
+      compose_file="${compose_folder}${compose_file_prefix}${file_name}"
+
+      # Check if the compose file exists
+      if [[ -f "$compose_file" ]]; then
+        echo "Updating file: $compose_file"
+
+        # Debug: Print the content of the file before replacement
+        echo "Before replacement, the file content is:"
+        grep "${image_prefix}--${old_version}" "$compose_file"
+
+        # Account for single quotes around image tags in the YAML file
+        sed -i.bak "s|${image_prefix}--${old_version}|${image_prefix}--${newest_version}|g" "$compose_file"
+        echo "SED: s|${image_prefix}--${old_version}|${image_prefix}--${newest_version}|g"
+
+        if ! grep -q "${image_prefix}--${old_version}" "$compose_file"; then
+          echo "Successfully replaced ${image_prefix}--${old_version} with ${image_prefix}--${newest_version} in $compose_file"
+         rm "$compose_file.bak"
+        else
+          echo "No replacement occurred. The old version still exists in $compose_file"
+          # Debug: Output the content after the failed replacement
+          echo "After replacement attempt, the file content is:"
+          grep "${image_prefix}" "$compose_file"
+         #mv "$compose_file.bak" "$compose_file"
+
+        fi
+      else
+        echo "File not found: $compose_file"
+      fi
+  else
+      echo "Line did not match the pattern: $line"
+  fi
+done <<< "$output"

--- a/ui/src/components/forms/stop-area/useUpsertStopArea.ts
+++ b/ui/src/components/forms/stop-area/useUpsertStopArea.ts
@@ -69,8 +69,7 @@ const mapFormStateToInput = ({
 
 export const useUpsertStopArea = () => {
   const { t } = useTranslation();
-  const { tryHandle: tryHandleApolloError } =
-    useStopAreaDetailsApolloErrorHandler();
+  const tryHandleApolloError = useStopAreaDetailsApolloErrorHandler();
   const [upsertStopAreaMutation] = useUpsertStopAreaMutation();
 
   /**

--- a/ui/src/components/forms/stop-area/useUpsertStopArea.ts
+++ b/ui/src/components/forms/stop-area/useUpsertStopArea.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client';
+import { ApolloError, gql } from '@apollo/client';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -13,6 +13,7 @@ import {
   showDangerToast,
 } from '../../../utils';
 import { StopAreaFormState } from './stopAreaFormSchema';
+import { useStopAreaDetailsApolloErrorHandler } from './util/stopAreaDetailsErrorHandler';
 
 const GQL_UPSERT_STOP_AREA = gql`
   mutation UpsertStopArea($object: stop_registry_GroupOfStopPlacesInput) {
@@ -68,6 +69,8 @@ const mapFormStateToInput = ({
 
 export const useUpsertStopArea = () => {
   const { t } = useTranslation();
+  const { tryHandle: tryHandleApolloError } =
+    useStopAreaDetailsApolloErrorHandler();
   const [upsertStopAreaMutation] = useUpsertStopAreaMutation();
 
   /**
@@ -94,7 +97,13 @@ export const useUpsertStopArea = () => {
   );
 
   const defaultErrorHandler = useCallback(
-    (error: unknown) => {
+    (error: unknown, details?: StopAreaFormState) => {
+      if (error instanceof ApolloError) {
+        const isKnowError = tryHandleApolloError(error, details);
+        if (isKnowError) {
+          return;
+        }
+      }
       if (error instanceof Error) {
         showDangerToast(
           `${t('errors.saveFailed')}, ${error}, ${error.message}`,
@@ -103,7 +112,7 @@ export const useUpsertStopArea = () => {
         showDangerToast(`${t('errors.saveFailed')}, ${error}`);
       }
     },
-    [t],
+    [t, tryHandleApolloError],
   );
 
   return {

--- a/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.spec.ts
+++ b/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.spec.ts
@@ -1,0 +1,145 @@
+import { ApolloError } from '@apollo/client';
+import { useTranslation } from 'react-i18next';
+import { showDangerToast } from '../../../../utils';
+import { renderHook } from '../../../../utils/test-utils';
+import { StopAreaFormState } from '../stopAreaFormSchema';
+import { useStopAreaDetailsApolloErrorHandler } from './stopAreaDetailsErrorHandler';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(),
+}));
+
+jest.mock('i18next', () => ({
+  use: jest.fn(() => ({
+    init: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../../utils', () => ({
+  showDangerToast: jest.fn(),
+}));
+
+type TestError = Partial<ApolloError> & {
+  cause: {
+    message: string;
+    extensions: { errorCode: string } | undefined;
+  };
+};
+const mockStateDefaults = {
+  indefinite: false,
+  latitude: 0,
+  longitude: 0,
+  memberStops: [],
+  validityStart: '',
+};
+
+describe('useStopAreaDetailsApolloErrorHandler', () => {
+  const tMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useTranslation as jest.Mock).mockReturnValue({ t: tMock });
+  });
+
+  test('should handle known error with details', () => {
+    const knownErrorCode = 'GROUP_OF_STOP_PLACES_UNIQUE_NAME';
+    const extensions = { errorCode: knownErrorCode };
+    const errorWithKnownCode: TestError = {
+      graphQLErrors: [],
+      networkError: null,
+      message: 'Known Error',
+      cause: { extensions, message: knownErrorCode },
+    };
+
+    tMock.mockImplementation(
+      (key, details) => `${key} ${JSON.stringify(details)}`,
+    );
+
+    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+
+    const details: StopAreaFormState = {
+      ...mockStateDefaults,
+      label: 'Testlabel1',
+      name: 'Testname1',
+    }; // Mock details data
+    const handled = result.current.tryHandle(
+      errorWithKnownCode as ApolloError,
+      details,
+    );
+
+    expect(handled).toBe(true);
+    expect(tMock).toHaveBeenCalledWith(
+      'stopAreaDetails.errors.groupOfStopPlacesUniqueName',
+      details,
+    );
+    expect(showDangerToast).toHaveBeenCalledWith(
+      'stopAreaDetails.errors.groupOfStopPlacesUniqueName {"indefinite":false,"latitude":0,"longitude":0,"memberStops":[],"validityStart":"","label":"Testlabel1","name":"Testname1"}',
+    );
+  });
+
+  test('should handle known error without details', () => {
+    const knownErrorCode = 'GROUP_OF_STOP_PLACES_UNIQUE_DESCRIPTION';
+    const extensions = { errorCode: knownErrorCode };
+    const errorWithKnownCode: TestError = {
+      graphQLErrors: [],
+      networkError: null,
+      message: 'Known Error',
+      cause: { extensions, message: knownErrorCode },
+    };
+
+    tMock.mockImplementation((key) => key);
+
+    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+
+    const handled = result.current.tryHandle(errorWithKnownCode as ApolloError);
+
+    expect(handled).toBe(true);
+    expect(tMock).toHaveBeenCalledWith(
+      'stopAreaDetails.errors.groupOfStopPlacesUniqueDescription',
+    );
+    expect(showDangerToast).toHaveBeenCalledWith(
+      'stopAreaDetails.errors.groupOfStopPlacesUniqueDescription',
+    );
+  });
+
+  test('should not handle unknown error', () => {
+    const unknownErrorCode = 'UNKNOWN_ERROR_CODE';
+    const extensions = { errorCode: unknownErrorCode };
+    const unknownError: TestError = {
+      graphQLErrors: [],
+      networkError: null,
+      message: 'Unknown Error',
+      cause: { extensions, message: unknownErrorCode },
+    };
+
+    tMock.mockImplementation((key) => key);
+
+    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+
+    const handled = result.current.tryHandle(unknownError as ApolloError);
+
+    expect(handled).toBe(false);
+    expect(tMock).not.toHaveBeenCalled();
+  });
+
+  test('should not handle errors with no extensions', () => {
+    const errorWithNoExtensions: TestError = {
+      ...mockStateDefaults,
+      graphQLErrors: [],
+      networkError: null,
+      message: 'Error with no extensions',
+      cause: { message: '', extensions: undefined }, // No extensions in this case
+    };
+
+    tMock.mockImplementation((key) => key);
+
+    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+
+    const handled = result.current.tryHandle(
+      errorWithNoExtensions as ApolloError,
+    );
+
+    expect(handled).toBe(false);
+    expect(tMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.spec.ts
+++ b/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.spec.ts
@@ -55,17 +55,15 @@ describe('useStopAreaDetailsApolloErrorHandler', () => {
       (key, details) => `${key} ${JSON.stringify(details)}`,
     );
 
-    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+    const tryHandle = renderHook(() => useStopAreaDetailsApolloErrorHandler())
+      .result.current;
 
     const details: StopAreaFormState = {
       ...mockStateDefaults,
       label: 'Testlabel1',
       name: 'Testname1',
     }; // Mock details data
-    const handled = result.current.tryHandle(
-      errorWithKnownCode as ApolloError,
-      details,
-    );
+    const handled = tryHandle(errorWithKnownCode as ApolloError, details);
 
     expect(handled).toBe(true);
     expect(tMock).toHaveBeenCalledWith(
@@ -89,9 +87,10 @@ describe('useStopAreaDetailsApolloErrorHandler', () => {
 
     tMock.mockImplementation((key) => key);
 
-    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+    const tryHandle = renderHook(() => useStopAreaDetailsApolloErrorHandler())
+      .result.current;
 
-    const handled = result.current.tryHandle(errorWithKnownCode as ApolloError);
+    const handled = tryHandle(errorWithKnownCode as ApolloError);
 
     expect(handled).toBe(true);
     expect(tMock).toHaveBeenCalledWith(
@@ -114,9 +113,10 @@ describe('useStopAreaDetailsApolloErrorHandler', () => {
 
     tMock.mockImplementation((key) => key);
 
-    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+    const tryHandle = renderHook(() => useStopAreaDetailsApolloErrorHandler())
+      .result.current;
 
-    const handled = result.current.tryHandle(unknownError as ApolloError);
+    const handled = tryHandle(unknownError as ApolloError);
 
     expect(handled).toBe(false);
     expect(tMock).not.toHaveBeenCalled();
@@ -133,11 +133,10 @@ describe('useStopAreaDetailsApolloErrorHandler', () => {
 
     tMock.mockImplementation((key) => key);
 
-    const { result } = renderHook(() => useStopAreaDetailsApolloErrorHandler());
+    const tryHandle = renderHook(() => useStopAreaDetailsApolloErrorHandler())
+      .result.current;
 
-    const handled = result.current.tryHandle(
-      errorWithNoExtensions as ApolloError,
-    );
+    const handled = tryHandle(errorWithNoExtensions as ApolloError);
 
     expect(handled).toBe(false);
     expect(tMock).not.toHaveBeenCalled();

--- a/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.spec.ts
+++ b/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.spec.ts
@@ -95,6 +95,7 @@ describe('useStopAreaDetailsApolloErrorHandler', () => {
     expect(handled).toBe(true);
     expect(tMock).toHaveBeenCalledWith(
       'stopAreaDetails.errors.groupOfStopPlacesUniqueDescription',
+      undefined,
     );
     expect(showDangerToast).toHaveBeenCalledWith(
       'stopAreaDetails.errors.groupOfStopPlacesUniqueDescription',

--- a/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.ts
+++ b/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.ts
@@ -1,0 +1,46 @@
+import { ApolloError } from '@apollo/client';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { showDangerToast } from '../../../../utils';
+import { StopAreaFormState } from '../stopAreaFormSchema';
+
+const ERRORS: Readonly<Map<string, string>> = new Map([
+  [
+    'GROUP_OF_STOP_PLACES_UNIQUE_NAME',
+    'stopAreaDetails.errors.groupOfStopPlacesUniqueName',
+  ],
+  [
+    'GROUP_OF_STOP_PLACES_UNIQUE_DESCRIPTION',
+    'stopAreaDetails.errors.groupOfStopPlacesUniqueDescription',
+  ],
+]);
+type ExtensionsType = { errorCode: string };
+
+export function useStopAreaDetailsApolloErrorHandler() {
+  const { t } = useTranslation();
+
+  const tryHandle = useCallback(
+    (error: ApolloError, details?: StopAreaFormState): boolean => {
+      const errorNames = Array.from(ERRORS.keys());
+      const knownError: string | undefined = errorNames.find((key) => {
+        const extensions: ExtensionsType | undefined = error.cause
+          ?.extensions as ExtensionsType;
+        return extensions?.errorCode === key;
+      });
+      if (knownError) {
+        const knownErrorKey = ERRORS.get(knownError);
+        if (knownErrorKey) {
+          if (details) {
+            showDangerToast(`${t(knownErrorKey, details)}`);
+            return true;
+          }
+          showDangerToast(`${t(knownErrorKey)}`);
+          return true;
+        }
+      }
+      return false;
+    },
+    [t],
+  );
+  return { tryHandle };
+}

--- a/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.ts
+++ b/ui/src/components/forms/stop-area/util/stopAreaDetailsErrorHandler.ts
@@ -35,9 +35,7 @@ export function useStopAreaDetailsApolloErrorHandler(): (
     (error: ApolloError, details?: StopAreaFormState): boolean => {
       const translationKey = mapApolloErrorToTranslationKey(error);
       if (translationKey) {
-        details
-          ? showDangerToast(t(translationKey, details))
-          : showDangerToast(t(translationKey));
+        showDangerToast(t(translationKey, details));
         return true;
       }
       return false;

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
@@ -78,7 +78,7 @@ const StopAreaDetailsEditImpl: ForwardRefRenderFunction<
       showSuccessToast(t('stopArea.editSuccess'));
       onFinishEditing();
     } catch (err) {
-      defaultErrorHandler(err as Error);
+      defaultErrorHandler(err as Error, state);
     }
     setIsLoading(false);
   };

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -154,6 +154,10 @@
         "title": "Removing stop from the stop area",
         "body": "The Stop will not be deleted, but it will no longer be associated with the stop area."
       }
+    },
+    "errors": {
+      "groupOfStopPlacesUniqueName": "Stop area should have unique label but {{label}} is already in use!",
+      "groupOfStopPlacesUniqueDescription": "Stop area should have unique name but {{name}} is already in use!"
     }
   },
   "stopPlaceTypes": {

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -154,6 +154,10 @@
         "title": "Poistetaan pysäkki pysäkkialueen käytöstä",
         "body": "Pysäkki jää edelleen jäljelle, se ei ole vain yhdistetty pysäkkialueeseen."
       }
+    },
+    "errors": {
+      "groupOfStopPlacesUniqueName": "Pysäkkialueella tulee olla uniikki tunnus, mutta tunnus {{label}} on jo jonkin toisen alueen käytössä!",
+      "groupOfStopPlacesUniqueDescription": "Pysäkkialueella tulee olla uniikki nimi, mutta nimi {{name}} on jo jonkin toisen alueen käytössä!"
     }
   },
   "stopPlaceTypes": {

--- a/ui/src/utils/i18n/snakeToCamel.ts
+++ b/ui/src/utils/i18n/snakeToCamel.ts
@@ -1,0 +1,12 @@
+export function snakeToCamel(snakeCaseStr: string): string {
+  return snakeCaseStr
+    .toLowerCase()
+    .split('_')
+    .map((word, index) => {
+      if (index === 0) {
+        return word;
+      }
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join('');
+}


### PR DESCRIPTION
Testing:

- Go to: //stop-registry/stop-areas/HSL:GroupOfStopPlaces:2?observationDate=2024-10-16
- Change label and name values to existing values ( for example these - Go to: //stop-registry/stop-areas/HSL:GroupOfStopPlaces:1?observationDate=2024-10-16)
- Should print errors with correct texts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/931)
<!-- Reviewable:end -->
