### PR TITLE
Search stops by line sorting & paging

### DIFF
--- a/cypress/pageObjects/Pagination.ts
+++ b/cypress/pageObjects/Pagination.ts
@@ -1,0 +1,13 @@
+export class Pagination {
+  getPreviousPageButton() {
+    return cy.getByTestId('Pagination::page::previous');
+  }
+
+  getPageButton(pageNumber: number) {
+    return cy.getByTestId(`Pagination::page::${pageNumber}`);
+  }
+
+  getNextPageButton() {
+    return cy.getByTestId('Pagination::page::next');
+  }
+}

--- a/cypress/pageObjects/index.ts
+++ b/cypress/pageObjects/index.ts
@@ -18,6 +18,7 @@ export * from './MapModal';
 export * from './MapObservationDateFiltersOverlay';
 export * from './Navbar';
 export * from './ObservationPeriodForm';
+export * from './Pagination';
 export * from './PreviewTimetablesPage';
 export * from './RouteEditor';
 export * from './RoutePropertiesForm';

--- a/cypress/pageObjects/stop-registry/SortByButton.ts
+++ b/cypress/pageObjects/stop-registry/SortByButton.ts
@@ -1,0 +1,32 @@
+type SortingDirections = 'asc' | 'desc' | 'groupOnly';
+
+export class SortByButton {
+  getButton(sortBy: string) {
+    return cy.getByTestId(`SortByButton::${sortBy}`);
+  }
+
+  getActive() {
+    return cy.get("[data-element-type='SortByButton'][data-is-active='true']");
+  }
+
+  assertSortBy(sortBy: string) {
+    return this.getActive().should(
+      'have.attr',
+      'data-testid',
+      `SortByButton::${sortBy}`,
+    );
+  }
+
+  assertSortDirection(direction: SortingDirections) {
+    return this.getActive().should(
+      'have.attr',
+      'data-sort-direction',
+      direction,
+    );
+  }
+
+  assertSorting(sortBy: string, direction: SortingDirections) {
+    this.assertSortBy(sortBy);
+    this.assertSortDirection(direction);
+  }
+}

--- a/cypress/pageObjects/stop-registry/StopSearchByLine.ts
+++ b/cypress/pageObjects/stop-registry/StopSearchByLine.ts
@@ -8,6 +8,10 @@ export class StopSearchByLine {
   }
 
   getRouteContainer(id: string) {
+    return cy.getByTestId(`StopSearchByLine::route::${id}`);
+  }
+
+  getRouteInfoContainer(id: string) {
     return cy.getByTestId(`StopSearchByLine::route::infoContainer::${id}`);
   }
 

--- a/cypress/pageObjects/stop-registry/index.ts
+++ b/cypress/pageObjects/stop-registry/index.ts
@@ -1,4 +1,5 @@
 export * from './SearchForStopAreas';
+export * from './SortByButton';
 export * from './StopAreaDetailsPage';
 export * from './stop-details';
 export * from './StopDetailsPage';

--- a/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
+++ b/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
@@ -24,7 +24,7 @@ export const StopRegistryMainPage: FC = () => {
   const { t } = useTranslation();
 
   const {
-    state: { filters },
+    state: { filters, pagingInfo },
   } = useStopSearchUrlState();
 
   const navigate = useNavigate();
@@ -34,7 +34,10 @@ export const StopRegistryMainPage: FC = () => {
         pathname: Path.stopSearch,
         search: stopSearchUrlStateToSearch({
           filters: nextFilters,
-          pagingInfo: defaultPagingInfo,
+          pagingInfo: {
+            ...defaultPagingInfo,
+            pageSize: pagingInfo.pageSize,
+          },
           sortingInfo: defaultSortingInfo,
         }),
       },

--- a/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
+++ b/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
@@ -1,11 +1,11 @@
-import { Dispatch, FC, SetStateAction } from 'react';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link, To, useLocation } from 'react-router-dom';
 import { Container, Row } from '../../../layoutComponents';
 import { resetSelectedRowsAction } from '../../../redux';
 import { Path } from '../../../router/routeDetails';
-import { PagingInfo, defaultPagingInfo } from '../../../types';
+import { defaultPagingInfo } from '../../../types';
 import { StopsByLineSearchResults } from './by-line';
 import { StopSearchByStopResults } from './by-stop';
 import { StopSearchBar } from './components';
@@ -13,8 +13,8 @@ import { StopAreaSearchResults } from './for-stop-areas/StopAreaSearchResults';
 import {
   SearchBy,
   SearchFor,
-  SortingInfo,
   StopSearchFilters,
+  StopSearchResultsProps,
   defaultSortingInfo,
 } from './types';
 import { trSearchFor, useStopSearchUrlState } from './utils';
@@ -29,15 +29,7 @@ function useCloseLink(): To {
   return { pathname: Path.stopRegistry, search };
 }
 
-type ResultsProps = {
-  readonly filters: StopSearchFilters;
-  readonly pagingInfo: PagingInfo;
-  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
-  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
-  readonly sortingInfo: SortingInfo;
-};
-
-const Results: FC<ResultsProps> = ({
+const Results: FC<StopSearchResultsProps> = ({
   filters,
   pagingInfo,
   setPagingInfo,

--- a/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
+++ b/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
@@ -87,8 +87,9 @@ export const StopSearchResultPage = (): React.ReactElement => {
     dispatch(resetSelectedRowsAction());
     setFlatState({
       ...nextFilters,
-      ...defaultPagingInfo,
       ...defaultSortingInfo,
+      ...defaultPagingInfo,
+      pageSize: pagingInfo.pageSize,
     });
   };
 

--- a/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
+++ b/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
@@ -45,7 +45,15 @@ const Results: FC<ResultsProps> = ({
   sortingInfo,
 }) => {
   if (filters.searchBy === SearchBy.Line) {
-    return <StopsByLineSearchResults filters={filters} />;
+    return (
+      <StopsByLineSearchResults
+        filters={filters}
+        pagingInfo={pagingInfo}
+        setPagingInfo={setPagingInfo}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
+      />
+    );
   }
 
   if (filters.searchFor === SearchFor.StopAreas) {

--- a/ui/src/components/stop-registry/search/by-line/CountAndSortingRow.tsx
+++ b/ui/src/components/stop-registry/search/by-line/CountAndSortingRow.tsx
@@ -1,0 +1,55 @@
+import { Dispatch, FC, SetStateAction } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { PagingInfo } from '../../../../types';
+import { ResultCountHeader } from '../components/ResultCountHeader';
+import { SortResultsBy } from '../components/SortResultsBy';
+import { SortStopsBy, SortingInfo } from '../types';
+
+const supportedSortingFields: ReadonlyArray<SortStopsBy> = [
+  SortStopsBy.LABEL,
+  SortStopsBy.NAME,
+  SortStopsBy.ADDRESS,
+  SortStopsBy.SEQUENCE_NUMBER,
+];
+
+const groupOnlyFields: ReadonlyArray<SortStopsBy> = [
+  SortStopsBy.SEQUENCE_NUMBER,
+];
+
+type CountAndSortingRowProps = {
+  readonly className?: string;
+  readonly resultCount: number;
+  readonly sortingInfo: SortingInfo;
+  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+};
+
+export const CountAndSortingRow: FC<CountAndSortingRowProps> = ({
+  className,
+  resultCount,
+  setPagingInfo,
+  setSortingInfo,
+  sortingInfo,
+}) => {
+  const { sortBy } = sortingInfo;
+
+  return (
+    <div className={twMerge('a flex items-center justify-between', className)}>
+      {sortBy === SortStopsBy.DEFAULT ||
+      sortBy === SortStopsBy.SEQUENCE_NUMBER ? (
+        <div />
+      ) : (
+        <ResultCountHeader resultCount={resultCount} />
+      )}
+
+      <SortResultsBy
+        groupOnlyFields={groupOnlyFields}
+        mapDefaultTo={SortStopsBy.SEQUENCE_NUMBER}
+        setPagingInfo={setPagingInfo}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
+        supportedFields={supportedSortingFields}
+      />
+    </div>
+  );
+};

--- a/ui/src/components/stop-registry/search/by-line/RouteStopsTable.tsx
+++ b/ui/src/components/stop-registry/search/by-line/RouteStopsTable.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react';
 import { Visible } from '../../../../layoutComponents';
-import { LoadingStopsErrorRow, LoadingStopsRow } from '../components';
-import { StopTableRow } from '../StopTableRow';
-import { LocatorActionButton } from '../StopTableRow/ActionButtons/LocatorActionButton';
-import { OpenDetailsPage } from '../StopTableRow/MenuItems/OpenDetailsPage';
-import { ShowOnMap } from '../StopTableRow/MenuItems/ShowOnMap';
+import {
+  LoadingStopsErrorRow,
+  LoadingStopsRow,
+  StopSearchResultStopsTable,
+} from '../components';
 import { RouteInfoRow } from './RouteInfoRow';
 import { FindStopByLineRouteInfo } from './useFindLinesByStopSearch';
 import { useGetStopResultsByRouteId } from './useGetStopResultsByRouteId';
@@ -41,21 +41,7 @@ export const RouteStopsTable: FC<RouteStopsTableProps> = ({
       </Visible>
 
       <Visible visible={!lineTransitionInProgress && stops.length > 0}>
-        <table className="border-x border-t border-x-light-grey border-t-light-grey">
-          <tbody>
-            {stops.map((stop) => (
-              <StopTableRow
-                key={stop.scheduled_stop_point_id}
-                actionButtons={<LocatorActionButton stop={stop} />}
-                menuItems={[
-                  <ShowOnMap key="showOnMap" stop={stop} />,
-                  <OpenDetailsPage key="openDetails" stop={stop} />,
-                ]}
-                stop={stop}
-              />
-            ))}
-          </tbody>
-        </table>
+        <StopSearchResultStopsTable stops={stops} />
       </Visible>
     </div>
   );

--- a/ui/src/components/stop-registry/search/by-line/RouteStopsTable.tsx
+++ b/ui/src/components/stop-registry/search/by-line/RouteStopsTable.tsx
@@ -9,6 +9,10 @@ import { RouteInfoRow } from './RouteInfoRow';
 import { FindStopByLineRouteInfo } from './useFindLinesByStopSearch';
 import { useGetStopResultsByRouteId } from './useGetStopResultsByRouteId';
 
+const testIds = {
+  container: (id: UUID) => `StopSearchByLine::route::${id}`,
+};
+
 type RouteStopsTableProps = {
   readonly className?: string;
   // Enable asynchronous rendering of the result tables on the background.
@@ -27,7 +31,7 @@ export const RouteStopsTable: FC<RouteStopsTableProps> = ({
   );
 
   return (
-    <div className={className}>
+    <div className={className} data-testid={testIds.container(route.route_id)}>
       <RouteInfoRow route={route} />
 
       <Visible

--- a/ui/src/components/stop-registry/search/by-line/StopsByLineNongroupedStopsResults.tsx
+++ b/ui/src/components/stop-registry/search/by-line/StopsByLineNongroupedStopsResults.tsx
@@ -1,0 +1,84 @@
+import React, { Dispatch, FC, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Visible } from '../../../../layoutComponents';
+import { PagingInfo } from '../../../../types';
+import { Pagination } from '../../../../uiComponents';
+import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
+import {
+  LoadingStopsErrorRow,
+  StopSearchResultStopsTable,
+} from '../components';
+import { SortingInfo } from '../types';
+import { CountAndSortingRow } from './CountAndSortingRow';
+import { FindStopByLineInfo } from './useFindLinesByStopSearch';
+import { useGetStopSearchByLinesResult } from './useGetStopSearchByLinesResult';
+
+const testIds = {
+  loadingSearchResults: 'LoadingWrapper::loadingStopSearchResults',
+};
+
+type StopsByLineNongroupedStopsResultsProps = {
+  readonly lines: ReadonlyArray<FindStopByLineInfo>;
+  readonly pagingInfo: PagingInfo;
+  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+  readonly sortingInfo: SortingInfo;
+};
+
+export const StopsByLineNongroupedStopsResults: FC<
+  StopsByLineNongroupedStopsResultsProps
+> = ({ lines, pagingInfo, setPagingInfo, setSortingInfo, sortingInfo }) => {
+  const { t } = useTranslation();
+
+  const {
+    stops,
+    resultCount,
+    loading,
+    error,
+    resolveStopPlaceIdsInError,
+    resolveStopPlaceIdsRefetch,
+    stopsInError,
+    stopsRefetch,
+  } = useGetStopSearchByLinesResult(lines, pagingInfo, sortingInfo);
+
+  return (
+    <LoadingWrapper
+      className="flex justify-center"
+      loadingText={t('search.searching')}
+      loading={loading}
+      testId={testIds.loadingSearchResults}
+    >
+      <CountAndSortingRow
+        className="mb-6"
+        resultCount={resultCount}
+        setPagingInfo={setPagingInfo}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
+      />
+
+      {error && resolveStopPlaceIdsInError && (
+        <LoadingStopsErrorRow
+          error={error}
+          refetch={resolveStopPlaceIdsRefetch}
+        />
+      )}
+
+      {error && stopsInError && (
+        <LoadingStopsErrorRow error={error} refetch={stopsRefetch} />
+      )}
+
+      {!error && <StopSearchResultStopsTable stops={stops} />}
+
+      <Visible visible={!!resultCount}>
+        <div className="grid grid-cols-4">
+          <Pagination
+            className="col-span-2 col-start-2 pt-4"
+            pagingInfo={pagingInfo}
+            setPagingInfo={setPagingInfo}
+            totalItemsCount={resultCount}
+          />
+        </div>
+      </Visible>
+    </LoadingWrapper>
+  );
+};

--- a/ui/src/components/stop-registry/search/by-line/StopsByLineSearchGroupedStopsResults.tsx
+++ b/ui/src/components/stop-registry/search/by-line/StopsByLineSearchGroupedStopsResults.tsx
@@ -1,0 +1,66 @@
+import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
+import { PagingInfo } from '../../../../types';
+import { SortingInfo } from '../types';
+import { ActiveLineHeader } from './ActiveLineHeader';
+import { CountAndSortingRow } from './CountAndSortingRow';
+import { LineRoutesListing } from './LineRoutesListing';
+import { LineSelector } from './LineSelector';
+import { FindStopByLineInfo } from './useFindLinesByStopSearch';
+
+type StopsByLineSearchGroupedStopsResultsProps = {
+  readonly lines: ReadonlyArray<FindStopByLineInfo>;
+  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+  readonly sortingInfo: SortingInfo;
+};
+
+export const StopsByLineSearchGroupedStopsResults: FC<
+  StopsByLineSearchGroupedStopsResultsProps
+> = ({ lines, setPagingInfo, setSortingInfo, sortingInfo }) => {
+  const [activeLineId, setActiveLineId] = useState<UUID | null>(
+    lines.at(0)?.line_id ?? null,
+  );
+
+  const lineToShow = lines.find((line) => line.line_id === activeLineId);
+
+  // If lines list changes, check to see if the selected line is still within
+  // the results, if not, then select the 1st line from the results as active,
+  // or null in case there are no results.
+  useEffect(() => {
+    if (
+      lineToShow &&
+      lines.some((line) => line.line_id === lineToShow.line_id)
+    ) {
+      return;
+    }
+
+    setActiveLineId(lines.at(0)?.line_id ?? null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lines]);
+
+  return (
+    <>
+      <CountAndSortingRow
+        className="mb-6"
+        resultCount={0}
+        setPagingInfo={setPagingInfo}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
+      />
+
+      <LineSelector
+        activeLineId={activeLineId}
+        className="mb-6"
+        lines={lines}
+        setActiveLineId={setActiveLineId}
+      />
+
+      {lineToShow && (
+        <>
+          <ActiveLineHeader line={lineToShow} />
+          <LineRoutesListing line={lineToShow} />
+        </>
+      )}
+    </>
+  );
+};

--- a/ui/src/components/stop-registry/search/by-line/StopsByLineSearchResults.tsx
+++ b/ui/src/components/stop-registry/search/by-line/StopsByLineSearchResults.tsx
@@ -1,8 +1,7 @@
-import { Dispatch, FC, SetStateAction } from 'react';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PagingInfo } from '../../../../types';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
-import { SortStopsBy, SortingInfo, StopSearchFilters } from '../types';
+import { SortStopsBy, StopSearchResultsProps } from '../types';
 import { StopsByLineNongroupedStopsResults } from './StopsByLineNongroupedStopsResults';
 import { StopsByLineSearchGroupedStopsResults } from './StopsByLineSearchGroupedStopsResults';
 import { useFindLinesByStopSearch } from './useFindLinesByStopSearch';
@@ -11,15 +10,7 @@ const testIds = {
   loadingSearchResults: 'LoadingWrapper::loadingStopByLinesSearchResults',
 };
 
-type StopsByLineSearchResultsProps = {
-  readonly filters: StopSearchFilters;
-  readonly pagingInfo: PagingInfo;
-  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
-  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
-  readonly sortingInfo: SortingInfo;
-};
-
-export const StopsByLineSearchResults: FC<StopsByLineSearchResultsProps> = ({
+export const StopsByLineSearchResults: FC<StopSearchResultsProps> = ({
   filters,
   pagingInfo,
   setPagingInfo,

--- a/ui/src/components/stop-registry/search/by-line/useGetStopSearchByLinesResult.ts
+++ b/ui/src/components/stop-registry/search/by-line/useGetStopSearchByLinesResult.ts
@@ -1,0 +1,73 @@
+import { gql } from '@apollo/client';
+import compact from 'lodash/compact';
+import uniq from 'lodash/uniq';
+import { useResolveStopPlaceNetextIdsByLineIdsQuery } from '../../../../generated/graphql';
+import { PagingInfo } from '../../../../types';
+import { SortingInfo } from '../types';
+import { useStopSearchResults } from '../utils/useStopSearchResults';
+import { FindStopByLineInfo } from './useFindLinesByStopSearch';
+
+const GQL_RESOLVE_STOP_PLACE_NETEXT_IDS_BY_ROUTE_IDS = gql`
+  query ResolveStopPlaceNetextIdsByLineIds($routeIds: [uuid!]!) {
+    stopPoints: service_pattern_scheduled_stop_point(
+      where: {
+        scheduled_stop_point_in_journey_patterns: {
+          journey_pattern: { on_route_id: { _in: $routeIds } }
+        }
+        stop_place_ref: { _is_null: false }
+      }
+    ) {
+      scheduled_stop_point_id
+      stop_place_ref
+    }
+  }
+`;
+
+export function useGetStopSearchByLinesResult(
+  lines: ReadonlyArray<FindStopByLineInfo>,
+  pagingInfo: PagingInfo,
+  sortingInfo: SortingInfo,
+) {
+  const routeIds = lines
+    .map((line) => line.line_routes.map((route) => route.route_id))
+    .flat(1);
+
+  const {
+    loading: resolveStopPlaceIdsLoading,
+    data: resolveStopPlaceIdsData,
+    error: resolveStopPlaceIdsError,
+    refetch: resolveStopPlaceIdsRefetch,
+  } = useResolveStopPlaceNetextIdsByLineIdsQuery({
+    variables: { routeIds },
+  });
+
+  const rawStopPlaceIds =
+    resolveStopPlaceIdsData?.stopPoints.map(
+      (stopPlace) => stopPlace.stop_place_ref,
+    ) ?? [];
+  const stopPlaceIds = uniq(compact(rawStopPlaceIds));
+
+  const {
+    stops,
+    resultCount,
+    loading: resultsLoading,
+    error: resultsError,
+    refetch: stopsRefetch,
+  } = useStopSearchResults({
+    where: { netex_id: { _in: stopPlaceIds } },
+    skip: stopPlaceIds.length === 0,
+    pagingInfo,
+    sortingInfo,
+  });
+
+  return {
+    stops,
+    resultCount,
+    loading: resolveStopPlaceIdsLoading || resultsLoading,
+    error: resolveStopPlaceIdsError ?? resultsError,
+    resolveStopPlaceIdsInError: !!resolveStopPlaceIdsError,
+    stopsInError: !!resultsError,
+    resolveStopPlaceIdsRefetch,
+    stopsRefetch,
+  };
+}

--- a/ui/src/components/stop-registry/search/by-stop/StopSearchByStopResults.tsx
+++ b/ui/src/components/stop-registry/search/by-stop/StopSearchByStopResults.tsx
@@ -1,14 +1,13 @@
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Visible } from '../../../../layoutComponents';
-import { PagingInfo } from '../../../../types';
 import { Pagination } from '../../../../uiComponents';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
 import {
   LoadingStopsErrorRow,
   StopSearchResultStopsTable,
 } from '../components';
-import { SortingInfo, StopSearchFilters } from '../types';
+import { StopSearchResultsProps } from '../types';
 import { CountAndSortingRow } from './CountAndSortingRow';
 import { useStopSearchByStopResults } from './useStopSearchByStopResults';
 
@@ -16,15 +15,7 @@ const testIds = {
   loadingSearchResults: 'LoadingWrapper::loadingStopSearchResults',
 };
 
-type StopSearchByStopResultsProps = {
-  readonly filters: StopSearchFilters;
-  readonly pagingInfo: PagingInfo;
-  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
-  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
-  readonly sortingInfo: SortingInfo;
-};
-
-export const StopSearchByStopResults: FC<StopSearchByStopResultsProps> = ({
+export const StopSearchByStopResults: FC<StopSearchResultsProps> = ({
   filters,
   pagingInfo,
   setPagingInfo,

--- a/ui/src/components/stop-registry/search/components/SortByButton.tsx
+++ b/ui/src/components/stop-registry/search/components/SortByButton.tsx
@@ -7,6 +7,10 @@ import { Visible } from '../../../../layoutComponents';
 import { PagingInfo, SortOrder, defaultPagingInfo } from '../../../../types';
 import { SortStopsBy, SortingInfo } from '../types';
 
+const testIds = {
+  button: (value: SortStopsBy) => `SortByButton::${value}`,
+};
+
 function trSortStopsBy(t: TFunction, value: SortStopsBy): ReactNode {
   switch (value) {
     case SortStopsBy.ADDRESS:
@@ -105,6 +109,10 @@ export const SortByButton: FC<SortByButtonProps> = ({
       )}
       type="button"
       onClick={onClick}
+      data-testid={testIds.button(sortBy)}
+      data-element-type="SortByButton"
+      data-is-active={isActive}
+      data-sort-direction={groupOnly ? 'groupOnly' : sortOrder}
     >
       <span>{trSortStopsBy(t, sortBy)}</span>
 

--- a/ui/src/components/stop-registry/search/for-stop-areas/StopAreaSearchResults.tsx
+++ b/ui/src/components/stop-registry/search/for-stop-areas/StopAreaSearchResults.tsx
@@ -1,8 +1,7 @@
-import { Dispatch, FC, SetStateAction } from 'react';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PagingInfo } from '../../../../types';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
-import { SortStopsBy, SortingInfo, StopSearchFilters } from '../types';
+import { SortStopsBy, StopSearchResultsProps } from '../types';
 import { StopAreaNongroupedStopsResults } from './StopAreaNongroupedStopsResults';
 import { StopAreaSearchGroupedStopsResults } from './StopAreaSearchGroupedStopsResults';
 import { useFindStopAreas } from './useFindStopAreas';
@@ -11,15 +10,7 @@ const testIds = {
   loadingSearchResults: 'LoadingWrapper::loadingStopAreaSearchResults',
 };
 
-type StopAreaSearchResultsProps = {
-  readonly filters: StopSearchFilters;
-  readonly pagingInfo: PagingInfo;
-  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
-  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
-  readonly sortingInfo: SortingInfo;
-};
-
-export const StopAreaSearchResults: FC<StopAreaSearchResultsProps> = ({
+export const StopAreaSearchResults: FC<StopSearchResultsProps> = ({
   filters,
   pagingInfo,
   setPagingInfo,

--- a/ui/src/components/stop-registry/search/types/StopSearchResultsProps.ts
+++ b/ui/src/components/stop-registry/search/types/StopSearchResultsProps.ts
@@ -1,0 +1,12 @@
+import { Dispatch, SetStateAction } from 'react';
+import { PagingInfo } from '../../../../types';
+import { SortingInfo } from './SortingInfo';
+import { StopSearchFilters } from './StopSearchFilters';
+
+export type StopSearchResultsProps = {
+  readonly filters: StopSearchFilters;
+  readonly pagingInfo: PagingInfo;
+  readonly setPagingInfo: (pagingInfo: PagingInfo) => void;
+  readonly setSortingInfo: Dispatch<SetStateAction<SortingInfo>>;
+  readonly sortingInfo: SortingInfo;
+};

--- a/ui/src/components/stop-registry/search/types/index.ts
+++ b/ui/src/components/stop-registry/search/types/index.ts
@@ -4,4 +4,5 @@ export * from './SortingInfo';
 export * from './SortStopsBy';
 export * from './StopPlaceSearchRowDetails';
 export * from './StopSearchFilters';
+export * from './StopSearchResultsProps';
 export * from './StopSearchRow';

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -66955,6 +66955,19 @@ export type GetStopsByRouteIdQuery = {
   }>;
 };
 
+export type ResolveStopPlaceNetextIdsByLineIdsQueryVariables = Exact<{
+  routeIds: Array<Scalars['uuid']['input']> | Scalars['uuid']['input'];
+}>;
+
+export type ResolveStopPlaceNetextIdsByLineIdsQuery = {
+  __typename?: 'query_root';
+  stopPoints: Array<{
+    __typename?: 'service_pattern_scheduled_stop_point';
+    scheduled_stop_point_id: UUID;
+    stop_place_ref?: string | null;
+  }>;
+};
+
 export type FindStopAreasQueryVariables = Exact<{
   query: Scalars['String']['input'];
   validOn: Scalars['timestamp']['input'];
@@ -74671,6 +74684,93 @@ export type GetStopsByRouteIdSuspenseQueryHookResult = ReturnType<
 export type GetStopsByRouteIdQueryResult = Apollo.QueryResult<
   GetStopsByRouteIdQuery,
   GetStopsByRouteIdQueryVariables
+>;
+export const ResolveStopPlaceNetextIdsByLineIdsDocument = gql`
+  query ResolveStopPlaceNetextIdsByLineIds($routeIds: [uuid!]!) {
+    stopPoints: service_pattern_scheduled_stop_point(
+      where: {
+        scheduled_stop_point_in_journey_patterns: {
+          journey_pattern: { on_route_id: { _in: $routeIds } }
+        }
+        stop_place_ref: { _is_null: false }
+      }
+    ) {
+      scheduled_stop_point_id
+      stop_place_ref
+    }
+  }
+`;
+
+/**
+ * __useResolveStopPlaceNetextIdsByLineIdsQuery__
+ *
+ * To run a query within a React component, call `useResolveStopPlaceNetextIdsByLineIdsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useResolveStopPlaceNetextIdsByLineIdsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useResolveStopPlaceNetextIdsByLineIdsQuery({
+ *   variables: {
+ *      routeIds: // value for 'routeIds'
+ *   },
+ * });
+ */
+export function useResolveStopPlaceNetextIdsByLineIdsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ResolveStopPlaceNetextIdsByLineIdsQuery,
+    ResolveStopPlaceNetextIdsByLineIdsQueryVariables
+  > &
+    (
+      | {
+          variables: ResolveStopPlaceNetextIdsByLineIdsQueryVariables;
+          skip?: boolean;
+        }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ResolveStopPlaceNetextIdsByLineIdsQuery,
+    ResolveStopPlaceNetextIdsByLineIdsQueryVariables
+  >(ResolveStopPlaceNetextIdsByLineIdsDocument, options);
+}
+export function useResolveStopPlaceNetextIdsByLineIdsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ResolveStopPlaceNetextIdsByLineIdsQuery,
+    ResolveStopPlaceNetextIdsByLineIdsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ResolveStopPlaceNetextIdsByLineIdsQuery,
+    ResolveStopPlaceNetextIdsByLineIdsQueryVariables
+  >(ResolveStopPlaceNetextIdsByLineIdsDocument, options);
+}
+export function useResolveStopPlaceNetextIdsByLineIdsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    ResolveStopPlaceNetextIdsByLineIdsQuery,
+    ResolveStopPlaceNetextIdsByLineIdsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    ResolveStopPlaceNetextIdsByLineIdsQuery,
+    ResolveStopPlaceNetextIdsByLineIdsQueryVariables
+  >(ResolveStopPlaceNetextIdsByLineIdsDocument, options);
+}
+export type ResolveStopPlaceNetextIdsByLineIdsQueryHookResult = ReturnType<
+  typeof useResolveStopPlaceNetextIdsByLineIdsQuery
+>;
+export type ResolveStopPlaceNetextIdsByLineIdsLazyQueryHookResult = ReturnType<
+  typeof useResolveStopPlaceNetextIdsByLineIdsLazyQuery
+>;
+export type ResolveStopPlaceNetextIdsByLineIdsSuspenseQueryHookResult =
+  ReturnType<typeof useResolveStopPlaceNetextIdsByLineIdsSuspenseQuery>;
+export type ResolveStopPlaceNetextIdsByLineIdsQueryResult = Apollo.QueryResult<
+  ResolveStopPlaceNetextIdsByLineIdsQuery,
+  ResolveStopPlaceNetextIdsByLineIdsQueryVariables
 >;
 export const FindStopAreasDocument = gql`
   query findStopAreas($query: String!, $validOn: timestamp!) {

--- a/ui/src/uiComponents/Pagination/CompatPagination.spec.tsx
+++ b/ui/src/uiComponents/Pagination/CompatPagination.spec.tsx
@@ -25,8 +25,8 @@ describe('Pagination - CompatPagination', () => {
     urlQueryMock.mockReturnValueOnce({ queryParams: { page: 1 } });
     render(<CompatPagination itemsPerPage={2} totalItemsCount={10} />);
 
-    const prevButton = await screen.findByTestId('prevPageButtonIcon');
-    const nextButton = await screen.findByTestId('nextPageButtonIcon');
+    const prevButton = await screen.findByTestId('Pagination::page::previous');
+    const nextButton = await screen.findByTestId('Pagination::page::next');
 
     expect(prevButton).toBeDisabled();
     expect(nextButton).toBeEnabled();
@@ -36,8 +36,8 @@ describe('Pagination - CompatPagination', () => {
     urlQueryMock.mockReturnValueOnce({ queryParams: { page: 5 } });
     render(<CompatPagination itemsPerPage={2} totalItemsCount={10} />);
 
-    const prevButton = await screen.findByTestId('prevPageButtonIcon');
-    const nextButton = await screen.findByTestId('nextPageButtonIcon');
+    const prevButton = await screen.findByTestId('Pagination::page::previous');
+    const nextButton = await screen.findByTestId('Pagination::page::next');
 
     expect(prevButton).toBeEnabled();
     expect(nextButton).toBeDisabled();
@@ -47,8 +47,8 @@ describe('Pagination - CompatPagination', () => {
     urlQueryMock.mockReturnValueOnce({ queryParams: { page: 1 } });
     render(<CompatPagination itemsPerPage={10} totalItemsCount={10} />);
 
-    const prevButton = await screen.findByTestId('prevPageButtonIcon');
-    const nextButton = await screen.findByTestId('nextPageButtonIcon');
+    const prevButton = await screen.findByTestId('Pagination::page::previous');
+    const nextButton = await screen.findByTestId('Pagination::page::next');
 
     expect(prevButton).toBeDisabled();
     expect(nextButton).toBeDisabled();

--- a/ui/src/uiComponents/Pagination/Pagination.spec.tsx
+++ b/ui/src/uiComponents/Pagination/Pagination.spec.tsx
@@ -46,8 +46,8 @@ describe('Pagination', () => {
       />,
     );
 
-    expect(screen.getByTestId('prevPageButtonIcon')).toBeDisabled();
-    expect(screen.getByTestId('nextPageButtonIcon')).toBeEnabled();
+    expect(screen.getByTestId('Pagination::page::previous')).toBeDisabled();
+    expect(screen.getByTestId('Pagination::page::next')).toBeEnabled();
   });
 
   test('next button should be disabled on last page', () => {
@@ -59,8 +59,8 @@ describe('Pagination', () => {
       />,
     );
 
-    expect(screen.getByTestId('prevPageButtonIcon')).toBeEnabled();
-    expect(screen.getByTestId('nextPageButtonIcon')).toBeDisabled();
+    expect(screen.getByTestId('Pagination::page::previous')).toBeEnabled();
+    expect(screen.getByTestId('Pagination::page::next')).toBeDisabled();
   });
 
   test('prev and next button should be disabled if only one page', () => {
@@ -72,8 +72,8 @@ describe('Pagination', () => {
       />,
     );
 
-    expect(screen.getByTestId('prevPageButtonIcon')).toBeDisabled();
-    expect(screen.getByTestId('nextPageButtonIcon')).toBeDisabled();
+    expect(screen.getByTestId('Pagination::page::previous')).toBeDisabled();
+    expect(screen.getByTestId('Pagination::page::next')).toBeDisabled();
   });
 
   test('current page should be SPAN element', () => {
@@ -190,7 +190,7 @@ describe('Pagination', () => {
     );
 
     // Go to next (2)
-    act(() => screen.getByTestId('nextPageButtonIcon').click());
+    act(() => screen.getByTestId('Pagination::page::next').click());
     expect(screen.getByRole('listitem', { current: 'page' })).toHaveTextContent(
       '02',
     );
@@ -202,7 +202,7 @@ describe('Pagination', () => {
     );
 
     // Go to previous (9)
-    act(() => screen.getByTestId('prevPageButtonIcon').click());
+    act(() => screen.getByTestId('Pagination::page::previous').click());
     expect(screen.getByRole('listitem', { current: 'page' })).toHaveTextContent(
       '09',
     );

--- a/ui/src/uiComponents/Pagination/Pagination.tsx
+++ b/ui/src/uiComponents/Pagination/Pagination.tsx
@@ -7,6 +7,12 @@ import { PagingInfo } from '../../types';
 import { IconButton } from '../IconButton';
 import { getDisplayedPageNumberList, getRenderedPageNumber } from './utils';
 
+const testId = {
+  previousPageButton: 'Pagination::page::previous',
+  pageButton: (pageNumber: number) => `Pagination::page::${pageNumber}`,
+  nextPageButton: 'Pagination::page::next',
+};
+
 const DEFAULT_AMOUNT_OF_NEIGHBOURS = 2;
 
 const currentPageClassName =
@@ -40,6 +46,7 @@ const PageButton: FC<PageButtonProps> = ({
       <button
         type="button"
         aria-label={`${t('accessibility:common.goToPage')} ${pageNumber}`}
+        data-testid={testId.pageButton(pageNumber)}
       >
         {getRenderedPageNumber(pageNumber)}
       </button>
@@ -119,7 +126,7 @@ export const Pagination: FC<PaginationProps> = ({
         disabled={onFirstPage}
         tooltip={ariaLabelPrevious}
         onClick={() => setPage(currentPage - 1)}
-        testId="prevPageButtonIcon"
+        testId={testId.previousPageButton}
         className="w-32"
         icon={
           <FaChevronLeft
@@ -190,7 +197,7 @@ export const Pagination: FC<PaginationProps> = ({
         disabled={onLastPage}
         tooltip={ariaLabelNext}
         onClick={() => setPage(currentPage + 1)}
-        testId="nextPageButtonIcon"
+        testId={testId.nextPageButton}
         className="w-32"
         icon={
           <FaChevronRight


### PR DESCRIPTION
### StopSearchByLine: Implement raw stop listing with sorting and paging


### StopSearch: Unified Result component props typing


### StopSearch: Preserve page size when submitting new search


### E2E: Sorting & Paging of stop search results

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/945)
<!-- Reviewable:end -->
