### PR TITLE
39802 - Route creation flow does not validate route validity correctly

### DIFF
--- a/cypress/e2e/editRoute.cy.ts
+++ b/cypress/e2e/editRoute.cy.ts
@@ -1,4 +1,5 @@
 import { Priority, RouteDirectionEnum } from '@hsl/jore4-test-db-manager';
+import { DateTime } from 'luxon';
 import {
   buildInfraLinksAlongRoute,
   buildStopsOnInfraLinks,
@@ -148,6 +149,158 @@ describe('Route editing', () => {
         .getRouteHeaderRow('901', RouteDirectionEnum.Inbound)
         .should('exist');
     });
+  });
+
+  describe('Should show error messages', () => {
+    before(() => {
+      cy.task<UUID[]>(
+        'getInfrastructureLinkIdsByExternalIds',
+        testInfraLinkExternalIds,
+      ).then((infraLinkIds) => {
+        const stops = buildStopsOnInfraLinks(infraLinkIds);
+        const infraLinksAlongRoute = buildInfraLinksAlongRoute(infraLinkIds);
+
+        const modifiedDbResources = {
+          ...baseDbResources,
+        };
+
+        modifiedDbResources.lines[0].validity_end =
+          DateTime.fromISO('2032-12-31');
+
+        dbResources = {
+          ...modifiedDbResources,
+          stops,
+          infraLinksAlongRoute,
+        };
+      });
+    });
+
+    beforeEach(() => {
+      cy.task('resetDbs');
+      insertToDbHelper(dbResources);
+
+      editRoutePage = new EditRoutePage();
+      lineDetailsPage = new LineDetailsPage();
+      lineRouteListItem = new LineRouteListItem();
+      toast = new Toast();
+
+      cy.setupTests();
+      cy.mockLogin();
+    });
+
+    function fillTestValuesToForm() {
+      // Edit the route's information
+      editRoutePage.routePropertiesForm.fillRouteProperties({
+        finnishName: 'Edited route name',
+        label: '901E',
+        variant: '8',
+        direction: RouteDirectionEnum.Outbound,
+        origin: {
+          finnishName: 'Edited origin FIN',
+          finnishShortName: 'Edited origin FIN shortName',
+          swedishName: 'Edited origin SWE',
+          swedishShortName: 'Edited origin SWE shortName',
+        },
+        destination: {
+          finnishName: 'Edited destination FIN',
+          finnishShortName: 'Edited destination FIN shortName',
+          swedishName: 'Edited destination SWE',
+          swedishShortName: 'Edited destination SWE shortName',
+        },
+      });
+    }
+
+    function visitPage() {
+      const { routeRow } = lineRouteListItem;
+      const line = baseDbResources.lines.find(
+        (l) => l.line_id === '08d1fa6b-440c-421e-ad4d-0778d65afe60',
+      );
+      const row = baseDbResources.routes.find(
+        (r) => r.route_id === '994a7d79-4991-423b-9c1a-0ca621a6d9ed',
+      );
+      if (!line?.line_id || !row?.label) {
+        throw new Error(
+          'Test configuration error. Line id or route label missing',
+        );
+      }
+      lineDetailsPage.visit(line?.line_id);
+      routeRow
+        .getEditRouteButton(row?.label, RouteDirectionEnum.Outbound)
+        .click();
+      return { line, row };
+    }
+
+    function setValidityPeriodToForm(
+      routeValidityStart: string,
+      routeValidityEnd: string | undefined,
+    ) {
+      editRoutePage.changeValidityForm.validityPeriodForm.setStartDate(
+        routeValidityStart,
+      );
+      if (routeValidityEnd) {
+        editRoutePage.changeValidityForm.validityPeriodForm.setEndDate(
+          routeValidityEnd,
+        );
+      }
+    }
+
+    it('should validate start after end', { tags: Tag.Routes }, () => {
+      const { line } = visitPage();
+      fillTestValuesToForm();
+
+      const endTime = line.validity_end?.minus({ months: 1 });
+      if (!endTime) {
+        throw new Error('Test configuration error. No end time for line');
+      }
+
+      const routeValidityEnd = endTime.toFormat('yyyy-LL-dd');
+
+      const routeValidityStart = endTime
+        ?.plus({ days: 1 })
+        ?.toFormat('yyyy-LL-dd');
+
+      if (!routeValidityStart || !routeValidityEnd) {
+        throw new Error(
+          'Test configuration error. No validity period for line',
+        );
+      }
+
+      setValidityPeriodToForm(routeValidityStart, routeValidityEnd);
+
+      editRoutePage.getSaveRouteButton().click();
+      toast.expectDangerToast(
+        'Reitin voimassaoloaijan alku ei voi olla ennen loppua',
+      );
+    });
+
+    it(
+      'should validate route validity outside line validity',
+      { tags: Tag.Routes },
+      () => {
+        const { line } = visitPage();
+
+        fillTestValuesToForm();
+
+        const routeValidityStart = line.validity_start
+          ?.minus({ days: 1 })
+          ?.toFormat('yyyy-LL-dd');
+
+        const routeValidityEnd = line.validity_end?.toFormat('yyyy-LL-dd');
+
+        if (!routeValidityStart || !routeValidityEnd) {
+          throw new Error(
+            'Test configuration error. No validity period for line',
+          );
+        }
+        setValidityPeriodToForm(routeValidityStart, routeValidityEnd);
+
+        editRoutePage.getSaveRouteButton().click();
+
+        toast.expectDangerToast(
+          'Reitin voimassaoloaika ei voi alkaa ennen linjan voimassaoloajan alkamista.',
+        );
+      },
+    );
   });
 
   describe('draft route', () => {

--- a/ui/src/hooks/routes/useValidateRoute.spec.ts
+++ b/ui/src/hooks/routes/useValidateRoute.spec.ts
@@ -1,0 +1,214 @@
+import { DateTime } from 'luxon';
+import { RouteFormState } from '../../components/forms/route/RoutePropertiesForm.types';
+import { RouteDirectionEnum } from '../../generated/graphql';
+import { mapLineDetailsResult } from '../../graphql';
+import { renderHook } from '../../utils/test-utils';
+import { useValidateRoute } from './useValidateRoute';
+
+jest.mock('@apollo/client', () => ({
+  useLazyQuery: jest.fn(),
+  gql: jest.fn(),
+}));
+
+jest.mock('i18next', () => ({
+  use: jest.fn(() => ({
+    init: jest.fn(),
+  })),
+  t: (key: string) => key,
+}));
+
+// Mock dependencies
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('../../generated/graphql', () => ({
+  ...jest.requireActual('../../generated/graphql'),
+  useGetLineDetailsByIdLazyQuery: jest.fn(() => [jest.fn()]),
+}));
+
+jest.mock('../../graphql', () => ({
+  mapLineDetailsResult: jest.fn(),
+}));
+
+const defaultRouteParams: Partial<RouteFormState> = {
+  destination: {
+    name: { fi_FI: '', sv_FI: '' },
+    shortName: { fi_FI: '', sv_FI: '' },
+  },
+  direction: RouteDirectionEnum.Anticlockwise,
+  finnishName: '',
+  label: '',
+  origin: {
+    name: { fi_FI: '', sv_FI: '' },
+    shortName: { fi_FI: '', sv_FI: '' },
+  },
+  priority: 10,
+  variant: 1,
+};
+
+describe('useValidateRoute', () => {
+  const { result } = renderHook(() => useValidateRoute());
+  const mockedGetLineDetailsByIdLazyQuery = jest.fn();
+
+  jest
+    .requireMock('../../generated/graphql')
+    .useGetLineDetailsByIdLazyQuery.mockImplementation(() => {
+      return [jest.fn(), jest.fn()];
+    });
+
+  mockedGetLineDetailsByIdLazyQuery.mockImplementation(() => [jest.fn()]);
+  const mockedMapLineDetailsResult = mapLineDetailsResult as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('validateStopCount', () => {
+    test('should throw an error if there are fewer than 2 stops', () => {
+      expect(() => result.current.validateStopCount(['Stop1'])).toThrow(
+        'routes.tooFewStops',
+      );
+    });
+
+    test('should not throw an error if there are 2 or more stops', () => {
+      expect(() =>
+        result.current.validateStopCount(['Stop1', 'Stop2']),
+      ).not.toThrow();
+    });
+  });
+
+  describe('validateJourneyPattern', () => {
+    test('should validate journey pattern by calling validateStopCount', async () => {
+      await expect(
+        result.current.validateJourneyPattern({
+          includedStopLabels: ['Stop1'],
+        }),
+      ).rejects.toThrow('routes.tooFewStops');
+    });
+  });
+
+  describe('checkIsRouteValidityInsideLineValidity', () => {
+    const line = {
+      validity_start: DateTime.local().minus({ days: 1 }),
+      validity_end: DateTime.local().plus({ days: 1 }),
+    };
+
+    test('should throw an error if route validity start is before line validity start', () => {
+      const route = {
+        validity_start: DateTime.local().minus({ days: 2 }),
+      };
+
+      expect(() =>
+        result.current.checkIsRouteValidityInsideLineValidity(route, line),
+      ).toThrow('routes.startNotInsideLineValidity');
+    });
+
+    test('should throw an error if route validity end is after line validity end', () => {
+      const route = {
+        validity_start: DateTime.local(),
+        validity_end: DateTime.local().plus({ days: 2 }),
+      };
+
+      expect(() =>
+        result.current.checkIsRouteValidityInsideLineValidity(route, line),
+      ).toThrow('routes.endNotInsideLineValidity');
+    });
+
+    test('should not throw an error if route validity is within line validity', () => {
+      const route = {
+        validity_start: DateTime.local(),
+        validity_end: DateTime.local(),
+      };
+
+      expect(() =>
+        result.current.checkIsRouteValidityInsideLineValidity(route, line),
+      ).not.toThrow();
+    });
+  });
+
+  describe('checkIsRouteValidityStartIsBeforeEnd', () => {
+    test('should throw an error if route validity start is not before validity end', () => {
+      const route = {
+        validity_start: DateTime.local().plus({ days: 1 }),
+        validity_end: DateTime.local(),
+      };
+
+      expect(() =>
+        result.current.checkIsRouteValidityStartIsBeforeEnd(route),
+      ).toThrow('routes.validityStartIsAfterEnd');
+    });
+
+    test('should not throw an error if route validity start is before validity end', () => {
+      const route = {
+        validity_start: DateTime.local(),
+        validity_end: DateTime.local().plus({ days: 1 }),
+      };
+
+      expect(() =>
+        result.current.checkIsRouteValidityStartIsBeforeEnd(route),
+      ).not.toThrow();
+    });
+  });
+
+  describe('validateMetadata', () => {
+    test('should validate metadata with line validity period', async () => {
+      const lineMock = {
+        validity_start: DateTime.local().minus({ days: 1 }),
+        validity_end: DateTime.local().plus({ days: 1 }),
+      };
+
+      jest
+        .requireMock('../../generated/graphql')
+        .useGetLineDetailsByIdLazyQuery.mockReturnValue(() => {
+          return [jest.fn(() => lineMock)];
+        });
+
+      mockedMapLineDetailsResult.mockReturnValue(lineMock);
+
+      const routeMetadata: Partial<RouteFormState> = {
+        ...defaultRouteParams,
+        onLineId: 'line-id',
+        validityStart: DateTime.local().toISO(),
+        validityEnd: DateTime.local().toISO(),
+        indefinite: false,
+      };
+
+      await expect(
+        result.current.validateMetadata(routeMetadata as RouteFormState),
+      ).resolves.toBe(undefined);
+    });
+
+    test('should throw an error if route metadata is outside line validity period', async () => {
+      const lineMock = {
+        validity_start: DateTime.local(),
+        validity_end: DateTime.local().plus({ days: 1 }),
+      };
+
+      mockedGetLineDetailsByIdLazyQuery.mockReturnValue([
+        () => Promise.resolve(lineMock),
+      ]);
+
+      jest
+        .requireMock('../../generated/graphql')
+        .useGetLineDetailsByIdLazyQuery.mockImplementation(() => {
+          return [mockedMapLineDetailsResult];
+        });
+      mockedMapLineDetailsResult.mockReturnValue(lineMock);
+
+      const routeMetadata: Partial<RouteFormState> = {
+        ...defaultRouteParams,
+        onLineId: 'line-id',
+        validityStart: DateTime.local().plus({ days: 2 }).toISO(),
+        validityEnd: DateTime.local().plus({ days: 3 }).toISO(),
+        indefinite: false,
+      };
+
+      await expect(
+        result.current.validateMetadata(routeMetadata as RouteFormState),
+      ).rejects.toThrow('routes.endNotInsideLineValidity');
+    });
+  });
+});

--- a/ui/src/hooks/routes/useValidateRoute.ts
+++ b/ui/src/hooks/routes/useValidateRoute.ts
@@ -54,6 +54,18 @@ export const useValidateRoute = () => {
     }
   };
 
+  const checkIsRouteValidityStartIsBeforeEnd = (
+    route: ValidityPeriodParams,
+  ) => {
+    if (
+      route.validity_start &&
+      route.validity_end &&
+      route.validity_start > route.validity_end
+    ) {
+      throw new Error(t('routes.validityStartIsAfterEnd'));
+    }
+  };
+
   const validateMetadata = async (routeMetadata: RouteFormState) => {
     // Check route's validity period is inside line's validity period
 
@@ -77,6 +89,10 @@ export const useValidateRoute = () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       line!,
     );
+    checkIsRouteValidityStartIsBeforeEnd({
+      validity_start: routeValidityStart,
+      validity_end: routeValidityEnd,
+    });
   };
 
   return {
@@ -84,5 +100,6 @@ export const useValidateRoute = () => {
     validateJourneyPattern,
     validateMetadata,
     checkIsRouteValidityInsideLineValidity,
+    checkIsRouteValidityStartIsBeforeEnd,
   };
 };

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -54,7 +54,8 @@
     "chooseDirection": "Choose direction",
     "tooFewStops": "There must be at least two stops on route.",
     "startNotInsideLineValidity": "Route's validity period cannot start before line's validity period.",
-    "endNotInsideLineValidity": "Route's validity period cannot exceed the line's validity period."
+    "endNotInsideLineValidity": "Route's validity period cannot exceed the line's validity period.",
+    "validityStartIsAfterEnd": "Route's validity period start cannot be after end."
   },
   "lines": {
     "createNew": "Create new line",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -54,7 +54,8 @@
     "chooseDirection": "Valitse suunta",
     "tooFewStops": "Reitillä on oltava ainakin kaksi pysäkkiä.",
     "startNotInsideLineValidity": "Reitin voimassaoloaika ei voi alkaa ennen linjan voimassaoloajan alkamista.",
-    "endNotInsideLineValidity": "Reitin voimassaoloaika ei voi jatkua linjan voimassaoloajan ulkopuolelle."
+    "endNotInsideLineValidity": "Reitin voimassaoloaika ei voi jatkua linjan voimassaoloajan ulkopuolelle.",
+    "validityStartIsAfterEnd": "Reitin voimassaoloaijan alku ei voi olla ennen loppua."
   },
   "lines": {
     "createNew": "Luo uusi linja",


### PR DESCRIPTION
Added validation to Route validity start date.

Testing

1. Go to Lines and routes
2. Choose route and edit it
3. Give validity start and end dates so start is after
4. Click save
5. Should show error and prevent saving 