### PR TITLE
StopSearch|E2E: Add priority visualization tests

### DIFF
--- a/cypress/pageObjects/stop-registry/StopSearchResultsPage.ts
+++ b/cypress/pageObjects/stop-registry/StopSearchResultsPage.ts
@@ -30,4 +30,8 @@ export class StopSearchResultsPage {
   getRowLinkByLabel(label: string) {
     return this.getRowByLabel(label).findByTestId('StopTableRow::link');
   }
+
+  getRowPriority() {
+    return cy.getByTestId('StopTableRow::priority');
+  }
 }

--- a/cypress/pageObjects/stop-registry/StopSearchResultsPage.ts
+++ b/cypress/pageObjects/stop-registry/StopSearchResultsPage.ts
@@ -19,6 +19,14 @@ export class StopSearchResultsPage {
     return cy.getByTestId(`StopTableRow::row::${label}`);
   }
 
+  getRowByNetexId(netexId: string) {
+    return cy.get(`[data-netext-id='${netexId}']`);
+  }
+
+  getRowByScheduledStopPointId(scheduledStopPointId: string) {
+    return cy.get(`[data-scheduled-stop-point-id='${scheduledStopPointId}'`);
+  }
+
   getRowLinkByLabel(label: string) {
     return this.getRowByLabel(label).findByTestId('StopTableRow::link');
   }

--- a/ui/src/components/stop-registry/search/StopTableRow/StopTableRow.tsx
+++ b/ui/src/components/stop-registry/search/StopTableRow/StopTableRow.tsx
@@ -33,6 +33,8 @@ export const StopTableRow: FC<Props> = ({
     <tr
       className={twMerge('text-hsl-dark-80', className)}
       data-testid={testIds.row(stop.label)}
+      data-netext-id={stop.stop_place.netexId ?? ''}
+      data-scheduled-stop-point-id={stop.scheduled_stop_point_id}
     >
       {/* TODO: select column */}
       <PriorityTd className={`w-auto ${yBorderClassNames}`} stop={stop} />


### PR DESCRIPTION
### StopTableRow|E2E: Add DB ids as data attributes
Multiple stops can share the same label, thus getting the rows by the
label in tests can be problematic.
Both the Tiamat Netext ID and ScheduledStopPoint DB UUID ID have been
added to the result row, so that tests can pick up the actual row for
assertions.


### StopSearch|E2E: Add priority visualization tests

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/949)
<!-- Reviewable:end -->
