### PR TITLE
Unify Top level page titles and set them as the browsers page title

### DIFF
--- a/ui/src/components/common/PageTitle.tsx
+++ b/ui/src/components/common/PageTitle.tsx
@@ -1,0 +1,98 @@
+import { ElementType, FC, ReactNode } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
+
+type PageTitleBaseProps = {
+  readonly as: ElementType;
+  readonly className?: string;
+  readonly testId?: string;
+};
+
+type SimplePageTitleProps = {
+  readonly children: string;
+  readonly titleText?: string;
+};
+
+type ComplexPageTitleProps = {
+  readonly children: ReactNode;
+  readonly titleText: string;
+};
+
+type PageTitleProps = PageTitleBaseProps &
+  (SimplePageTitleProps | ComplexPageTitleProps);
+
+const PageTitleImpl: FC<PageTitleProps> = ({
+  as: As, // Capitalized so that it can be used as a <JsxConstructor>
+  children,
+  className,
+  testId,
+  titleText,
+}) => {
+  const { t } = useTranslation();
+
+  const title = titleText ?? children;
+
+  if (typeof title !== 'string') {
+    throw new Error(
+      `Either a string based children or a titleText prop must be provided! Children: ${children} | titleText: ${titleText}`,
+    );
+  }
+
+  // Only pass data-testid to HTML Elements.
+  // Provide React components with both data- and custom prop version.
+  const testIdProps =
+    typeof As === 'string'
+      ? { 'data-testid': testId }
+      : { 'data-testid': testId, testId };
+
+  return (
+    <>
+      <Helmet>
+        <title>{t('navigation.pageTitle', { title })}</title>
+      </Helmet>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <As className={className} {...testIdProps}>
+        {children}
+      </As>
+    </>
+  );
+};
+
+function getElementName(as: ElementType): string {
+  if (typeof as === 'string') {
+    return as;
+  }
+
+  if (as.displayName) {
+    return as.displayName;
+  }
+
+  return as.name || 'UnnamedBaseElement';
+}
+
+type FixedElementPageTitleProps = Omit<PageTitleBaseProps, 'as'> &
+  (SimplePageTitleProps | ComplexPageTitleProps);
+
+function createFixedElementPageTitle(
+  as: ElementType,
+): FC<FixedElementPageTitleProps> {
+  const FixedElementPageTitle: FC<FixedElementPageTitleProps> = (props) => (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <PageTitleImpl as={as} {...props} />
+  );
+
+  const elementName = getElementName(as);
+  const capitalizedElementName = `${elementName.charAt(0).toUpperCase()}${elementName.slice(1)}`;
+  FixedElementPageTitle.displayName = `PageTitle${capitalizedElementName}`;
+
+  return FixedElementPageTitle;
+}
+
+export const PageTitle = Object.assign(PageTitleImpl, {
+  H1: createFixedElementPageTitle('h1'),
+  H2: createFixedElementPageTitle('h2'),
+  H3: createFixedElementPageTitle('h3'),
+  H4: createFixedElementPageTitle('h4'),
+  H5: createFixedElementPageTitle('h5'),
+  H6: createFixedElementPageTitle('h6'),
+});

--- a/ui/src/components/common/index.ts
+++ b/ui/src/components/common/index.ts
@@ -1,6 +1,7 @@
 export * from './DateControl';
 export * from './DateInput';
 export * from './LineTableRow';
+export * from './PageTitle';
 export * from './RedirectWithQuery';
 export * from './RouteLineTableRow';
 export * from './RouteTableRow';

--- a/ui/src/components/main/MainPage.tsx
+++ b/ui/src/components/main/MainPage.tsx
@@ -4,6 +4,7 @@ import { LOGIN_URL } from '../../api/user';
 import { useAppSelector } from '../../hooks';
 import { selectUser } from '../../redux';
 import { SimpleButton } from '../../uiComponents';
+import { PageTitle } from '../common';
 
 const testIds = {
   main: 'Main',
@@ -19,9 +20,9 @@ export const MainPage: React.FC = () => {
       className="min-h-screen bg-brand bg-opacity-50 p-20"
     >
       <div className="mx-auto w-4/5 rounded-lg bg-white p-10 leading-8 shadow-2xl">
-        <h1 className="mb-10 text-center text-4xl">
+        <PageTitle.H1 className="mb-10 text-center text-4xl">
           {t('welcomePage.heading')}
-        </h1>
+        </PageTitle.H1>
         <div className="mb-6 space-y-6 text-xl">
           <h3>{t('welcomePage.subheading1')}</h3>
           <p>{t('welcomePage.paragraph1')}</p>

--- a/ui/src/components/map/MapHeader.tsx
+++ b/ui/src/components/map/MapHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Row } from '../../layoutComponents';
 import { CloseIconButton } from '../../uiComponents';
+import { PageTitle } from '../common';
 
 const testIds = {
   closeButton: 'MapHeader::closeButton',
@@ -15,7 +16,9 @@ export const MapHeader: React.FC<Props> = ({ onClose }) => {
   const { t } = useTranslation();
   return (
     <Row className="bg-white px-11 py-4">
-      <h2>{t('map.joreMap')}</h2>
+      <PageTitle.H2 titleText={t('map.pageTitle')}>
+        {t('map.joreMap')}
+      </PageTitle.H2>
       <CloseIconButton
         className="ml-auto font-bold text-brand"
         label={t('close')}

--- a/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
+++ b/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
@@ -11,6 +11,7 @@ import { Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { Priority } from '../../../types/enums';
 import { showSuccessToast } from '../../../utils';
+import { PageTitle } from '../../common';
 import { FormState, LineForm } from '../../forms/line/LineForm';
 import {
   ConflictResolverModal,
@@ -58,6 +59,7 @@ export const CreateNewLinePage = (): React.ReactElement => {
       />
     );
   }
+
   return (
     <Container>
       <ConflictResolverModal
@@ -66,7 +68,7 @@ export const CreateNewLinePage = (): React.ReactElement => {
       />
       <Row>
         <i className="icon-bus-alt text-6xl text-tweaked-brand" />
-        <h1>{t('lines.createNew')}</h1>
+        <PageTitle.H1>{t('lines.createNew')}</PageTitle.H1>
       </Row>
       <LineForm onSubmit={onSubmit} defaultValues={defaultValues} />
     </Container>

--- a/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
@@ -15,6 +15,7 @@ import {
   mapToVariables,
   showSuccessToast,
 } from '../../../utils';
+import { PageTitle } from '../../common';
 import { FormState, LineForm } from '../../forms/line/LineForm';
 import {
   ConflictResolverModal,
@@ -75,6 +76,8 @@ export const EditLinePage = (): React.ReactElement => {
     );
   }
 
+  const pageTitleText = t('lines.line', { label: line?.label });
+
   return (
     <div>
       <ConflictResolverModal
@@ -82,10 +85,10 @@ export const EditLinePage = (): React.ReactElement => {
         conflicts={conflicts.map(mapLineToCommonConflictItem)}
       />
       <PageHeader>
-        <h1>
+        <PageTitle.H1 titleText={pageTitleText}>
           <i className="icon-bus-alt text-tweaked-brand" />
-          {t('lines.line', { label: line?.label })}
-        </h1>
+          {pageTitleText}
+        </PageTitle.H1>
       </PageHeader>
       <Container>
         {line && (

--- a/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -24,6 +24,7 @@ import {
   showSuccessToast,
   submitFormByRef,
 } from '../../../utils';
+import { PageTitle } from '../../common';
 import { RedirectWithQuery } from '../../common/RedirectWithQuery';
 import { RouteDraftStopsConfirmationDialog } from '../../forms/route/RouteDraftStopsConfirmationDialog';
 import { RoutePropertiesForm } from '../../forms/route/RoutePropertiesForm';
@@ -155,13 +156,17 @@ export const EditRoutePage = (): React.ReactElement => {
     );
   }
 
+  const pageTitleText = t('lines.line', {
+    label: route?.route_line?.label ?? '',
+  });
+
   return (
     <div>
       <PageHeader>
-        <h1>
+        <PageTitle.H1 titleText={pageTitleText}>
           <i className="icon-bus-alt text-tweaked-brand" />
-          {t('lines.line', { label: route?.route_line?.label ?? '' })}
-        </h1>
+          {pageTitleText}
+        </PageTitle.H1>
       </PageHeader>
       <Container>
         <Row className="mt-10">

--- a/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineTitle.tsx
@@ -7,6 +7,7 @@ import { LineWithRoutesUniqueFieldsFragment } from '../../../generated/graphql';
 import { useGetRoutesDisplayedInList } from '../../../hooks';
 import { Column, Row } from '../../../layoutComponents';
 import { IconButton, SimpleSmallButton } from '../../../uiComponents';
+import { PageTitle } from '../../common';
 import { LineValidityPeriod } from './LineValidityPeriod';
 
 const testIds = {
@@ -59,9 +60,9 @@ export const LineTitle: React.FC<Props> = ({
   return (
     <Column>
       <Row className={`items-center ${className}`}>
-        <h1 className="mr-4" data-testid={testIds.heading}>
+        <PageTitle.H1 className="mr-4" data-testid={testIds.heading}>
           {t('lines.line', { label: line.label })}
-        </h1>
+        </PageTitle.H1>
         <span className="space-x-2">
           {lineRoutes?.length > 0 &&
             lineRoutes.map((item) => (

--- a/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
+++ b/ui/src/components/routes-and-lines/line-drafts/LineDraftsPage.tsx
@@ -6,6 +6,7 @@ import {
 import { useGetLineDraftDetails } from '../../../hooks/line-drafts/useGetLineDraftDetails';
 import { Column, Container, Row } from '../../../layoutComponents';
 import { CloseIconButton } from '../../../uiComponents';
+import { PageTitle } from '../../common';
 import { ObservationDateControl } from '../../common/ObservationDateControl';
 import { LineRouteList } from '../line-details/LineRouteList';
 
@@ -23,7 +24,7 @@ export const LineDraftsPage = (): React.ReactElement => {
   return (
     <Container>
       <Row>
-        <h2>{`${t('lines.draftsTitle')} | ${t('lines.line', { label })}`}</h2>
+        <PageTitle.H1>{`${t('lines.draftsTitle')} | ${t('lines.line', { label })}`}</PageTitle.H1>
         <CloseIconButton
           label={t('close')}
           className="ml-auto text-base font-bold text-brand"

--- a/ui/src/components/routes-and-lines/main/RoutesAndLinesMainPage.tsx
+++ b/ui/src/components/routes-and-lines/main/RoutesAndLinesMainPage.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { SimpleButton } from '../../../uiComponents';
+import { PageTitle } from '../../common';
 import { OpenDefaultMapButton } from '../../common/OpenDefaultMapButton';
 import { SearchContainer } from '../search/SearchContainer';
 import { RoutesAndLinesLists } from './RoutesAndLinesLists';
@@ -17,7 +18,7 @@ export const RoutesAndLinesMainPage = (): React.ReactElement => {
   return (
     <Container>
       <Row>
-        <h1>{t('routes.routes')}</h1>
+        <PageTitle.H1>{t('routes.routes')}</PageTitle.H1>
         <OpenDefaultMapButton containerClassName="ml-auto" />
         <SimpleButton
           id="create-line-button"

--- a/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
+++ b/ui/src/components/routes-and-lines/search/SearchResultPage.tsx
@@ -9,6 +9,7 @@ import {
   usePagination,
 } from '../../../uiComponents';
 import { LoadingWrapper } from '../../../uiComponents/LoadingWrapper';
+import { PageTitle } from '../../common';
 import { RouteLineTableRowVariant } from '../../common/RouteLineTableRow';
 import { ResultList } from '../../common/search/ResultList';
 import { ExportToolbar } from './ExportToolbar';
@@ -54,9 +55,9 @@ export const SearchResultPage = (): React.ReactElement => {
   return (
     <Container testId={testIds.container}>
       <Row>
-        <h2>{`${t('search.searchResultsTitle')} | ${
-          displayInformation.title
-        }`}</h2>
+        <PageTitle.H1>
+          {`${t('search.searchResultsTitle')} | ${displayInformation.title}`}
+        </PageTitle.H1>
         <CloseIconButton
           label={t('close')}
           className="ml-auto text-base font-bold text-brand"

--- a/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
+++ b/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
@@ -5,6 +5,7 @@ import { Container, Row } from '../../../layoutComponents';
 import { Path } from '../../../router/routeDetails';
 import { defaultPagingInfo } from '../../../types';
 import { SimpleButton } from '../../../uiComponents';
+import { PageTitle } from '../../common';
 import { OpenDefaultMapButton } from '../../common/OpenDefaultMapButton';
 import {
   StopSearchBar,
@@ -48,7 +49,7 @@ export const StopRegistryMainPage: FC = () => {
   return (
     <Container>
       <Row className="justify-between">
-        <h1>{t('stops.stops')}</h1>
+        <PageTitle.H1>{t('stops.stops')}</PageTitle.H1>
         <OpenDefaultMapButton containerClassName="ml-auto" />
         <SimpleButton
           // TODO: actual implementation for this button.

--- a/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
+++ b/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
@@ -6,6 +6,7 @@ import { Container, Row } from '../../../layoutComponents';
 import { resetSelectedRowsAction } from '../../../redux';
 import { Path } from '../../../router/routeDetails';
 import { defaultPagingInfo } from '../../../types';
+import { PageTitle } from '../../common';
 import { StopsByLineSearchResults } from './by-line';
 import { StopSearchByStopResults } from './by-stop';
 import { StopSearchBar } from './components';
@@ -96,7 +97,9 @@ export const StopSearchResultPage = (): React.ReactElement => {
   return (
     <Container testId={testIds.container}>
       <Row>
-        <h2>{`${t('search.searchResultsTitle')} | ${trSearchFor(t, filters.searchFor)}`}</h2>
+        <PageTitle.H1>
+          {`${t('search.searchResultsTitle')} | ${trSearchFor(t, filters.searchFor)}`}
+        </PageTitle.H1>
         <Link
           className="ml-auto text-base font-bold text-brand"
           to={closeLink}

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaTitleRow.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaTitleRow.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { twMerge } from 'tailwind-merge';
+import { PageTitle } from '../../../../common';
 import { ObservationDateControl } from '../../../../common/ObservationDateControl';
 import { StopAreaComponentProps } from './StopAreaComponentProps';
 
@@ -14,9 +15,9 @@ export const StopAreaTitleRow: FC<StopAreaComponentProps> = ({
 }) => (
   <div className={twMerge('flex items-center', className)}>
     <i className="icon-bus-alt mr-2 text-3xl text-tweaked-brand" />
-    <h2 className="mr-2 font-bold" data-testid={testIds.name}>
-      {area.name?.value ?? null}
-    </h2>
+    <PageTitle.H1 className="mr-2" testId={testIds.name}>
+      {area.name?.value ?? ''}
+    </PageTitle.H1>
 
     <div className="text-xl" data-testid={testIds.description}>
       {area.description?.value ?? null}

--- a/ui/src/components/stop-registry/stops/stop-details/title-row/StopTitleRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/title-row/StopTitleRow.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { StopWithDetails } from '../../../../../hooks';
+import { PageTitle } from '../../../../common';
 import { EditValidityButton } from './EditValidityButton';
 import { ExtraActions } from './ExtraActions';
 import { OpenOnMapButton } from './OpenOnMapButton';
@@ -18,9 +19,9 @@ export const StopTitleRow: FC<StopTitleRowProps> = ({ stopDetails, label }) => {
   return (
     <div className="flex items-center">
       <i className="icon-bus-alt mr-2 text-3xl text-tweaked-brand" />
-      <h2 className="mr-2 font-bold" data-testid={testIds.label}>
+      <PageTitle.H1 className="mr-2" testId={testIds.label}>
         {label}
-      </h2>
+      </PageTitle.H1>
       <div className="text-xl" data-testid={testIds.names}>
         <span>
           {

--- a/ui/src/components/timetables/import/ImportTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/ImportTimetablesPage.tsx
@@ -19,6 +19,7 @@ import {
   SimpleButton,
 } from '../../../uiComponents';
 import { showDangerToastWithError, showSuccessToast } from '../../../utils';
+import { PageTitle } from '../../common';
 import { FormRow } from '../../forms/common';
 import { ConfirmTimetablesImportModal } from './ConfirmTimetablesImportModal';
 import { FileImportDragAndDrop } from './FileImportDragAndDrop';
@@ -111,7 +112,7 @@ export const ImportTimetablesPage = (): React.ReactElement => {
   return (
     <Container>
       <Row>
-        <h1>{t('import.importTimetablesFromHastus')}</h1>
+        <PageTitle.H1>{t('import.importTimetablesFromHastus')}</PageTitle.H1>
         <CloseIconButton
           testId={testIds.closeButton}
           label={t('close')}

--- a/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/PreviewTimetablesPage.tsx
@@ -21,6 +21,7 @@ import { selectIsJoreOperationLoading } from '../../../redux';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { AccordionButton, SimpleButton } from '../../../uiComponents';
 import { submitFormByRef } from '../../../utils';
+import { PageTitle } from '../../common';
 import { CombineSameContractWarning } from './CombineSameContractWarning';
 import { ConfirmPreviewedTimetablesImportForm } from './ConfirmPreviewedTimetablesImportForm';
 import { ImportContentsView } from './contents-view';
@@ -109,7 +110,7 @@ export const PreviewTimetablesPage = (): React.ReactElement => {
 
   return (
     <Container>
-      <h1>{t('timetablesPreview.preview')}</h1>
+      <PageTitle.H1>{t('timetablesPreview.preview')}</PageTitle.H1>
       <div className="overflow-none mt-9 rounded border border-grey">
         <Row className="justify-between rounded-t-sm border-brand bg-brand pl-16 pr-8 text-white">
           <h2 className="py-2" data-testid={testIds.previewTitle}>

--- a/ui/src/components/timetables/main/TimetablesMainPage.tsx
+++ b/ui/src/components/timetables/main/TimetablesMainPage.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Container, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { SimpleButton } from '../../../uiComponents';
+import { PageTitle } from '../../common';
 import { SearchContainer } from '../../routes-and-lines/search/SearchContainer';
 
 const testIds = {
@@ -19,7 +20,7 @@ export const TimetablesMainPage = (): React.ReactElement => {
   return (
     <Container>
       <Row className="justify-between">
-        <h1>{t('timetables.timetables')}</h1>
+        <PageTitle.H1>{t('timetables.timetables')}</PageTitle.H1>
         <div className="space-x-4">
           <SimpleButton
             id="timetables-settings-button"

--- a/ui/src/components/timetables/substitute-day-settings/SubstituteDaySettingsPage.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/SubstituteDaySettingsPage.tsx
@@ -12,6 +12,7 @@ import { selectTimetable } from '../../../redux';
 import { Path } from '../../../router/routeDetails';
 import { ConfirmationDialog } from '../../../uiComponents';
 import { CloseIconButton } from '../../../uiComponents/CloseIconButton';
+import { PageTitle } from '../../common';
 import { ObservationPeriodForm } from '../../forms/timetables/ObservationPeriodForm';
 import { CommonSubstitutePeriodSection } from './CommonSubstitutePeriod/CommonSubstitutePeriodSection';
 import { DateRange } from './DateRange';
@@ -79,7 +80,7 @@ export const SubstituteDaySettingsPage = (): React.ReactElement => {
   return (
     <Container>
       <Row className="justify-between py-8">
-        <h1>{t('timetables.daySettings')}</h1>
+        <PageTitle.H1>{t('timetables.daySettings')}</PageTitle.H1>
         <CloseIconButton
           testId={testIds.closeButton}
           label={t('close')}

--- a/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionsPage.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../redux';
 import { TimetablePriority } from '../../../types/enums';
 import { CloseIconButton } from '../../../uiComponents';
-import { TimeRangeControl } from '../../common';
+import { PageTitle, TimeRangeControl } from '../../common';
 import { FormColumn, FormRow } from '../../forms/common';
 import { ChangeTimetablesValidityModal } from '../common/ChangeTimetablesValidityModal';
 import { DeleteTimetableModal } from './DeleteTimetableModal';
@@ -97,10 +97,9 @@ export const TimetableVersionsPage = (): React.ReactElement => {
   return (
     <Container>
       <FormRow mdColumns={2}>
-        <h1 className="text-2xl">
-          {`${t('timetables.versionsTitle')} |
-          ${t('lines.line', { label })}`}
-        </h1>
+        <PageTitle.H1>
+          {`${t('timetables.versionsTitle')} | ${t('lines.line', { label })}`}
+        </PageTitle.H1>
         <FormColumn className="items-end">
           <CloseIconButton
             label={t('close')}

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -469,6 +469,7 @@
     "saveSuccess": "Hastus place created"
   },
   "navigation": {
+    "pageTitle": "{{title}} - Jore4 Test version",
     "logout": "Log out",
     "user": "User"
   },

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -480,6 +480,7 @@
     "showNetwork": "Show network",
     "showStops": "Show stops",
     "joreMap": "Jore 4.0 map",
+    "pageTitle": "Map",
     "drawRoute": "Draw route",
     "editRoute": "Edit route",
     "addStop": "Add stop",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -469,6 +469,7 @@
     "saveSuccess": "Hastus-paikka luotu"
   },
   "navigation": {
+    "pageTitle": "{{title}} - Jore4 Testiversio",
     "logout": "Kirjaudu ulos",
     "user": "Käyttäjä"
   },

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -480,6 +480,7 @@
     "showNetwork": "Näytä verkko",
     "showStops": "Näytä pysäkit",
     "joreMap": "Jore 4.0 kartta",
+    "pageTitle": "Kartta",
     "drawRoute": "Vedä reitti",
     "editRoute": "Muokkaa reittiä",
     "addStop": "Lisää pysäkki",

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -3,6 +3,7 @@ import React, { FC, PropsWithChildren, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { getUserInfo } from '../api/user';
+import { PageTitle } from '../components/common';
 import { MainPage } from '../components/main/MainPage';
 import { MapModal } from '../components/map';
 import { JoreLoader } from '../components/map/JoreLoader';
@@ -36,7 +37,12 @@ import { showDangerToast } from '../utils';
 import { Path } from './routeDetails';
 
 const FallbackRoute: FC = () => {
-  return React.createElement('p', null, `404, page not found`);
+  return (
+    <div className="flex flex-col items-center">
+      <PageTitle.H1>404</PageTitle.H1>
+      <p>page not found</p>
+    </div>
+  );
 };
 
 export const ProtectedRoute: FC<PropsWithChildren> = ({ children }) => {


### PR DESCRIPTION

### Implement PageTitle component
Sets the given `titleText` as the page (browser window/tab) title and
also renders a visual title/header element on the page.

Uses `<Helmet>` to set the page `<title>` tag, so PageTitles rendered
in child  or latter sibling components will temporarily override the
given title. Unmounting a component revers the title back to the higher
level or earlier sibling component. i.e in React "render order".

Allows to render the visual on the page title inside any wrapper
element. Basic implementations/aliases have been created for HTML
header tags: `<PageTitle.H1>`, `<PageTitle.H2>`, …


### Unify Top level page titles and set them as Page Titles
* All Top level page titles are now a standard h1-level header.
* All of them set the text as `<PageTitle>`
* Map modal header left as a H2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/994)
<!-- Reviewable:end -->
