### PR TITLE
Add and delete info spots

### DIFF
--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -1916,6 +1916,109 @@ describe('Stop details', () => {
         });
       },
     );
+
+    it(
+      'should be able to add and delete info spots',
+      { tags: [Tag.StopRegistry] },
+      () => {
+        infoSpotView.getNthContainer(0).within(() => {
+          stopDetailsPage.infoSpots.getEditButton().click();
+          infoSpotView.getContainers().should('not.exist');
+
+          // Add more infoSpots.
+          infoSpotForm.getInfoSpots().should('have.length', 1);
+          infoSpotForm.getAddNewInfoSpotButton().click();
+          infoSpotForm.getInfoSpots().should('have.length', 2);
+
+          const infoSpot = infoSpotForm.infoSpots;
+          infoSpotForm.getNthInfoSpot(0).within(() => {
+            infoSpot
+              .getDeleteInfoSpotButton()
+              .shouldHaveText('Poista infopaikka');
+            infoSpot.getDeleteInfoSpotButton().click();
+            infoSpot.getDeleteInfoSpotButton().shouldHaveText('Peruuta poisto');
+            infoSpot.getDeleteInfoSpotButton().click();
+            infoSpot
+              .getDeleteInfoSpotButton()
+              .shouldHaveText('Poista infopaikka');
+            infoSpot.getDeleteInfoSpotButton().click();
+            infoSpot.getDeleteInfoSpotButton().shouldHaveText('Peruuta poisto');
+          });
+
+          infoSpotForm.getNthInfoSpot(1).within(() => {
+            infoSpot
+              .getDeleteInfoSpotButton()
+              .shouldHaveText('Poista infopaikka');
+            infoSpot.getDeleteInfoSpotButton().click();
+          });
+        });
+
+        // Submit.
+        stopDetailsPage.infoSpots.getSaveButton().click();
+        toast.checkSuccessToastHasMessage('Pysäkki muokattu');
+        infoSpotView.getContainers().shouldBeVisible();
+
+        infoSpotView.getNthContainer(0).within(() => {
+          stopDetailsPage.infoSpots.getTitle().contains('Ei infopaikkoja');
+        });
+
+        infoSpotView.getNthContainer(0).within(() => {
+          stopDetailsPage.infoSpots.getAddNewButton().click();
+          infoSpotView.getContainers().should('not.exist');
+
+          infoSpotForm.getInfoSpots().should('have.length', 1);
+
+          const infoSpot = infoSpotForm.infoSpots;
+          infoSpotForm.getNthInfoSpot(0).within(() => {
+            infoSpot.getLabel().clearAndType('IP123');
+            infoSpot.getPurpose().clearAndType('Dynaaminen tarkoitus');
+            infoSpot.getInfoSpotTypeButton().click();
+            infoSpot.getInfoSpotTypeOptions().contains('Dynaaminen').click();
+            infoSpot.getDisplayTypeButton().click();
+            infoSpot
+              .getDisplayTypeOptions()
+              .contains('Patteri, E-muste')
+              .click();
+            infoSpot.getSpeechPropertyButton().click();
+            infoSpot.getSpeechPropertyOptions().contains('Kyllä').click();
+            infoSpot.getDescription().clearAndType('Dynaamisen kuvaus');
+            infoSpot.getZoneLabel().clearAndType('A');
+            infoSpot.getRailInformation().clearAndType('1');
+            infoSpot.getFloor().clearAndType('3');
+          });
+        });
+
+        // Submit.
+        stopDetailsPage.infoSpots.getSaveButton().click();
+        toast.checkSuccessToastHasMessage('Pysäkki muokattu');
+        infoSpotView.getContainers().shouldBeVisible();
+
+        infoSpotView.getNthContainer(0).within(() => {
+          stopDetailsPage.infoSpots.getTitle().contains('Infopaikat');
+
+          infoSpotView.getDescription().shouldHaveText('Dynaamisen kuvaus');
+          infoSpotView.getLabel().shouldHaveText('IP123');
+          infoSpotView.getInfoSpotType().shouldHaveText('Dynaaminen');
+          infoSpotView.getPurpose().shouldHaveText('Dynaaminen tarkoitus');
+          infoSpotView.getDisplayType().shouldHaveText('Patteri, E-muste');
+          infoSpotView.getSpeechProperty().shouldHaveText('Kyllä');
+          infoSpotView.getLatitude().shouldHaveText('60.16490775039894');
+          infoSpotView.getLongitude().shouldHaveText('24.92904198486008');
+          infoSpotView.getFloor().shouldHaveText('3');
+          infoSpotView.getRailInformation().shouldHaveText('1');
+          infoSpotView.getStops().shouldHaveText('V1562');
+          infoSpotView.getTerminals().shouldHaveText('-');
+          infoSpotView.getZoneLabel().shouldHaveText('A');
+
+          infoSpotView.getBacklight().should('not.exist');
+          infoSpotView.getPosterPlaceSize().should('not.exist');
+          infoSpotView.getMaintenance().should('not.exist');
+          infoSpotView.getPosterSize().should('not.exist');
+          infoSpotView.getPosterLabel().should('not.exist');
+          infoSpotView.getPosterLines().should('not.exist');
+        });
+      },
+    );
   });
 
   // A regression test to ensure that our mutations don't eg. reset any fields they are not supposed to.

--- a/cypress/pageObjects/stop-registry/stop-details/InfoSpotFormFields.ts
+++ b/cypress/pageObjects/stop-registry/stop-details/InfoSpotFormFields.ts
@@ -55,4 +55,7 @@ export class InfoSpotFormFields {
 
   getPosterLines = () =>
     cy.getByTestId('InfoSpotPosterFormFields::posterLines');
+
+  getDeleteInfoSpotButton = () =>
+    cy.getByTestId('InfoSpotFormFields::deleteInfoSpot');
 }

--- a/cypress/pageObjects/stop-registry/stop-details/InfoSpotSection.ts
+++ b/cypress/pageObjects/stop-registry/stop-details/InfoSpotSection.ts
@@ -14,6 +14,10 @@ export class InfoSpotsSection {
     return cy.getByTestId('InfoSpotsSection::editButton');
   }
 
+  getAddNewButton() {
+    return cy.getByTestId('InfoSpotsSection::addNewItemButton');
+  }
+
   getSaveButton() {
     return cy.getByTestId('InfoSpotsSection::saveButton');
   }

--- a/cypress/pageObjects/stop-registry/stop-details/InfoSpotsForm.ts
+++ b/cypress/pageObjects/stop-registry/stop-details/InfoSpotsForm.ts
@@ -10,4 +10,8 @@ export class InfoSpotsForm {
   getNthInfoSpot(index: number) {
     return this.getInfoSpots().eq(index);
   }
+
+  getAddNewInfoSpotButton() {
+    return cy.getByTestId('InfoSpotsForm::addInfoSpot');
+  }
 }

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsForm.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsForm.tsx
@@ -1,38 +1,74 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import React, { ForwardRefRenderFunction } from 'react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';
 import {
   HorizontalSeparator,
   Visible,
 } from '../../../../../../layoutComponents';
+import { SlimSimpleButton } from '../../layout';
 import { InfoSpotFormFields } from './InfoSpotsFormFields';
-import { InfoSpotsFormSchema, InfoSpotsFormState } from './schema';
+import {
+  InfoSpotsFormSchema,
+  InfoSpotsFormState,
+  mapInfoSpotDataToFormState,
+} from './schema';
 
 const testIds = {
   infoSpot: 'InfoSpotsForm::infoSpot',
+  addInfoSpot: 'InfoSpotsForm::addInfoSpot',
+  deleteInfoSpot: 'InfoSpotsForm::deleteInfoSpot',
 };
 
 type Props = {
   readonly className?: string;
   readonly defaultValues: InfoSpotsFormState;
   readonly onSubmit: (state: InfoSpotsFormState) => void;
+  readonly infoSpotLocations: (string | null)[];
 };
 
 const InfoSpotsFormComponent: ForwardRefRenderFunction<
   HTMLFormElement,
   Props
-> = ({ className, defaultValues, onSubmit }, ref) => {
+> = ({ className, defaultValues, infoSpotLocations, onSubmit }, ref) => {
+  const { t } = useTranslation();
+
   const methods = useForm<InfoSpotsFormState>({
     defaultValues,
     resolver: zodResolver(InfoSpotsFormSchema),
   });
-  const { control, handleSubmit } = methods;
+  const { control, setValue, getValues, handleSubmit } = methods;
 
-  const { fields: infoSpots } = useFieldArray({
+  const {
+    append,
+    fields: infoSpots,
+    remove,
+  } = useFieldArray({
     control,
     name: 'infoSpots',
   });
+
+  const addNewInfoSpot = () => {
+    append(
+      mapInfoSpotDataToFormState({
+        infoSpotLocations,
+      }),
+    );
+  };
+  const onRemoveInfoSpot = (idx: number) => {
+    const infoSpot = infoSpots[idx];
+    if (!infoSpot.infoSpotId) {
+      remove(idx);
+      return;
+    }
+
+    const newToBeDeleted = !getValues(`infoSpots.${idx}.toBeDeleted`);
+    setValue(`infoSpots.${idx}.toBeDeleted`, newToBeDeleted, {
+      shouldDirty: true,
+      shouldTouch: true,
+    });
+  };
 
   const isLast = (idx: number) => idx === infoSpots.length - 1;
 
@@ -46,12 +82,15 @@ const InfoSpotsFormComponent: ForwardRefRenderFunction<
       >
         {infoSpots.map((infoSpot, idx) => (
           <div key={infoSpot.id} data-testid={testIds.infoSpot}>
-            <InfoSpotFormFields index={idx} />
+            <InfoSpotFormFields index={idx} onRemove={onRemoveInfoSpot} />
             <Visible visible={!isLast(idx)}>
               <HorizontalSeparator className="my-4" />
             </Visible>
           </div>
         ))}
+        <SlimSimpleButton testId={testIds.addInfoSpot} onClick={addNewInfoSpot}>
+          {t('stopDetails.infoSpots.addInfoSpot')}
+        </SlimSimpleButton>
       </form>
     </FormProvider>
   );

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsFormFields.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsFormFields.tsx
@@ -17,6 +17,7 @@ import {
   InputField,
   NullableBooleanDropdown,
 } from '../../../../../forms/common';
+import { SlimSimpleButton } from '../../layout';
 import { InfoSpotsFormState } from './schema';
 
 const testIds = {
@@ -39,14 +40,18 @@ const testIds = {
   posterSize: 'InfoSpotPosterFormFields::posterSize',
   posterLabel: 'InfoSpotPosterFormFields::posterLabel',
   posterLines: 'InfoSpotPosterFormFields::posterLines',
+  deleteInfoSpot: 'InfoSpotFormFields::deleteInfoSpot',
 };
 
 type Props = {
   readonly index: number;
+  readonly onRemove: (index: number) => void;
 };
 
-export const InfoSpotFormFields: FC<Props> = ({ index }) => {
-  const { watch } = useFormContext<InfoSpotsFormState>();
+export const InfoSpotFormFields: FC<Props> = ({ index, onRemove }) => {
+  const { register, watch } = useFormContext<InfoSpotsFormState>();
+  const toBeDeleted = watch(`infoSpots.${index}.toBeDeleted`);
+
   const infoSpotType = watch(`infoSpots.${index}.infoSpotType`);
   const posters = watch(`infoSpots.${index}.poster`);
 
@@ -58,12 +63,14 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
           translationPrefix="stopDetails"
           fieldPath={`infoSpots.${index}.label`}
           testId={testIds.label}
+          disabled={toBeDeleted}
         />
         <InputField<InfoSpotsFormState>
           type="text"
           translationPrefix="stopDetails"
           fieldPath={`infoSpots.${index}.purpose`}
           testId={testIds.purpose}
+          disabled={toBeDeleted}
         />
         <InputField<InfoSpotsFormState>
           translationPrefix="stopDetails"
@@ -77,6 +84,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
               uiNameMapper={mapStopRegistryInfoSpotTypeEnumToUiName}
               buttonClassName="min-w-36"
               includeNullOption
+              disabled={toBeDeleted}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...props}
             />
@@ -109,6 +117,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
               <NullableBooleanDropdown
                 placeholder={t('unknown')}
                 buttonClassName="min-w-32"
+                disabled={toBeDeleted}
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...props}
               />
@@ -134,6 +143,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
                 uiNameMapper={mapStopRegistryDisplayTypeEnumToUiName}
                 buttonClassName="min-w-36"
                 includeNullOption
+                disabled={toBeDeleted}
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...props}
               />
@@ -148,6 +158,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
               <NullableBooleanDropdown
                 placeholder={t('unknown')}
                 buttonClassName="min-w-32"
+                disabled={toBeDeleted}
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...props}
               />
@@ -162,6 +173,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
           fieldPath={`infoSpots.${index}.description.value`}
           testId={testIds.description}
           customTitlePath="stopDetails.infoSpots.description"
+          disabled={toBeDeleted}
         />
       </Row>
       <Visible visible={infoSpotType === 'static'}>
@@ -182,6 +194,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
                     uiNameMapper={mapStopRegistryPosterPlaceSizeEnumToUiName}
                     buttonClassName="min-w-36"
                     includeNullOption
+                    disabled={toBeDeleted}
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...props}
                   />
@@ -200,6 +213,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
                 fieldPath={`infoSpots.${index}.poster.${posterIndex}.lines`}
                 customTitlePath="stopDetails.infoSpots.posterLines"
                 testId={testIds.posterLines}
+                disabled={toBeDeleted}
               />
             </React.Fragment>
           ))}
@@ -211,6 +225,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
           translationPrefix="stopDetails"
           fieldPath={`infoSpots.${index}.zoneLabel`}
           testId={testIds.zoneLabel}
+          disabled={toBeDeleted}
         />
         <InputField<InfoSpotsFormState>
           type="text"
@@ -218,6 +233,7 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
           fieldPath={`infoSpots.${index}.railInformation`}
           inputClassName="w-20"
           testId={testIds.railInformation}
+          disabled={toBeDeleted}
         />
         <InputField<InfoSpotsFormState>
           type="text"
@@ -225,8 +241,25 @@ export const InfoSpotFormFields: FC<Props> = ({ index }) => {
           fieldPath={`infoSpots.${index}.floor`}
           inputClassName="w-20"
           testId={testIds.floor}
+          disabled={toBeDeleted}
         />
       </Row>
+      <input
+        type="checkbox"
+        hidden
+        {...register(`infoSpots.${index}.toBeDeleted`)}
+      />
+      <SlimSimpleButton
+        testId={testIds.deleteInfoSpot}
+        onClick={() => onRemove(index)}
+        inverted
+      >
+        {t(
+          toBeDeleted
+            ? 'stopDetails.infoSpots.cancelDeleteInfoSpot'
+            : 'stopDetails.infoSpots.deleteInfoSpot',
+        )}
+      </SlimSimpleButton>
     </Column>
   );
 };

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/schema.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/schema.ts
@@ -36,6 +36,7 @@ const infoSpotSchema = z.object({
     })
     .array()
     .nullable(),
+  toBeDeleted: z.boolean(),
 });
 
 export const InfoSpotsFormSchema = z.object({
@@ -72,5 +73,6 @@ export const mapInfoSpotDataToFormState = (
         posterSize: p?.posterSize ?? null,
         lines: p?.lines ?? null,
       })) ?? [],
+    toBeDeleted: false,
   };
 };

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -353,6 +353,8 @@
       "posterLines": "Lines",
       "shelterTypeSubtitle": "Shelter {{index}} | {{shelterType}}",
       "addInfoSpot": "Add info spot",
+      "deleteInfoSpot": "Delete info spot",
+      "cancelDeleteInfoSpot": "Cancel deletion",
       "type": {
         "static": "Static",
         "dynamic": "Dynamic",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -353,6 +353,8 @@
       "posterLines": "Linjat",
       "shelterTypeSubtitle": "Katos {{index}} | {{shelterType}}",
       "addInfoSpot": "Lisää infopaikka",
+      "deleteInfoSpot": "Poista infopaikka",
+      "cancelDeleteInfoSpot": "Peruuta poisto",
       "type": {
         "dynamic": "Dynaaminen",
         "static": "Staattinen",


### PR DESCRIPTION
Adding and deleting info spots.

infoSpotLocations need to be added separately when saving a new info spot, because user can't edit them.
Info spots are not fully deleted, instead the connection to shelter and stop is removed.
GetHighestPriorityStopDetailsByLabelAndDate needs to be refetched when adding a new info spot when there are no previous ones, or the view won't update without manual refresh.

**Testing**
Open any stop, [for example](http://localhost:3300/stop-registry/stops/V1562?observationDate=2024-11-12)
Navigate to Infopaikat
Play around with adding and removing info spots (remove all, add multiple, remove just one, add just one....)
Check that everything works

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/942)
<!-- Reviewable:end -->
