### PR TITLE
E2E: Fix map tests to work on custom viewport sizes

### DIFF
--- a/cypress/.eslintrc.js
+++ b/cypress/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
         // cypress runs tests with mocha instead of jest, so jest-specific rules make no sense.
         // TODO: rather disable whole 'plugin:jest/recommended' at once (but how?)
         'jest/expect-expect': 'off',
+        'jest/valid-describe-callback': 'off',
         'cypress/no-pause': 'error',
       },
     },

--- a/cypress/e2e/editStop.cy.ts
+++ b/cypress/e2e/editStop.cy.ts
@@ -28,7 +28,7 @@ import {
   expectGraphQLCallToSucceed,
 } from '../utils/assertions';
 import { debug } from '../utils/templateStringHelpers';
-import { InsertedStopRegistryIds } from './utils';
+import { InsertedStopRegistryIds, mapViewport } from './utils';
 
 const testTimingPlaceLabels = {
   label1: 'Test created timing place label 1',
@@ -93,7 +93,7 @@ describe('Stop editing tests', () => {
 
   it(
     'Should move a stop on the map',
-    { tags: Tag.Stops, scrollBehavior: 'bottom' },
+    { tags: Tag.Stops, scrollBehavior: 'bottom', ...mapViewport },
     () => {
       // Coordinates for the point where the stop is moved in the test.
       const endCoordinates = {

--- a/cypress/e2e/map/createRoute.cy.ts
+++ b/cypress/e2e/map/createRoute.cy.ts
@@ -15,8 +15,9 @@ import { FilterPanel } from '../../pageObjects/FilterPanel';
 import { RouteStopsOverlay } from '../../pageObjects/RouteStopsOverlay';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
+import { mapViewport } from '../utils';
 
-describe('Route creation', () => {
+describe('Route creation', mapViewport, () => {
   let mapModal: MapModal;
   let routeStopsOverlay: RouteStopsOverlay;
   let mapFooter: MapFooter;

--- a/cypress/e2e/map/createStop.cy.ts
+++ b/cypress/e2e/map/createStop.cy.ts
@@ -14,6 +14,7 @@ import {
 } from '../../pageObjects';
 import { FilterPanel } from '../../pageObjects/FilterPanel';
 import { insertToDbHelper } from '../../utils';
+import { mapViewport } from '../utils';
 
 const testStopLabels = {
   testLabel1: 'T0001',
@@ -26,7 +27,7 @@ const dbResources = {
   timingPlaces,
 };
 
-describe('Stop creation tests', () => {
+describe('Stop creation tests', mapViewport, () => {
   let mapModal: MapModal;
   let mapFilterPanel: FilterPanel;
   let changeValidityForm: ChangeValidityForm;

--- a/cypress/e2e/map/editRouteShape.cy.ts
+++ b/cypress/e2e/map/editRouteShape.cy.ts
@@ -17,8 +17,9 @@ import {
 import { RouteStopsOverlay } from '../../pageObjects/RouteStopsOverlay';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
+import { mapViewport } from '../utils';
 
-describe('Edit route geometry', () => {
+describe('Edit route geometry', mapViewport, () => {
   let map: Map;
   let routeStopsOverlay: RouteStopsOverlay;
   let routeEditor: RouteEditor;

--- a/cypress/e2e/map/editStopAreas.cy.ts
+++ b/cypress/e2e/map/editStopAreas.cy.ts
@@ -14,8 +14,9 @@ import { ConfirmationDialog, MapModal } from '../../pageObjects';
 import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
 import { expectGraphQLCallToSucceed } from '../../utils/assertions';
+import { mapViewport } from '../utils';
 
-describe('Stop areas on map', () => {
+describe('Stop areas on map', mapViewport, () => {
   let dbResources: SupportedResources;
 
   const baseDbResources = getClonedBaseDbResources();

--- a/cypress/e2e/utils/index.ts
+++ b/cypress/e2e/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './mapViewport';
 export * from './string';
 export * from './tasks';

--- a/cypress/e2e/utils/mapViewport.ts
+++ b/cypress/e2e/utils/mapViewport.ts
@@ -1,0 +1,6 @@
+export const mapViewport: Cypress.SuiteConfigOverrides = {
+  // These tests use raw pixel values that have been designed for this
+  // particular viewport size.
+  viewportWidth: 1920,
+  viewportHeight: 1080,
+};

--- a/cypress/pageObjects/Map.ts
+++ b/cypress/pageObjects/Map.ts
@@ -64,9 +64,11 @@ export class Map {
   }
 
   clickRelativePoint(xPercentage: number, yPercentage: number) {
-    const x = (Cypress.config('viewportWidth') / 100) * xPercentage;
-    const y = (Cypress.config('viewportHeight') / 100) * yPercentage;
-    cy.getByTestId('mapModal').click(x, y);
+    cy.window().then((window) => {
+      const x = (window.innerWidth / 100) * xPercentage;
+      const y = (window.innerHeight / 100) * yPercentage;
+      cy.getByTestId('mapModal').click(x, y);
+    });
   }
 
   getStopByStopLabelAndPriority(testStopLabel: string, priority: Priority) {


### PR DESCRIPTION
* Disable another jest Eslint rule on Cypress dir (Eslint configs should be fixed properly at some point)
* Set viewport to 1920x1080 on map tests, by setting a test suite config override.
* Changed a map click helper to read the window size from the window, and not from the config, which migt not be accurate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/981)
<!-- Reviewable:end -->
