### PR TITLE
Update the version of `upload-artifact` action: `v3` -> `v4`

### DIFF
--- a/github-actions/run-cypress-tests/action.yml
+++ b/github-actions/run-cypress-tests/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Upload test reports as an artifact
       # should be run even if the tests fail
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cypress-docker-reports
         path: |


### PR DESCRIPTION
Artifact actions v3 will be closing down by January 30, 2025.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/967)
<!-- Reviewable:end -->
