### PR TITLE
Utility updates

### DIFF
--- a/ui/src/components/forms/common/InputLabel.tsx
+++ b/ui/src/components/forms/common/InputLabel.tsx
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import { ForwardedRef, forwardRef } from 'react';
 import { FieldValues, Path, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { TranslationKey } from '../../../i18n';
@@ -9,11 +10,10 @@ interface Props<FormState extends FieldValues> {
   translationPrefix: TranslationKey;
 }
 
-export const InputLabel = <FormState extends FieldValues>({
-  className = '',
-  fieldPath,
-  translationPrefix,
-}: Props<FormState>): React.ReactElement => {
+const InputLabelImpl = <FormState extends FieldValues>(
+  { className = '', fieldPath, translationPrefix }: Props<FormState>,
+  ref: ForwardedRef<HTMLLabelElement>,
+): React.ReactElement => {
   const { t } = useTranslation();
   const {
     formState: { errors },
@@ -22,7 +22,11 @@ export const InputLabel = <FormState extends FieldValues>({
   const hasError = !!get(errors, fieldPath);
 
   return (
-    <label className={className} htmlFor={`${translationPrefix}.${fieldPath}`}>
+    <label
+      className={className}
+      htmlFor={`${translationPrefix}.${fieldPath}`}
+      ref={ref}
+    >
       {/* Regex removes dot and series of numbers eg. ".10"
           This is needed for translation to work with fields that are
           created with React Hook Form useFieldArray */}
@@ -31,3 +35,9 @@ export const InputLabel = <FormState extends FieldValues>({
     </label>
   );
 };
+
+export const InputLabel = forwardRef(InputLabelImpl) as <
+  FormState extends FieldValues,
+>(
+  props: Props<FormState> & { readonly ref?: ForwardedRef<HTMLLabelElement> },
+) => ReturnType<typeof InputLabelImpl>;

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/useFindStopPlaceByQuery.ts
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/useFindStopPlaceByQuery.ts
@@ -4,10 +4,7 @@ import {
   StopsDatabaseStopPlaceNewestVersionBoolExp,
   useFindStopPlacesByQueryAndGroupQuery,
 } from '../../../../generated/graphql';
-import {
-  AllOptionEnum,
-  buildSearchStopsGqlQueryVariables,
-} from '../../../../utils';
+import { buildSearchStopByLabelOrNameFilter } from '../../../../utils';
 import { stopAreaMemberStopSchema } from '../stopAreaFormSchema';
 
 const LIMIT = 20;
@@ -44,12 +41,7 @@ function buildMemberStopGqlFilter(
   query: string,
   editedStopAreaId: string | null | undefined,
 ): StopsDatabaseStopPlaceNewestVersionBoolExp {
-  const baseWhere = buildSearchStopsGqlQueryVariables({
-    elyNumber: '',
-    municipalities: AllOptionEnum.All,
-    // Automatic wild card as this is an "autocomplete" component.
-    labelOrName: `${query}%`,
-  });
+  const baseWhere = buildSearchStopByLabelOrNameFilter(`${query}%`);
 
   const notInGroup: StopsDatabaseStopPlaceNewestVersionBoolExp = {
     _not: { group_of_stop_places_members: {} },

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -21,6 +21,7 @@ export * from './usePagination';
 export * from './useRequiredParams';
 export * from './useShowRoutesOnModal';
 export * from './useToggle';
+export * from './useTypedUrlState';
 export * from './vehicle-schedule-frame';
 export * from './vehicle-service';
 export * from './via';

--- a/ui/src/hooks/useTypedUrlState.ts
+++ b/ui/src/hooks/useTypedUrlState.ts
@@ -1,0 +1,356 @@
+import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
+import without from 'lodash/without';
+import xor from 'lodash/xor';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { log } from '../utils';
+
+type UrlStateSerializer<T> = (value: T) => string;
+type UrlStateDeserializer<T> = (value: string) => T;
+
+/**
+ * Mapping from a state object to a collection of transformer functions
+ * needed to stringify the individual fields of the state object.
+ */
+export type UrlStateSerializers<StateT extends object> = {
+  readonly [key in keyof StateT]: UrlStateSerializer<StateT[key]>;
+};
+
+/**
+ * Mapping from a state object to a collection of transformer functions
+ * needed to retrieve the actual value of the state objects field,
+ * from its string representation.
+ */
+export type UrlStateDeserializers<StateT extends object> = {
+  readonly [key in keyof StateT]: UrlStateDeserializer<StateT[key]>;
+};
+
+const INTERNAL_PARAMS = 'INTERNAL_PARAMS' as const;
+
+/**
+ * State object with an extra slot for unknown URL params.
+ * Needed for compatability with the old untyped and unmanaged setUrlParam system.
+ */
+type StateWithInternalParams<T extends object> = T & {
+  readonly [INTERNAL_PARAMS]: { readonly [key: string]: ReadonlyArray<string> };
+};
+
+/**
+ * Helper type used when reassembling the state from the URl params field by field.
+ */
+type PartialState = Record<string, unknown> & {
+  [INTERNAL_PARAMS]: { [key: string]: ReadonlyArray<string> };
+};
+
+// On dev mode throws error, otherwise (in prod) logs a warning, with the expectation
+// that the calling function has a sane fallback for the error.
+export function warnOrThrow(message: string, cause?: unknown) {
+  if (process.env.NODE_ENV === 'development') {
+    throw new Error(message, { cause });
+  } else {
+    log.warn(cause ? `${message} Cause: ${String(cause)}` : message);
+  }
+}
+
+/**
+ * Actual serialization implementation. Transforms state to URLSearchParams
+ *
+ * Diffs state with default values to determine changed fields that need to be
+ * stored in the URL. Then calls the associated serializer with the given field's
+ * value and sets the param in the URLSearchParams. Finally copies over any extra
+ * fields from the { [INTERNAL_PARAMS] } slot from the interbal state object.
+ *
+ * @param serializers state to url param mappers
+ * @param defaultValues default values
+ * @param state current state
+ * @returns URLSearchParams that can be transformed into the search string
+ */
+function serializeInternalState<StateT extends object>(
+  serializers: UrlStateSerializers<StateT>,
+  defaultValues: StateT,
+  state: StateWithInternalParams<StateT>,
+): URLSearchParams {
+  const unknownParams = Object.entries(state.INTERNAL_PARAMS)
+    .map(([key, values]) => values.map((value) => [key, value]))
+    .flat(1);
+
+  const serializableKeys = Object.keys(serializers) as unknown as ReadonlyArray<
+    keyof StateT
+  >;
+  const serializedParams = serializableKeys
+    .filter((knownKey) => !isEqual(defaultValues[knownKey], state[knownKey]))
+    .map((knownKey) => [
+      knownKey as string,
+      serializers[knownKey](state[knownKey] as ExplicitAny),
+    ]);
+
+  return new URLSearchParams([...unknownParams, ...serializedParams]);
+}
+
+/**
+ * Allow serializing a state for custom navigation.
+ *
+ * {@link useTypedUrlState} does not allow changing the url, its job is to simply
+ * keep the page's state and URL in sync. If we need to navigate to another page,
+ * this function can be used to construct a properly formatted query params string
+ * for the page.
+ *
+ * This function should always be curried to provide the proper serializers and
+ * default values, and then only be called with the state param.
+ *
+ * Sets the { [INTERNAL_PARAMS] } slot to be empty. A page using {@link useTypedUrlState}
+ * should never have/depend on any extra params not present in the "typed URL state".
+ * But technically those could be added into the returned URLSearchParams manually.
+ *
+ * @example
+ * navigate({
+ *   pathname: Paths.searchResults,
+ *   // serializeState should be curried tough
+ *   search: serializeState(
+ *     SEARCH_SERIALIZERS,
+ *     SEARCH_DEFAULT_STATE,
+ *     { query: 'H100*' }
+ *   ).toString()
+ * });
+ *
+ * @param serializers state to url param mappers
+ * @param defaultValues default values
+ * @param state current state
+ * @returns URLSearchParams that can be transformed into the search string
+ */
+export function serializeState<StateT extends object>(
+  serializers: UrlStateSerializers<StateT>,
+  defaultValues: StateT,
+  state: StateT,
+): URLSearchParams {
+  return serializeInternalState(serializers, defaultValues, {
+    ...state,
+    [INTERNAL_PARAMS]: {},
+  });
+}
+
+/**
+ * Retrieves and parses the requested state field's value from the URL Params
+ * or fallback on to the default value of the field.
+ *
+ * In Dev mode requires the known params to be valid and deserializable.
+ * But on Prod simply logs a warning and falls back on the default value.
+ *
+ * @param deserializers url param string to state value mappers
+ * @param defaultValues default values
+ * @param params query params present on the URL
+ * @param key name of the field being parsed
+ * @returns StateT[typeof key] value for the field
+ */
+function resolveStateValue<StateT extends object>(
+  deserializers: UrlStateDeserializers<StateT>,
+  defaultValues: StateT,
+  params: URLSearchParams,
+  key: keyof StateT,
+): StateT[typeof key] {
+  const defaultValue = defaultValues[key];
+  const urlParamValue = params.get(key as string);
+
+  if (urlParamValue !== null) {
+    try {
+      return deserializers[key](urlParamValue);
+    } catch (e) {
+      warnOrThrow(
+        `Failed to parse url param (${key as string}) with value of (${urlParamValue})!`,
+        e,
+      );
+    }
+  }
+
+  return defaultValue;
+}
+
+/**
+ * Deserializes a state object from the values present in the URL Params.
+ *
+ * Assumes that the defaultValues function argument respects the shape of the
+ * wanted state, and it is used as a source of truth for the field names assumed
+ * to be in the state.
+ *
+ * Takes and deserializes the last instance of each named field from the URL Params
+ * into the state object. Thus, in case of Arrays duplication of the param in the
+ * URL is not possible aka `?a=1&a=2` cannot be deserialized into `{a: [1,2]}`,
+ * but will instead result in `{ a: 2 }`.
+ *
+ * If the field is not present in the URL the default value is used instead.
+ * See {@link resolveStateValue} for more details.
+ *
+ * Stores any extra params found from the URL Params in the { [INTERNAL_PARAMS] }
+ * slot of the internal state object. For these, all duplicate params values are
+ * preserved.
+ *
+ * @param deserializers url param string to state value mappers
+ * @param defaultValues default values
+ * @param search the url search string
+ */
+function deserializeState<StateT extends object>(
+  deserializers: UrlStateDeserializers<StateT>,
+  defaultValues: StateT,
+  search: string,
+): StateWithInternalParams<StateT> {
+  const params = new URLSearchParams(search);
+  const deserialized: PartialState = { [INTERNAL_PARAMS]: {} };
+
+  const stateKeys = Object.keys(defaultValues) as unknown as ReadonlyArray<
+    keyof StateT
+  >;
+
+  stateKeys.forEach((key) => {
+    if (!(key in deserializers)) {
+      warnOrThrow(`Missing deserializer for key (${key as string})!`);
+    }
+
+    deserialized[key as string] = resolveStateValue(
+      deserializers,
+      defaultValues,
+      params,
+      key,
+    );
+  });
+
+  const extraParamKeys = without(
+    Array.from(params.keys()),
+    ...(stateKeys as unknown as ReadonlyArray<string>),
+  );
+  extraParamKeys.forEach((key) => {
+    deserialized.INTERNAL_PARAMS[key] = params.getAll(key);
+  });
+
+  return deserialized as unknown as StateWithInternalParams<StateT>;
+}
+
+function useAssertProperSerializationData<StateT extends object>(
+  serializers: UrlStateSerializers<StateT>,
+  deserializers: UrlStateDeserializers<StateT>,
+  defaultValues: StateT,
+) {
+  const stableInputRef = useRef({
+    serializers,
+    deserializers,
+    defaultValues,
+  });
+
+  if (process.env.NODE_ENV !== 'development') {
+    return;
+  }
+
+  if (
+    stableInputRef.current.serializers !== serializers ||
+    stableInputRef.current.deserializers !== deserializers ||
+    stableInputRef.current.defaultValues !== defaultValues
+  ) {
+    throw new Error(
+      'Serializers, deserializers and defaultValues provided into useTypedUrlState need to be stable!',
+    );
+  }
+
+  const expectedKeys = Object.keys(defaultValues);
+  if (
+    xor(expectedKeys, Object.keys(serializers)).length ||
+    xor(expectedKeys, Object.keys(deserializers)).length
+  ) {
+    throw new Error(
+      'Serializers, deserializers and defaultValues all need to have the same keys!',
+    );
+  }
+}
+
+export function useTypedUrlState<StateT extends object>(
+  serializers: UrlStateSerializers<StateT>,
+  deserializers: UrlStateDeserializers<StateT>,
+  defaultValues: StateT,
+): [StateT, Dispatch<SetStateAction<StateT>>] {
+  // Drop check on PROD build
+  // eslint-disable-next-line spaced-comment
+  /*#__PURE__*/ useAssertProperSerializationData(
+    serializers,
+    deserializers,
+    defaultValues,
+  );
+
+  const { search } = useLocation();
+  const navigate = useNavigate();
+
+  const expectedSearchRef = useRef<string>(search);
+  const [internalState, setInternalState] = useState<
+    StateWithInternalParams<StateT>
+  >(() => deserializeState(deserializers, defaultValues, search));
+
+  const state = useMemo(
+    () => omit(internalState, INTERNAL_PARAMS) as unknown as StateT,
+    [internalState],
+  );
+
+  // If URL search is changed externally, update the state to reflect that.
+  useEffect(() => {
+    if (expectedSearchRef.current !== search) {
+      setInternalState(deserializeState(deserializers, state, search));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  const setState = useCallback(
+    (newState: StateT | ((previousState: StateT) => StateT)) => {
+      setInternalState((prevState) => {
+        const nextState =
+          typeof newState === 'function' ? newState(prevState) : newState;
+        const nextInternalState = {
+          ...nextState,
+          [INTERNAL_PARAMS]: prevState[INTERNAL_PARAMS],
+        };
+
+        const nextSearchString = serializeInternalState(
+          serializers,
+          defaultValues,
+          nextInternalState,
+        ).toString();
+
+        expectedSearchRef.current = nextSearchString;
+        navigate(
+          { pathname: '.', search: nextSearchString },
+          { replace: true },
+        );
+
+        return nextInternalState;
+      });
+    },
+    // All externals are checked and assumed to be stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return [state, setState];
+}
+
+/**
+ * Create a deserializer for String enum `enum My { A='a', B='b' }`
+ *
+ * @param knownValues Object.values(MyEnum)
+ */
+export function toEnum<T extends string | number>(
+  knownValues: ReadonlyArray<T>,
+): (value: string) => T {
+  return (value: string) => {
+    if (knownValues.includes(value as ExplicitAny)) {
+      return value as unknown as T;
+    }
+
+    throw new TypeError(
+      `Value (${value}) is not a valid enum value! Known values are: ${knownValues}`,
+    );
+  };
+}

--- a/ui/src/uiComponents/ChevronToggle.tsx
+++ b/ui/src/uiComponents/ChevronToggle.tsx
@@ -2,6 +2,7 @@ import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
 import { IconButton } from './IconButton';
 
 type Props = {
+  className?: string;
   isToggled: boolean;
   testId?: string;
   onClick: () => void;
@@ -11,6 +12,7 @@ type Props = {
 };
 
 export const ChevronToggle = ({
+  className,
   isToggled,
   onClick,
   testId,
@@ -21,6 +23,7 @@ export const ChevronToggle = ({
   const iconClassName = 'text-3xl text-tweaked-brand';
   return (
     <IconButton
+      className={className}
       tooltip={isToggled ? closeTooltip : openTooltip}
       onClick={onClick}
       icon={

--- a/ui/src/uiComponents/Listbox.tsx
+++ b/ui/src/uiComponents/Listbox.tsx
@@ -72,11 +72,9 @@ export const Listbox = ({
           <ListboxButton
             arrowButtonClassNames={arrowButtonClassNames}
             buttonClassNames={buttonClassNames}
-            open={open}
             hasError={hasError}
             testId={`${testId}::ListboxButton`}
             buttonContent={buttonContent}
-            disabled={disabled}
           />
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <Transition show={open} as={Fragment} {...dropdownTransition}>

--- a/ui/src/uiComponents/ListboxButton.tsx
+++ b/ui/src/uiComponents/ListboxButton.tsx
@@ -1,46 +1,43 @@
 import { Listbox as HUIListbox } from '@headlessui/react';
-import { ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 const buttonErrorStyles =
   '!border-hsl-red !bg-hsl-red !bg-opacity-5 !border-2 text-hsl-red';
 
 const arrowErrorStyles = 'text-hsl-red';
+
 interface Props {
-  open: boolean;
   hasError: boolean;
   testId?: string;
   buttonContent: ReactNode;
   buttonClassNames?: string;
   arrowButtonClassNames?: string;
-  disabled?: boolean;
 }
-export const ListboxButton = ({
-  open,
+export const ListboxButton: FC<Props> = ({
   hasError,
   testId,
   buttonContent,
   buttonClassNames,
   arrowButtonClassNames,
-  disabled,
-}: Props): React.ReactElement => {
+}) => {
   return (
     <HUIListbox.Button
       className={twMerge(
-        `${hasError ? buttonErrorStyles : ''} ${
-          disabled ? 'input-disabled' : ''
-        } flex w-full items-center rounded-md border border-grey bg-white px-2 py-3 text-left ${buttonClassNames}`,
+        'flex w-full items-center rounded-md border border-grey bg-white px-2 py-3 text-left',
+        'ui-disabled:input-disabled',
+        hasError ? buttonErrorStyles : '',
+        buttonClassNames,
       )}
       data-testid={testId}
     >
       {buttonContent}
       <i
         className={twMerge(
-          `${
-            hasError ? arrowErrorStyles : ''
-          } icon-arrow ml-auto text-tweaked-brand transition duration-150 ease-in-out ${
-            open ? '-rotate-180' : 'rotate-0'
-          } ${arrowButtonClassNames}`,
+          'icon-arrow ml-auto text-tweaked-brand',
+          '-rotate-180 transition duration-150 ease-in-out ui-not-open:rotate-0',
+          hasError ? arrowErrorStyles : '',
+          arrowButtonClassNames,
         )}
         style={{ fontSize: 10 }}
       />

--- a/ui/src/uiComponents/MultiSelectListbox.tsx
+++ b/ui/src/uiComponents/MultiSelectListbox.tsx
@@ -106,11 +106,9 @@ export const MultiSelectListbox = ({
           <ListboxButton
             arrowButtonClassNames={arrowButtonClassNames}
             buttonClassNames={buttonClassNames}
-            open={open}
             hasError={hasError}
             testId={`${testId}::ListboxButton`}
             buttonContent={buttonContent}
-            disabled={disabled}
           />
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <Transition show={open} as={Fragment} {...dropdownTransition}>

--- a/ui/src/uiComponents/SimpleButton.tsx
+++ b/ui/src/uiComponents/SimpleButton.tsx
@@ -21,7 +21,7 @@ interface CommonButtonProps {
 }
 
 interface ButtonProps {
-  onClick: () => void;
+  onClick?: () => void;
   type?: 'button' | 'reset' | 'submit' | undefined;
   href?: never;
 }
@@ -49,25 +49,25 @@ const getHoverStyles = (inverted = false, disabled = false) => {
     : `${hoverStyle} hover:bg-opacity-50`;
 };
 
-export const SimpleButton: React.FC<Props> = (props) => {
-  const {
-    id,
-    className = '',
-    inverted,
-    selected,
-    disabled,
-    testId,
-    children,
-    containerClassName = '',
-    invertedClassName = '',
-    tooltip,
-    disabledTooltip,
-    ariaSelected,
-    role,
-    ariaControls,
-    type = 'button',
-  } = props;
-
+export const SimpleButton: React.FC<Props> = ({
+  id,
+  className = '',
+  inverted,
+  selected,
+  disabled,
+  testId,
+  children,
+  containerClassName = '',
+  invertedClassName = '',
+  tooltip,
+  disabledTooltip,
+  ariaSelected,
+  role,
+  ariaControls,
+  type = 'button',
+  onClick,
+  href,
+}) => {
   const colorClassNames = inverted
     ? `text-brand bg-white border border-grey active:border-brand ${invertedClassName}`
     : `text-white bg-brand border border-brand active:bg-opacity-50`;
@@ -79,29 +79,7 @@ export const SimpleButton: React.FC<Props> = (props) => {
     disabled,
   )} ${disabledClassNames}`;
 
-  if ((props as ButtonProps).onClick) {
-    return (
-      <span className={`inline-flex ${containerClassName}`}>
-        <button
-          id={id}
-          data-selected={selected}
-          className={twMerge(`${commonClassNames} ${className}`)}
-          // eslint-disable-next-line react/button-has-type
-          type={type}
-          onClick={(props as ButtonProps).onClick}
-          disabled={disabled}
-          data-testid={testId}
-          title={disabled ? disabledTooltip : tooltip}
-          aria-selected={ariaSelected}
-          role={role}
-          aria-controls={ariaControls}
-        >
-          {children}
-        </button>
-      </span>
-    );
-  }
-  if ((props as LinkButtonProps).href) {
+  if (href) {
     // Try to take accessibility of disabled link buttons into account as stated
     // in Bootstrap's documentation:
     // https://getbootstrap.com/docs/5.1/components/buttons/#link-functionality-caveat
@@ -115,7 +93,7 @@ export const SimpleButton: React.FC<Props> = (props) => {
           )}
           type="button"
           // @ts-expect-error we want to pass undefined as href for disabled buttons
-          to={disabled ? undefined : (props as LinkButtonProps).href}
+          to={disabled ? undefined : href}
           aria-disabled={disabled}
           tabIndex={disabled ? -1 : undefined}
           data-testid={testId}
@@ -126,6 +104,34 @@ export const SimpleButton: React.FC<Props> = (props) => {
       </span>
     );
   }
+
+  if (
+    (type === 'button' && onClick !== undefined) ||
+    type === 'submit' ||
+    type === 'reset'
+  ) {
+    return (
+      <span className={`inline-flex ${containerClassName}`}>
+        <button
+          id={id}
+          data-selected={selected}
+          className={twMerge(`${commonClassNames} ${className}`)}
+          // eslint-disable-next-line react/button-has-type
+          type={type}
+          onClick={onClick}
+          disabled={disabled}
+          data-testid={testId}
+          title={disabled ? disabledTooltip : tooltip}
+          aria-selected={ariaSelected}
+          role={role}
+          aria-controls={ariaControls}
+        >
+          {children}
+        </button>
+      </span>
+    );
+  }
+
   // eslint-disable-next-line no-console
   console.error('"onClick" or "href" prop is required');
   return null;

--- a/ui/src/utils/areEqual.spec.ts
+++ b/ui/src/utils/areEqual.spec.ts
@@ -1,0 +1,32 @@
+import isEqual from 'lodash/isEqual';
+import { DateTime } from 'luxon';
+import { areEqual } from './areEqual';
+
+describe('areEqual', () => {
+  it('cloned valid DateTimes should be equal', () => {
+    const now = DateTime.now();
+    const cloned = now.plus({ days: 0 });
+
+    expect(now !== cloned).toBeTruthy();
+    expect(areEqual(now, cloned)).toBeTruthy();
+  });
+
+  it('invalid DateTimes should not be equal', () => {
+    const a = DateTime.fromMillis(Number.NaN);
+    const b = DateTime.fromMillis(Number.NaN);
+
+    expect(a !== b).toBeTruthy();
+    expect(isEqual(a, b)).toBeTruthy();
+    expect(areEqual(a, b)).toBeFalsy();
+  });
+
+  it('should work if the other value is nullish', () => {
+    const now = DateTime.now();
+    expect(areEqual({ now }, { now: null })).toBeFalsy();
+    expect(areEqual({ now: null }, { now })).toBeFalsy();
+    expect(areEqual({ now }, { now: undefined })).toBeFalsy();
+    expect(areEqual({ now: undefined }, { now })).toBeFalsy();
+    expect(areEqual({ now }, {})).toBeFalsy();
+    expect(areEqual({}, { now })).toBeFalsy();
+  });
+});

--- a/ui/src/utils/areEqual.ts
+++ b/ui/src/utils/areEqual.ts
@@ -1,0 +1,29 @@
+import isEqualWith from 'lodash/isEqualWith';
+
+type HasEquals = { readonly equals: (other: unknown) => boolean };
+
+function hasEquals(value: unknown): value is HasEquals {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'equals' in value &&
+    typeof value.equals === 'function'
+  );
+}
+
+/**
+ * Lodash isEqual with proper handling for classes with custom equals methods.
+ * Such as Luxon DateTime.
+ *
+ * @param a
+ * @param b
+ */
+export function areEqual(a: unknown, b: unknown): boolean {
+  return isEqualWith(a, b, (subA, subB) => {
+    if (hasEquals(subA) && hasEquals(subB)) {
+      return subA.equals(subB);
+    }
+
+    return undefined;
+  });
+}

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './journeyPattern';
 export * from './localizedString';
 export * from './logger';
 export * from './misc';
+export * from './numberEnumHelpers';
 export * from './object';
 export * from './route';
 export * from './routeShape';

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './areEqual';
 export * from './components';
 export * from './download';
 export * from './enum';

--- a/ui/src/utils/numberEnumHelpers.spec.ts
+++ b/ui/src/utils/numberEnumHelpers.spec.ts
@@ -1,0 +1,29 @@
+import {
+  numberEnumEntries,
+  numberEnumKeys,
+  numberEnumValues,
+} from './numberEnumHelpers';
+
+describe('numberEnumHelpers', () => {
+  enum TestEnum {
+    A = 1,
+    B,
+    C,
+  }
+
+  it('should get proper entries', () => {
+    expect(numberEnumEntries(TestEnum)).toEqual([
+      ['A', 1],
+      ['B', 2],
+      ['C', 3],
+    ]);
+  });
+
+  it('should get proper keys', () => {
+    expect(numberEnumKeys(TestEnum)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('should get proper values', () => {
+    expect(numberEnumValues(TestEnum)).toEqual([1, 2, 3]);
+  });
+});

--- a/ui/src/utils/numberEnumHelpers.ts
+++ b/ui/src/utils/numberEnumHelpers.ts
@@ -1,0 +1,78 @@
+type NumberEnumEntry<KeyT extends string, ValueT extends number> = [
+  KeyT,
+  ValueT,
+];
+
+function isNumberEnumEntry<KeyT extends string, ValueT extends number>(
+  entry: [unknown, unknown],
+): entry is NumberEnumEntry<KeyT, ValueT> {
+  const [key, value] = entry;
+  return typeof key === 'string' && typeof value === 'number';
+}
+
+/**
+ * Gets [key, value] pairs from a number based enums runtime type.
+ *
+ * enum MyEnum { A = 1, B, C} => [['A',1], ['B',2], ['C', 3]]
+ *
+ * @param enumDefinition runtime enum definition
+ */
+export function numberEnumEntries<KeyT extends string, ValueT extends number>(
+  enumDefinition: Readonly<Record<KeyT, ValueT>>,
+): Array<NumberEnumEntry<KeyT, ValueT>> {
+  return Object.entries(enumDefinition).filter(isNumberEnumEntry<KeyT, ValueT>);
+}
+
+function isNumberEnumKey<KeyT extends string>(
+  enumDefinition: Readonly<Record<string | number, string | number>>,
+  key: unknown,
+): key is KeyT {
+  if (typeof key === 'string') {
+    const value = enumDefinition[key];
+    return typeof value === 'number' && enumDefinition[value] === key;
+  }
+
+  return false;
+}
+
+/**
+ * Gets the enum keys (strings) from a number based enums runtime type.
+ *
+ * enum MyEnum { A = 1, B, C} => ['A', 'B', 'C']
+ *
+ * @param enumDefinition runtime enum definition
+ */
+export function numberEnumKeys<KeyT extends string, ValueT extends number>(
+  enumDefinition: Readonly<Record<KeyT, ValueT>>,
+): Array<KeyT> {
+  return Object.values(enumDefinition).filter((it) =>
+    isNumberEnumKey<KeyT>(enumDefinition, it),
+  );
+}
+
+function isNumberEnumValue<ValueT extends number>(
+  enumDefinition: Readonly<Record<string | number, string | number>>,
+  value: unknown,
+): value is ValueT {
+  if (typeof value === 'number') {
+    const key = enumDefinition[value];
+    return typeof key === 'string' && enumDefinition[key] === value;
+  }
+
+  return false;
+}
+
+/**
+ * Gets the enum values (numbers) from a number based enums runtime type.
+ *
+ * enum MyEnum { A = 1, B, C} => [1, 2, 3]
+ *
+ * @param enumDefinition runtime enum definition
+ */
+export function numberEnumValues<KeyT extends string, ValueT extends number>(
+  enumDefinition: Readonly<Record<KeyT, ValueT>>,
+): Array<ValueT> {
+  return Object.values(enumDefinition).filter((it) =>
+    isNumberEnumValue<ValueT>(enumDefinition, it),
+  );
+}

--- a/ui/src/utils/stop-registry/buildSearchStopByLabelOrNameFilter.ts
+++ b/ui/src/utils/stop-registry/buildSearchStopByLabelOrNameFilter.ts
@@ -1,0 +1,24 @@
+import { StopsDatabaseStopPlaceNewestVersionBoolExp } from '../../generated/graphql';
+import {
+  buildTiamatStopQuayPublicCodeLikeGqlFilter,
+  buildTiamatStopQuayPublicCodeOrNameLikeGqlFilter,
+} from '../gql';
+import {
+  buildOptionalSearchConditionGqlFilter,
+  mapToSqlLikeValue,
+} from '../search';
+
+// By design, we only accept search by name when the input is at least 4 characters.
+export function buildSearchStopByLabelOrNameFilter(
+  query: string,
+): StopsDatabaseStopPlaceNewestVersionBoolExp {
+  const labelOrNameFilterToUse =
+    query.length >= 4
+      ? buildTiamatStopQuayPublicCodeOrNameLikeGqlFilter
+      : buildTiamatStopQuayPublicCodeLikeGqlFilter;
+
+  return buildOptionalSearchConditionGqlFilter<
+    string,
+    StopsDatabaseStopPlaceNewestVersionBoolExp
+  >(mapToSqlLikeValue(query), labelOrNameFilterToUse);
+}

--- a/ui/src/utils/stop-registry/buildSearchStopsGqlQueryVariables.ts
+++ b/ui/src/utils/stop-registry/buildSearchStopsGqlQueryVariables.ts
@@ -6,29 +6,19 @@ import {
   buildTiamatAddressLikeGqlFilter,
   buildTiamatMunicipalityGqlFilter,
   buildTiamatPrivateCodeLikeGqlFilter,
-  buildTiamatStopQuayPublicCodeLikeGqlFilter,
-  buildTiamatStopQuayPublicCodeOrNameLikeGqlFilter,
 } from '../gql';
 import {
   buildOptionalSearchConditionGqlFilter,
   mapToSqlLikeValue,
 } from '../search';
+import { buildSearchStopByLabelOrNameFilter } from './buildSearchStopByLabelOrNameFilter';
 
 export function buildSearchStopsGqlQueryVariables(
   searchConditions: StopSearchConditions,
 ): StopsDatabaseStopPlaceNewestVersionBoolExp {
-  const labelOrName = searchConditions.labelOrName ?? '';
-
-  // By design, we only accept search by name when the input is at least 4 characters.
-  const labelOrNameFilterToUse =
-    labelOrName.length >= 4
-      ? buildTiamatStopQuayPublicCodeOrNameLikeGqlFilter
-      : buildTiamatStopQuayPublicCodeLikeGqlFilter;
-
-  const labelOrNameFilter = buildOptionalSearchConditionGqlFilter<
-    string,
-    StopsDatabaseStopPlaceNewestVersionBoolExp
-  >(mapToSqlLikeValue(labelOrName), labelOrNameFilterToUse);
+  const labelOrNameFilter = buildSearchStopByLabelOrNameFilter(
+    searchConditions.labelOrName ?? '',
+  );
 
   const elyNumberFilter = buildOptionalSearchConditionGqlFilter<
     string,

--- a/ui/src/utils/stop-registry/index.ts
+++ b/ui/src/utils/stop-registry/index.ts
@@ -1,3 +1,4 @@
 export * from './stopPlace';
 export * from './alternativeNames';
+export * from './buildSearchStopByLabelOrNameFilter';
 export * from './buildSearchStopsGqlQueryVariables';


### PR DESCRIPTION
### Add helper utils to deal with numbered enums.
Number based Typescript enum definitions contain a reverse mapping of
the enum on the runtime object, making regular Object methods hard to
use on them for iteration.

Given enum definition: `enum MyEnum { A = 1, B, C }`
* `Object.entries` would produce:
  `[['A',1], ['B',2], ['C',3], ['1', 'A'], ['2', 'B'], ['3', 'C']]`
* `Object.keys: `['A', 'B', 'C', '1', '2', '3']`
* `Object.values`: `['1', '2', '3', 'A', 'B', 'C]`

This commit introduces helper functions that exclude the reverse
mapping from the entries/values/keys methods.

* numberEnumEntries: Get properly typed array `Array[EnumKey, EnumValue]>`
                     of enum entries.
* numberEnumValues: Get array of the actual enum values `Array<EnumValue>`
* numberEnumKeys: Get array of the actual enum keys `Array<EnumKey>`


### Add `areEqual` utility - dispatches to obj's own equals methods
Lodash's `isEqual` which performs a simple deep comparison of objects
based on their own enumerable properties. But some times classes
provide their own semantics on equality. For example Luxons DateTime
does so and in some cases `a.equals(b)` !== `isEqual(a, b)`.

This helper cheks the objects being compared for custom
implementations of `equals` funktion and dispatched the compartion to
that function instead.


### Add useTypedUrlState hook for better URL state management

Instead of random hooks nested in multiple components within the
same page, all poking, reading and parsing the URL on each render
cycle, provide a single unified useState -like hook.

### Problems with the existing useUrlQuery hook:

* Not typed, on multiple levels:
  - No typing on info on the over shape of the collection of params
    present in the URL. Individual fields are referenced to with
    just random strings.
  - Individual fields are not typed, instead every read to the param
    can happen under different type of "fetcher" get-function.
* Does not provide an elegant API. Instead of providing all of the
  params as plain values out of the hook, each field needs an explicit
  read call to be made.
* Has limited set of supported data types. Could be expanded, but
  each addition changes the API.
* Can cause duplicate work: Hook recommends a coding pattern where the
  hook is always called at the use site, in each individual sub
  component. This can cause the same URL params to be read and parsed
  multiple times within one render cycle of a single component.
  - This is a bigger problem overall on the code base as whole. Same
    complex hook chains that might perform network calls and complex
    data transformation are called from multiple levels on a single
    page. Instead it would be better to propagate the data down trough
    component props or with the help of Contexts. Also the hooks
    should be split into smaller pieces so that functionality A can be
    used where needed, without having to also pull in B, C, D, and E.
* Can cause problems with synchronization of state between
  components. As each field requires an explicit read, if Component A
  writes to field F, and the same field is used in Component B, B must
  contain proper logic to be able to correctly react to the
  change. This can especially cause a bug if the value or some
  derivative of it is stored in useState slot.
* Also based on above point, even local updates might require an
  explicit reread of the URL params after an update. As the component
  does not necessarily automatically react to the change of the fields
  value.
* Does not provide referential stability. Each read of a complex
  object (DateTime, Array) outputs a new instance, rendering the use
  of memoization null.
* Does not allow for "Navigate to other page with URL params" type of
  navigation. Instead that needs to be handled manually

### Pros of the existing useUrlQuery hook:

* Allows for very easy updates to be made to the URL params, as no
  state needs to be passed down from parent components.
* Allows for very easy read of the URL Params, as no state needs to be
  passed down from parent components.

### Points on the new useTypedUrlState hook:

* Single source of truth:
  - Multiple calls to the hook are not supported within a single page.
    Instead the state, full or partial, must be passed down to
    children trough the use of component props or React contexts.
    It is more than likely that the children need only a part of the
    complete URL Params, and even then it is likely to be a derived
    version of the data they need, and not the actual raw value, thus
    the data can be refined as it being passed down the component
    tree.
  - While not initially provided, it is trivial to construct a
    `Context<[StateT, Dispatch<SetStateAction<StateT>>]>` context,
    that is provided and the top level of the page, and which then
    allows for full easy access to the URL state with
    `useContext(pageAUrlState)` hook call.
  - Provides proper synchronization: Even if the URL state gets somehow
    changed externally, a call through the old useUrlQuery for example,
    the state gets properly synchronized.
* Mandates the field names to be declared beforehand, only providing
  access to known fields. Thus providing typings to the shape of the
  collection of URL params.
* Mandates each field to have a predefined and fixed type. Allowing
  for custom serializers and deserializers for each field.
* Provides a simple useState -like API:
  ```typescript
  const [urlState, setUrlState] = useTypedUrlState(...);
  const onReset = () => setUrlState(defaultValues);
  const onToggleA = () => setUrlState(p => ({ ...p, a: !p.a }));
  ```
* Default values:
  - Prefers to keep the URL clean. By default the search string should
    always be empty, but we should still have a proper state available
    in the code.
  - Just like useState takes in an initiaValue -param, useTypedUrlState
    takes in defaultValues -param.
  - Any field not present in the URL Params, gets its value from the
    default values object.
  - Unlike useState, default values must be a static object and cannot
    contain dynamic data. useTypedUrlState should always be called on
    the top level of the page's component tree, thus there should not
    event be any other data to derive the state from.
  - If a "dynamic initial" value is needed, that should be provided
    on initial URL during a page navigation.
  - Can provide a single source of truth for handling "unset" fields.
* Diffs the state, only including those fields in the URL that have
  values different from the default values.
* Prefers replacing the URL state, instead of pushing an state change
  into the navigation history. Changing the values on a form input,
  should not cause the browser history be polluted by million state
  changes. If a new entry is needed in the back navigation history,
  then an explicit page navigation needs to be made.
* Can, but should not, coexist with useUrlQuery, as long as data
  injected into the URL params is compatible.


### Allow passing custom CSS classes into ChevronToggle


### Use Tailwind classes for ListboxButton
* Drop open prop. Replaced with tailwind open-state classes.
* Drop disabled. Handled internally by HeadlessUI. Replaced with
  disabled-state classes.
* General cleanup of CSS class declarations.


### Allow SimpleButton to be used as raw form submit/reset button
Both href and onClick are optional.


### Allow InputLabel to be used as Listbox.Label implementation
Simply pass in ForwardedRef.


### Split buildSearchStopByLabelOrNameFilter from buildSearchStopsGqlQueryVariables
Allows for better reusability, without having to specify full set of
filters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/932)
<!-- Reviewable:end -->
