### PR TITLE
Fix KeyHelpers.NonNullableKeys typings

### DIFF
--- a/ui/src/components/forms/stop/StopForm.tsx
+++ b/ui/src/components/forms/stop/StopForm.tsx
@@ -11,7 +11,7 @@ import {
   ReusableComponentsVehicleModeEnum,
   ServicePatternScheduledStopPoint,
 } from '../../../generated/graphql';
-import { ScheduledStopPointSetInput } from '../../../graphql';
+import { PartialScheduledStopPointSetInput } from '../../../graphql';
 import {
   CreateChanges,
   EditChanges,
@@ -111,7 +111,7 @@ function mapFormStateToInput(state: FormState) {
 }
 
 const isDirtyMap: {
-  readonly [key in keyof ScheduledStopPointSetInput]: ReadonlyArray<
+  readonly [key in keyof PartialScheduledStopPointSetInput]: ReadonlyArray<
     keyof FormState
   >;
 } = {
@@ -126,11 +126,11 @@ const isDirtyMap: {
 // Only pick changed fields, needed to keep Tiamat happy when updating fields,
 // not in Tiamat.
 function pickChangedFieldsForPatch(
-  input: ScheduledStopPointSetInput,
+  input: PartialScheduledStopPointSetInput,
   dirtyFields: Partial<Readonly<FieldNamesMarkedBoolean<FormState>>>,
-): ScheduledStopPointSetInput {
+): PartialScheduledStopPointSetInput {
   const dirty = Object.entries(input).filter(([key]) => {
-    const formKeys = isDirtyMap[key as keyof ScheduledStopPointSetInput];
+    const formKeys = isDirtyMap[key as keyof PartialScheduledStopPointSetInput];
     if (formKeys) {
       return formKeys.some((formKey) => dirtyFields[formKey]);
     }

--- a/ui/src/components/map/stops/EditStopLayer.tsx
+++ b/ui/src/components/map/stops/EditStopLayer.tsx
@@ -7,7 +7,10 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { MapLayerMouseEvent } from 'react-map-gl/maplibre';
 import { useDispatch } from 'react-redux';
-import { ScheduledStopPointSetInput, StopWithLocation } from '../../../graphql';
+import {
+  PartialScheduledStopPointSetInput,
+  StopWithLocation,
+} from '../../../graphql';
 import {
   CreateChanges,
   DeleteChanges,
@@ -167,7 +170,7 @@ export const EditStopLayer = forwardRef<EditStoplayerRef, Props>(
 
       if (stopId) {
         // if this is a stop existing on the backend, also prepare the changes to be confirmed
-        const patch: ScheduledStopPointSetInput = {
+        const patch: PartialScheduledStopPointSetInput = {
           measured_location: mapLngLatToGeoJSON(event.lngLat.toArray()),
         };
         setIsLoadingBrokenRoutes(true);

--- a/ui/src/graphql/servicePattern.ts
+++ b/ui/src/graphql/servicePattern.ts
@@ -23,6 +23,11 @@ export type ScheduledStopPointSetInput = NonNullableKeys<
   | 'priority'
 >;
 
+// Copy of ScheduledStopPointSetInput that can be used for update scenarios,
+// when it is not necessary to always update the non-nullable fields.
+export type PartialScheduledStopPointSetInput =
+  Partial<ScheduledStopPointSetInput>;
+
 const SCHEDULED_STOP_POINT_DEFAULT_FIELDS = gql`
   fragment scheduled_stop_point_default_fields on service_pattern_scheduled_stop_point {
     priority

--- a/ui/src/hooks/stop-registry/useEditStopBasicDetails.ts
+++ b/ui/src/hooks/stop-registry/useEditStopBasicDetails.ts
@@ -14,7 +14,10 @@ import {
   useGetStopWithRouteGraphDataByIdLazyQuery,
   useUpdateStopPlaceMutation,
 } from '../../generated/graphql';
-import { ScheduledStopPointSetInput, mapStopResultToStop } from '../../graphql';
+import {
+  PartialScheduledStopPointSetInput,
+  mapStopResultToStop,
+} from '../../graphql';
 import {
   InternalError,
   TimingPlaceRequiredError,
@@ -37,7 +40,7 @@ interface EditRoutesAndLinesParams {
 interface EditRoutesAndLinesChanges {
   stopId: UUID;
   stopLabel: string;
-  patch: ScheduledStopPointSetInput;
+  patch: PartialScheduledStopPointSetInput;
   editedStop: ServicePatternScheduledStopPoint;
   deleteStopFromRoutes: RouteUniqueFieldsFragment[];
   deleteStopFromJourneyPatternIds?: UUID[];

--- a/ui/src/hooks/stops/useEditStop.ts
+++ b/ui/src/hooks/stops/useEditStop.ts
@@ -21,7 +21,7 @@ import {
   useGetStopWithRouteGraphDataByIdLazyQuery,
 } from '../../generated/graphql';
 import {
-  ScheduledStopPointSetInput,
+  PartialScheduledStopPointSetInput,
   mapGetRoutesBrokenByStopChangeResult,
   mapStopResultToStop,
 } from '../../graphql';
@@ -135,13 +135,13 @@ const GQL_EDIT_STOP_PLACE = gql`
 interface EditParams {
   stopId: UUID;
   stopPlaceRef?: string | null;
-  patch: ScheduledStopPointSetInput;
+  patch: PartialScheduledStopPointSetInput;
 }
 
 export interface EditChanges {
   stopId: UUID;
   stopLabel: string;
-  patch: ScheduledStopPointSetInput;
+  patch: PartialScheduledStopPointSetInput;
   stopPlacePatch: StopRegistryStopPlaceInput | null;
   editedStop: ScheduledStopPointAllFieldsFragment;
   deleteStopFromRoutes: RouteUniqueFieldsFragment[];
@@ -152,7 +152,7 @@ export interface EditChanges {
 export interface BrokenRouteCheckParams {
   newLink: InfrastructureNetworkInfrastructureLink;
   newDirection: InfrastructureNetworkDirectionEnum;
-  newStop: ScheduledStopPointSetInput;
+  newStop: PartialScheduledStopPointSetInput;
   label: string;
   priority: number;
   stopId: UUID | null;
@@ -178,7 +178,7 @@ function mapEditChangesToVariables(
 
 function stopPointPatchToStopPlacePatch(
   stopPlaceRef: string | null | undefined,
-  patch: ScheduledStopPointSetInput,
+  patch: PartialScheduledStopPointSetInput,
   stopPlace: Pick<StopRegistryStopPlace, 'keyValues'> | null,
 ): StopRegistryStopPlaceInput | null {
   if (!stopPlaceRef) {
@@ -298,7 +298,7 @@ function useGetConflictingStops() {
   return async (
     stopId: string,
     label: string,
-    patch: ScheduledStopPointSetInput,
+    patch: PartialScheduledStopPointSetInput,
     stopWithRouteGraphData: ServicePatternScheduledStopPoint,
   ) => {
     const hasEditedValidity =
@@ -340,7 +340,7 @@ function useOnStopLocationChanged() {
 
   return async (
     oldStop: ScheduledStopPointAllFieldsFragment,
-    newStop: ScheduledStopPointSetInput,
+    newStop: PartialScheduledStopPointSetInput,
     stopId: UUID,
   ): Promise<OnStopLocationChangedResult> => {
     // if we modified the location of the stop, have to also fetch the new infra link and direction
@@ -377,7 +377,7 @@ function useGetLocationChanges() {
 
   return async (
     stopId: string,
-    patch: ScheduledStopPointSetInput,
+    patch: PartialScheduledStopPointSetInput,
     stopWithRouteGraphData: ServicePatternScheduledStopPoint,
   ): Promise<Partial<OnStopLocationChangedResult>> => {
     const newLocation = patch.measured_location;
@@ -399,7 +399,7 @@ function useValidateTimingPlaceChanges() {
 
   return async (
     stopLabel: string,
-    patch: ScheduledStopPointSetInput,
+    patch: PartialScheduledStopPointSetInput,
     stopWithRouteGraphData: ServicePatternScheduledStopPoint,
   ) => {
     if (patch.timing_place_id === undefined) {

--- a/ui/src/types/KeyHelpers.ts
+++ b/ui/src/types/KeyHelpers.ts
@@ -1,12 +1,12 @@
 // Make given keys of a type required, leave the rest as-is
-export type RequiredKeys<T, K extends keyof T> = Required<Pick<T, K>> &
-  Omit<T, K>;
+export type RequiredKeys<T, K extends keyof T> = Omit<T, K> &
+  Required<Pick<T, K>>;
 
 // Make given keys of a type optional, leave the rest as-is
-export type OptionalKeys<T, K extends keyof T> = Partial<Pick<T, K>> &
-  Omit<T, K>;
+export type OptionalKeys<T, K extends keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>>;
 
 // Make given keys of a type not nullable, leave the rest as-is
-export type NonNullableKeys<T, K extends keyof T> = {
-  [P in K]: NonNullable<T[P]>;
-} & Omit<T, K>;
+export type NonNullableKeys<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: NonNullable<T[P]>;
+};


### PR DESCRIPTION
* Changed all RequiredKeys, OptionalKeys and NonNullableKeys typings to omit the requested keys 1st. No effect on the type, but makes logically more sense to drop the fields (mark then with type never) and then override those fields, than to 1st make the changes and then merger them with never types.

* NnnNullableKeys did not do what it's docstring said it would. Previously any optional fields were passed trough as optionals, essentially typing the field as having `undefined` as one of the field value types. Now the optional marker is removed and the value in question has to truly be a nonnullable value. `value !== null && value !== undefined`

* As a result of fixing the NonNullabelKeys type, some other types derived with it started breaking code. Stop UPDATE-operation related code has been fixed to allow partial updates, and to not require all of the non-null DB fields. INSERT-operations still use the proper no-nulls type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/965)
<!-- Reviewable:end -->
