### PR TITLE
E2E: Improvements

### DIFF
--- a/cypress/e2e/commonSubstituteDays.cy.ts
+++ b/cypress/e2e/commonSubstituteDays.cy.ts
@@ -99,8 +99,7 @@ describe('Common substitute operating periods', () => {
       substituteDaySettingsPage.commonSubstitutePeriodForm
         .getSaveButton()
         .click();
-      toast.checkSuccessToastHasMessage('Tallennus onnistui');
-      toast.getSuccessToast().should('not.exist');
+      toast.expectSuccessToast('Tallennus onnistui');
 
       // Navigate to the vehicleSchedule page
       substituteDaySettingsPage.commonSubstitutePeriodForm
@@ -216,7 +215,7 @@ describe('Common substitute operating periods', () => {
         'Tapaninpäivä 2023',
       );
 
-      toast.checkSuccessToastHasMessage('Tallennus onnistui');
+      toast.expectSuccessToast('Tallennus onnistui');
 
       // And navigate again to the vehicle schedules
       substituteDaySettingsPage.commonSubstitutePeriodForm
@@ -327,7 +326,7 @@ describe('Common substitute operating periods', () => {
       substituteDaySettingsPage.commonSubstitutePeriodForm
         .getSaveButton()
         .click();
-      toast.checkSuccessToastHasMessage('Tallennus onnistui');
+      toast.expectSuccessToast('Tallennus onnistui');
 
       // Navigate to the vehicleSchedule page
       substituteDaySettingsPage.commonSubstitutePeriodForm
@@ -468,7 +467,7 @@ describe('Common substitute operating periods', () => {
           .getSaveButton()
           .click();
 
-        toast.checkSuccessToastHasMessage('Tallennus onnistui');
+        toast.expectSuccessToast('Tallennus onnistui');
 
         // Make sure the page is clear
         substituteDaySettingsPage.observationPeriodForm.setObservationPeriod(
@@ -497,7 +496,7 @@ describe('Common substitute operating periods', () => {
         substituteDaySettingsPage.commonSubstitutePeriodForm
           .getSaveButton()
           .click();
-        substituteDaySettingsPage.toast.checkDangerToastHasMessage(
+        substituteDaySettingsPage.toast.expectDangerToast(
           'Tallennus epäonnistui: GraphQL errors: Exclusion violation. conflicting key ' +
             'value violates exclusion constraint "substitute_operating_day_by_line_type_no_timespan_overlap"',
         );

--- a/cypress/e2e/editRoute.cy.ts
+++ b/cypress/e2e/editRoute.cy.ts
@@ -139,7 +139,7 @@ describe('Route editing', () => {
 
       editRoutePage.confirmationDialog.getConfirmButton().click();
       expectGraphQLCallToSucceed('@gqlDeleteRoute');
-      toast.checkSuccessToastHasMessage('Reitti poistettu');
+      toast.expectSuccessToast('Reitti poistettu');
 
       routeRow
         .getRouteHeaderRow('901', RouteDirectionEnum.Outbound)

--- a/cypress/e2e/editStop.cy.ts
+++ b/cypress/e2e/editStop.cy.ts
@@ -19,6 +19,7 @@ import {
   StopForm,
   StopFormInfo,
   Toast,
+  ToastType,
 } from '../pageObjects';
 import { UUID } from '../types';
 import { SupportedResources, insertToDbHelper } from '../utils';
@@ -127,7 +128,7 @@ describe('Stop editing tests', () => {
         });
       });
 
-      toast.checkSuccessToastHasMessage('Pysäkki muokattu');
+      toast.expectSuccessToast('Pysäkki muokattu');
 
       map.waitForLoadToComplete();
 
@@ -160,7 +161,7 @@ describe('Stop editing tests', () => {
 
       expectGraphQLCallToSucceed('@gqlRemoveStop');
 
-      toast.checkSuccessToastHasMessage('Pysäkki poistettu');
+      toast.expectSuccessToast('Pysäkki poistettu');
 
       map
         .getStopByStopLabelAndPriority(stops[0].label, stops[0].priority)
@@ -216,7 +217,10 @@ describe('Stop editing tests', () => {
         });
       });
 
-      toast.checkSuccessToastHasMessage('Pysäkki muokattu');
+      toast.expectMultipleToasts([
+        { type: ToastType.SUCCESS, message: 'Pysäkki muokattu' },
+        { type: ToastType.WARNING, message: 'Pysäkkien suodattimia muutettu' },
+      ]);
 
       map
         .getStopByStopLabelAndPriority(
@@ -270,7 +274,7 @@ describe('Stop editing tests', () => {
 
       confirmationDialog.getConfirmButton().click();
 
-      toast.checkSuccessToastHasMessage('Hastus-paikka luotu');
+      toast.expectSuccessToast('Hastus-paikka luotu');
 
       expectGraphQLCallToSucceed('@gqlEditStop');
 
@@ -311,7 +315,7 @@ describe('Stop editing tests', () => {
     stopForm.save();
     confirmationDialog.getConfirmButton().click();
 
-    toast.checkDangerToastHasMessage(
+    toast.expectDangerToast(
       'Tallennus epäonnistui, ApolloError: range lower bound must be less than or equal to range upper bound, range lower bound must be less than or equal to range upper bound',
     );
     expectGraphQLCallToReturnError('@gqlEditStop');

--- a/cypress/e2e/hastusExport.cy.ts
+++ b/cypress/e2e/hastusExport.cy.ts
@@ -150,7 +150,7 @@ describe('Hastus export', () => {
           .getRouteLineTableRowCheckbox('901')
           .check();
         routesAndLinesPage.exportToolBar.getExportSelectedButton().click();
-        routesAndLinesPage.toast.checkDangerToastHasMessage(
+        routesAndLinesPage.toast.expectDangerToast(
           'Seuraavia reittejä ei voida viedä: 901 (outbound). Ensimmäisen ja viimeisen pysäkin täytyy olla asetettuna käyttämään Hastus-paikkaa.',
         );
       },
@@ -190,7 +190,7 @@ describe('Hastus export', () => {
           .getRouteLineTableRowCheckbox('901')
           .check();
         routesAndLinesPage.exportToolBar.getExportSelectedButton().click();
-        routesAndLinesPage.toast.checkDangerToastHasMessage(
+        routesAndLinesPage.toast.expectDangerToast(
           'Seuraavia reittejä ei voida viedä: 901 (outbound). Ensimmäisen ja viimeisen pysäkin täytyy olla asetettuna käyttämään Hastus-paikkaa.',
         );
       },
@@ -247,7 +247,7 @@ describe('Hastus export', () => {
           .getRouteLineTableRowCheckbox('901')
           .check();
         routesAndLinesPage.exportToolBar.getExportSelectedButton().click();
-        routesAndLinesPage.toast.checkDangerToastHasMessage(
+        routesAndLinesPage.toast.expectDangerToast(
           'Seuraavia reittejä ei voida viedä: 901 (outbound). Ensimmäisen ja viimeisen pysäkin täytyy olla asetettuna käyttämään Hastus-paikkaa.',
         );
       },

--- a/cypress/e2e/map/createRoute.cy.ts
+++ b/cypress/e2e/map/createRoute.cy.ts
@@ -125,7 +125,7 @@ describe('Route creation', () => {
       mapModal.map.getLoader().should('not.exist');
 
       mapFooter.save();
-      toast.checkSuccessToastHasMessage('Reitti tallennettu');
+      toast.expectSuccessToast('Reitti tallennettu');
 
       // Check from routeStopsOverlay that everything is correct
       routeStopsOverlay
@@ -207,7 +207,7 @@ describe('Route creation', () => {
       });
 
       mapFooter.save();
-      toast.checkSuccessToastHasMessage('Reitti tallennettu');
+      toast.expectSuccessToast('Reitti tallennettu');
 
       routeStopsOverlay
         .getHeader()
@@ -282,7 +282,7 @@ describe('Route creation', () => {
       });
 
       mapFooter.save();
-      toast.checkDangerToastHasMessage(
+      toast.expectDangerToast(
         'Tallennus epäonnistui: Reitillä on oltava ainakin kaksi pysäkkiä.',
       );
     },
@@ -339,7 +339,7 @@ describe('Route creation', () => {
       mapModal.map.getLoader().should('not.exist');
 
       mapFooter.save();
-      toast.checkSuccessToastHasMessage('Reitti tallennettu');
+      toast.expectSuccessToast('Reitti tallennettu');
     },
   );
 

--- a/cypress/e2e/map/editStopAreas.cy.ts
+++ b/cypress/e2e/map/editStopAreas.cy.ts
@@ -83,6 +83,7 @@ describe('Stop areas on map', () => {
     });
 
     expectGraphQLCallToSucceed('@gqlGetStopAreasByLocation');
+    mapModal.map.waitForLoadToComplete();
   });
 
   it('should create new stop area with member stops', () => {

--- a/cypress/e2e/occasionalSubstituteDays.cy.ts
+++ b/cypress/e2e/occasionalSubstituteDays.cy.ts
@@ -103,7 +103,7 @@ describe('Occasional substitute operating periods', () => {
       substituteDaySettingsPage.occasionalSubstitutePeriodForm
         .getSaveButton()
         .click();
-      toast.checkSuccessToastHasMessage('Tallennus onnistui');
+      toast.expectSuccessToast('Tallennus onnistui');
 
       // Navigate to route's timetable
       navbar.getTimetablesLink().click();
@@ -259,7 +259,7 @@ describe('Occasional substitute operating periods', () => {
       substituteDaySettingsPage.occasionalSubstitutePeriodForm
         .getSaveButton()
         .click();
-      toast.checkSuccessToastHasMessage('Tallennus onnistui');
+      toast.expectSuccessToast('Tallennus onnistui');
 
       // Navigate to route's timetable
       navbar.getTimetablesLink().click();
@@ -341,7 +341,7 @@ describe('Occasional substitute operating periods', () => {
       substituteDaySettingsPage.occasionalSubstitutePeriodForm
         .getSaveButton()
         .click();
-      toast.checkSuccessToastHasMessage('Tallennus onnistui');
+      toast.expectSuccessToast('Tallennus onnistui');
 
       // Navigate to route's timetable
       navbar.getTimetablesLink().click();

--- a/cypress/e2e/routeStops.cy.ts
+++ b/cypress/e2e/routeStops.cy.ts
@@ -157,7 +157,7 @@ describe('Line details page: stops on route', () => {
         });
       });
 
-      toast.checkSuccessToastHasMessage('Reitti tallennettu');
+      toast.expectSuccessToast('Reitti tallennettu');
 
       lineRouteList.getNthLineRouteListItem(0).within(() => {
         // Verify that E2E003 is now part of the route
@@ -179,10 +179,7 @@ describe('Line details page: stops on route', () => {
         });
       });
 
-      // TODO: Until we can close toast messages, we have to check that both of them
-      // contains success message, because they are both visible at the same time.
-      toast.getSuccessToast().eq(0).shouldHaveText('Reitti tallennettu');
-      toast.getSuccessToast().eq(1).shouldHaveText('Reitti tallennettu');
+      toast.expectSuccessToast('Reitti tallennettu');
 
       lineRouteList.getNthLineRouteListItem(0).within(() => {
         // Verify that E2E004 is no longer part of route
@@ -241,9 +238,7 @@ describe('Line details page: stops on route', () => {
         });
       });
 
-      toast.checkDangerToastHasMessage(
-        'Reitillä on oltava ainakin kaksi pysäkkiä.',
-      );
+      toast.expectDangerToast('Reitillä on oltava ainakin kaksi pysäkkiä.');
     },
   );
 
@@ -279,7 +274,7 @@ describe('Line details page: stops on route', () => {
 
       viaForm.getSaveButton().click();
 
-      toast.checkSuccessToastHasMessage('Via-tieto asetettu');
+      toast.expectSuccessToast('Via-tieto asetettu');
 
       // Check that via-icon exists and all info is saved
       lineRouteListItem.getNthRouteStopListItem(2).within(() => {
@@ -294,7 +289,7 @@ describe('Line details page: stops on route', () => {
       viaForm.getViaSwedishShortNameInput().should('have.value', 'Kort namn');
 
       viaForm.getRemoveButton().click();
-      toast.checkSuccessToastHasMessage('Via-tieto poistettu');
+      toast.expectSuccessToast('Via-tieto poistettu');
 
       // Check that via-icon no longer exists and the create via button is visible
       lineRouteListItem.getNthRouteStopListItem(2).within(() => {
@@ -354,7 +349,7 @@ describe('Line details page: stops on route', () => {
       timingSettingsForm.getIsLoadingTimeAllowedCheckbox().check();
 
       timingSettingsForm.getSavebutton().click();
-      toast.checkSuccessToastHasMessage('Aika-asetusten tallennus onnistui');
+      toast.expectSuccessToast('Aika-asetusten tallennus onnistui');
 
       lineRouteList.getNthLineRouteListItem(0).within(() => {
         lineRouteListItem.getNthRouteStopListItem(2).within(() => {

--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -280,7 +280,6 @@ describe('Stop area details', () => {
     function waitForSaveToBeFinished() {
       expectGraphQLCallToSucceed('@gqlUpsertStopArea');
       toast.expectSuccessToast('Pysäkkialue muokattu');
-      toast.getSuccessToast().should('not.exist');
     }
 
     function inputBasicDetails(inputs: ExpectedBasicDetails) {

--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -609,6 +609,8 @@ describe('Stop details', () => {
           .click();
 
         stopDetailsPage.basicDetails.getSaveButton().click();
+        toast.expectSuccessToast('Pysäkki muokattu');
+
         bdView.getTransportMode().shouldHaveText('Raitiovaunu');
         bdView.getStopState().shouldHaveText('Käytössä');
         bdView.getTimingPlaceId().shouldHaveText('1AACKT');

--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -2294,7 +2294,7 @@ describe('Stop details', () => {
           form.submitButton().click();
         });
 
-      toast.expectSuccessToast('Uusi versio luotu Avataan uusi versio');
+      toast.expectSuccessToast('Uusi versio luotu\nAvataan uusi versio');
       copyModal.modal().should('not.exist');
       stopDetailsPage.loadingStopDetails().should('not.exist');
 

--- a/cypress/e2e/timetableImport.cy.ts
+++ b/cypress/e2e/timetableImport.cy.ts
@@ -99,7 +99,7 @@ describe('Timetable import', () => {
       timetablesMainPage.getImportButton().click();
       importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
       importTimetablesPage.getUploadButton().click();
-      importTimetablesPage.toast.checkSuccessToastHasMessage(
+      importTimetablesPage.toast.expectSuccessToast(
         `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
       );
       // Files uploaded -> nothing left to upload.
@@ -215,7 +215,7 @@ describe('Timetable import', () => {
         });
 
       previewTimetablesPage.getSaveButton().click();
-      importTimetablesPage.toast.checkSuccessToastHasMessage(
+      importTimetablesPage.toast.expectSuccessToast(
         'Aikataulujen tuonti onnistui!',
       );
 
@@ -435,10 +435,10 @@ describe('Timetable import', () => {
         ]);
         importTimetablesPage.getUploadButton().click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME_2} lataus onnistui`,
         );
 
@@ -490,7 +490,7 @@ describe('Timetable import', () => {
           });
 
         previewTimetablesPage.getSaveButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
       },
@@ -516,7 +516,7 @@ describe('Timetable import', () => {
         importTimetablesPage.selectFilesToImport([IMPORT_FILENAME]);
         importTimetablesPage.getUploadButton().click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -538,7 +538,7 @@ describe('Timetable import', () => {
           });
 
         previewTimetablesPage.getSaveButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
 
@@ -624,7 +624,7 @@ describe('Timetable import', () => {
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -646,7 +646,7 @@ describe('Timetable import', () => {
           });
 
         previewTimetablesPage.getSaveButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
 
@@ -738,7 +738,7 @@ describe('Timetable import', () => {
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -791,7 +791,7 @@ describe('Timetable import', () => {
           });
 
         previewTimetablesPage.getSaveButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
 
@@ -873,7 +873,7 @@ describe('Timetable import', () => {
         ]);
         importTimetablesPage.getUploadButton().click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -907,12 +907,12 @@ describe('Timetable import', () => {
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
         importTimetablesPage.getAbortButton().click();
         importTimetablesPage.confirmationDialog.getConfirmButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti keskeytetty',
         );
 

--- a/cypress/e2e/timetableValidityPeriod.cy.ts
+++ b/cypress/e2e/timetableValidityPeriod.cy.ts
@@ -112,7 +112,7 @@ describe('Timetable validity period', () => {
         routeTimetablesSection.getLoader().shouldBeVisible();
         routeTimetablesSection.getLoader().should('not.exist');
 
-        vehicleScheduleDetailsPage.toast.checkSuccessToastHasMessage(
+        vehicleScheduleDetailsPage.toast.expectSuccessToast(
           'Aikataulun voimassaolo tallennettu',
         );
 
@@ -220,7 +220,7 @@ describe('Timetable validity period', () => {
         routeTimetablesSection.getLoader().shouldBeVisible();
         routeTimetablesSection.getLoader().should('not.exist');
 
-        vehicleScheduleDetailsPage.toast.checkSuccessToastHasMessage(
+        vehicleScheduleDetailsPage.toast.expectSuccessToast(
           'Aikataulun voimassaolo tallennettu',
         );
 
@@ -329,7 +329,7 @@ describe('Timetable validity period', () => {
           .getSaveButton()
           .click();
 
-        vehicleScheduleDetailsPage.toast.checkDangerToastHasMessage(
+        vehicleScheduleDetailsPage.toast.expectDangerToast(
           'Tallennus epäonnistui: GraphQL errors: conflicting schedules detected',
         );
       },

--- a/cypress/e2e/timetableVersionDetailsPanel.cy.ts
+++ b/cypress/e2e/timetableVersionDetailsPanel.cy.ts
@@ -218,7 +218,7 @@ describe('Timetable version details panel', () => {
     changeTimetablesValidityForm.setValidityEndDate('2024-03-31');
     changeTimetablesValidityForm.getSaveButton().click();
 
-    toast.getSuccessToast().should('be.visible');
+    toast.expectSuccessToast('Aikataulun voimassaolo tallennettu');
 
     // Check that the panel heading's validity changed
     timetableVersionDetailsPanel

--- a/cypress/e2e/timetablesReplaceAndCombine.cy.ts
+++ b/cypress/e2e/timetablesReplaceAndCombine.cy.ts
@@ -113,14 +113,14 @@ describe('Timetable replacement and combination', () => {
         timetablesMainPage.getImportButton().click();
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
         importTimetablesPage.clickPreviewButton();
         previewTimetablesPage.priorityForm.setAsStandard();
         previewTimetablesPage.getSaveButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
 
@@ -226,7 +226,7 @@ describe('Timetable replacement and combination', () => {
         timetablesMainPage.getImportButton().click();
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -240,7 +240,7 @@ describe('Timetable replacement and combination', () => {
           .getSaveButton()
           .click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
       },
@@ -305,7 +305,7 @@ describe('Timetable replacement and combination', () => {
         timetablesMainPage.getImportButton().click();
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -316,7 +316,7 @@ describe('Timetable replacement and combination', () => {
           .check();
 
         previewTimetablesPage.getSaveButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
 
@@ -507,7 +507,7 @@ describe('Timetable replacement and combination', () => {
         timetablesMainPage.getImportButton().click();
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -520,7 +520,7 @@ describe('Timetable replacement and combination', () => {
           .getSaveButton()
           .click();
 
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           'Aikataulujen tuonti onnistui!',
         );
       },
@@ -572,7 +572,7 @@ describe('Timetable replacement and combination', () => {
         timetablesMainPage.getImportButton().click();
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 
@@ -661,7 +661,7 @@ describe('Timetable replacement and combination', () => {
         timetablesMainPage.getImportButton().click();
         importTimetablesPage.selectFileToImport(IMPORT_FILENAME);
         importTimetablesPage.getUploadButton().click();
-        importTimetablesPage.toast.checkSuccessToastHasMessage(
+        importTimetablesPage.toast.expectSuccessToast(
           `Tiedoston ${IMPORT_FILENAME} lataus onnistui`,
         );
 

--- a/cypress/pageObjects/CommonSubstitutePeriodForm.ts
+++ b/cypress/pageObjects/CommonSubstitutePeriodForm.ts
@@ -23,10 +23,10 @@ export class CommonSubstitutePeriodForm {
           .click();
         cy.get('[role="option"]').contains(values.substituteDay).click();
 
-        if (values.lineTypes) {
+        if (values.lineTypes?.length) {
           this.commonSubstitutePeriodItem.getLineTypeDropdown().click();
 
-          cy.wrap(values.lineTypes).each((lineType: string) => {
+          values.lineTypes.forEach((lineType: string) => {
             this.commonSubstitutePeriodItem
               .getLineTypesList()
               .find('[role="option"]')

--- a/cypress/pageObjects/LineForm.ts
+++ b/cypress/pageObjects/LineForm.ts
@@ -59,6 +59,6 @@ export class LineForm {
   }
 
   checkLineSubmitSuccess() {
-    this.toast.checkSuccessToastHasMessage('Linja tallennettu');
+    this.toast.expectSuccessToast('Linja tallennettu');
   }
 }

--- a/cypress/pageObjects/MapModal.ts
+++ b/cypress/pageObjects/MapModal.ts
@@ -54,7 +54,7 @@ export class MapModal {
   };
 
   checkStopSubmitSuccessToast() {
-    this.toast.checkSuccessToastHasMessage('Pysäkki luotu');
+    this.toast.expectSuccessToast('Pysäkki luotu');
   }
 
   gqlStopShouldBeCreatedSuccessfully() {

--- a/cypress/pageObjects/OccasionalSubstitutePeriodForm.ts
+++ b/cypress/pageObjects/OccasionalSubstitutePeriodForm.ts
@@ -78,7 +78,7 @@ export class OccasionalSubstitutePeriodForm {
     this.getOccasionalSubstitutePeriodFormLineTypesDropdown().click();
     cy.get('[role="option"]').contains('Kaikki').click();
 
-    cy.wrap(lineTypes).each((lineType: string) => {
+    lineTypes.forEach((lineType: string) => {
       cy.get('[role="option"]').contains(lineType).click();
     });
 

--- a/cypress/pageObjects/RouteEditor.ts
+++ b/cypress/pageObjects/RouteEditor.ts
@@ -24,6 +24,6 @@ export class RouteEditor {
   }
 
   checkRouteSubmitSuccessToast() {
-    this.toast.checkSuccessToastHasMessage('Reitti tallennettu');
+    this.toast.expectSuccessToast('Reitti tallennettu');
   }
 }

--- a/cypress/pageObjects/Toast.ts
+++ b/cypress/pageObjects/Toast.ts
@@ -6,43 +6,11 @@ export enum ToastType {
 }
 
 export class Toast {
-  getToastByType(toastType: ToastType) {
-    return cy.getByTestId(toastType);
-  }
-
-  getPrimaryToast() {
-    return this.getToastByType(ToastType.PRIMARY);
-  }
-
-  getSuccessToast() {
-    return this.getToastByType(ToastType.SUCCESS);
-  }
-
-  getDangerToast() {
-    return this.getToastByType(ToastType.DANGER);
-  }
-
-  getWarningToast() {
-    return this.getToastByType(ToastType.WARNING);
-  }
-
-  checkToastHasMessage(message: string, toastType: ToastType) {
-    this.getToastByType(toastType).contains(message);
-  }
-
-  checkDangerToastHasMessage(message: string) {
-    this.getDangerToast().contains(message);
-  }
-
-  checkSuccessToastHasMessage(message: string) {
-    this.getSuccessToast().contains(message);
-  }
-
-  checkWarningToastHasMessage(message: string) {
-    this.getWarningToast().contains(message);
-  }
-
-  expectToast(toastType: ToastType, message?: string) {
+  expectToast(
+    toastType: ToastType,
+    message: string = '',
+    dismiss: boolean = true,
+  ) {
     // Find any toast
     cy.get('[data-test-element-type="toast"]')
       // And wait it to become fully visible
@@ -51,26 +19,53 @@ export class Toast {
       .then((toast) => {
         // eslint-disable-next-line jest/valid-expect
         expect(toast).have.attr('data-testid', toastType);
+
+        if (message) {
+          // eslint-disable-next-line jest/valid-expect
+          expect(toast).to.contain(message);
+        }
+
+        if (dismiss) {
+          toast.find('[data-testid="Toast::closeButton"]').trigger('click');
+        }
       });
-
-    if (message) {
-      this.checkToastHasMessage(message, toastType);
-    }
   }
 
-  expectPrimaryToast(message?: string) {
-    this.expectToast(ToastType.PRIMARY, message);
+  expectMultipleToasts(
+    messages: ReadonlyArray<{
+      readonly type: ToastType;
+      readonly message: string;
+    }>,
+  ) {
+    messages.forEach(({ type, message }) => {
+      cy.get(`[data-test-element-type="toast"][data-testid=${type}]`)
+        // And wait it to become fully visible
+        .should('have.css', 'opacity', '1')
+        // Then assert it is of a right type.
+        .should((toast) => {
+          // eslint-disable-next-line jest/valid-expect
+          expect(toast).to.contain(message);
+          return toast;
+        })
+        .then((toast) =>
+          toast.find('[data-testid="Toast::closeButton"]').trigger('click'),
+        );
+    });
   }
 
-  expectSuccessToast(message?: string) {
-    this.expectToast(ToastType.SUCCESS, message);
+  expectPrimaryToast(message?: string, dismiss?: boolean) {
+    this.expectToast(ToastType.PRIMARY, message, dismiss);
   }
 
-  expectDangerToast(message?: string) {
-    this.expectToast(ToastType.DANGER, message);
+  expectSuccessToast(message?: string, dismiss?: boolean) {
+    this.expectToast(ToastType.SUCCESS, message, dismiss);
   }
 
-  expectWarningToast(message?: string) {
-    this.expectToast(ToastType.WARNING, message);
+  expectDangerToast(message?: string, dismiss?: boolean) {
+    this.expectToast(ToastType.DANGER, message, dismiss);
+  }
+
+  expectWarningToast(message?: string, dismiss?: boolean) {
+    this.expectToast(ToastType.WARNING, message, dismiss);
   }
 }

--- a/ui/src/uiComponents/Toast.tsx
+++ b/ui/src/uiComponents/Toast.tsx
@@ -1,12 +1,18 @@
-import { ForwardRefRenderFunction, ReactNode, forwardRef } from 'react';
-import { twMerge } from 'tailwind-merge';
+import React, { ForwardRefRenderFunction, ReactNode, forwardRef } from 'react';
+import { toast } from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { twJoin, twMerge } from 'tailwind-merge';
 import { Row } from '../layoutComponents';
+import { IconButton } from './IconButton';
+
+const testIds = { closeButton: 'Toast::closeButton' };
 
 export type ToastType = 'primary' | 'success' | 'danger' | 'warning';
 
 type ToastProps = {
   readonly className?: string;
   readonly message: ReactNode;
+  readonly toastId: string;
   readonly type?: ToastType;
 };
 
@@ -51,9 +57,11 @@ const propsByType: Record<
 };
 
 const ToastImpl: ForwardRefRenderFunction<HTMLDivElement, ToastProps> = (
-  { message, type = 'primary', className },
+  { message, type = 'primary', toastId, className },
   ref,
 ) => {
+  const { t } = useTranslation();
+
   const { icon, textColor, bg, border, testId } = propsByType[type];
 
   return (
@@ -64,7 +72,18 @@ const ToastImpl: ForwardRefRenderFunction<HTMLDivElement, ToastProps> = (
       ref={ref}
     >
       <div className={`${bg} ${border} rounded-md border`}>
-        <Row className="my-6 ml-16 mr-16 items-center">
+        <Row>
+          <IconButton
+            tooltip={t('close')}
+            icon={
+              <i className={twJoin(`icon-close-large text-lg`, textColor)} />
+            }
+            className="-mb-2 ml-auto px-4 pt-2"
+            onClick={() => toast.dismiss(toastId)}
+            testId={testIds.closeButton}
+          />
+        </Row>
+        <Row className="mx-16 mb-6 items-center">
           <i className={icon} />
           <p className={`${textColor} ml-2 text-sm`}>{message}</p>
         </Row>

--- a/ui/src/utils/toastService.tsx
+++ b/ui/src/utils/toastService.tsx
@@ -17,7 +17,12 @@ export const showToast = ({
 }: ToastOptions) => {
   toast.custom((t) => (
     <ToastTransition show={t.visible}>
-      <Toast className={className} message={message} type={type} />
+      <Toast
+        className={className}
+        message={message}
+        toastId={t.id}
+        type={type}
+      />
     </ToastTransition>
   ));
 };


### PR DESCRIPTION
### Add close button to Toasts


### E2E: Add missing 'Save succeeded' check


### E2E: StopAreas - Wait for loaders to close on beforeEach


### E2E: Avoid unneeded cy.wrap calls on arrays


### E2E: Replace all old Toas message checks with proper expections
The old way would silently fail in case a toas of different type spawned on screen. For example if a form save failed, instead of being notified about that, Cypress would just say that the success Toas was newer on screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/977)
<!-- Reviewable:end -->
