### PR TITLE
Add support for running headless Cypress in 4K

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -13,37 +13,11 @@ jobs:
       CYPRESS_IMAGE_NAME: hsldevcom/jore4-cypress
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
       - name: Extract metadata to env variables
         uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
 
-      - name: Start e2e env
-        uses: HSLdevcom/jore4-tools/github-actions/setup-e2e-environment@setup-e2e-environment-v8
+      - name: Setup environment and run e2e tests from GitHub action
+        uses: HSLdevcom/jore4-tools/github-actions/run-ci@main
         with:
           ui_version: '${{ env.IMAGE_NAME }}:${{ env.COMMIT_ID }}'
           cypress_version: '${{ env.CYPRESS_IMAGE_NAME }}:${{ env.COMMIT_ID }}'
-
-      - name: Set up PostgreSQL client
-        run: |
-          sudo apt-get -yqq install postgresql-client
-
-      - name: Seed db with infrastructure links
-        env:
-          DUMP_PATH: ./test-db-manager/src/dumps/infraLinks/infraLinks.sql
-        run: |
-          psql postgresql://dbadmin:adminpassword@localhost:6432/jore4e2e < ${{ env.DUMP_PATH }}
-
-      - name: Seed Tiamat DB
-        run: scripts/seed-municipalities-and-fare-zones.sh 3010
-
-      - name: Run e2e tests from GitHub action
-        env:
-          CYPRESS_TESTS_KEPT_IN_MEMORY: 0
-        timeout-minutes: 30
-        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v3-wip
-        with:
-          test-tags: ''

--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -44,6 +44,6 @@ jobs:
         env:
           CYPRESS_TESTS_KEPT_IN_MEMORY: 0
         timeout-minutes: 30
-        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v1
+        uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v3-wip
         with:
           test-tags: ''

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress';
 import * as tasks from './e2e/utils/tasks';
+import { onLaunchBrowser } from './support/setHeadlessScreenSize';
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({
@@ -31,6 +32,7 @@ export default defineConfig({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     setupNodeEvents(on, config) {
       on('task', tasks);
+      on('before:browser:launch', onLaunchBrowser);
     },
     env: process.env,
   },

--- a/cypress/run_cypress_in_4K_xvfb.sh
+++ b/cypress/run_cypress_in_4K_xvfb.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+trap "pkill Xvfb" EXIT
+
+export CYPRESS_SCREEN_WIDTH=3840
+export CYPRESS_SCREEN_HEIGHT=2160
+export CYPRESS_VIEWPORT_WIDTH=3000
+export CYPRESS_VIEWPORT_HEIGHT=1800
+
+export DISPLAY=:91
+
+runArgs=(ws:e2e)
+
+if [[ $TEST_VIDEO = "true" ]]; then
+  runArgs+=(cy:run:video)
+else
+  runArgs+=(cy:run)
+fi
+
+if [[ -n $TEST_TAGS ]]; then
+  runArgs+=(--env grepTags=\'"${TEST_TAGS}"\')
+fi
+
+# Start a "virtual" X11 framebuffer server with a 4K resolution.
+Xvfb -screen 0 ${CYPRESS_SCREEN_WIDTH}x${CYPRESS_SCREEN_HEIGHT}x24 $DISPLAY &
+
+yarn "${runArgs[@]}"

--- a/cypress/support/setHeadlessScreenSize.ts
+++ b/cypress/support/setHeadlessScreenSize.ts
@@ -1,0 +1,103 @@
+/* eslint-disable no-console */
+
+// Original code from: https://www.cypress.io/blog/generate-high-resolution-videos-and-screenshots
+
+// let's increase the browser window size when running headlessly
+// this will produce higher resolution images and videos
+// https://on.cypress.io/browser-launch-api
+
+/**
+ * The browser width and height we want to get our screenshots and videos
+ * will be of that resolution. + Normal launch options
+ *
+ * @param width
+ * @param height
+ * @param browser
+ * @param launchOptions
+ */
+function launchHeadlessBrowserWithScreenSize(
+  width: number,
+  height: number,
+  browser: Cypress.Browser,
+  launchOptions: Cypress.BeforeBrowserLaunchOptions,
+): Cypress.BeforeBrowserLaunchOptions {
+  console.log('Setting the browser window size to %d x %d', width, height);
+
+  if (browser.name === 'chrome') {
+    return {
+      ...launchOptions,
+      args: launchOptions.args.concat(
+        `--window-size=${width},${height}`,
+        // force screen to be non-retina and just use our given resolution
+        '--force-device-scale-factor=1',
+      ),
+    };
+  }
+
+  if (browser.name === 'electron') {
+    return {
+      ...launchOptions,
+      preferences: {
+        ...launchOptions.preferences,
+        // might not work on CI for some reason
+        width,
+        height,
+      },
+    };
+  }
+
+  if (browser.name === 'firefox') {
+    return {
+      ...launchOptions,
+      args: launchOptions.args.concat(`--width=${width}`, `--height=${height}`),
+    };
+  }
+
+  return launchOptions;
+}
+
+export function onLaunchBrowser(
+  browser: Cypress.Browser,
+  launchOptions: Cypress.BeforeBrowserLaunchOptions,
+): Cypress.BeforeBrowserLaunchOptions {
+  console.log(
+    'Launching browser %s | is headless? %s',
+    browser.name,
+    browser.isHeadless,
+  );
+
+  if (!browser.isHeadless) {
+    console.log('Not headless - Launching with default options!');
+    return launchOptions;
+  }
+
+  const rawWidth = process.env.CYPRESS_SCREEN_WIDTH;
+  const rawHeight = process.env.CYPRESS_SCREEN_HEIGHT;
+  const width = Number(rawWidth);
+  const height = Number(rawHeight);
+
+  if (Number.isInteger(width) && Number.isInteger(height)) {
+    console.log(
+      'Headless - Found proper width and height - Launching with custom size!',
+    );
+    return launchHeadlessBrowserWithScreenSize(
+      width,
+      height,
+      browser,
+      launchOptions,
+    );
+  }
+
+  if (rawWidth || rawHeight) {
+    throw new Error(
+      `Cannot launch headless browser! Found invalid screen size env variables: CYPRESS_SCREEN_WIDTH=${rawWidth} | CYPRESS_SCREEN_HEIGHT=${rawHeight}`,
+    );
+  }
+
+  console.log('Headless - Launching with default options!');
+  return launchOptions;
+}
+
+export function registerBrowserLaunchHook() {
+  console.log('Registering custom browser launcher hook!');
+}


### PR DESCRIPTION
### Add support for running headless Cypress in 4K
* Added a script that starts a custom Xvfb X11 server.
* Added a Cypress helper hook to start the browser with specified
  width and height.


### Use run-ci Action to run E2E tests

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/980)
<!-- Reviewable:end -->
