### PR TITLE
Copy stop

### DIFF
--- a/cypress/e2e/map/createStop.cy.ts
+++ b/cypress/e2e/map/createStop.cy.ts
@@ -227,7 +227,7 @@ describe('Stop creation tests', () => {
 
       // NOTE: After adding the name inputs to stop creation flow, this will fail and
       // needs to be updated to the correct names
-      stopDetailsPage.names().shouldHaveText('T0001|-');
+      stopDetailsPage.titleRow.names().shouldHaveText('T0001|-');
     },
   );
 });

--- a/cypress/pageObjects/stop-registry/StopDetailsPage.ts
+++ b/cypress/pageObjects/stop-registry/StopDetailsPage.ts
@@ -1,11 +1,13 @@
 import {
   BasicDetailsSection,
+  CreateCopyModal,
   InfoSpotsSection,
   LocationDetailsSection,
   MaintenanceSection,
   MeasurementsSection,
   SheltersSection,
   SignageDetailsSection,
+  TitleRow,
 } from './stop-details';
 
 export class StopDetailsPage {
@@ -23,20 +25,16 @@ export class StopDetailsPage {
 
   maintenance = new MaintenanceSection();
 
+  titleRow = new TitleRow();
+
+  copyModal = new CreateCopyModal();
+
   visit(label: string) {
     cy.visit(`/stop-registry/stops/${label}`);
   }
 
   page() {
     return cy.getByTestId('StopDetailsPage::page');
-  }
-
-  label() {
-    return cy.getByTestId('StopTitleRow::label');
-  }
-
-  names() {
-    return cy.getByTestId('StopTitleRow::names');
   }
 
   validityPeriod() {
@@ -65,5 +63,9 @@ export class StopDetailsPage {
 
   infoSpotsTabPanel() {
     return cy.getByTestId('StopDetailsPage::infoSpotsTabPanel');
+  }
+
+  loadingStopDetails() {
+    return cy.getByTestId('StopDetailsPage::loadingStopDetails');
   }
 }

--- a/cypress/pageObjects/stop-registry/stop-details/CreateCopyModal.ts
+++ b/cypress/pageObjects/stop-registry/stop-details/CreateCopyModal.ts
@@ -1,0 +1,17 @@
+import { StopVersionForm } from './StopVersionForm';
+
+export class CreateCopyModal {
+  form = new StopVersionForm();
+
+  modal() {
+    return cy.getByTestId('CopyStopModal::modal');
+  }
+
+  names() {
+    return cy.getByTestId('CopyStopModal::names');
+  }
+
+  validity() {
+    return cy.getByTestId('CopyStopModal::validity');
+  }
+}

--- a/cypress/pageObjects/stop-registry/stop-details/StopVersionForm.ts
+++ b/cypress/pageObjects/stop-registry/stop-details/StopVersionForm.ts
@@ -1,0 +1,28 @@
+import { PriorityForm } from '../../PriorityForm';
+import { ValidityPeriodForm } from '../../ValidityPeriodForm';
+
+export class StopVersionForm {
+  priority = new PriorityForm();
+
+  validity = new ValidityPeriodForm();
+
+  form() {
+    return cy.getByTestId('StopVersionForm::form');
+  }
+
+  versionName() {
+    return cy.getByTestId('StopVersionForm::versionName');
+  }
+
+  versionDescription() {
+    return cy.getByTestId('StopVersionForm::versionDescription');
+  }
+
+  submitButton() {
+    return cy.getByTestId('StopVersionForm::submitButton');
+  }
+
+  cancelButton() {
+    return cy.getByTestId('StopVersionForm::cancelButton');
+  }
+}

--- a/cypress/pageObjects/stop-registry/stop-details/TitleRow.ts
+++ b/cypress/pageObjects/stop-registry/stop-details/TitleRow.ts
@@ -1,0 +1,25 @@
+export class TitleRow {
+  label() {
+    return cy.getByTestId('StopTitleRow::label');
+  }
+
+  names() {
+    return cy.getByTestId('StopTitleRow::names');
+  }
+
+  editValidityButton() {
+    return cy.getByTestId('StopTitleRow::editValidityButton');
+  }
+
+  openOnMapButton() {
+    return cy.getByTestId('StopTitleRow::StopTitleRow::openOnMapButton');
+  }
+
+  actionsMenuButton() {
+    return cy.getByTestId('StopTitleRow::extraActions::menu');
+  }
+
+  actionsMenuCopyButton() {
+    return cy.getByTestId('StopTitleRow::extraActions::copy');
+  }
+}

--- a/cypress/pageObjects/stop-registry/stop-details/index.ts
+++ b/cypress/pageObjects/stop-registry/stop-details/index.ts
@@ -1,6 +1,7 @@
 export * from './BasicDetailsForm';
 export * from './BasicDetailsSection';
 export * from './BasicDetailsViewCard';
+export * from './CreateCopyModal';
 export * from './InfoSpotSection';
 export * from './InfoSpotsForm';
 export * from './InfoSpotViewCard';
@@ -20,3 +21,4 @@ export * from './ShelterViewCard';
 export * from './SignageDetailsForm';
 export * from './SignageDetailsSection';
 export * from './SignageDetailsViewCard';
+export * from './TitleRow';

--- a/test-db-manager/src/datasets/stopRegistry/infoSpots.ts
+++ b/test-db-manager/src/datasets/stopRegistry/infoSpots.ts
@@ -16,79 +16,91 @@ const mapToInfoSpotInput = (seedInfoSpot: InfoSpotInput): InfoSpotInput => {
   return seedInfoSpot;
 };
 
+const infoSpotJP1234568: StopRegistryInfoSpotInput = {
+  description: {
+    lang: 'fi',
+    value: 'Ensimmäinen kerros, portaiden vieressä',
+  },
+  floor: '1',
+  label: 'JP1234568',
+  maintenance: 'Huoltotietojen tekstit tähän...',
+  infoSpotType: StopRegistryInfoSpotType.Static,
+  purpose: 'Tiedotteet',
+  railInformation: '7',
+  zoneLabel: 'A',
+  displayType: null, // Only set if posterPlaceType = Dynamic
+  speechProperty: null, // Only set if posterPlaceType = Dynamic
+  backlight: true, // Only set if posterPlaceType = Static
+  posterPlaceSize: StopRegistryPosterPlaceSize.Cm80x120, // Only set if posterPlaceType = Static
+  poster: [
+    // Only set if posterPlaceType = Static
+    {
+      label: 'PT1234',
+      posterSize: StopRegistryPosterPlaceSize.A4,
+      lines: '1, 6, 17',
+    },
+  ],
+};
+
+const infoSpotJP1234567: StopRegistryInfoSpotInput = {
+  description: {
+    lang: 'fi',
+    value: 'Ensimmäinen kerros, portaiden takana',
+  },
+  floor: '1',
+  label: 'JP1234567',
+  maintenance: 'Huoltotietojen tekstit tähän...',
+  purpose: 'Dynaaminen näyttö',
+  railInformation: '8',
+  zoneLabel: 'B',
+  infoSpotType: StopRegistryInfoSpotType.Dynamic,
+  displayType: StopRegistryDisplayType.BatteryMultiRow, // Only set if posterPlaceType = Dynamic
+  speechProperty: true, // Only set if posterPlaceType = Dynamic
+  backlight: null, // Only set if posterPlaceType = Static
+  posterPlaceSize: null, // Only set if posterPlaceType = Static
+  poster: null, // Only set if posterPlaceType = Static
+};
+
+const infoSpotJP1234569: StopRegistryInfoSpotInput = {
+  infoSpotType: StopRegistryInfoSpotType.SoundBeacon,
+  description: {
+    lang: 'fi',
+    value: 'Tolpassa',
+  },
+  floor: '1',
+  label: 'JP1234569',
+  maintenance: 'Huoltotietojen tekstit tähän...',
+  purpose: 'Infopaikan käyttötarkoitus',
+  railInformation: '9',
+  zoneLabel: 'C',
+  displayType: null, // Only set if posterPlaceType = Dynamic
+  speechProperty: null, // Only set if posterPlaceType = Dynamic
+  backlight: null, // Only set if posterPlaceType = Static
+  posterPlaceSize: null, // Only set if posterPlaceType = Static
+  poster: null, // Only set if posterPlaceType = Static
+};
+
 const infoSpots: Array<InfoSpotInput> = [
   {
-    infoSpot: {
-      description: {
-        lang: 'fi',
-        value: 'Ensimmäinen kerros, portaiden vieressä',
-      },
-      floor: '1',
-      label: 'JP1234568',
-      maintenance: 'Huoltotietojen tekstit tähän...',
-      infoSpotType: StopRegistryInfoSpotType.Static,
-      purpose: 'Tiedotteet',
-      railInformation: '7',
-      zoneLabel: 'A',
-      displayType: null, // Only set if posterPlaceType = Dynamic
-      speechProperty: null, // Only set if posterPlaceType = Dynamic
-      backlight: true, // Only set if posterPlaceType = Static
-      posterPlaceSize: StopRegistryPosterPlaceSize.Cm80x120, // Only set if posterPlaceType = Static
-      poster: [
-        // Only set if posterPlaceType = Static
-        {
-          label: 'PT1234',
-          posterSize: StopRegistryPosterPlaceSize.A4,
-          lines: '1, 6, 17',
-        },
-      ],
-    },
+    infoSpot: infoSpotJP1234568,
     locatedOnStopLabel: 'V1562',
     associatedShelter: 0,
   },
   {
-    infoSpot: {
-      description: {
-        lang: 'fi',
-        value: 'Ensimmäinen kerros, portaiden takana',
-      },
-      floor: '1',
-      label: 'JP1234567',
-      maintenance: 'Huoltotietojen tekstit tähän...',
-      purpose: 'Dynaaminen näyttö',
-      railInformation: '8',
-      zoneLabel: 'B',
-      infoSpotType: StopRegistryInfoSpotType.Dynamic,
-      displayType: StopRegistryDisplayType.BatteryMultiRow, // Only set if posterPlaceType = Dynamic
-      speechProperty: true, // Only set if posterPlaceType = Dynamic
-      backlight: null, // Only set if posterPlaceType = Static
-      posterPlaceSize: null, // Only set if posterPlaceType = Static
-      poster: null, // Only set if posterPlaceType = Static
-    },
+    infoSpot: infoSpotJP1234567,
     locatedOnStopLabel: 'V1562',
     associatedShelter: 1,
   },
   {
-    infoSpot: {
-      infoSpotType: StopRegistryInfoSpotType.SoundBeacon,
-      description: {
-        lang: 'fi',
-        value: 'Tolpassa',
-      },
-      floor: '1',
-      label: 'JP1234569',
-      maintenance: 'Huoltotietojen tekstit tähän...',
-      purpose: 'Infopaikan käyttötarkoitus',
-      railInformation: '9',
-      zoneLabel: 'C',
-      displayType: null, // Only set if posterPlaceType = Dynamic
-      speechProperty: null, // Only set if posterPlaceType = Dynamic
-      backlight: null, // Only set if posterPlaceType = Static
-      posterPlaceSize: null, // Only set if posterPlaceType = Static
-      poster: null, // Only set if posterPlaceType = Static
-    },
+    infoSpot: infoSpotJP1234569,
     locatedOnStopLabel: 'V1562',
     associatedShelter: 2,
+  },
+  {
+    // Reusing info same spot on another stop
+    infoSpot: infoSpotJP1234568,
+    locatedOnStopLabel: 'H2003',
+    associatedShelter: 0,
   },
 ];
 

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopBoilerPlate.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopBoilerPlate.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StopWithDetails } from '../../../../../hooks';
+import { mapPriorityToUiName } from '../../../../../i18n/uiNameMappings';
+import { mapToShortDate } from '../../../../../time';
+
+const testIds = {
+  names: 'CopyStopModal::names',
+  validity: 'CopyStopModal::validity',
+};
+
+type CopyStopBoilerPlateProps = {
+  readonly originalStop: StopWithDetails;
+};
+
+export const CopyStopBoilerPlate: FC<CopyStopBoilerPlateProps> = ({
+  originalStop,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="w-[550px] bg-hsl-neutral-blue p-4">
+      <p>{t('stopDetails.version.copyBoilerPlate')}</p>
+      <p className="mt-1 font-bold" data-testid={testIds.names}>
+        <span>{originalStop.label}</span>{' '}
+        <span>{originalStop.stop_place?.nameFin ?? '-'}</span>
+        <span className="mx-2">|</span>
+        <span>{originalStop.stop_place?.nameSwe ?? '-'}</span>
+      </p>
+      <p className="mt-1" data-testid={testIds.validity}>
+        <span className="font-bold">
+          {mapPriorityToUiName(originalStop.priority)}
+        </span>
+        <span className="mx-2">|</span>
+        <span>
+          {mapToShortDate(originalStop.validity_start)}
+          <span className="mx-1">-</span>
+          {mapToShortDate(originalStop.validity_end)}
+        </span>
+      </p>
+    </div>
+  );
+};

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopForm.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopForm.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+import { FormProvider } from 'react-hook-form';
+import { StopWithDetails } from '../../../../../hooks';
+import { StopVersionForm } from './StopVersionForm';
+import { CreateStopVersionResult } from './types';
+import { useCopyStopFormUtils } from './utils';
+
+type CopyStopFormProps = {
+  readonly className?: string;
+  readonly onCancel: () => void;
+  readonly onCopyCreated: (result: CreateStopVersionResult) => void;
+  readonly originalStop: StopWithDetails;
+};
+
+export const CopyStopForm: FC<CopyStopFormProps> = ({
+  className,
+  onCancel,
+  onCopyCreated,
+  originalStop,
+}) => {
+  const { methods, onFormSubmit } = useCopyStopFormUtils(
+    originalStop,
+    onCopyCreated,
+  );
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <FormProvider {...methods}>
+      <StopVersionForm
+        className={className}
+        onCancel={onCancel}
+        onSubmit={methods.handleSubmit(onFormSubmit)}
+      />
+    </FormProvider>
+  );
+};

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopModal.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopModal.tsx
@@ -1,0 +1,65 @@
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  StopWithDetails,
+  useObservationDateQueryParam,
+} from '../../../../../hooks';
+import { Modal, ModalHeader } from '../../../../../uiComponents';
+import { LoadingWrapper } from '../../../../../uiComponents/LoadingWrapper';
+import { ModalBody } from '../../../../map/modal';
+import { CopyStopBoilerPlate } from './CopyStopBoilerPlate';
+import { CopyStopForm } from './CopyStopForm';
+import { CreateStopVersionResult } from './types';
+
+const testIds = {
+  modal: 'CopyStopModal::modal',
+  loading: 'CopyStopModal::loading',
+};
+
+type CopyStopModalProps = {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  readonly originalStop: StopWithDetails | null;
+};
+
+export const CopyStopModal: FC<CopyStopModalProps> = ({
+  isOpen,
+  onClose,
+  originalStop,
+}) => {
+  const { t } = useTranslation();
+
+  const { setObservationDateToUrl } = useObservationDateQueryParam();
+
+  const onCopyCreated = (result: CreateStopVersionResult) => {
+    onClose();
+    if (result.stopPointInput.validity_start) {
+      setObservationDateToUrl(result.stopPointInput.validity_start);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} testId={testIds.modal}>
+      <ModalHeader
+        onClose={onClose}
+        heading={t('stopDetails.version.title.copy')}
+      />
+      <LoadingWrapper testId={testIds.loading} loading={!originalStop}>
+        {originalStop && (
+          <ModalBody>
+            <CopyStopBoilerPlate originalStop={originalStop} />
+            <h4 className="mt-4">
+              {t('stopDetails.version.title.copySubTitle')}
+            </h4>
+            <CopyStopForm
+              className="mt-4"
+              originalStop={originalStop}
+              onCancel={onClose}
+              onCopyCreated={onCopyCreated}
+            />
+          </ModalBody>
+        )}
+      </LoadingWrapper>
+    </Modal>
+  );
+};

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/StopVersionForm.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/StopVersionForm.tsx
@@ -1,0 +1,77 @@
+import { FC, FormEventHandler } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
+import { Row } from '../../../../../layoutComponents';
+import { SimpleButton } from '../../../../../uiComponents';
+import {
+  FormRow,
+  InputField,
+  PriorityForm,
+  ValidityPeriodForm,
+} from '../../../../forms/common';
+import { StopVersionFormState } from './types';
+
+const testIds = {
+  form: 'StopVersionForm::form',
+  versionName: 'StopVersionForm::versionName',
+  versionDescription: 'StopVersionForm::versionDescription',
+  submitButton: 'StopVersionForm::submitButton',
+  cancelButton: 'StopVersionForm::cancelButton',
+};
+
+type StopVersionFormProps = {
+  readonly className?: string;
+  readonly onCancel: () => void;
+  readonly onSubmit: FormEventHandler<HTMLFormElement>;
+};
+
+export const StopVersionForm: FC<StopVersionFormProps> = ({
+  className,
+  onCancel,
+  onSubmit,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className={twMerge(`space-y-4`, className)}
+      data-testid={testIds.form}
+    >
+      <FormRow>
+        <InputField<StopVersionFormState>
+          type="text"
+          translationPrefix="stopDetails.version.fields"
+          fieldPath="versionName"
+          testId={testIds.versionName}
+        />
+      </FormRow>
+      <FormRow>
+        <InputField<StopVersionFormState>
+          type="text"
+          translationPrefix="stopDetails.version.fields"
+          fieldPath="versionDescription"
+          testId={testIds.versionDescription}
+          disabled
+        />
+      </FormRow>
+
+      <FormRow>
+        <PriorityForm />
+      </FormRow>
+
+      <FormRow>
+        <ValidityPeriodForm />
+      </FormRow>
+
+      <Row className="justify-end space-x-4">
+        <SimpleButton inverted onClick={onCancel} testId={testIds.cancelButton}>
+          {t('cancel')}
+        </SimpleButton>
+        <SimpleButton type="submit" testId={testIds.submitButton}>
+          {t('save')}
+        </SimpleButton>
+      </Row>
+    </form>
+  );
+};

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/FailedToResolveExistingShelter.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/FailedToResolveExistingShelter.ts
@@ -1,0 +1,1 @@
+export class FailedToResolveExistingShelter extends Error {}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/FailedToResolveNewShelters.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/FailedToResolveNewShelters.ts
@@ -1,0 +1,1 @@
+export class FailedToResolveNewShelters extends Error {}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/StopPlaceInsertFailed.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/StopPlaceInsertFailed.ts
@@ -1,0 +1,1 @@
+export class StopPlaceInsertFailed extends Error {}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/StopPlaceRevertFailed.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/StopPlaceRevertFailed.ts
@@ -1,0 +1,1 @@
+export class StopPlaceRevertFailed extends AggregateError {}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/StopPointInsertFailed.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/StopPointInsertFailed.ts
@@ -1,0 +1,1 @@
+export class StopPointInsertFailed extends Error {}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/index.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/errors/index.ts
@@ -1,0 +1,5 @@
+export * from './FailedToResolveExistingShelter';
+export * from './FailedToResolveNewShelters';
+export * from './StopPlaceInsertFailed';
+export * from './StopPlaceRevertFailed';
+export * from './StopPointInsertFailed';

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/index.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/index.ts
@@ -1,0 +1,1 @@
+export * from './CopyStopModal';

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/types/CreateStopVersionResult.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/types/CreateStopVersionResult.ts
@@ -1,0 +1,9 @@
+import { StopRegistryStopPlaceInput } from '../../../../../../generated/graphql';
+import { ScheduledStopPointSetInput } from '../../../../../../graphql';
+
+export type CreateStopVersionResult = {
+  readonly stopPlaceId: string;
+  readonly stopPlaceInput: StopRegistryStopPlaceInput;
+  readonly stopPointId: UUID;
+  readonly stopPointInput: ScheduledStopPointSetInput;
+};

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/types/InfoSpotInputHelper.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/types/InfoSpotInputHelper.ts
@@ -1,0 +1,10 @@
+import {
+  StopRegistryInfoSpotInput,
+  StopRegistryShelterEquipmentInput,
+} from '../../../../../../generated/graphql';
+
+export type InfoSpotInputHelper = {
+  readonly originalShelter: StopRegistryShelterEquipmentInput;
+  readonly originalShelterIndex: number;
+  readonly infoSpotInput: StopRegistryInfoSpotInput;
+};

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/types/StopVersionFormState.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/types/StopVersionFormState.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import {
+  priorityFormSchema,
+  requiredString,
+  validityPeriodFormSchema,
+} from '../../../../../forms/common';
+
+export const stopVersionSchema = z
+  .object({
+    versionName: requiredString,
+    versionDescription: z.string().optional(), // Not implemented
+  })
+  .merge(validityPeriodFormSchema)
+  .merge(priorityFormSchema);
+
+export type StopVersionFormState = z.infer<typeof stopVersionSchema>;

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/types/index.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/types/index.ts
@@ -1,2 +1,3 @@
+export * from './CreateStopVersionResult';
 export * from './InfoSpotInputHelper';
 export * from './StopVersionFormState';

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/types/index.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/types/index.ts
@@ -1,0 +1,1 @@
+export * from './StopVersionFormState';

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/types/index.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/types/index.ts
@@ -1,1 +1,2 @@
+export * from './InfoSpotInputHelper';
 export * from './StopVersionFormState';

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/hasDuplicateShelters.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/hasDuplicateShelters.ts
@@ -1,0 +1,39 @@
+import { StopRegistryShelterEquipment } from '../../../../../../generated/graphql';
+
+function compareShelters(
+  shelterA: StopRegistryShelterEquipment,
+  shelterB: StopRegistryShelterEquipment,
+): boolean {
+  const aRecord = shelterA as Record<string, unknown>;
+  const bRecord = shelterB as Record<string, unknown>;
+
+  return Object.entries(aRecord).every(([aKey, aValue]) => {
+    if (aKey === 'id') {
+      return true;
+    }
+
+    const bValue = bRecord[aKey];
+    // Treat undefined as === to null
+    return (aValue ?? null) === (bValue ?? null);
+  });
+}
+
+export function hasDuplicateShelters(
+  shelters: ReadonlyArray<StopRegistryShelterEquipment> | null | undefined,
+): boolean {
+  if (!shelters || shelters.length < 2) {
+    return false;
+  }
+
+  for (let i = 0; i < shelters.length - 1; i += 1) {
+    for (let j = i + 1; j < shelters.length; j += 1) {
+      const equal = compareShelters(shelters[i], shelters[j]);
+
+      if (equal) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/index.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './useCopyStopFormUtils';

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/mapCompactOrNull.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/mapCompactOrNull.ts
@@ -1,0 +1,28 @@
+import compact from 'lodash/compact';
+
+/**
+ * Map effed up Timat output type to valid input
+ *
+ * - Filter out nulls from OutputType/input arrays.
+ * - Map remaining defined objects
+ * - Filter out any potential nulls produced by mapper
+ * - Finally if resulting InputType/output array is empty,
+ *   return null instead.
+ *
+ * @param array Input array of OutputType T entities
+ * @param mapper Mapper function OutputType T to InputType R
+ */
+export function mapCompactOrNull<T, R>(
+  array: ReadonlyArray<T | null | undefined> | null | undefined,
+  mapper: (item: T) => R | null,
+): Array<R> | null {
+  if (!array) {
+    return null;
+  }
+
+  const compactedInput = compact(array);
+  const mapped = compactedInput.map(mapper);
+  const compactedOutput = compact(mapped);
+
+  return compactedOutput.length ? compactedOutput : null;
+}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/mapCreateCopyFormStateToInputs.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/mapCreateCopyFormStateToInputs.ts
@@ -1,0 +1,147 @@
+import compact from 'lodash/compact';
+import pick from 'lodash/pick';
+import { DateTime } from 'luxon';
+import {
+  ServicePatternScheduledStopPointInsertInput,
+  StopRegistryKeyValues,
+  StopRegistryStopPlaceInput,
+} from '../../../../../../generated/graphql';
+import { ScheduledStopPointSetInput } from '../../../../../../graphql';
+import { StopWithDetails } from '../../../../../../hooks';
+import {
+  mapDateInputToValidityEnd,
+  mapDateInputToValidityStart,
+  patchKeyValues,
+} from '../../../../../../utils';
+import { FailedToResolveExistingShelter } from '../errors';
+import { InfoSpotInputHelper, StopVersionFormState } from '../types';
+import { mapCompactOrNull } from './mapCompactOrNull';
+import { mapInfoSpotToInput, mapOriginalToInput } from './mapOriginalToInput';
+
+type CreateCopyInputs = {
+  readonly stopPlaceInput: StopRegistryStopPlaceInput;
+  readonly stopPointInput: ScheduledStopPointSetInput;
+  readonly infoSpotInputs: ReadonlyArray<InfoSpotInputHelper> | null;
+};
+
+type ValidityInput = {
+  validityStart: DateTime;
+  validityEnd: DateTime | null;
+};
+
+function getValidity(state: StopVersionFormState): ValidityInput {
+  const validityStart = mapDateInputToValidityStart(state.validityStart);
+  if (!validityStart) {
+    throw new Error('Cannot map state with null validityStart');
+  }
+  const validityEnd: DateTime | null =
+    mapDateInputToValidityEnd(state.validityEnd, state.indefinite) ?? null;
+
+  return { validityStart, validityEnd };
+}
+
+function getKeyValues(
+  state: StopVersionFormState,
+  originalStop: StopWithDetails,
+): Array<StopRegistryKeyValues | null> {
+  return patchKeyValues(
+    originalStop.stop_place,
+    compact([
+      { key: 'validityStart', values: [state.validityStart] },
+      !state.indefinite
+        ? {
+            key: 'validityEnd',
+            values: [state.validityEnd as string],
+          }
+        : undefined,
+      { key: 'priority', values: [state.priority.toString(10)] },
+    ]),
+  );
+}
+
+function mapStopPlaceInput(
+  state: StopVersionFormState,
+  originalStop: StopWithDetails,
+): StopRegistryStopPlaceInput {
+  return {
+    ...mapOriginalToInput(originalStop),
+    id: null,
+    keyValues: getKeyValues(state, originalStop),
+    versionComment: state.versionName,
+    // versionDescription: state.versionDescription, // Not implemented
+    validBetween: {
+      fromDate: DateTime.now(),
+      toDate: null,
+    },
+  };
+}
+
+function mapStopPointInput(
+  state: StopVersionFormState,
+  originalStop: StopWithDetails,
+): ServicePatternScheduledStopPointInsertInput {
+  const validity = getValidity(state);
+
+  return {
+    ...pick(originalStop, [
+      'direction',
+      'label',
+      'located_on_infrastructure_link_id',
+      'measured_location',
+      'timing_place_id',
+    ]),
+    validity_start: validity.validityStart,
+    validity_end: validity.validityEnd,
+    priority: state.priority,
+    vehicle_mode_on_scheduled_stop_point: {
+      data: [
+        {
+          vehicle_mode:
+            originalStop.vehicle_mode_on_scheduled_stop_point[0].vehicle_mode,
+        },
+      ],
+    },
+  };
+}
+
+export function mapInfoSpotsToInputs(
+  originalStop: StopWithDetails,
+): ReadonlyArray<InfoSpotInputHelper> | null {
+  return mapCompactOrNull(originalStop.stop_place?.infoSpots, (infoSpot) => {
+    const shelters =
+      originalStop.stop_place?.quays?.at(0)?.placeEquipments?.shelterEquipment;
+
+    const originalShelter =
+      shelters?.find(
+        (shelter) =>
+          shelter &&
+          shelter.id &&
+          infoSpot.infoSpotLocations?.includes(shelter.id),
+      ) ?? null;
+
+    const originalShelterIndex = shelters?.indexOf(originalShelter) ?? -1;
+
+    if (!originalShelter || originalShelterIndex < 0) {
+      throw new FailedToResolveExistingShelter(
+        `Failed to resolve existing shelter for infoSpot: ${JSON.stringify(infoSpot)}`,
+      );
+    }
+
+    return {
+      originalShelter,
+      originalShelterIndex,
+      infoSpotInput: mapInfoSpotToInput(infoSpot),
+    };
+  });
+}
+
+export function mapCreateCopyFormStateToInputs(
+  state: StopVersionFormState,
+  originalStop: StopWithDetails,
+): CreateCopyInputs {
+  const stopPlaceInput = mapStopPlaceInput(state, originalStop);
+  const stopPointInput = mapStopPointInput(state, originalStop);
+  const infoSpotInputs = mapInfoSpotsToInputs(originalStop);
+
+  return { stopPlaceInput, stopPointInput, infoSpotInputs };
+}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/mapOriginalToInput.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/mapOriginalToInput.ts
@@ -1,0 +1,293 @@
+import omit from 'lodash/omit';
+import pick from 'lodash/pick';
+import {
+  InfoSpotDetailsFragment,
+  InputMaybe,
+  Maybe,
+  StopRegistryAccessibilityAssessment,
+  StopRegistryAccessibilityAssessmentInput,
+  StopRegistryAlternativeName,
+  StopRegistryAlternativeNameInput,
+  StopRegistryBoardingPosition,
+  StopRegistryBoardingPositionInput,
+  StopRegistryGeneralSign,
+  StopRegistryGeneralSignInput,
+  StopRegistryGeoJson,
+  StopRegistryGeoJsonInput,
+  StopRegistryInfoSpotInput,
+  StopRegistryLimitationStatusType,
+  StopRegistryPlaceEquipments,
+  StopRegistryPlaceEquipmentsInput,
+  StopRegistryPrivateCode,
+  StopRegistryPrivateCodeInput,
+  StopRegistryQuay,
+  StopRegistryQuayInput,
+  StopRegistryStopPlaceInput,
+  StopRegistryStopPlaceOrganisationRef,
+  StopRegistryStopPlaceOrganisationRefInput,
+  StopRegistryTariffZone,
+  StopRegistryVersionLessEntityRef,
+  StopRegistryVersionLessEntityRefInput,
+} from '../../../../../../generated/graphql';
+import { StopWithDetails } from '../../../../../../hooks';
+import { mapCompactOrNull } from './mapCompactOrNull';
+
+function omitTypeName<T extends object>(
+  value: T | null | undefined,
+): Omit<T, '__typename'> | null {
+  if (!value) {
+    return null;
+  }
+
+  return omit(value, ['__typename']) as Omit<T, '__typename'>;
+}
+
+function omitIdAndTypeName<T extends object>(
+  value: T | null | undefined,
+): Omit<T, 'id' | '__typename'> | null {
+  if (!value) {
+    return null;
+  }
+
+  return omit(value, ['id', '__typename']) as Omit<T, 'id' | '__typename'>;
+}
+
+function mapGeoJsonToInput(
+  geoJson: StopRegistryGeoJson | null | undefined,
+): InputMaybe<StopRegistryGeoJsonInput> {
+  if (!geoJson || !geoJson.coordinates || !geoJson.type) {
+    return null;
+  }
+
+  return {
+    coordinates: geoJson.coordinates,
+    type: geoJson.type,
+  };
+}
+
+function mapAccessibilityAssessmentToInput(
+  originalAccessibilityAssessment:
+    | StopRegistryAccessibilityAssessment
+    | null
+    | undefined,
+): InputMaybe<StopRegistryAccessibilityAssessmentInput> {
+  if (!originalAccessibilityAssessment) {
+    return null;
+  }
+
+  const { limitations, hslAccessibilityProperties } =
+    originalAccessibilityAssessment;
+
+  return {
+    hslAccessibilityProperties: omitTypeName(hslAccessibilityProperties),
+    limitations: limitations
+      ? {
+          audibleSignalsAvailable:
+            limitations.audibleSignalsAvailable ??
+            StopRegistryLimitationStatusType.Unknown,
+          escalatorFreeAccess:
+            limitations.escalatorFreeAccess ??
+            StopRegistryLimitationStatusType.Unknown,
+          liftFreeAccess:
+            limitations.liftFreeAccess ??
+            StopRegistryLimitationStatusType.Unknown,
+          stepFreeAccess:
+            limitations.stepFreeAccess ??
+            StopRegistryLimitationStatusType.Unknown,
+          wheelchairAccess:
+            limitations.wheelchairAccess ??
+            StopRegistryLimitationStatusType.Unknown,
+        }
+      : null,
+  };
+}
+
+function mapPrivateCodeToInput(
+  privateCode: StopRegistryPrivateCode | null | undefined,
+): InputMaybe<StopRegistryPrivateCodeInput> {
+  if (!privateCode || !privateCode.value) {
+    return null;
+  }
+
+  return {
+    type: privateCode.type,
+    value: privateCode.value,
+  };
+}
+
+function mapGeneralSignToInput(
+  generalSign: StopRegistryGeneralSign | null | undefined,
+): InputMaybe<StopRegistryGeneralSignInput> {
+  if (!generalSign) {
+    return null;
+  }
+
+  return {
+    ...pick(generalSign, [
+      'lineSignage',
+      'mainLineSign',
+      'numberOfFrames',
+      'replacesRailSign',
+      'signContentType',
+    ]),
+    content: omitTypeName(generalSign.content),
+    note: omitTypeName(generalSign.note),
+    privateCode: mapPrivateCodeToInput(generalSign.privateCode),
+  };
+}
+
+function mapPlaceEquipmentsToInput(
+  equipments: StopRegistryPlaceEquipments | null | undefined,
+): InputMaybe<StopRegistryPlaceEquipmentsInput> {
+  if (!equipments) {
+    return null;
+  }
+
+  return {
+    cycleStorageEquipment: mapCompactOrNull(
+      equipments.cycleStorageEquipment,
+      omitIdAndTypeName,
+    ),
+    generalSign: mapCompactOrNull(
+      equipments.generalSign,
+      mapGeneralSignToInput,
+    ),
+    sanitaryEquipment: mapCompactOrNull(
+      equipments.sanitaryEquipment,
+      omitIdAndTypeName,
+    ),
+    shelterEquipment: mapCompactOrNull(
+      equipments.shelterEquipment,
+      omitIdAndTypeName,
+    ),
+    ticketingEquipment: mapCompactOrNull(
+      equipments.ticketingEquipment,
+      omitIdAndTypeName,
+    ),
+    waitingRoomEquipment: mapCompactOrNull(
+      equipments.waitingRoomEquipment,
+      omitIdAndTypeName,
+    ),
+  };
+}
+
+function mapBoardingPositionsToInput(
+  positions:
+    | ReadonlyArray<Maybe<StopRegistryBoardingPosition>>
+    | null
+    | undefined,
+): Array<StopRegistryBoardingPositionInput> | null {
+  return mapCompactOrNull(positions, (position) => ({
+    geometry: mapGeoJsonToInput(position.geometry),
+    publicCode: position.publicCode,
+  }));
+}
+
+function mapAdjacentSitesToInput(
+  adjacentSites:
+    | ReadonlyArray<Maybe<StopRegistryVersionLessEntityRef>>
+    | null
+    | undefined,
+): Array<StopRegistryVersionLessEntityRefInput> | null {
+  return mapCompactOrNull(adjacentSites, (site) =>
+    site?.ref ? { ref: site.ref } : null,
+  );
+}
+
+const mapTariffZonesToInput = (
+  refs: ReadonlyArray<Maybe<StopRegistryTariffZone>> | null | undefined,
+): Array<StopRegistryVersionLessEntityRefInput> | null => {
+  return mapCompactOrNull(refs, (ref) => (ref?.id ? { ref: ref.id } : null));
+};
+
+function mapAlternativeNames(
+  alternativeNames:
+    | ReadonlyArray<Maybe<StopRegistryAlternativeName>>
+    | null
+    | undefined,
+): Array<StopRegistryAlternativeNameInput> | null {
+  return mapCompactOrNull(alternativeNames, (alt) => ({
+    name: { lang: alt.name.lang, value: alt.name.value },
+    nameType: alt.nameType,
+  }));
+}
+
+function mapQuaysToInput(
+  quays: ReadonlyArray<Maybe<StopRegistryQuay>> | null | undefined,
+): Array<StopRegistryQuayInput> | null {
+  return mapCompactOrNull(quays, (quay) => ({
+    ...pick(quay, ['compassBearing', 'keyValues', 'publicCode']),
+    name: omitTypeName(quay.name),
+    description: omitTypeName(quay.description),
+    shortName: omitTypeName(quay.shortName),
+    alternativeNames: mapAlternativeNames(quay.alternativeNames),
+    accessibilityAssessment: mapAccessibilityAssessmentToInput(
+      quay.accessibilityAssessment,
+    ),
+    boardingPositions: mapBoardingPositionsToInput(quay.boardingPositions),
+    geometry: mapGeoJsonToInput(quay.geometry),
+    placeEquipments: mapPlaceEquipmentsToInput(quay.placeEquipments),
+    privateCode: mapPrivateCodeToInput(quay.privateCode),
+  }));
+}
+
+function mapOrganizationsToInput(
+  organizations:
+    | ReadonlyArray<Maybe<StopRegistryStopPlaceOrganisationRef>>
+    | null
+    | undefined,
+): Array<StopRegistryStopPlaceOrganisationRefInput> | null {
+  return mapCompactOrNull(organizations, (org) => ({
+    organisationRef: org.organisationRef,
+    relationshipType: org.relationshipType,
+  }));
+}
+
+export function mapOriginalToInput(
+  originalStop: StopWithDetails,
+): StopRegistryStopPlaceInput {
+  const stopPlace = originalStop.stop_place;
+  if (!stopPlace) {
+    throw new Error('Cannot clone a stop without a StopPlace!');
+  }
+
+  return {
+    ...pick(stopPlace, [
+      'keyValues',
+      'parentSiteRef',
+      'publicCode',
+      'stopPlaceType',
+      'submode',
+      'transportMode',
+      'weighting',
+    ]),
+    name: omitTypeName(stopPlace.name),
+    description: omitTypeName(stopPlace.description),
+    shortName: omitTypeName(stopPlace.shortName),
+    alternativeNames: mapAlternativeNames(stopPlace.alternativeNames),
+    accessibilityAssessment: mapAccessibilityAssessmentToInput(
+      stopPlace.accessibilityAssessment,
+    ),
+    geometry: mapGeoJsonToInput(stopPlace.geometry),
+    placeEquipments: mapPlaceEquipmentsToInput(stopPlace.placeEquipments),
+    privateCode: mapPrivateCodeToInput(stopPlace.privateCode),
+    organisations: mapOrganizationsToInput(stopPlace.organisations),
+    quays: mapQuaysToInput(stopPlace.quays),
+    adjacentSites: mapAdjacentSitesToInput(stopPlace.adjacentSites),
+    tariffZones: mapTariffZonesToInput(stopPlace.tariffZones),
+    validBetween: null,
+    // Location properties:
+    // Note: Tiamat sets topographicPlace and fareZone automatically based on coordinates. They can not be changed otherwise.
+  };
+}
+
+export function mapInfoSpotToInput(
+  infoSpot: InfoSpotDetailsFragment,
+): StopRegistryInfoSpotInput {
+  return {
+    ...omitIdAndTypeName(infoSpot),
+    infoSpotLocations: null,
+    description: omitTypeName(infoSpot.description),
+    poster: mapCompactOrNull(infoSpot.poster, omitTypeName),
+  };
+}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useCopyStop.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useCopyStop.ts
@@ -1,0 +1,184 @@
+import { useCallback } from 'react';
+import {
+  StopRegistryInfoSpotInput,
+  StopRegistryStopPlaceInput,
+  useInsertStopMutation,
+  useInsertStopPlaceMutation,
+  useUpdateInfoSpotMutation,
+} from '../../../../../../generated/graphql';
+import { ScheduledStopPointSetInput } from '../../../../../../graphql';
+import { StopWithDetails } from '../../../../../../hooks';
+import {
+  FailedToResolveNewShelters,
+  StopPlaceInsertFailed,
+  StopPlaceRevertFailed,
+} from '../errors';
+import {
+  CreateStopVersionResult,
+  InfoSpotInputHelper,
+  StopVersionFormState,
+} from '../types';
+import { mapCreateCopyFormStateToInputs } from './mapCreateCopyFormStateToInputs';
+import { useDeleteStopPlace } from './useDeleteStopPlace';
+import { useGetShelterResolver } from './useGetShelterResolver';
+import { wrapErrors } from './wrapErrors';
+
+function useInsertStopPlace() {
+  const [insertStopPlaceMutation] = useInsertStopPlaceMutation();
+
+  return useCallback(
+    async (stopPlaceInput: StopRegistryStopPlaceInput): Promise<string> => {
+      const response = await wrapErrors(
+        insertStopPlaceMutation({ variables: { object: stopPlaceInput } }),
+        StopPlaceInsertFailed,
+        'Failed to insert new StopPlace!',
+      );
+
+      const id = response.data?.stop_registry?.mutateStopPlace?.at(0)?.id;
+
+      if (!id) {
+        throw new StopPlaceInsertFailed(
+          `StopPlace insert seems to have failed. No ID returned. Response: ${JSON.stringify(response, null, 0)}`,
+        );
+      }
+
+      return id;
+    },
+    [insertStopPlaceMutation],
+  );
+}
+
+function useRevertStopPlaceInsert() {
+  const deleteStopPlace = useDeleteStopPlace();
+
+  return useCallback(
+    async (stopPlaceId: string, cause: unknown): Promise<true> => {
+      try {
+        const deleted = await deleteStopPlace(stopPlaceId);
+
+        if (!deleted) {
+          throw new Error(
+            'Expected Tiamat to return true on delete, but response was false!',
+          );
+        }
+
+        return true;
+      } catch (stopPlaceReverFailedCause) {
+        throw new StopPlaceRevertFailed(
+          [cause, stopPlaceReverFailedCause],
+          'Failed to reverse StopPlace insertion after failed attempt at creating a StopPoint for it!',
+        );
+      }
+    },
+    [deleteStopPlace],
+  );
+}
+
+function useInsertStopPoint() {
+  const [insertStopMutation] = useInsertStopMutation();
+  const revertStopPlaceInsert = useRevertStopPlaceInsert();
+
+  return useCallback(
+    async (
+      stopPointInput: ScheduledStopPointSetInput,
+      stopPlaceId: string,
+    ): Promise<UUID> => {
+      try {
+        const response = await wrapErrors(
+          insertStopMutation({
+            variables: {
+              object: { ...stopPointInput, stop_place_ref: stopPlaceId },
+            },
+          }),
+          StopPlaceInsertFailed,
+          'Failed to insert new StopPoint!',
+        );
+
+        const stopPointId =
+          response.data?.insert_service_pattern_scheduled_stop_point_one
+            ?.scheduled_stop_point_id;
+
+        if (!stopPointId) {
+          throw new StopPlaceInsertFailed(
+            `StopPoint insert seems to have failed. No ID returned. Response: ${JSON.stringify(response, null, 0)}`,
+          );
+        }
+
+        return stopPointId;
+      } catch (stopPointInsertFailedCause) {
+        await revertStopPlaceInsert(stopPlaceId, stopPointInsertFailedCause);
+        throw stopPointInsertFailedCause;
+      }
+    },
+    [insertStopMutation, revertStopPlaceInsert],
+  );
+}
+
+function useInsertInfoSpots() {
+  const [updateInfoSpotMutation] = useUpdateInfoSpotMutation();
+  const getShelterResolver = useGetShelterResolver();
+
+  return useCallback(
+    async (
+      infoSpots: ReadonlyArray<InfoSpotInputHelper> | null,
+      stopPlaceId: string,
+    ): Promise<boolean> => {
+      if (infoSpots === null) {
+        return false;
+      }
+
+      const shelterResolver = await getShelterResolver(stopPlaceId);
+      const resolveByIndex = shelterResolver.shouldResolveByIndex();
+
+      const withLocations = infoSpots.map(
+        (input): StopRegistryInfoSpotInput => {
+          const { originalShelter, originalShelterIndex, infoSpotInput } =
+            input;
+
+          const shelterId = resolveByIndex
+            ? shelterResolver.getIdForIndex(originalShelterIndex)
+            : shelterResolver.getIdForShelter(originalShelter);
+
+          if (!shelterId) {
+            throw new FailedToResolveNewShelters(
+              `Failed to resolve new shelter ID for: ${JSON.stringify(input)}`,
+            );
+          }
+
+          return {
+            ...infoSpotInput,
+            infoSpotLocations: [stopPlaceId, shelterId],
+          };
+        },
+      );
+
+      await updateInfoSpotMutation({ variables: { input: withLocations } });
+
+      return true;
+    },
+    [getShelterResolver, updateInfoSpotMutation],
+  );
+}
+
+export function useCopyStop() {
+  const insertStopPlace = useInsertStopPlace();
+  const insertStopPoint = useInsertStopPoint();
+  const insertInfoSpots = useInsertInfoSpots();
+
+  return useCallback(
+    async (
+      state: StopVersionFormState,
+      originalStop: StopWithDetails,
+    ): Promise<CreateStopVersionResult> => {
+      const { stopPlaceInput, stopPointInput, infoSpotInputs } =
+        mapCreateCopyFormStateToInputs(state, originalStop);
+
+      const stopPlaceId = await insertStopPlace(stopPlaceInput);
+      const stopPointId = await insertStopPoint(stopPointInput, stopPlaceId);
+      await insertInfoSpots(infoSpotInputs, stopPlaceId);
+
+      return { stopPlaceId, stopPlaceInput, stopPointId, stopPointInput };
+    },
+    [insertStopPlace, insertStopPoint, insertInfoSpots],
+  );
+}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useCopyStopFormUtils.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useCopyStopFormUtils.ts
@@ -1,0 +1,120 @@
+import { ApolloError } from '@apollo/client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { StopWithDetails, useLoader } from '../../../../../../hooks';
+import { Operation } from '../../../../../../redux';
+import { log, showToast } from '../../../../../../utils';
+import { getApolloErrorMessage } from '../../../../../../utils/apolloErrors';
+import {
+  StopPlaceInsertFailed,
+  StopPlaceRevertFailed,
+  StopPointInsertFailed,
+} from '../errors';
+import {
+  CreateStopVersionResult,
+  StopVersionFormState,
+  stopVersionSchema,
+} from '../types';
+import { useCopyStop } from './useCopyStop';
+
+function extractMessageFromError(error: unknown) {
+  if (error instanceof ApolloError) {
+    return getApolloErrorMessage(error);
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return JSON.stringify(error, null, 0);
+}
+
+function useErrorHandler() {
+  const { t } = useTranslation();
+
+  const resolveErrorMessage = (error: unknown) => {
+    if (error instanceof StopPlaceInsertFailed) {
+      return t('stopDetails.version.errors.stopPlaceInsertFailed', {
+        reason: extractMessageFromError(error.cause),
+      });
+    }
+
+    if (error instanceof StopPointInsertFailed) {
+      return t(
+        'stopDetails.version.errors.stopPointInsertFailedStopPlaceReverted',
+        { reason: extractMessageFromError(error.cause) },
+      );
+    }
+
+    if (error instanceof StopPlaceRevertFailed) {
+      return t(
+        'stopDetails.version.errors.stopPointInsertFailedStopPlaceNotReverted',
+        { reason: error.errors.map(extractMessageFromError).join('\n') },
+      );
+    }
+
+    return extractMessageFromError(error);
+  };
+
+  return (error: unknown) => {
+    log.error('Failed to create copy of stop place:', error);
+    showToast({
+      className: 'whitespace-pre-line',
+      message: t('stopDetails.version.errors.copy', {
+        reason: resolveErrorMessage(error),
+      }),
+      type: 'danger',
+    });
+  };
+}
+
+export const useCopyStopFormUtils = (
+  originalStop: StopWithDetails,
+  onCopyCreated: (result: CreateStopVersionResult) => void,
+) => {
+  const { t } = useTranslation();
+
+  const { setIsLoading } = useLoader(Operation.SaveStop);
+  const copyStop = useCopyStop();
+
+  const defaultValues: StopVersionFormState = useMemo(
+    () => ({
+      indefinite: originalStop.validity_end === null,
+      validityStart: originalStop.validity_start?.toISODate() ?? '',
+      validityEnd: originalStop.validity_end?.toISODate(),
+      priority: originalStop.priority,
+      versionDescription: '',
+      versionName: '',
+    }),
+    [originalStop],
+  );
+
+  const methods = useForm<StopVersionFormState>({
+    defaultValues,
+    resolver: zodResolver(stopVersionSchema),
+  });
+
+  const handleError = useErrorHandler();
+
+  const handleSuccess = (result: CreateStopVersionResult) => {
+    showToast({
+      className: 'whitespace-pre-line',
+      message: t('stopDetails.version.success.copy'),
+      type: 'success',
+    });
+    onCopyCreated(result);
+  };
+
+  const onFormSubmit = (state: StopVersionFormState) => {
+    setIsLoading(true);
+    copyStop(state, originalStop).then(handleSuccess).catch(handleError);
+    setIsLoading(false);
+  };
+
+  return {
+    methods,
+    onFormSubmit,
+  };
+};

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useDeleteStopPlace.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useDeleteStopPlace.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client';
+import { useCallback } from 'react';
+import { useDeleteStopPlaceMutation } from '../../../../../../generated/graphql';
+
+const GQL_DELETE_STOP_PLACE = gql`
+  mutation DeleteStopPlace($stopPlaceId: String!) {
+    stop_registry {
+      deleteStopPlace(stopPlaceId: $stopPlaceId)
+    }
+  }
+`;
+
+export function useDeleteStopPlace() {
+  const [deleteStopPlaceMutation] = useDeleteStopPlaceMutation();
+
+  return useCallback(
+    (stopPlaceId: string): Promise<boolean> =>
+      deleteStopPlaceMutation({ variables: { stopPlaceId } }).then(
+        (result) => !!result.data?.stop_registry?.deleteStopPlace,
+      ),
+    [deleteStopPlaceMutation],
+  );
+}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useGetShelterResolver.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useGetShelterResolver.ts
@@ -1,0 +1,115 @@
+import { gql } from '@apollo/client';
+import compact from 'lodash/compact';
+import { useCallback } from 'react';
+import {
+  ResolveStopSheltersQuery,
+  StopRegistryShelterEquipment,
+  useResolveStopSheltersLazyQuery,
+} from '../../../../../../generated/graphql';
+import { FailedToResolveNewShelters } from '../errors';
+import { hasDuplicateShelters } from './hasDuplicateShelters';
+
+const GQL_RESOLVE_STOP_SHELTERS = gql`
+  query ResolveStopShelters($netexId: String!) {
+    stop_registry {
+      stopPlace(id: $netexId) {
+        id
+
+        ... on stop_registry_StopPlace {
+          quays {
+            id
+
+            placeEquipments {
+              id
+              shelterEquipment {
+                ...shelter_equipment_details
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+function compareShelters(
+  original: StopRegistryShelterEquipment,
+  saved: StopRegistryShelterEquipment,
+): boolean {
+  const originalRecord = original as Readonly<Record<string, unknown>>;
+  const savedRecord = saved as Readonly<Record<string, unknown>>;
+
+  return Object.entries(originalRecord).every(([key, originalValue]) => {
+    // Skip ID
+    if (key === 'id') {
+      return true;
+    }
+
+    const savedValue = savedRecord[key];
+    // Treat undefined as === to null
+    return (originalValue ?? null) === (savedValue ?? null);
+  });
+}
+
+class ShelterResolver {
+  public shelters: ReadonlyArray<StopRegistryShelterEquipment>;
+
+  constructor(shelters: ReadonlyArray<StopRegistryShelterEquipment>) {
+    this.shelters = shelters;
+  }
+
+  getIdForShelter(
+    originalShelter: StopRegistryShelterEquipment,
+  ): string | null {
+    return (
+      this.shelters.find((saved) => compareShelters(originalShelter, saved))
+        ?.id ?? null
+    );
+  }
+
+  getIdForIndex(index: number): string | null {
+    return this.shelters.at(index)?.id ?? null;
+  }
+
+  shouldResolveByIndex() {
+    return hasDuplicateShelters(this.shelters);
+  }
+}
+
+function getSheltersFromResult(
+  data: ResolveStopSheltersQuery | undefined,
+): Array<StopRegistryShelterEquipment> {
+  const stopPlace = data?.stop_registry?.stopPlace?.at(0);
+
+  if (stopPlace && 'quays' in stopPlace) {
+    const rawShelterList =
+      stopPlace.quays?.at(0)?.placeEquipments?.shelterEquipment;
+
+    if (rawShelterList) {
+      return compact(rawShelterList);
+    }
+  }
+
+  return [];
+}
+
+export function useGetShelterResolver() {
+  const [resolveStopShelters] = useResolveStopSheltersLazyQuery();
+
+  return useCallback(
+    async (netexId: string) => {
+      try {
+        const result = await resolveStopShelters({ variables: { netexId } });
+        const shelters = getSheltersFromResult(result.data);
+
+        return new ShelterResolver(shelters);
+      } catch (cause) {
+        throw new FailedToResolveNewShelters(
+          "Failed to resolve new stop's shelters!",
+          { cause },
+        );
+      }
+    },
+    [resolveStopShelters],
+  );
+}

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/wrapErrors.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/wrapErrors.ts
@@ -1,0 +1,15 @@
+interface TypedErrorConstructor<T extends Error> {
+  new (message?: string, options?: ErrorOptions): T;
+}
+
+export async function wrapErrors<PromisedValue, ErrorType extends Error>(
+  promise: Promise<PromisedValue>,
+  WrapperError: TypedErrorConstructor<ErrorType>,
+  message: string,
+): Promise<PromisedValue> {
+  try {
+    return await promise;
+  } catch (cause) {
+    throw new WrapperError(message, { cause });
+  }
+}

--- a/ui/src/components/stop-registry/stops/stop-details/title-row/EditValidityButton.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/title-row/EditValidityButton.tsx
@@ -5,7 +5,7 @@ import { StopWithDetails } from '../../../../../hooks';
 const DISABLE_UNTIL_IMPLEMENTED = true;
 
 const testIds = {
-  button: 'StopDetailsPage::editValidityButton',
+  button: 'StopTitleRow::editValidityButton',
 };
 
 type EditValidityButtonProps = {

--- a/ui/src/components/stop-registry/stops/stop-details/title-row/ExtraActions.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/title-row/ExtraActions.tsx
@@ -10,8 +10,8 @@ import {
 import { CopyStopModal } from '../stop-version';
 
 const testIds = {
-  actionMenu: 'StopDetailsPage::extraActions::menu',
-  copy: 'StopDetailsPage::extraActions::copy',
+  actionMenu: 'StopTitleRow::extraActions::menu',
+  copy: 'StopTitleRow::extraActions::copy',
 };
 
 type ExtraActionsProps = {

--- a/ui/src/components/stop-registry/stops/stop-details/title-row/ExtraActions.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/title-row/ExtraActions.tsx
@@ -1,5 +1,4 @@
-import noop from 'lodash/noop';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twJoin } from 'tailwind-merge';
 import { StopWithDetails } from '../../../../../hooks';
@@ -8,8 +7,7 @@ import {
   SimpleDropdownMenu,
   SimpleDropdownMenuItem,
 } from '../../../../../uiComponents';
-
-const DISABLE_UNTIL_IMPLEMENTED = true;
+import { CopyStopModal } from '../stop-version';
 
 const testIds = {
   actionMenu: 'StopDetailsPage::extraActions::menu',
@@ -24,24 +22,33 @@ type ExtraActionsProps = {
 export const ExtraActions: FC<ExtraActionsProps> = ({ className, stop }) => {
   const { t } = useTranslation();
 
+  const [showCopyModal, setShowCopyModal] = useState(false);
+
   return (
-    <SimpleDropdownMenu
-      className={className}
-      buttonClassName={twJoin(
-        'flex h-11 w-11 items-center justify-center border border-grey',
-        'disabled:pointer-events-none disabled:bg-background disabled:opacity-70',
-      )}
-      tooltip={t('accessibility:common.actionMenu')}
-      alignItems={AlignDirection.Left}
-      testId={testIds.actionMenu}
-      disabled={!stop}
-    >
-      <SimpleDropdownMenuItem
-        text={t('stopDetails.actions.extra.copy')}
-        disabled={DISABLE_UNTIL_IMPLEMENTED}
-        onClick={noop}
-        testId={testIds.copy}
+    <>
+      <SimpleDropdownMenu
+        className={className}
+        buttonClassName={twJoin(
+          'flex h-11 w-11 items-center justify-center border border-grey',
+          'disabled:pointer-events-none disabled:bg-background disabled:opacity-70',
+        )}
+        tooltip={t('accessibility:common.actionMenu')}
+        alignItems={AlignDirection.Left}
+        testId={testIds.actionMenu}
+        disabled={!stop}
+      >
+        <SimpleDropdownMenuItem
+          text={t('stopDetails.actions.extra.copy')}
+          onClick={() => setShowCopyModal(true)}
+          testId={testIds.copy}
+        />
+      </SimpleDropdownMenu>
+
+      <CopyStopModal
+        isOpen={showCopyModal}
+        onClose={() => setShowCopyModal(false)}
+        originalStop={stop}
       />
-    </SimpleDropdownMenu>
+    </>
   );
 };

--- a/ui/src/components/stop-registry/stops/stop-details/title-row/OpenOnMapButton.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/title-row/OpenOnMapButton.tsx
@@ -5,6 +5,10 @@ import { StopWithDetails } from '../../../../../hooks';
 import { LocatorButton } from '../../../../../uiComponents';
 import { useOpenStopOnMap } from '../../../search/StopTableRow/utils';
 
+const testIds = {
+  button: 'StopTitleRow::openOnMapButton',
+};
+
 type OpenOnMapButtonProps = {
   readonly className?: string;
   readonly label: string;
@@ -30,6 +34,7 @@ export const OpenOnMapButton: FC<OpenOnMapButtonProps> = ({
       className={twMerge('h-11 w-11', className)}
       disabled={!stop}
       onClick={onClick}
+      testId={testIds.button}
       tooltipText={t('accessibility:common.showOnMap', { label })}
     />
   );

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -68007,6 +68007,50 @@ export type DeleteStopPlaceMutation = {
   } | null;
 };
 
+export type ResolveStopSheltersQueryVariables = Exact<{
+  netexId: Scalars['String']['input'];
+}>;
+
+export type ResolveStopSheltersQuery = {
+  __typename?: 'query_root';
+  stop_registry?: {
+    __typename?: 'stop_registryStopPlaceRegister';
+    stopPlace?: Array<
+      | { __typename?: 'stop_registry_ParentStopPlace'; id?: string | null }
+      | {
+          __typename?: 'stop_registry_StopPlace';
+          id?: string | null;
+          quays?: Array<{
+            __typename?: 'stop_registry_Quay';
+            id?: string | null;
+            placeEquipments?: {
+              __typename?: 'stop_registry_PlaceEquipments';
+              id?: string | null;
+              shelterEquipment?: Array<{
+                __typename?: 'stop_registry_ShelterEquipment';
+                id?: string | null;
+                enclosed?: boolean | null;
+                stepFree?: boolean | null;
+                shelterType?: StopRegistryShelterType | null;
+                shelterElectricity?: StopRegistryShelterElectricity | null;
+                shelterLighting?: boolean | null;
+                shelterCondition?: StopRegistryShelterCondition | null;
+                timetableCabinets?: number | null;
+                trashCan?: boolean | null;
+                shelterHasDisplay?: boolean | null;
+                bicycleParking?: boolean | null;
+                leaningRail?: boolean | null;
+                outsideBench?: boolean | null;
+                shelterFasciaBoardTaping?: boolean | null;
+              } | null> | null;
+            } | null;
+          } | null> | null;
+        }
+      | null
+    > | null;
+  } | null;
+};
+
 export type VehicleJourneyByStopFragment = {
   __typename?: 'timetables_vehicle_journey_vehicle_journey';
   journey_pattern_ref_id: UUID;
@@ -76581,6 +76625,97 @@ export type DeleteStopPlaceMutationResult =
 export type DeleteStopPlaceMutationOptions = Apollo.BaseMutationOptions<
   DeleteStopPlaceMutation,
   DeleteStopPlaceMutationVariables
+>;
+export const ResolveStopSheltersDocument = gql`
+  query ResolveStopShelters($netexId: String!) {
+    stop_registry {
+      stopPlace(id: $netexId) {
+        id
+        ... on stop_registry_StopPlace {
+          quays {
+            id
+            placeEquipments {
+              id
+              shelterEquipment {
+                ...shelter_equipment_details
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${ShelterEquipmentDetailsFragmentDoc}
+`;
+
+/**
+ * __useResolveStopSheltersQuery__
+ *
+ * To run a query within a React component, call `useResolveStopSheltersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useResolveStopSheltersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useResolveStopSheltersQuery({
+ *   variables: {
+ *      netexId: // value for 'netexId'
+ *   },
+ * });
+ */
+export function useResolveStopSheltersQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ResolveStopSheltersQuery,
+    ResolveStopSheltersQueryVariables
+  > &
+    (
+      | { variables: ResolveStopSheltersQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ResolveStopSheltersQuery,
+    ResolveStopSheltersQueryVariables
+  >(ResolveStopSheltersDocument, options);
+}
+export function useResolveStopSheltersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ResolveStopSheltersQuery,
+    ResolveStopSheltersQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ResolveStopSheltersQuery,
+    ResolveStopSheltersQueryVariables
+  >(ResolveStopSheltersDocument, options);
+}
+export function useResolveStopSheltersSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    ResolveStopSheltersQuery,
+    ResolveStopSheltersQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    ResolveStopSheltersQuery,
+    ResolveStopSheltersQueryVariables
+  >(ResolveStopSheltersDocument, options);
+}
+export type ResolveStopSheltersQueryHookResult = ReturnType<
+  typeof useResolveStopSheltersQuery
+>;
+export type ResolveStopSheltersLazyQueryHookResult = ReturnType<
+  typeof useResolveStopSheltersLazyQuery
+>;
+export type ResolveStopSheltersSuspenseQueryHookResult = ReturnType<
+  typeof useResolveStopSheltersSuspenseQuery
+>;
+export type ResolveStopSheltersQueryResult = Apollo.QueryResult<
+  ResolveStopSheltersQuery,
+  ResolveStopSheltersQueryVariables
 >;
 export const GetRouteWithJourneyPatternDocument = gql`
   query GetRouteWithJourneyPattern($routeId: uuid!) {

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -67995,6 +67995,18 @@ export type GetOrganisationsQuery = {
   } | null;
 };
 
+export type DeleteStopPlaceMutationVariables = Exact<{
+  stopPlaceId: Scalars['String']['input'];
+}>;
+
+export type DeleteStopPlaceMutation = {
+  __typename?: 'mutation_root';
+  stop_registry?: {
+    __typename?: 'stop_registryStopPlaceMutation';
+    deleteStopPlace?: boolean | null;
+  } | null;
+};
+
 export type VehicleJourneyByStopFragment = {
   __typename?: 'timetables_vehicle_journey_vehicle_journey';
   journey_pattern_ref_id: UUID;
@@ -76519,6 +76531,56 @@ export type GetOrganisationsSuspenseQueryHookResult = ReturnType<
 export type GetOrganisationsQueryResult = Apollo.QueryResult<
   GetOrganisationsQuery,
   GetOrganisationsQueryVariables
+>;
+export const DeleteStopPlaceDocument = gql`
+  mutation DeleteStopPlace($stopPlaceId: String!) {
+    stop_registry {
+      deleteStopPlace(stopPlaceId: $stopPlaceId)
+    }
+  }
+`;
+export type DeleteStopPlaceMutationFn = Apollo.MutationFunction<
+  DeleteStopPlaceMutation,
+  DeleteStopPlaceMutationVariables
+>;
+
+/**
+ * __useDeleteStopPlaceMutation__
+ *
+ * To run a mutation, you first call `useDeleteStopPlaceMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteStopPlaceMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteStopPlaceMutation, { data, loading, error }] = useDeleteStopPlaceMutation({
+ *   variables: {
+ *      stopPlaceId: // value for 'stopPlaceId'
+ *   },
+ * });
+ */
+export function useDeleteStopPlaceMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DeleteStopPlaceMutation,
+    DeleteStopPlaceMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    DeleteStopPlaceMutation,
+    DeleteStopPlaceMutationVariables
+  >(DeleteStopPlaceDocument, options);
+}
+export type DeleteStopPlaceMutationHookResult = ReturnType<
+  typeof useDeleteStopPlaceMutation
+>;
+export type DeleteStopPlaceMutationResult =
+  Apollo.MutationResult<DeleteStopPlaceMutation>;
+export type DeleteStopPlaceMutationOptions = Apollo.BaseMutationOptions<
+  DeleteStopPlaceMutation,
+  DeleteStopPlaceMutationVariables
 >;
 export const GetRouteWithJourneyPatternDocument = gql`
   query GetRouteWithJourneyPattern($routeId: uuid!) {

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -390,6 +390,28 @@
       "extra": {
         "copy": "Make a new copy"
       }
+    },
+    "version": {
+      "copyBoilerPlate": "All properties from the existing stop will be copied over. You can edit the properties of the new copy after its creation.",
+      "title": {
+        "edit": "Edit version",
+        "copy": "Copy a new version",
+        "copySubTitle": "New version details"
+      },
+      "fields": {
+        "versionName": "Version name",
+        "versionDescription": "Reason for change"
+      },
+      "success": {
+        "edit": "Version saved",
+        "copy": "New version created\nOpening up new version"
+      },
+      "errors": {
+        "copy": "Failed to save copy:\n{{reason}}",
+        "stopPlaceInsertFailed": "Failed to create entry in StopRegistry! Reason:\n{{reason}}",
+        "stopPointInsertFailedStopPlaceReverted": "Failed to create a scheduled stop point in the lines and routers database! Reason:\n{{reason}}",
+        "stopPointInsertFailedStopPlaceNotReverted": "Failed to create a scheduled stop point in the lines and routers database, and the previusly created entry in StopRegistry could be deleted. Jore databases contains errors. Reason:\n{{reason}}"
+      }
     }
   },
   "stopRegistrySearch": {

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -390,6 +390,28 @@
       "extra": {
         "copy": "Kopioi uudeksi versioksi"
       }
+    },
+    "version": {
+      "copyBoilerPlate": "Pysäkin kaikki ominaisuudet kopioidaan mukana. Voit muokata uuden version ominaisuuksia kopioinnin jälkeen.",
+      "title": {
+        "edit": "Muokkaa versiota",
+        "copy": "Kopioidaan uudeksi versioksi",
+        "copySubTitle": "Uuden version tiedot"
+      },
+      "fields": {
+        "versionName": "Version nimi",
+        "versionDescription": "Muutoksen peruste"
+      },
+      "success": {
+        "edit": "Versio tallennettu",
+        "copy": "Uusi versio luotu\nAvataan uusi versio"
+      },
+      "errors": {
+        "copy": "Kopion tallennus epäonnistui:\n{{reason}}",
+        "stopPlaceInsertFailed": "Pysäkkirekisteritietueen luonti epäonnistui! Syy:\n{{reason}}",
+        "stopPointInsertFailedStopPlaceReverted": "Pysähdyspisteen luonti linjastotietokantaan epäonnistui! Syy:\n{{reason}}",
+        "stopPointInsertFailedStopPlaceNotReverted": "Pysähdyspisteen luonti linjastotietokantaan epäonnistui eikä aiemmin luotua pysäkkirekisteritietuetta saatu poistettua. Jore tietokannoissa on nyt virheitä. Syy:\n{{reason}}"
+      }
     }
   },
   "stopRegistrySearch": {

--- a/ui/src/uiComponents/Toast.tsx
+++ b/ui/src/uiComponents/Toast.tsx
@@ -1,13 +1,14 @@
-import { ForwardRefRenderFunction, forwardRef } from 'react';
+import { ForwardRefRenderFunction, ReactNode, forwardRef } from 'react';
+import { twMerge } from 'tailwind-merge';
 import { Row } from '../layoutComponents';
 
 export type ToastType = 'primary' | 'success' | 'danger' | 'warning';
 
-interface Props {
-  message: string;
-  type?: ToastType;
-  className?: string;
-}
+type ToastProps = {
+  readonly className?: string;
+  readonly message: ReactNode;
+  readonly type?: ToastType;
+};
 
 const propsByType: Record<
   ToastType,
@@ -49,14 +50,15 @@ const propsByType: Record<
   },
 };
 
-const ToastImpl: ForwardRefRenderFunction<HTMLDivElement, Props> = (
-  { message, type = 'primary', className = '' },
+const ToastImpl: ForwardRefRenderFunction<HTMLDivElement, ToastProps> = (
+  { message, type = 'primary', className },
   ref,
 ) => {
   const { icon, textColor, bg, border, testId } = propsByType[type];
+
   return (
     <div
-      className={`rounded-md bg-white ${className}`}
+      className={twMerge(`rounded-md bg-white`, className)}
       data-test-element-type="toast"
       data-testid={testId}
       ref={ref}

--- a/ui/src/utils/toastService.tsx
+++ b/ui/src/utils/toastService.tsx
@@ -1,18 +1,23 @@
 import { ApolloError } from '@apollo/client';
+import { ReactNode } from 'react';
 import { toast } from 'react-hot-toast';
 import { Toast, ToastTransition, ToastType } from '../uiComponents';
 import { getApolloErrorMessage } from './apolloErrors';
 
-interface ToastOptions {
-  message: string;
-  type?: ToastType;
-}
+type ToastOptions = {
+  readonly className?: string;
+  readonly message: ReactNode;
+  readonly type?: ToastType;
+};
 
-export const showToast = (options: ToastOptions) => {
-  const { message, type = 'primary' } = options;
+export const showToast = ({
+  className,
+  message,
+  type = 'primary',
+}: ToastOptions) => {
   toast.custom((t) => (
     <ToastTransition show={t.visible}>
-      <Toast type={type} message={message} />
+      <Toast className={className} message={message} type={type} />
     </ToastTransition>
   ));
 };


### PR DESCRIPTION

### Improve Toast component


### Add StopVersionForm base implementation


### Add new Error classes needed for CopyStop -functionality


### Add DELETE StopPlace query to revert partial Stop copy


### Add utilities for mapping existing stop a new copy


### Add utilities needed to map Copied InfoSpots to new shelters
Shelters don't have specific ID that could be used to match the old
version to the new one. Thus we need to equality checking in order to
attach the InfoSpots to them once they are copied.

By default the matching happens based on the Shelters properties, but
if there are multiple identical Shelters a index based 🤞🏻olution is
used instead. But technically the Shelters are not ordered in anyway
on the DB levels, thus the indexes might chance. Tough in practice
PostgreSQL should return data in INSERT order, and the insertion the
Shelter copies should also happen in specific order.


### Add utilites to perform the actual copying of a Stop(Place)


### Implement the actial CopyModal


### Add CopyStop -action to ExtraActions menu


### E2E: Add tests for copying a Stop(Place)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/973)
<!-- Reviewable:end -->
