### PR TITLE
StopSearch: Optimize useFindLinesByStopSearch query

### DIFF
--- a/ui/src/components/stop-registry/search/by-line/useFindLinesByStopSearch.ts
+++ b/ui/src/components/stop-registry/search/by-line/useFindLinesByStopSearch.ts
@@ -64,7 +64,6 @@ const GQL_FIND_LINES_BY_STOP_SEARCH_QUERY = gql`
     name_i18n
 
     direction
-    route_shape
 
     priority
     validity_start

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -66875,7 +66875,6 @@ export type FindLinesByStopSearchQuery = {
       label: string;
       name_i18n: LocalizedString;
       direction: RouteDirectionEnum;
-      route_shape?: GeoJSON.LineString | null;
       priority: number;
       validity_start?: luxon.DateTime | null;
       validity_end?: luxon.DateTime | null;
@@ -66896,7 +66895,6 @@ export type FindStopByLineInfoFragment = {
     label: string;
     name_i18n: LocalizedString;
     direction: RouteDirectionEnum;
-    route_shape?: GeoJSON.LineString | null;
     priority: number;
     validity_start?: luxon.DateTime | null;
     validity_end?: luxon.DateTime | null;
@@ -66909,7 +66907,6 @@ export type FindStopByLineRouteInfoFragment = {
   label: string;
   name_i18n: LocalizedString;
   direction: RouteDirectionEnum;
-  route_shape?: GeoJSON.LineString | null;
   priority: number;
   validity_start?: luxon.DateTime | null;
   validity_end?: luxon.DateTime | null;
@@ -73140,7 +73137,6 @@ export const FindStopByLineRouteInfoFragmentDoc = gql`
     label
     name_i18n
     direction
-    route_shape
     priority
     validity_start
     validity_end


### PR DESCRIPTION
`route_shape` is not needed, and that column contains a lot of data. Witht the seed data set searching for `*` the result set goes down to 50KB from 4MB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/947)
<!-- Reviewable:end -->
