### PR TITLE
Basic stop search sorting and paging

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run e2e tests from github action
         env:
           CYPRESS_TESTS_KEPT_IN_MEMORY: 0
-        timeout-minutes: 15
+        timeout-minutes: 30
         uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v1
         with:
           test-tags: ''

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -38,7 +38,7 @@ services:
   jore4-tiamat:
     # Pin tiamat to a compatible version.
     # Note: also update jore4-tiamat-e2e in docker-compose.e2e when changing this.
-    image: "hsldevcom/jore4-tiamat:main--20241014-cba17b4a34867ed4e814b94497a51ca03afd54a8"
+    image: "hsldevcom/jore4-tiamat:main--20241107-e2d81c097eaa63516f70fb6808e28d440a4b0838"
 
   jore4-timetablesapi:
     # Pin timetables api to a compatible version.

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -11,7 +11,7 @@ services:
     extends:
       file: docker-compose.base.yml
       service: jore4-tiamat-base
-    image: "hsldevcom/jore4-tiamat:main--20241014-cba17b4a34867ed4e814b94497a51ca03afd54a8"
+    image: "hsldevcom/jore4-tiamat:main--20241107-e2d81c097eaa63516f70fb6808e28d440a4b0838"
     container_name: "tiamat-e2e"
     environment:
       - TIAMAT_DB_URL=jdbc:postgresql://jore4-testdb-e2e:5432/stopdb?stringtype=unspecified

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -10898,9 +10898,11 @@ export enum StopRegistryPedestrianCrossingRampType {
 
 export type StopRegistryPoster = {
   __typename?: 'stop_registry_poster';
+  id?: Maybe<Scalars['String']['output']>;
   label?: Maybe<Scalars['String']['output']>;
   lines?: Maybe<Scalars['String']['output']>;
   posterSize?: Maybe<StopRegistryPosterPlaceSize>;
+  version?: Maybe<Scalars['String']['output']>;
 };
 
 export type StopRegistryPosterInput = {
@@ -41148,6 +41150,7 @@ export type StopsDatabaseStopPlaceNewestVersion = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
+  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   scheduled_stop_point_instance?: Maybe<ServicePatternScheduledStopPoint>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
@@ -41181,6 +41184,7 @@ export type StopsDatabaseStopPlaceNewestVersion = {
   /** An aggregate relationship */
   stop_place_tariff_zones_aggregate: StopsDatabaseStopPlaceTariffZonesAggregate;
   stop_place_type?: Maybe<Scalars['String']['output']>;
+  street_address?: Maybe<Scalars['String']['output']>;
   telecabin_submode?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
   topographic_place_id?: Maybe<Scalars['bigint']['output']>;
@@ -41471,6 +41475,7 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   private_code_type?: InputMaybe<StringComparisonExp>;
   private_code_value?: InputMaybe<StringComparisonExp>;
   public_code?: InputMaybe<StringComparisonExp>;
+  quay_public_code?: InputMaybe<StringComparisonExp>;
   rail_submode?: InputMaybe<StringComparisonExp>;
   short_name_lang?: InputMaybe<StringComparisonExp>;
   short_name_value?: InputMaybe<StringComparisonExp>;
@@ -41489,6 +41494,7 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   stop_place_tariff_zones?: InputMaybe<StopsDatabaseStopPlaceTariffZonesBoolExp>;
   stop_place_tariff_zones_aggregate?: InputMaybe<StopPlaceTariffZonesAggregateBoolExp>;
   stop_place_type?: InputMaybe<StringComparisonExp>;
+  street_address?: InputMaybe<StringComparisonExp>;
   telecabin_submode?: InputMaybe<StringComparisonExp>;
   to_date?: InputMaybe<TimestampComparisonExp>;
   topographic_place_id?: InputMaybe<BigintComparisonExp>;
@@ -41532,6 +41538,7 @@ export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
+  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;
@@ -41543,6 +41550,7 @@ export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
   stop_place_quays?: InputMaybe<StopsDatabaseStopPlaceQuaysArrRelInsertInput>;
   stop_place_tariff_zones?: InputMaybe<StopsDatabaseStopPlaceTariffZonesArrRelInsertInput>;
   stop_place_type?: InputMaybe<Scalars['String']['input']>;
+  street_address?: InputMaybe<Scalars['String']['input']>;
   telecabin_submode?: InputMaybe<Scalars['String']['input']>;
   to_date?: InputMaybe<Scalars['timestamp']['input']>;
   topographic_place_id?: InputMaybe<Scalars['bigint']['input']>;
@@ -41582,10 +41590,12 @@ export type StopsDatabaseStopPlaceNewestVersionMaxFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
+  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
   stop_place_type?: Maybe<Scalars['String']['output']>;
+  street_address?: Maybe<Scalars['String']['output']>;
   telecabin_submode?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
   topographic_place_id?: Maybe<Scalars['bigint']['output']>;
@@ -41625,10 +41635,12 @@ export type StopsDatabaseStopPlaceNewestVersionMinFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
+  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
   stop_place_type?: Maybe<Scalars['String']['output']>;
+  street_address?: Maybe<Scalars['String']['output']>;
   telecabin_submode?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
   topographic_place_id?: Maybe<Scalars['bigint']['output']>;
@@ -41677,6 +41689,7 @@ export type StopsDatabaseStopPlaceNewestVersionOrderBy = {
   private_code_type?: InputMaybe<OrderBy>;
   private_code_value?: InputMaybe<OrderBy>;
   public_code?: InputMaybe<OrderBy>;
+  quay_public_code?: InputMaybe<OrderBy>;
   rail_submode?: InputMaybe<OrderBy>;
   short_name_lang?: InputMaybe<OrderBy>;
   short_name_value?: InputMaybe<OrderBy>;
@@ -41688,6 +41701,7 @@ export type StopsDatabaseStopPlaceNewestVersionOrderBy = {
   stop_place_quays_aggregate?: InputMaybe<StopsDatabaseStopPlaceQuaysAggregateOrderBy>;
   stop_place_tariff_zones_aggregate?: InputMaybe<StopsDatabaseStopPlaceTariffZonesAggregateOrderBy>;
   stop_place_type?: InputMaybe<OrderBy>;
+  street_address?: InputMaybe<OrderBy>;
   telecabin_submode?: InputMaybe<OrderBy>;
   to_date?: InputMaybe<OrderBy>;
   topographic_place_id?: InputMaybe<OrderBy>;
@@ -41760,6 +41774,8 @@ export enum StopsDatabaseStopPlaceNewestVersionSelectColumn {
   /** column name */
   PublicCode = 'public_code',
   /** column name */
+  QuayPublicCode = 'quay_public_code',
+  /** column name */
   RailSubmode = 'rail_submode',
   /** column name */
   ShortNameLang = 'short_name_lang',
@@ -41767,6 +41783,8 @@ export enum StopsDatabaseStopPlaceNewestVersionSelectColumn {
   ShortNameValue = 'short_name_value',
   /** column name */
   StopPlaceType = 'stop_place_type',
+  /** column name */
+  StreetAddress = 'street_address',
   /** column name */
   TelecabinSubmode = 'telecabin_submode',
   /** column name */
@@ -41862,10 +41880,12 @@ export type StopsDatabaseStopPlaceNewestVersionStreamCursorValueInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
+  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;
   stop_place_type?: InputMaybe<Scalars['String']['input']>;
+  street_address?: InputMaybe<Scalars['String']['input']>;
   telecabin_submode?: InputMaybe<Scalars['String']['input']>;
   to_date?: InputMaybe<Scalars['timestamp']['input']>;
   topographic_place_id?: InputMaybe<Scalars['bigint']['input']>;

--- a/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
+++ b/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Container, Row } from '../../../layoutComponents';
 import { Path } from '../../../router/routeDetails';
+import { defaultPagingInfo } from '../../../types';
 import { SimpleButton } from '../../../uiComponents';
 import { OpenDefaultMapButton } from '../../common/OpenDefaultMapButton';
 import { StopSearchBar, StopSearchFilters } from '../search';
@@ -18,14 +19,19 @@ const testIds = {
 export const StopRegistryMainPage: FC = () => {
   const { t } = useTranslation();
 
-  const [urlState] = useStopSearchUrlState();
+  const {
+    state: { filters },
+  } = useStopSearchUrlState();
 
   const navigate = useNavigate();
-  const onSubmit = (filters: StopSearchFilters) => {
+  const onSubmit = (nextFilters: StopSearchFilters) => {
     navigate(
       {
         pathname: Path.stopSearch,
-        search: stopSearchUrlStateToSearch(filters),
+        search: stopSearchUrlStateToSearch({
+          filters: nextFilters,
+          pagingInfo: defaultPagingInfo,
+        }),
       },
       { replace: true },
     );
@@ -47,7 +53,7 @@ export const StopRegistryMainPage: FC = () => {
           {t('stops.createStop')}
         </SimpleButton>
       </Row>
-      <StopSearchBar initialFilters={urlState} onSubmit={onSubmit} />
+      <StopSearchBar initialFilters={filters} onSubmit={onSubmit} />
     </Container>
   );
 };

--- a/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
+++ b/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
@@ -6,7 +6,11 @@ import { Path } from '../../../router/routeDetails';
 import { defaultPagingInfo } from '../../../types';
 import { SimpleButton } from '../../../uiComponents';
 import { OpenDefaultMapButton } from '../../common/OpenDefaultMapButton';
-import { StopSearchBar, StopSearchFilters } from '../search';
+import {
+  StopSearchBar,
+  StopSearchFilters,
+  defaultSortingInfo,
+} from '../search';
 import {
   stopSearchUrlStateToSearch,
   useStopSearchUrlState,
@@ -31,6 +35,7 @@ export const StopRegistryMainPage: FC = () => {
         search: stopSearchUrlStateToSearch({
           filters: nextFilters,
           pagingInfo: defaultPagingInfo,
+          sortingInfo: defaultSortingInfo,
         }),
       },
       { replace: true },

--- a/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
+++ b/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { Dispatch, FC, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link, To, useLocation } from 'react-router-dom';
@@ -13,6 +13,7 @@ import { StopAreaSearchResults } from './for-stop-areas/StopAreaSearchResults';
 import {
   SearchBy,
   SearchFor,
+  SortingInfo,
   StopSearchFilters,
   defaultSortingInfo,
 } from './types';
@@ -32,9 +33,17 @@ type ResultsProps = {
   readonly filters: StopSearchFilters;
   readonly pagingInfo: PagingInfo;
   readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+  readonly sortingInfo: SortingInfo;
 };
 
-const Results: FC<ResultsProps> = ({ filters, pagingInfo, setPagingInfo }) => {
+const Results: FC<ResultsProps> = ({
+  filters,
+  pagingInfo,
+  setPagingInfo,
+  setSortingInfo,
+  sortingInfo,
+}) => {
   if (filters.searchBy === SearchBy.Line) {
     return <StopsByLineSearchResults filters={filters} />;
   }
@@ -48,6 +57,8 @@ const Results: FC<ResultsProps> = ({ filters, pagingInfo, setPagingInfo }) => {
       filters={filters}
       pagingInfo={pagingInfo}
       setPagingInfo={setPagingInfo}
+      setSortingInfo={setSortingInfo}
+      sortingInfo={sortingInfo}
     />
   );
 };
@@ -58,9 +69,10 @@ export const StopSearchResultPage = (): React.ReactElement => {
 
   const closeLink = useCloseLink();
   const {
-    state: { filters, pagingInfo },
-    setPagingInfo,
+    state: { filters, pagingInfo, sortingInfo },
     setFlatState,
+    setPagingInfo,
+    setSortingInfo,
   } = useStopSearchUrlState();
 
   const onSubmitFilters = (nextFilters: StopSearchFilters) => {
@@ -91,6 +103,8 @@ export const StopSearchResultPage = (): React.ReactElement => {
         filters={filters}
         pagingInfo={pagingInfo}
         setPagingInfo={setPagingInfo}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
       />
     </Container>
   );

--- a/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
+++ b/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
@@ -10,7 +10,12 @@ import { StopsByLineSearchResults } from './by-line';
 import { StopSearchByStopResults } from './by-stop';
 import { StopSearchBar } from './components';
 import { StopAreaSearchResults } from './for-stop-areas/StopAreaSearchResults';
-import { SearchBy, SearchFor, StopSearchFilters } from './types';
+import {
+  SearchBy,
+  SearchFor,
+  StopSearchFilters,
+  defaultSortingInfo,
+} from './types';
 import { trSearchFor, useStopSearchUrlState } from './utils';
 
 const testIds = {
@@ -60,7 +65,11 @@ export const StopSearchResultPage = (): React.ReactElement => {
 
   const onSubmitFilters = (nextFilters: StopSearchFilters) => {
     dispatch(resetSelectedRowsAction());
-    setFlatState({ ...nextFilters, ...defaultPagingInfo });
+    setFlatState({
+      ...nextFilters,
+      ...defaultPagingInfo,
+      ...defaultSortingInfo,
+    });
   };
 
   return (

--- a/ui/src/components/stop-registry/search/by-stop/CountAndSortingRow.tsx
+++ b/ui/src/components/stop-registry/search/by-stop/CountAndSortingRow.tsx
@@ -1,0 +1,37 @@
+import { Dispatch, FC, SetStateAction } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { ResultCountHeader } from '../components/ResultCountHeader';
+import { SortResultsBy } from '../components/SortResultsBy';
+import { SortStopsBy, SortingInfo } from '../types';
+
+const supportedSortingFields: ReadonlyArray<SortStopsBy> = [
+  SortStopsBy.LABEL,
+  SortStopsBy.NAME,
+  SortStopsBy.ADDRESS,
+];
+
+type CountAndSortingRowProps = {
+  readonly className?: string;
+  readonly resultCount: number;
+  readonly sortingInfo: SortingInfo;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+};
+
+export const CountAndSortingRow: FC<CountAndSortingRowProps> = ({
+  className,
+  resultCount,
+  setSortingInfo,
+  sortingInfo,
+}) => {
+  return (
+    <div className={twMerge('a flex items-center justify-between', className)}>
+      <ResultCountHeader resultCount={resultCount} />
+      <SortResultsBy
+        mapDefaultTo={SortStopsBy.LABEL}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
+        supportedFields={supportedSortingFields}
+      />
+    </div>
+  );
+};

--- a/ui/src/components/stop-registry/search/by-stop/StopSearchByStopResultList.tsx
+++ b/ui/src/components/stop-registry/search/by-stop/StopSearchByStopResultList.tsx
@@ -1,20 +1,21 @@
+import { FC } from 'react';
 import { StopTableRow } from '../StopTableRow';
 import { LocatorActionButton } from '../StopTableRow/ActionButtons/LocatorActionButton';
 import { OpenDetailsPage } from '../StopTableRow/MenuItems/OpenDetailsPage';
 import { ShowOnMap } from '../StopTableRow/MenuItems/ShowOnMap';
 import { StopSearchRow } from '../types';
 
-interface Props {
-  stops: Array<StopSearchRow>;
-}
-
 const testIds = {
   table: 'StopSearchByStopResultList::table',
 };
 
-export const StopSearchByStopResultList = ({
-  stops,
-}: Props): React.ReactElement => {
+type StopSearchByStopResultListProps = {
+  readonly stops: ReadonlyArray<StopSearchRow>;
+};
+
+export const StopSearchByStopResultList: FC<
+  StopSearchByStopResultListProps
+> = ({ stops }) => {
   return (
     <table
       className="h-1 w-full border-x border-x-light-grey"

--- a/ui/src/components/stop-registry/search/by-stop/StopSearchByStopResults.tsx
+++ b/ui/src/components/stop-registry/search/by-stop/StopSearchByStopResults.tsx
@@ -1,10 +1,11 @@
-import { FC, useMemo } from 'react';
+import { Dispatch, FC, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Visible } from '../../../../layoutComponents';
 import { PagingInfo } from '../../../../types';
 import { Pagination } from '../../../../uiComponents';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
-import { StopSearchFilters, StopSearchRow } from '../types';
+import { SortingInfo, StopSearchFilters } from '../types';
+import { CountAndSortingRow } from './CountAndSortingRow';
 import { StopSearchByStopResultList } from './StopSearchByStopResultList';
 import { useStopSearchResults } from './useStopSearchResults';
 
@@ -12,39 +13,28 @@ const testIds = {
   loadingSearchResults: 'LoadingWrapper::loadingStopSearchResults',
 };
 
-// TODO: Replace with proper backend pagination once backend sorting is also in place.
-function useSortedAndPaginatedStops(
-  stops: ReadonlyArray<StopSearchRow>,
-  { page, pageSize }: PagingInfo,
-): ReadonlyArray<StopSearchRow> {
-  const sorted = useMemo(
-    () => stops.toSorted((a, b) => a.label.localeCompare(b.label)),
-    [stops],
-  );
-
-  return useMemo(() => {
-    const startIndex = (page - 1) * pageSize;
-    const endIndex = startIndex + pageSize;
-    return sorted.slice(startIndex, endIndex);
-  }, [page, pageSize, sorted]);
-}
-
 type StopSearchByStopResultsProps = {
   readonly filters: StopSearchFilters;
   readonly pagingInfo: PagingInfo;
   readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+  readonly sortingInfo: SortingInfo;
 };
 
 export const StopSearchByStopResults: FC<StopSearchByStopResultsProps> = ({
   filters,
   pagingInfo,
   setPagingInfo,
+  setSortingInfo,
+  sortingInfo,
 }) => {
   const { t } = useTranslation();
 
-  const { stops, loading, resultCount } = useStopSearchResults(filters);
-
-  const displayedStops = useSortedAndPaginatedStops(stops, pagingInfo);
+  const { stops, loading, resultCount } = useStopSearchResults(
+    filters,
+    sortingInfo,
+    pagingInfo,
+  );
 
   return (
     <LoadingWrapper
@@ -53,9 +43,13 @@ export const StopSearchByStopResults: FC<StopSearchByStopResultsProps> = ({
       loading={loading}
       testId={testIds.loadingSearchResults}
     >
-      {/* TODO: Search result filter input */}
-      {/* TODO: Selection toolbar */}
-      <StopSearchByStopResultList stops={displayedStops} />
+      <CountAndSortingRow
+        className="mb-6"
+        resultCount={resultCount}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
+      />
+      <StopSearchByStopResultList stops={stops} />
       <Visible visible={!!resultCount}>
         <div className="grid grid-cols-4">
           <Pagination

--- a/ui/src/components/stop-registry/search/by-stop/useStopSearchResults.ts
+++ b/ui/src/components/stop-registry/search/by-stop/useStopSearchResults.ts
@@ -1,7 +1,11 @@
 import { gql } from '@apollo/client';
 import { useMemo } from 'react';
 import { useSearchStopsQuery } from '../../../../generated/graphql';
-import { StopSearchFilters, hasMeaningfulFilters } from '../types';
+import {
+  StopSearchFilters,
+  StopSearchRow,
+  hasMeaningfulFilters,
+} from '../types';
 import { mapQueryResultToStopSearchRows } from '../utils';
 import { buildSearchStopsGqlQueryVariables } from './filtersToQueryVariables';
 
@@ -59,7 +63,7 @@ export const useStopSearchResults = (filters: StopSearchFilters) => {
     skip,
   });
 
-  const stopSearchRows = useMemo(() => {
+  const stopSearchRows: ReadonlyArray<StopSearchRow> = useMemo(() => {
     if (!data) {
       return [];
     }

--- a/ui/src/components/stop-registry/search/components/LoadingStopsRow.tsx
+++ b/ui/src/components/stop-registry/search/components/LoadingStopsRow.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import PulseLoader from 'react-spinners/PulseLoader';
 import { theme } from '../../../../generated/theme';
 
@@ -7,14 +8,18 @@ const testIds = {
 };
 
 export const LoadingStopsRow: FC = () => {
+  const { t } = useTranslation();
+
   return (
-    <div className="flex items-center justify-center border border-light-grey p-8">
+    <div className="flex-column items-center justify-center border border-light-grey p-8">
       <PulseLoader
         data-testid={testIds.loader}
         color={theme.colors.brand}
         size={25}
         speedMultiplier={0.7}
       />
+
+      <span className="mt-4">{t('search.searching')}</span>
     </div>
   );
 };

--- a/ui/src/components/stop-registry/search/components/ResultCountHeader.tsx
+++ b/ui/src/components/stop-registry/search/components/ResultCountHeader.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type ResultCountHeader = {
+  readonly className?: string;
+  readonly resultCount: number;
+};
+
+export const ResultCountHeader: FC<ResultCountHeader> = ({
+  className,
+  resultCount,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <h2 className={className}>
+      {t('stopRegistrySearch.resultCount', { count: resultCount })}
+    </h2>
+  );
+};

--- a/ui/src/components/stop-registry/search/components/SortByButton.tsx
+++ b/ui/src/components/stop-registry/search/components/SortByButton.tsx
@@ -1,0 +1,120 @@
+import { TFunction } from 'i18next';
+import { Dispatch, FC, ReactNode, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
+import { twMerge } from 'tailwind-merge';
+import { Visible } from '../../../../layoutComponents';
+import { PagingInfo, SortOrder, defaultPagingInfo } from '../../../../types';
+import { SortStopsBy, SortingInfo } from '../types';
+
+function trSortStopsBy(t: TFunction, value: SortStopsBy): ReactNode {
+  switch (value) {
+    case SortStopsBy.ADDRESS:
+      return t('stopRegistrySearch.sortBy.address');
+
+    case SortStopsBy.LABEL:
+      return t('stopRegistrySearch.sortBy.label');
+
+    case SortStopsBy.NAME:
+      return t('stopRegistrySearch.sortBy.name');
+
+    case SortStopsBy.SEQUENCE_NUMBER:
+      return t('stopRegistrySearch.sortBy.sequenceNumber');
+
+    case SortStopsBy.BY_STOP_AREA:
+      return t('stopRegistrySearch.sortBy.byStopArea');
+
+    default:
+      return null;
+  }
+}
+
+function reverseSortingOrder(sortOrder: SortOrder): SortOrder {
+  if (sortOrder === SortOrder.ASCENDING) {
+    return SortOrder.DESCENDING;
+  }
+
+  return SortOrder.ASCENDING;
+}
+
+const iconClassName = 'text-tweaked-brand';
+
+type ProperSortable = {
+  readonly groupOnly?: false;
+  readonly setPagingInfo?: (pagingInfo: PagingInfo) => void;
+};
+
+type GroupOnly = {
+  readonly groupOnly: true;
+  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+};
+
+type SortByButtonProps = {
+  readonly className?: string;
+  readonly isActive: boolean;
+  readonly isDefault: boolean;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+  readonly sortBy: SortStopsBy;
+  readonly sortOrder: SortOrder;
+} & (ProperSortable | GroupOnly);
+
+export const SortByButton: FC<SortByButtonProps> = ({
+  className,
+  groupOnly,
+  isActive,
+  isDefault,
+  setPagingInfo,
+  setSortingInfo,
+  sortBy,
+  sortOrder,
+}) => {
+  const { t } = useTranslation();
+
+  const setToOnClick = isDefault ? SortStopsBy.DEFAULT : sortBy;
+
+  const onClick = () => {
+    setSortingInfo((p) => {
+      if (groupOnly) {
+        return { sortBy: setToOnClick, sortOrder: SortOrder.ASCENDING };
+      }
+
+      if (
+        p.sortBy === sortBy ||
+        (isDefault && p.sortBy === SortStopsBy.DEFAULT)
+      ) {
+        return {
+          sortBy: setToOnClick,
+          sortOrder: reverseSortingOrder(p.sortOrder),
+        };
+      }
+
+      return { sortBy: setToOnClick, sortOrder: p.sortOrder };
+    });
+
+    if (groupOnly) {
+      setPagingInfo(defaultPagingInfo);
+    }
+  };
+
+  return (
+    <button
+      className={twMerge(
+        'flex items-center gap-2',
+        isActive ? 'underline' : '',
+        className,
+      )}
+      type="button"
+      onClick={onClick}
+    >
+      <span>{trSortStopsBy(t, sortBy)}</span>
+
+      <Visible visible={!groupOnly}>
+        {sortOrder === SortOrder.ASCENDING ? (
+          <FaChevronDown className={iconClassName} aria-hidden />
+        ) : (
+          <FaChevronUp className={iconClassName} aria-hidden />
+        )}
+      </Visible>
+    </button>
+  );
+};

--- a/ui/src/components/stop-registry/search/components/SortResultsBy.tsx
+++ b/ui/src/components/stop-registry/search/components/SortResultsBy.tsx
@@ -1,0 +1,63 @@
+import { Dispatch, FC, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
+import { PagingInfo } from '../../../../types';
+import { SortStopsBy, SortingInfo } from '../types';
+import { SortByButton } from './SortByButton';
+
+type WithoutGroupOnlyFields = {
+  readonly groupOnlyFields?: never;
+  readonly setPagingInfo?: never;
+};
+
+type WithGroupOnlyFields = {
+  readonly groupOnlyFields: ReadonlyArray<SortStopsBy>;
+  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+};
+
+type SortResultsByProps = {
+  readonly className?: string;
+  readonly mapDefaultTo: SortStopsBy;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+  readonly sortingInfo: SortingInfo;
+  readonly supportedFields: ReadonlyArray<SortStopsBy>;
+} & (WithoutGroupOnlyFields | WithGroupOnlyFields);
+
+export const SortResultsBy: FC<SortResultsByProps> = ({
+  className,
+  groupOnlyFields,
+  mapDefaultTo,
+  setPagingInfo,
+  setSortingInfo,
+  sortingInfo: { sortBy: activeOrder, sortOrder },
+  supportedFields,
+}) => {
+  const { t } = useTranslation();
+
+  const actualOrder =
+    activeOrder === SortStopsBy.DEFAULT ? mapDefaultTo : activeOrder;
+
+  return (
+    <div className={twMerge('flex gap-4', className)}>
+      <p className="font-bold">{t('stopRegistrySearch.sortOrder')}</p>
+
+      {supportedFields.map((sortBy) => (
+        <SortByButton
+          key={sortBy}
+          isActive={actualOrder === sortBy}
+          isDefault={mapDefaultTo === sortBy}
+          setSortingInfo={setSortingInfo}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...(groupOnlyFields
+            ? {
+                groupOnly: groupOnlyFields.includes(sortBy),
+                setPagingInfo,
+              }
+            : { groupOnly: false })}
+        />
+      ))}
+    </div>
+  );
+};

--- a/ui/src/components/stop-registry/search/for-stop-areas/useGetStopResultByStopAreaId.ts
+++ b/ui/src/components/stop-registry/search/for-stop-areas/useGetStopResultByStopAreaId.ts
@@ -7,7 +7,7 @@ import { mapQueryResultToStopSearchRows } from '../utils';
 const GQL_GET_STOPS_BY_STOP_AREA_ID = gql`
   query getStopsByStopAreaId($stopAreaId: bigint!) {
     stops_database {
-      stops_database_stop_place_newest_version(
+      stops: stops_database_stop_place_newest_version(
         where: {
           group_of_stop_places_members: {
             group_of_stop_places_id: { _eq: $stopAreaId }
@@ -26,11 +26,11 @@ export const useGetStopResultByStopAreaId = (stopAreaId: number | bigint) => {
   });
 
   const stopSearchRows: ReadonlyArray<StopSearchRow> = useMemo(() => {
-    if (!data) {
+    if (!data?.stops_database?.stops) {
       return [];
     }
 
-    return mapQueryResultToStopSearchRows(data);
+    return mapQueryResultToStopSearchRows(data.stops_database.stops);
   }, [data]);
 
   return {

--- a/ui/src/components/stop-registry/search/types/SortStopsBy.ts
+++ b/ui/src/components/stop-registry/search/types/SortStopsBy.ts
@@ -1,0 +1,17 @@
+export enum SortStopsBy {
+  // Same enum will be used for: stops, StopAreas and Terminals.
+  // All which have a different default sorting value.
+  //
+  // In Stop search by-label, or by-address: LABEL,
+  // In Stop search by-line: SEQUENCE_NUMBER
+  // In Stop Area search: BY_STOP_AREA
+  DEFAULT = 'default',
+
+  LABEL = 'label',
+  NAME = 'name',
+  ADDRESS = 'address',
+
+  SEQUENCE_NUMBER = 'sequenceNumber',
+
+  BY_STOP_AREA = 'byStopArea',
+}

--- a/ui/src/components/stop-registry/search/types/SortingInfo.ts
+++ b/ui/src/components/stop-registry/search/types/SortingInfo.ts
@@ -1,0 +1,12 @@
+import { SortOrder } from '../../../../types';
+import { SortStopsBy } from './SortStopsBy';
+
+export type SortingInfo = {
+  readonly sortBy: SortStopsBy;
+  readonly sortOrder: SortOrder;
+};
+
+export const defaultSortingInfo: SortingInfo = {
+  sortBy: SortStopsBy.DEFAULT,
+  sortOrder: SortOrder.ASCENDING,
+};

--- a/ui/src/components/stop-registry/search/types/index.ts
+++ b/ui/src/components/stop-registry/search/types/index.ts
@@ -1,5 +1,7 @@
 export * from './SearchBy';
 export * from './SearchFor';
+export * from './SortingInfo';
+export * from './SortStopsBy';
 export * from './StopPlaceSearchRowDetails';
 export * from './StopSearchFilters';
 export * from './StopSearchRow';

--- a/ui/src/components/stop-registry/search/utils/resultMappers.ts
+++ b/ui/src/components/stop-registry/search/utils/resultMappers.ts
@@ -1,5 +1,4 @@
 import {
-  SearchStopsQuery,
   StopTableRowFragment,
   StopTableRowStopPlaceFragment,
 } from '../../../../generated/graphql';
@@ -23,9 +22,9 @@ const mapResultRowToStopSearchRow = (
 };
 
 export const mapQueryResultToStopSearchRows = (
-  data: SearchStopsQuery,
+  stops: ReadonlyArray<StopTableRowStopPlaceFragment>,
 ): StopSearchRow[] =>
-  data.stops_database?.stops_database_stop_place_newest_version
+  stops
     // Filter out stops which do not have a matching stop in routes and lines
     .filter((stop) => !!stop.scheduled_stop_point_instance)
-    .map(mapResultRowToStopSearchRow) ?? [];
+    .map(mapResultRowToStopSearchRow);

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -10901,9 +10901,11 @@ export enum StopRegistryPedestrianCrossingRampType {
 
 export type StopRegistryPoster = {
   __typename?: 'stop_registry_poster';
+  id?: Maybe<Scalars['String']['output']>;
   label?: Maybe<Scalars['String']['output']>;
   lines?: Maybe<Scalars['String']['output']>;
   posterSize?: Maybe<StopRegistryPosterPlaceSize>;
+  version?: Maybe<Scalars['String']['output']>;
 };
 
 export type StopRegistryPosterInput = {
@@ -41151,6 +41153,7 @@ export type StopsDatabaseStopPlaceNewestVersion = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
+  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   scheduled_stop_point_instance?: Maybe<ServicePatternScheduledStopPoint>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
@@ -41184,6 +41187,7 @@ export type StopsDatabaseStopPlaceNewestVersion = {
   /** An aggregate relationship */
   stop_place_tariff_zones_aggregate: StopsDatabaseStopPlaceTariffZonesAggregate;
   stop_place_type?: Maybe<Scalars['String']['output']>;
+  street_address?: Maybe<Scalars['String']['output']>;
   telecabin_submode?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
   topographic_place_id?: Maybe<Scalars['bigint']['output']>;
@@ -41474,6 +41478,7 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   private_code_type?: InputMaybe<StringComparisonExp>;
   private_code_value?: InputMaybe<StringComparisonExp>;
   public_code?: InputMaybe<StringComparisonExp>;
+  quay_public_code?: InputMaybe<StringComparisonExp>;
   rail_submode?: InputMaybe<StringComparisonExp>;
   short_name_lang?: InputMaybe<StringComparisonExp>;
   short_name_value?: InputMaybe<StringComparisonExp>;
@@ -41492,6 +41497,7 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   stop_place_tariff_zones?: InputMaybe<StopsDatabaseStopPlaceTariffZonesBoolExp>;
   stop_place_tariff_zones_aggregate?: InputMaybe<StopPlaceTariffZonesAggregateBoolExp>;
   stop_place_type?: InputMaybe<StringComparisonExp>;
+  street_address?: InputMaybe<StringComparisonExp>;
   telecabin_submode?: InputMaybe<StringComparisonExp>;
   to_date?: InputMaybe<TimestampComparisonExp>;
   topographic_place_id?: InputMaybe<BigintComparisonExp>;
@@ -41535,6 +41541,7 @@ export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
+  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;
@@ -41546,6 +41553,7 @@ export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
   stop_place_quays?: InputMaybe<StopsDatabaseStopPlaceQuaysArrRelInsertInput>;
   stop_place_tariff_zones?: InputMaybe<StopsDatabaseStopPlaceTariffZonesArrRelInsertInput>;
   stop_place_type?: InputMaybe<Scalars['String']['input']>;
+  street_address?: InputMaybe<Scalars['String']['input']>;
   telecabin_submode?: InputMaybe<Scalars['String']['input']>;
   to_date?: InputMaybe<Scalars['timestamp']['input']>;
   topographic_place_id?: InputMaybe<Scalars['bigint']['input']>;
@@ -41585,10 +41593,12 @@ export type StopsDatabaseStopPlaceNewestVersionMaxFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
+  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
   stop_place_type?: Maybe<Scalars['String']['output']>;
+  street_address?: Maybe<Scalars['String']['output']>;
   telecabin_submode?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
   topographic_place_id?: Maybe<Scalars['bigint']['output']>;
@@ -41628,10 +41638,12 @@ export type StopsDatabaseStopPlaceNewestVersionMinFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
+  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
   stop_place_type?: Maybe<Scalars['String']['output']>;
+  street_address?: Maybe<Scalars['String']['output']>;
   telecabin_submode?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
   topographic_place_id?: Maybe<Scalars['bigint']['output']>;
@@ -41680,6 +41692,7 @@ export type StopsDatabaseStopPlaceNewestVersionOrderBy = {
   private_code_type?: InputMaybe<OrderBy>;
   private_code_value?: InputMaybe<OrderBy>;
   public_code?: InputMaybe<OrderBy>;
+  quay_public_code?: InputMaybe<OrderBy>;
   rail_submode?: InputMaybe<OrderBy>;
   short_name_lang?: InputMaybe<OrderBy>;
   short_name_value?: InputMaybe<OrderBy>;
@@ -41691,6 +41704,7 @@ export type StopsDatabaseStopPlaceNewestVersionOrderBy = {
   stop_place_quays_aggregate?: InputMaybe<StopsDatabaseStopPlaceQuaysAggregateOrderBy>;
   stop_place_tariff_zones_aggregate?: InputMaybe<StopsDatabaseStopPlaceTariffZonesAggregateOrderBy>;
   stop_place_type?: InputMaybe<OrderBy>;
+  street_address?: InputMaybe<OrderBy>;
   telecabin_submode?: InputMaybe<OrderBy>;
   to_date?: InputMaybe<OrderBy>;
   topographic_place_id?: InputMaybe<OrderBy>;
@@ -41763,6 +41777,8 @@ export enum StopsDatabaseStopPlaceNewestVersionSelectColumn {
   /** column name */
   PublicCode = 'public_code',
   /** column name */
+  QuayPublicCode = 'quay_public_code',
+  /** column name */
   RailSubmode = 'rail_submode',
   /** column name */
   ShortNameLang = 'short_name_lang',
@@ -41770,6 +41786,8 @@ export enum StopsDatabaseStopPlaceNewestVersionSelectColumn {
   ShortNameValue = 'short_name_value',
   /** column name */
   StopPlaceType = 'stop_place_type',
+  /** column name */
+  StreetAddress = 'street_address',
   /** column name */
   TelecabinSubmode = 'telecabin_submode',
   /** column name */
@@ -41865,10 +41883,12 @@ export type StopsDatabaseStopPlaceNewestVersionStreamCursorValueInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
+  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;
   stop_place_type?: InputMaybe<Scalars['String']['input']>;
+  street_address?: InputMaybe<Scalars['String']['input']>;
   telecabin_submode?: InputMaybe<Scalars['String']['input']>;
   to_date?: InputMaybe<Scalars['timestamp']['input']>;
   topographic_place_id?: InputMaybe<Scalars['bigint']['input']>;

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -67002,13 +67002,16 @@ export type StopTableRowStopPlaceFragment = {
 
 export type SearchStopsQueryVariables = Exact<{
   stopFilter?: InputMaybe<StopsDatabaseStopPlaceNewestVersionBoolExp>;
+  orderBy: StopsDatabaseStopPlaceNewestVersionOrderBy;
+  offset: Scalars['Int']['input'];
+  limit: Scalars['Int']['input'];
 }>;
 
 export type SearchStopsQuery = {
   __typename?: 'query_root';
   stops_database?: {
     __typename?: 'stops_database_stops_database_query';
-    stops_database_stop_place_newest_version: Array<{
+    stops: Array<{
       __typename?: 'stops_database_stop_place_newest_version';
       id?: any | null;
       netex_id?: string | null;
@@ -67037,6 +67040,13 @@ export type SearchStopsQuery = {
         } | null;
       } | null;
     }>;
+    resultCount: {
+      __typename?: 'stops_database_stop_place_newest_version_aggregate';
+      aggregate?: {
+        __typename?: 'stops_database_stop_place_newest_version_aggregate_fields';
+        count: number;
+      } | null;
+    };
   } | null;
 };
 
@@ -67087,7 +67097,7 @@ export type GetStopsByStopAreaIdQuery = {
   __typename?: 'query_root';
   stops_database?: {
     __typename?: 'stops_database_stops_database_query';
-    stops_database_stop_place_newest_version: Array<{
+    stops: Array<{
       __typename?: 'stops_database_stop_place_newest_version';
       id?: any | null;
       netex_id?: string | null;
@@ -74665,10 +74675,25 @@ export type GetStopsByRouteIdQueryResult = Apollo.QueryResult<
 export const SearchStopsDocument = gql`
   query SearchStops(
     $stopFilter: stops_database_stop_place_newest_version_bool_exp
+    $orderBy: stops_database_stop_place_newest_version_order_by!
+    $offset: Int!
+    $limit: Int!
   ) {
     stops_database {
-      stops_database_stop_place_newest_version(where: $stopFilter) {
+      stops: stops_database_stop_place_newest_version(
+        where: $stopFilter
+        order_by: [$orderBy]
+        offset: $offset
+        limit: $limit
+      ) {
         ...stop_table_row_stop_place
+      }
+      resultCount: stops_database_stop_place_newest_version_aggregate(
+        where: $stopFilter
+      ) {
+        aggregate {
+          count
+        }
       }
     }
   }
@@ -74688,14 +74713,21 @@ export const SearchStopsDocument = gql`
  * const { data, loading, error } = useSearchStopsQuery({
  *   variables: {
  *      stopFilter: // value for 'stopFilter'
+ *      orderBy: // value for 'orderBy'
+ *      offset: // value for 'offset'
+ *      limit: // value for 'limit'
  *   },
  * });
  */
 export function useSearchStopsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
+  baseOptions: Apollo.QueryHookOptions<
     SearchStopsQuery,
     SearchStopsQueryVariables
-  >,
+  > &
+    (
+      | { variables: SearchStopsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<SearchStopsQuery, SearchStopsQueryVariables>(
@@ -74847,7 +74879,7 @@ export type FindStopAreasQueryResult = Apollo.QueryResult<
 export const GetStopsByStopAreaIdDocument = gql`
   query getStopsByStopAreaId($stopAreaId: bigint!) {
     stops_database {
-      stops_database_stop_place_newest_version(
+      stops: stops_database_stop_place_newest_version(
         where: {
           group_of_stop_places_members: {
             group_of_stop_places_id: { _eq: $stopAreaId }

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -389,6 +389,8 @@
     "stopAreaLabel": "Stop area {{name}} | {{description}}",
     "showStopAreaOnMap": "Show stop area on the map",
     "sortOrder": "Sort by:",
+    "resultCount": "{{count}} search result",
+    "resultCount_other": "{{count}} search results",
 
     "stopRowActions": {
       "openDetails": "Open stop details page",

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -388,6 +388,7 @@
     "tryToRefetch": "Try to refetch stops",
     "stopAreaLabel": "Stop area {{name}} | {{description}}",
     "showStopAreaOnMap": "Show stop area on the map",
+    "sortOrder": "Sort by:",
 
     "stopRowActions": {
       "openDetails": "Open stop details page",
@@ -405,6 +406,14 @@
       "searchFor": "Search for",
       "elyNumber": "ELY number",
       "municipalities": "Municipality"
+    },
+
+    "sortBy": {
+      "label": "Label",
+      "name": "Name",
+      "address": "Address",
+      "sequenceNumber": "Sequence number",
+      "byStopArea": "By stop"
     }
   },
   "timingPlaces": {

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -388,6 +388,7 @@
     "tryToRefetch": "Yritä noutaa pysäkit uudelleen",
     "stopAreaLabel": "Pysäkkialue {{name}} | {{description}}",
     "showStopAreaOnMap": "Näytä pysäkkialue kartalla",
+    "sortOrder": "Järjestys:",
 
     "stopRowActions": {
       "openDetails": "Näytä pysäkin tiedot",
@@ -405,6 +406,14 @@
       "searchFor": "Hakukohde",
       "elyNumber": "ELY-numero",
       "municipalities": "Kunta"
+    },
+
+    "sortBy": {
+      "label": "Tunnus",
+      "name": "Nimi",
+      "address": "Osoite",
+      "sequenceNumber": "Järjestysnumero",
+      "byStopArea": "Pysäkkialueen mukaan"
     }
   },
   "timingPlaces": {

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -389,6 +389,8 @@
     "stopAreaLabel": "Pysäkkialue {{name}} | {{description}}",
     "showStopAreaOnMap": "Näytä pysäkkialue kartalla",
     "sortOrder": "Järjestys:",
+    "resultCount": "{{count}} hakutulos",
+    "resultCount_other": "{{count}} hakutulosta",
 
     "stopRowActions": {
       "openDetails": "Näytä pysäkin tiedot",

--- a/ui/src/types/SortOrder.ts
+++ b/ui/src/types/SortOrder.ts
@@ -1,0 +1,4 @@
+export enum SortOrder {
+  ASCENDING = 'asc',
+  DESCENDING = 'desc',
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './GeoHelpers';
 export * from './KeyHelpers';
 export * from './PagingInfo';
+export * from './SortOrder';
 export * from './stopAreaByIdResult';
 export * from './StopSearchConditions';

--- a/ui/src/uiComponents/LoadingWrapper.tsx
+++ b/ui/src/uiComponents/LoadingWrapper.tsx
@@ -38,7 +38,7 @@ export const LoadingWrapper: FC<Props> = ({
             size={size}
             speedMultiplier={speedMultiplier}
           />
-          {loadingText && <span>{loadingText}</span>}
+          {loadingText && <span className="mt-4">{loadingText}</span>}
         </div>
       </div>
     );

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './graphql';
 export * from './journeyPattern';
 export * from './localizedString';
 export * from './logger';
+export * from './memoizeOne';
 export * from './misc';
 export * from './numberEnumHelpers';
 export * from './object';

--- a/ui/src/utils/memoizeOne.ts
+++ b/ui/src/utils/memoizeOne.ts
@@ -1,0 +1,60 @@
+// Inspired by https://github.com/alexreardon/memoize-one
+
+type ComparatorFn<T> = (a: T, b: T) => boolean;
+
+function paramsAreEqual(
+  last: ReadonlyArray<unknown>,
+  next: ReadonlyArray<unknown>,
+  comparator: ComparatorFn<unknown>,
+) {
+  if (last.length !== next.length) {
+    return false;
+  }
+
+  for (let i = 0; i < last.length; i += 1) {
+    if (!comparator(last[i], next[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+type Cache<TFunc extends (...args: ExplicitAny[]) => ExplicitAny> = {
+  params: Parameters<TFunc> | null;
+  result: ReturnType<TFunc> | null;
+};
+
+/**
+ * Create a memoized version of the given function
+ *
+ * Only has a single cache slot. Thus, multiple consecutive calls with
+ * the same arguments, provide the same result with referential equality.
+ *
+ * Does not support functions that use `this`.
+ * By default, uses Object.is to compare the function parameters.
+ *
+ * @param fn function to memoize
+ * @param comparator function to compare individual parameters with
+ */
+export function memoizeOne<
+  TFunc extends (...args: ExplicitAny[]) => ExplicitAny,
+>(fn: TFunc, comparator: ComparatorFn<unknown> = Object.is): TFunc {
+  const cache: Cache<TFunc> = {
+    params: null,
+    result: null,
+  };
+
+  return ((...args: Parameters<TFunc>): ReturnType<TFunc> => {
+    if (
+      cache.params === null ||
+      !paramsAreEqual(cache.params, args, comparator)
+    ) {
+      cache.result = fn.call(null, ...args) as ReturnType<TFunc>;
+      cache.params = args as Parameters<TFunc>;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return cache.result!;
+  }) as TFunc;
+}


### PR DESCRIPTION
### Add memoize function implementation with a single item cache
Lodash does provide a memoization function, but that has an infinite cache size, thus by default it causes a memory leak.

Inspired by https://github.com/alexreardon/memoize-one, but a simplified version of it, with a very basic functionality. Could be replaced by memoize-one in future, if a more robust implementation is needed.

By default uses Object.is to compare the function parameters with, but allows for alternative comparators too.


### Update Tiamat & regen GraphQL files


### Add some margin to LoadingWrapper


### StopSearch: Add 'searching...' subtext to LoadingStopRow


### StopSearch: Use the new Paging component
* Add paging to StopSearchUrlState.
* Pass down paging info into result stop result list.
* Actual paging still handled UI side. (Backend paging also needs backend side sorting)
* Reset paging, when submitting new filters.


### StopSearch: Add initial URL state bits for sorting
Add types, default values and serialization bits needed to implement proper sorting of the results.


### StopSearch: Add SortResultsBy component


### StopSearch: Add ResultCountHeader component


### StopSearch: Add CountAndSortingRow component


### StopSearch: Implement backend sorting and paging on basic stop search

- - -

### Testing:
1. Go to http://localhost:3300/stop-registry
2. Search for Stops by Label or Address
3. Results should be sortable by Label, Name & Address.
4. Pagination should work 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/943)
<!-- Reviewable:end -->
