### PR TITLE
E2E: Fix 'Should show arrival times' test

### DIFF
--- a/cypress/e2e/timetablePassingTimes.cy.ts
+++ b/cypress/e2e/timetablePassingTimes.cy.ts
@@ -153,7 +153,7 @@ describe('Timetable passing times', () => {
 
       passingTimesByStopTable
         .getAllPassingTimeArrivalTimes()
-        .should('have.length', 0);
+        .should('have.length', 60);
 
       vehicleScheduleDetailsPage.getArrivalTimesSwitch().click();
 


### PR DESCRIPTION
A recent change to LoadingWrapper seems to have broken the test. Some sort of an timing change in the render cycle has taken place and previously the test checked that there were 0 times on the screen, and that test passed because at the time there was a spinner on the screen instead, but now the actual contents that would have been displayed after the spinner get to the screen before cypress has a chance to verify the non existence of the arrival times.

Changed the test to assume that the data does actually get onto the screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/951)
<!-- Reviewable:end -->
