### PR TITLE
Stop model refactoring stop versions page

### DIFF
--- a/ui/src/components/stop-registry/components/LocatorActionButton.tsx
+++ b/ui/src/components/stop-registry/components/LocatorActionButton.tsx
@@ -1,13 +1,12 @@
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LocatorButton } from '../../../uiComponents';
-import { LocatableStopProps } from '../types';
+import { LocatableStopWithObserveOnValidityStartProps } from '../types';
 import { useShowStopOnMap } from '../utils/useShowStopOnMap';
 
-export const LocatorActionButton: FC<LocatableStopProps> = ({
-  className,
-  stop,
-}) => {
+export const LocatorActionButton: FC<
+  LocatableStopWithObserveOnValidityStartProps
+> = ({ className, observeOnStopValidityStartDate = false, stop }) => {
   const { t } = useTranslation();
 
   const openStopOnMap = useShowStopOnMap();
@@ -15,7 +14,7 @@ export const LocatorActionButton: FC<LocatableStopProps> = ({
   return (
     <LocatorButton
       className={className}
-      onClick={() => openStopOnMap(stop)}
+      onClick={() => openStopOnMap(stop, observeOnStopValidityStartDate)}
       tooltipText={t('accessibility:common.showOnMap', {
         label: stop.label,
       })}

--- a/ui/src/components/stop-registry/components/MenuItems/OpenDetailsPage.tsx
+++ b/ui/src/components/stop-registry/components/MenuItems/OpenDetailsPage.tsx
@@ -1,9 +1,10 @@
+import qs from 'qs';
 import { ForwardRefRenderFunction, forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Path, routeDetails } from '../../../../router/routeDetails';
 import { SimpleDropdownMenuItem } from '../../../../uiComponents';
-import { LocatableStopProps } from '../../types';
+import { LocatableStopWithObservationDateProps } from '../../types';
 
 const testIds = {
   showStopDetails: 'StopTableRow::ActionMenu::ShowStopDetails',
@@ -11,19 +12,23 @@ const testIds = {
 
 const OpenDetailsPageImpl: ForwardRefRenderFunction<
   HTMLButtonElement,
-  LocatableStopProps
-> = ({ className, stop }, ref) => {
+  LocatableStopWithObservationDateProps
+> = ({ className, observationDate, stop }, ref) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+
+  const pathname = routeDetails[Path.stopDetails].getLink(stop.label);
+  const search = qs.stringify(
+    { observationDate: observationDate?.toISODate() },
+    { addQueryPrefix: true },
+  );
 
   return (
     <SimpleDropdownMenuItem
       ref={ref}
       className={className}
       text={t('stopRegistrySearch.stopRowActions.openDetails')}
-      onClick={() =>
-        navigate(routeDetails[Path.stopDetails].getLink(stop.label))
-      }
+      onClick={() => navigate({ pathname, search })}
       testId={testIds.showStopDetails}
     />
   );

--- a/ui/src/components/stop-registry/components/MenuItems/ShowOnMap.tsx
+++ b/ui/src/components/stop-registry/components/MenuItems/ShowOnMap.tsx
@@ -1,7 +1,7 @@
 import { ForwardRefRenderFunction, forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SimpleDropdownMenuItem } from '../../../../uiComponents';
-import { LocatableStopProps } from '../../types';
+import { LocatableStopWithObserveOnValidityStartProps } from '../../types';
 import { useShowStopOnMap } from '../../utils/useShowStopOnMap';
 
 const testIds = {
@@ -10,8 +10,8 @@ const testIds = {
 
 const ShowOnMapImpl: ForwardRefRenderFunction<
   HTMLButtonElement,
-  LocatableStopProps
-> = ({ className, stop }, ref) => {
+  LocatableStopWithObserveOnValidityStartProps
+> = ({ className, observeOnStopValidityStartDate = false, stop }, ref) => {
   const { t } = useTranslation();
   const openStopOnMap = useShowStopOnMap();
 
@@ -20,7 +20,7 @@ const ShowOnMapImpl: ForwardRefRenderFunction<
       ref={ref}
       className={className}
       text={t('stopRegistrySearch.stopRowActions.showOnMap')}
-      onClick={() => openStopOnMap(stop)}
+      onClick={() => openStopOnMap(stop, observeOnStopValidityStartDate)}
       testId={testIds.showOnMap}
     />
   );

--- a/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdWarning } from 'react-icons/md';
-import { useGetStopDetails, useRequiredParams } from '../../../../hooks';
+import {
+  makeBackNavigationIsSafeState,
+  useGetStopDetails,
+  useRequiredParams,
+} from '../../../../hooks';
 import { Container, Row, Visible } from '../../../../layoutComponents';
 import { Path, routeDetails } from '../../../../router/routeDetails';
 import { mapToShortDate } from '../../../../time';
@@ -50,7 +54,8 @@ export const StopDetailsPage = (): React.ReactElement => {
         <ObservationDateControl className="col-start-6" />
         <SimpleButton
           inverted
-          href={routeDetails[Path.stopVersions].getLink(label)}
+          href={{ pathname: routeDetails[Path.stopVersions].getLink(label) }}
+          state={makeBackNavigationIsSafeState()}
         >
           {t('stopDetails.actions.showVersions')}
         </SimpleButton>

--- a/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdWarning } from 'react-icons/md';
 import { useGetStopDetails, useRequiredParams } from '../../../../hooks';
-import { Container, Visible } from '../../../../layoutComponents';
+import { Container, Row, Visible } from '../../../../layoutComponents';
+import { Path, routeDetails } from '../../../../router/routeDetails';
 import { mapToShortDate } from '../../../../time';
+import { SimpleButton } from '../../../../uiComponents';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
 import { ObservationDateControl } from '../../../common/ObservationDateControl';
-import { FormRow } from '../../../forms/common';
 import { BasicDetailsSection } from './basic-details/BasicDetailsSection';
 import {
   DetailTabSelector,
@@ -24,6 +25,7 @@ import { StopTitleRow } from './title-row/StopTitleRow';
 
 const testIds = {
   page: 'StopDetailsPage::page',
+  versionsLink: 'StopDetailsPage::versionsLink',
   validityPeriod: 'StopDetailsPage::validityPeriod',
   basicDetailsTabPanel: 'StopDetailsPage::basicDetailsTabPanel',
   technicalFeaturesTabPanel: 'StopDetailsPage::technicalFeaturesTabPanel',
@@ -43,10 +45,16 @@ export const StopDetailsPage = (): React.ReactElement => {
     <Container testId={testIds.page}>
       <StopTitleRow stopDetails={stopDetails} label={label} />
       <StopHeaderSummaryRow className="my-2" stopDetails={stopDetails} />
-      <FormRow mdColumns={6}>
+      <Row className="items-end justify-end gap-4">
         {/* TODO: Stop/Announcement/Breakroom/Lines tabs */}
         <ObservationDateControl className="col-start-6" />
-      </FormRow>
+        <SimpleButton
+          inverted
+          href={routeDetails[Path.stopVersions].getLink(label)}
+        >
+          {t('stopDetails.actions.showVersions')}
+        </SimpleButton>
+      </Row>
       <hr className="my-4" />
       <div className="my-4 flex items-center">
         <h2 className="">{t('stopDetails.stopDetails')}</h2>

--- a/ui/src/components/stop-registry/stops/versions/StopVersionsPage.tsx
+++ b/ui/src/components/stop-registry/stops/versions/StopVersionsPage.tsx
@@ -1,0 +1,56 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRequiredParams } from '../../../../hooks';
+import { Container, Row } from '../../../../layoutComponents';
+import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
+import { PageTitle } from '../../../common';
+import { StopVersionContainers } from './components/StopVersionContainers';
+import { useGetStopVersionPageInfo } from './queries/useGetStopVersionPageInfo';
+
+const testIds = {
+  container: 'StopVersionsPage::Container',
+  loadingWrapper: 'StopVersionsPage::LoadingWrapper',
+};
+
+export const StopVersionsPage: FC = () => {
+  const { t } = useTranslation();
+
+  const { label: publicCode } = useRequiredParams<{ label: string }>();
+  const { loading, stopVersions, stopPlaceName } =
+    useGetStopVersionPageInfo(publicCode);
+
+  const titleText = stopPlaceName?.name
+    ? t('stopVersion.titleWithName', { publicCode, name: stopPlaceName.name })
+    : t(t('stopVersion.title', { publicCode }));
+
+  return (
+    <Container testId={testIds.container}>
+      <Row>
+        <PageTitle.H1 titleText={titleText}>
+          {t('stopVersion.title', { publicCode })}
+        </PageTitle.H1>
+      </Row>
+      <Row>
+        {stopPlaceName && (
+          <h2>
+            <span>{stopPlaceName.name}</span>
+            {' - '}
+            <span>{stopPlaceName.nameSwe}</span>
+          </h2>
+        )}
+      </Row>
+
+      <LoadingWrapper
+        className="flex justify-center"
+        loadingText={t('stopVersion.loading')}
+        loading={loading}
+        testId={testIds.loadingWrapper}
+      >
+        <StopVersionContainers
+          publicCode={publicCode}
+          stopVersions={stopVersions}
+        />
+      </LoadingWrapper>
+    </Container>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/StopVersionsPage.tsx
+++ b/ui/src/components/stop-registry/stops/versions/StopVersionsPage.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useRequiredParams } from '../../../../hooks';
+import { useNavigateBackSafely, useRequiredParams } from '../../../../hooks';
 import { Container, Row } from '../../../../layoutComponents';
+import { Path, routeDetails } from '../../../../router/routeDetails';
+import { CloseIconButton } from '../../../../uiComponents';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
 import { PageTitle } from '../../../common';
 import { StopVersionContainers } from './components/StopVersionContainers';
@@ -10,10 +12,13 @@ import { useGetStopVersionPageInfo } from './queries/useGetStopVersionPageInfo';
 const testIds = {
   container: 'StopVersionsPage::Container',
   loadingWrapper: 'StopVersionsPage::LoadingWrapper',
+  returnButton: 'StopVersionsPage::returnButton',
 };
 
 export const StopVersionsPage: FC = () => {
   const { t } = useTranslation();
+
+  const goBack = useNavigateBackSafely();
 
   const { label: publicCode } = useRequiredParams<{ label: string }>();
   const { loading, stopVersions, stopPlaceName } =
@@ -25,10 +30,21 @@ export const StopVersionsPage: FC = () => {
 
   return (
     <Container testId={testIds.container}>
-      <Row>
+      <Row className="items-end justify-between">
         <PageTitle.H1 titleText={titleText}>
           {t('stopVersion.title', { publicCode })}
         </PageTitle.H1>
+
+        <CloseIconButton
+          className="font-bold text-brand [&>i]:text-xl"
+          onClick={() =>
+            goBack(routeDetails[Path.stopDetails].getLink(publicCode), {
+              replace: true,
+            })
+          }
+          testId={testIds.returnButton}
+          label={t('stopVersion.goBack')}
+        />
       </Row>
       <Row>
         {stopPlaceName && (

--- a/ui/src/components/stop-registry/stops/versions/components/DateRangeInputs.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/DateRangeInputs.tsx
@@ -1,0 +1,62 @@
+import max from 'lodash/max';
+import min from 'lodash/min';
+import { DateTime } from 'luxon';
+import { Dispatch, FC, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
+import { Row } from '../../../../../layoutComponents';
+import { DateRange } from '../../../../../types';
+import { DateInput } from '../../../../common';
+
+const testIds = {
+  startDate: 'ScheduledVersionsContainer::DateRangeInputs::startDate',
+  endDate: 'ScheduledVersionsContainer::DateRangeInputs::endDate',
+};
+
+type DateRangeInputsProps = {
+  readonly className?: string;
+  readonly dateRange: DateRange;
+  readonly setDateRange: Dispatch<SetStateAction<DateRange>>;
+};
+
+export const DateRangeInputs: FC<DateRangeInputsProps> = ({
+  className,
+  dateRange,
+  setDateRange,
+}) => {
+  const { t } = useTranslation();
+
+  const onStartDateChange = (newFromDate: DateTime) => {
+    setDateRange((prevState) => ({
+      startDate: newFromDate,
+      endDate: max([newFromDate, prevState.endDate]) as DateTime,
+    }));
+  };
+
+  const onEndDateChange = (newToDate: DateTime) => {
+    setDateRange((prevState) => ({
+      startDate: min([prevState.startDate, newToDate]) as DateTime,
+      endDate: newToDate,
+    }));
+  };
+
+  return (
+    <Row className={twMerge('gap-4', className)}>
+      <DateInput
+        value={dateRange.startDate}
+        label={t('validityPeriod.validityStart')}
+        onChange={onStartDateChange}
+        testId={testIds.startDate}
+        dateInputId={testIds.startDate}
+      />
+
+      <DateInput
+        value={dateRange.endDate}
+        label={t('validityPeriod.validityEnd')}
+        onChange={onEndDateChange}
+        testId={testIds.endDate}
+        dateInputId={testIds.endDate}
+      />
+    </Row>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/DraftVersionsContainer.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/DraftVersionsContainer.tsx
@@ -1,0 +1,83 @@
+import { FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Row } from '../../../../../layoutComponents';
+import { SortOrder } from '../../../../../types';
+import { ExpandButton } from '../../../../../uiComponents';
+import { StopVersion, StopVersionTableSortingInfo } from '../types';
+import { getAccordionClassNames, useSortedStopVersions } from '../utils';
+import { StopVersionTable } from './StopVersionTable';
+
+const ID = 'DraftVersionsContainer';
+const HeaderId = `${ID}-Header`;
+
+const testIds = {
+  showHideButton: 'DraftVersionsContainer::showHideButton',
+};
+
+function useControls() {
+  const [expanded, setExpanded] = useState<boolean>(true);
+
+  const [sortingInfo, setSortingInfo] = useState<StopVersionTableSortingInfo>({
+    sortBy: 'VALIDITY_START',
+    sortOrder: SortOrder.ASCENDING,
+  });
+
+  return {
+    expanded,
+    setExpanded,
+    setSortingInfo,
+    sortingInfo,
+  };
+}
+
+type DraftVersionsContainerProps = {
+  readonly className?: string;
+  readonly publicCode: string;
+  readonly stopVersions: ReadonlyArray<StopVersion>;
+};
+
+export const DraftVersionsContainer: FC<DraftVersionsContainerProps> = ({
+  className,
+  publicCode,
+  stopVersions,
+}) => {
+  const { t } = useTranslation();
+
+  const { expanded, setExpanded, sortingInfo, setSortingInfo } = useControls();
+
+  const sortedStopVersions = useSortedStopVersions(sortingInfo, stopVersions);
+
+  return (
+    <div className={className}>
+      <Row className="justify-between">
+        <h4 id={HeaderId}>{t('stopVersion.drafts.title')}</h4>
+
+        <ExpandButton
+          className="self-end"
+          ariaControls={ID}
+          expanded={expanded}
+          expandedText={t('stopVersion.drafts.hide')}
+          collapsedText={t('stopVersion.drafts.show')}
+          onClick={() => setExpanded((p) => !p)}
+          testId={testIds.showHideButton}
+        />
+      </Row>
+
+      <div
+        className={getAccordionClassNames(expanded)}
+        id={ID}
+        role="region"
+        aria-hidden={!expanded}
+        aria-labelledby={HeaderId}
+      >
+        <StopVersionTable
+          publicCode={publicCode}
+          noVersionsText={t('stopVersion.drafts.noVersions')}
+          stopVersions={sortedStopVersions}
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/NoVersionRow.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/NoVersionRow.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+
+type NoVersionRowProps = { noVersionsText: string };
+
+export const NoVersionRow: FC<NoVersionRowProps> = ({ noVersionsText }) => {
+  return (
+    <tr>
+      <td className="border px-4 py-2 text-center font-bold" colSpan={9}>
+        {noVersionsText}
+      </td>
+    </tr>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/ScheduledVersionsContainer.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/ScheduledVersionsContainer.tsx
@@ -1,0 +1,127 @@
+import { DateTime } from 'luxon';
+import { FC, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Column } from '../../../../../layoutComponents';
+import { DateRange, SortOrder } from '../../../../../types';
+import { ExpandButton } from '../../../../../uiComponents';
+import { StopVersion, StopVersionTableSortingInfo } from '../types';
+import { getAccordionClassNames, useSortedStopVersions } from '../utils';
+import { DateRangeInputs } from './DateRangeInputs';
+import { StopVersionTable } from './StopVersionTable';
+
+const ID = 'ScheduledVersionsContainer';
+const HeaderId = `${ID}-Header`;
+
+const testIds = {
+  showHideButton: 'ScheduledVersionsContainer::showHideButton',
+};
+
+function useFilterVersionsByDateRange(
+  stopVersions: ReadonlyArray<StopVersion>,
+  dateRange: DateRange,
+): ReadonlyArray<StopVersion> {
+  const from = dateRange.startDate.valueOf();
+  const to = dateRange.endDate.valueOf();
+
+  return useMemo(() => {
+    return stopVersions.filter((stopVersion) => {
+      const stopFrom = stopVersion.validity_start.valueOf();
+      const stopTo =
+        stopVersion.validity_end?.valueOf() ?? Number.POSITIVE_INFINITY;
+
+      return !(
+        stopTo < from || // End before range start
+        stopFrom > to // Starts after range end
+      );
+    });
+  }, [stopVersions, from, to]);
+}
+
+function useControls() {
+  const [expanded, setExpanded] = useState<boolean>(true);
+
+  const [dateRange, setDateRange] = useState<DateRange>(() => ({
+    startDate: DateTime.now().minus({ month: 1 }).startOf('month'),
+    endDate: DateTime.now().plus({ months: 12 }).endOf('month'),
+  }));
+
+  const [sortingInfo, setSortingInfo] = useState<StopVersionTableSortingInfo>({
+    sortBy: 'VALIDITY_START',
+    sortOrder: SortOrder.ASCENDING,
+  });
+
+  return {
+    expanded,
+    setExpanded,
+    dateRange,
+    setDateRange,
+    setSortingInfo,
+    sortingInfo,
+  };
+}
+
+type ScheduledVersionsContainerProps = {
+  readonly className?: string;
+  readonly publicCode: string;
+  readonly stopVersions: ReadonlyArray<StopVersion>;
+};
+
+export const ScheduledVersionsContainer: FC<
+  ScheduledVersionsContainerProps
+> = ({ className, publicCode, stopVersions }) => {
+  const { t } = useTranslation();
+
+  const {
+    expanded,
+    setExpanded,
+    dateRange,
+    setDateRange,
+    sortingInfo,
+    setSortingInfo,
+  } = useControls();
+
+  const filteredStopVersions = useFilterVersionsByDateRange(
+    useSortedStopVersions(sortingInfo, stopVersions),
+    dateRange,
+  );
+
+  return (
+    <div className={className}>
+      <Column>
+        <h4 id={HeaderId}>{t('stopVersion.scheduled.title')}</h4>
+
+        <DateRangeInputs
+          className="mt-4 gap-4"
+          dateRange={dateRange}
+          setDateRange={setDateRange}
+        />
+
+        <ExpandButton
+          className="self-end"
+          ariaControls={ID}
+          expanded={expanded}
+          expandedText={t('stopVersion.scheduled.hide')}
+          collapsedText={t('stopVersion.scheduled.show')}
+          onClick={() => setExpanded((p) => !p)}
+          testId={testIds.showHideButton}
+        />
+      </Column>
+
+      <div
+        className={getAccordionClassNames(expanded)}
+        id={ID}
+        role="region"
+        aria-hidden={!expanded}
+        aria-labelledby={HeaderId}
+      >
+        <StopVersionTable
+          publicCode={publicCode}
+          noVersionsText={t('stopVersion.scheduled.noVersions')}
+          stopVersions={filteredStopVersions}
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionActionMenu.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionActionMenu.tsx
@@ -5,7 +5,7 @@ import {
   SimpleDropdownMenu,
 } from '../../../../../uiComponents';
 import { OpenDetailsPage, ShowOnMap } from '../../../components';
-import { LocatableStop } from '../../../types';
+import { ActionMenuStop } from '../types/ActionMenuStop';
 
 const testIds = {
   actionMenu: 'StopVersion::actionMenu',
@@ -13,12 +13,12 @@ const testIds = {
 
 type StopVersionActionMenuProps = {
   readonly className?: string;
-  readonly locatableStop: LocatableStop;
+  readonly stop: ActionMenuStop;
 };
 
 export const StopVersionActionMenu: FC<StopVersionActionMenuProps> = ({
   className,
-  locatableStop,
+  stop,
 }) => {
   const { t } = useTranslation();
 
@@ -30,8 +30,8 @@ export const StopVersionActionMenu: FC<StopVersionActionMenuProps> = ({
       alignItems={AlignDirection.LeftBottom}
       testId={testIds.actionMenu}
     >
-      <ShowOnMap stop={locatableStop} />
-      <OpenDetailsPage stop={locatableStop} />
+      <ShowOnMap stop={stop} observeOnStopValidityStartDate />
+      <OpenDetailsPage stop={stop} observationDate={stop.startDate} />
     </SimpleDropdownMenu>
   );
 };

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionActionMenu.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionActionMenu.tsx
@@ -1,0 +1,37 @@
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  AlignDirection,
+  SimpleDropdownMenu,
+} from '../../../../../uiComponents';
+import { OpenDetailsPage, ShowOnMap } from '../../../components';
+import { LocatableStop } from '../../../types';
+
+const testIds = {
+  actionMenu: 'StopVersion::actionMenu',
+};
+
+type StopVersionActionMenuProps = {
+  readonly className?: string;
+  readonly locatableStop: LocatableStop;
+};
+
+export const StopVersionActionMenu: FC<StopVersionActionMenuProps> = ({
+  className,
+  locatableStop,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <SimpleDropdownMenu
+      className={className}
+      buttonClassName="h-10 w-10 justify-center"
+      tooltip={t('accessibility:common.actionMenu')}
+      alignItems={AlignDirection.LeftBottom}
+      testId={testIds.actionMenu}
+    >
+      <ShowOnMap stop={locatableStop} />
+      <OpenDetailsPage stop={locatableStop} />
+    </SimpleDropdownMenu>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionContainers.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionContainers.tsx
@@ -1,0 +1,41 @@
+import groupBy from 'lodash/groupBy';
+import { FC, useMemo } from 'react';
+import { StopVersion } from '../types';
+import { DraftVersionsContainer } from './DraftVersionsContainer';
+import { ScheduledVersionsContainer } from './ScheduledVersionsContainer';
+
+const emptyList: ReadonlyArray<StopVersion> = [];
+
+type StopVersionContainersProps = {
+  readonly publicCode: string;
+  readonly stopVersions: ReadonlyArray<StopVersion> | null;
+};
+
+export const StopVersionContainers: FC<StopVersionContainersProps> = ({
+  publicCode,
+  stopVersions,
+}) => {
+  const { scheduled = emptyList, drafts = emptyList } = useMemo(
+    () =>
+      groupBy(stopVersions ?? [], (it) =>
+        it.status !== 'DRAFT' ? 'scheduled' : 'drafts',
+      ),
+    [stopVersions],
+  );
+
+  return (
+    <>
+      <ScheduledVersionsContainer
+        className="mt-8"
+        publicCode={publicCode}
+        stopVersions={scheduled}
+      />
+
+      <DraftVersionsContainer
+        className="mt-8"
+        publicCode={publicCode}
+        stopVersions={drafts}
+      />
+    </>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
@@ -1,0 +1,90 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twJoin, twMerge } from 'tailwind-merge';
+import { mapToShortDate, mapToShortDateTime } from '../../../../../time';
+import { LocatorActionButton } from '../../../components';
+import { LocatableStop } from '../../../types';
+import { StopVersion, StopVersionStatus } from '../types';
+import { trStatus } from '../utils';
+import { StopVersionActionMenu } from './StopVersionActionMenu';
+
+function statusToCellClasses(status: StopVersionStatus): string {
+  switch (status) {
+    case StopVersionStatus.ACTIVE:
+      return 'bg-hsl-dark-green text-white';
+
+    case StopVersionStatus.STANDARD:
+      return 'bg-tweaked-brand text-white';
+
+    case StopVersionStatus.TEMPORARY:
+      return 'bg-city-bicycle-yellow';
+
+    case StopVersionStatus.DRAFT:
+      return 'bg-background';
+
+    default:
+      return '';
+  }
+}
+
+type StopVersionRowProps = {
+  readonly className?: string;
+  readonly publicCode: string;
+  readonly stopVersion: StopVersion;
+};
+
+export const StopVersionRow: FC<StopVersionRowProps> = ({
+  className,
+  publicCode,
+  stopVersion,
+}) => {
+  const { t } = useTranslation();
+
+  const locatableStop: LocatableStop = {
+    label: publicCode,
+    netextId: stopVersion.netex_id,
+    location: stopVersion.location,
+  };
+
+  return (
+    <tr
+      className={twMerge(
+        'text-nowrap border-b *:border-x *:px-4 *:py-2',
+        className,
+      )}
+    >
+      <td
+        className={twJoin(
+          'text-center',
+          statusToCellClasses(stopVersion.status),
+        )}
+      >
+        {trStatus(t, stopVersion.status)}
+      </td>
+
+      <td className="!border-r-0 text-right">
+        {mapToShortDate(stopVersion.validity_start)}
+      </td>
+
+      <td className="!border-x-0 !p-0">-</td>
+
+      <td className="!border-l-0 text-right">
+        {mapToShortDate(stopVersion.validity_end)}
+      </td>
+
+      <td className="text-pretty">{stopVersion.version_comment}</td>
+
+      <td className="text-right">{mapToShortDateTime(stopVersion.changed)}</td>
+
+      <td>{stopVersion.changed_by}</td>
+
+      <td className="!px-2">
+        <LocatorActionButton stop={locatableStop} />
+      </td>
+
+      <td className="!p-0">
+        <StopVersionActionMenu className="p-2" locatableStop={locatableStop} />
+      </td>
+    </tr>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { twJoin, twMerge } from 'tailwind-merge';
 import { mapToShortDate, mapToShortDateTime } from '../../../../../time';
 import { LocatorActionButton } from '../../../components';
-import { LocatableStop } from '../../../types';
 import { StopVersion, StopVersionStatus } from '../types';
+import { ActionMenuStop } from '../types/ActionMenuStop';
 import { trStatus } from '../utils';
 import { StopVersionActionMenu } from './StopVersionActionMenu';
 
@@ -40,10 +40,11 @@ export const StopVersionRow: FC<StopVersionRowProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const locatableStop: LocatableStop = {
+  const stopForActions: ActionMenuStop = {
     label: publicCode,
     netextId: stopVersion.netex_id,
     location: stopVersion.location,
+    startDate: stopVersion.validity_start,
   };
 
   return (
@@ -79,11 +80,14 @@ export const StopVersionRow: FC<StopVersionRowProps> = ({
       <td>{stopVersion.changed_by}</td>
 
       <td className="!px-2">
-        <LocatorActionButton stop={locatableStop} />
+        <LocatorActionButton
+          observeOnStopValidityStartDate
+          stop={stopForActions}
+        />
       </td>
 
       <td className="!p-0">
-        <StopVersionActionMenu className="p-2" locatableStop={locatableStop} />
+        <StopVersionActionMenu className="p-2" stop={stopForActions} />
       </td>
     </tr>
   );

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionTable.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionTable.tsx
@@ -1,0 +1,50 @@
+import { Dispatch, FC, SetStateAction } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { StopVersion, StopVersionTableSortingInfo } from '../types';
+import { NoVersionRow } from './NoVersionRow';
+import { StopVersionRow } from './StopVersionRow';
+import { StopVersionTableHeader } from './StopVersionTableHeader';
+
+type StopVersionTableProps = {
+  readonly className?: string;
+  readonly noVersionsText: string;
+  readonly publicCode: string;
+  readonly stopVersions: ReadonlyArray<StopVersion>;
+  readonly sortingInfo: StopVersionTableSortingInfo;
+  readonly setSortingInfo: Dispatch<
+    SetStateAction<StopVersionTableSortingInfo>
+  >;
+};
+
+export const StopVersionTable: FC<StopVersionTableProps> = ({
+  className,
+  noVersionsText,
+  publicCode,
+  stopVersions,
+  sortingInfo,
+  setSortingInfo,
+}) => {
+  return (
+    <table className={twMerge('border-light-grey', className)}>
+      <StopVersionTableHeader
+        className="border-b"
+        sortingInfo={sortingInfo}
+        setSortingInfo={setSortingInfo}
+      />
+
+      <tbody>
+        {stopVersions.length ? (
+          stopVersions.map((stopVersion) => (
+            <StopVersionRow
+              key={stopVersion.id}
+              publicCode={publicCode}
+              stopVersion={stopVersion}
+            />
+          ))
+        ) : (
+          <NoVersionRow noVersionsText={noVersionsText} />
+        )}
+      </tbody>
+    </table>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionTableHeader.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionTableHeader.tsx
@@ -1,0 +1,78 @@
+import { Dispatch, FC, SetStateAction } from 'react';
+import { StopVersionTableSortingInfo } from '../types';
+import { StopVersionTableHeaderSortableCell } from './StopVersionTableHeaderSortableCell';
+
+const EmptyColumnHeader: FC<{ readonly className?: string }> = ({
+  className,
+}) => (
+  // eslint-disable-next-line jsx-a11y/control-has-associated-label
+  <td className={className} />
+);
+
+type StopVersionTableHeaderProps = {
+  readonly className?: string;
+  readonly sortingInfo: StopVersionTableSortingInfo;
+  readonly setSortingInfo: Dispatch<
+    SetStateAction<StopVersionTableSortingInfo>
+  >;
+};
+
+export const StopVersionTableHeader: FC<StopVersionTableHeaderProps> = ({
+  className,
+  sortingInfo,
+  setSortingInfo,
+}) => {
+  return (
+    <thead className={className}>
+      <tr className="text-nowrap *:px-4 *:py-2">
+        <StopVersionTableHeaderSortableCell
+          className="mr-auto"
+          columnType="STATUS"
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+
+        <StopVersionTableHeaderSortableCell
+          className="ml-auto"
+          columnType="VALIDITY_START"
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+
+        <EmptyColumnHeader className="w-fit !p-0" />
+
+        <StopVersionTableHeaderSortableCell
+          className="ml-auto"
+          columnType="VALIDITY_END"
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+
+        <StopVersionTableHeaderSortableCell
+          className="mx-auto"
+          tdClassName="w-full"
+          columnType="VERSION_COMMENT"
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+
+        <StopVersionTableHeaderSortableCell
+          className="mx-auto"
+          columnType="CHANGED"
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+
+        <StopVersionTableHeaderSortableCell
+          className="mx-auto"
+          columnType="CHANGED_BY"
+          sortingInfo={sortingInfo}
+          setSortingInfo={setSortingInfo}
+        />
+
+        <EmptyColumnHeader />
+        <EmptyColumnHeader />
+      </tr>
+    </thead>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionTableHeaderSortableCell.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionTableHeaderSortableCell.tsx
@@ -1,0 +1,75 @@
+import { TFunction } from 'i18next';
+import { Dispatch, FC, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twJoin } from 'tailwind-merge';
+import { SortOrder } from '../../../../../types';
+import { ExpandButton } from '../../../../../uiComponents';
+import { StopVersionTableColumn, StopVersionTableSortingInfo } from '../types';
+
+function trColumnName(t: TFunction, columnType: StopVersionTableColumn) {
+  switch (columnType) {
+    case 'CHANGED':
+      return t('stopVersion.header.changed');
+    case 'CHANGED_BY':
+      return t('stopVersion.header.changed_by');
+    case 'STATUS':
+      return t('stopVersion.header.status');
+    case 'VALIDITY_END':
+      return t('stopVersion.header.validity_end');
+    case 'VALIDITY_START':
+      return t('stopVersion.header.validity_start');
+    case 'VERSION_COMMENT':
+      return t('stopVersion.header.version_comment');
+
+    default:
+      return '';
+  }
+}
+
+type StopVersionTableHeaderSortableCellProps = {
+  readonly className?: string;
+  readonly tdClassName?: string;
+  readonly columnType: StopVersionTableColumn;
+  readonly sortingInfo: StopVersionTableSortingInfo;
+  readonly setSortingInfo: Dispatch<
+    SetStateAction<StopVersionTableSortingInfo>
+  >;
+};
+
+export const StopVersionTableHeaderSortableCell: FC<
+  StopVersionTableHeaderSortableCellProps
+> = ({ className, tdClassName, columnType, sortingInfo, setSortingInfo }) => {
+  const { t } = useTranslation();
+
+  const active = sortingInfo.sortBy === columnType;
+  const ascending = sortingInfo.sortOrder === SortOrder.ASCENDING;
+
+  const onClick = () => {
+    setSortingInfo((prevState) => {
+      if (prevState.sortBy === columnType) {
+        return {
+          ...prevState,
+          sortOrder:
+            prevState.sortOrder === SortOrder.ASCENDING
+              ? SortOrder.DESCENDING
+              : SortOrder.ASCENDING,
+        };
+      }
+
+      return { ...prevState, sortBy: columnType };
+    });
+  };
+
+  return (
+    <td className={tdClassName}>
+      <ExpandButton
+        className={twJoin(active ? 'underline' : '', className)}
+        iconClassName="text-base"
+        ariaControls="a"
+        expanded={!ascending}
+        expandedText={trColumnName(t, columnType)}
+        onClick={onClick}
+      />
+    </td>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/index.ts
+++ b/ui/src/components/stop-registry/stops/versions/index.ts
@@ -1,0 +1,1 @@
+export * from './StopVersionsPage';

--- a/ui/src/components/stop-registry/stops/versions/queries/useGetStopPlaceName.ts
+++ b/ui/src/components/stop-registry/stops/versions/queries/useGetStopPlaceName.ts
@@ -1,0 +1,82 @@
+import { gql } from '@apollo/client';
+import compact from 'lodash/compact';
+import { useMemo } from 'react';
+import {
+  StopRegistryEmbeddableMultilingualString,
+  useGetStopPlaceNameQuery,
+} from '../../../../../generated/graphql';
+import { StopPlaceName } from '../types';
+
+const GQL_GET_STOP_PLACE_NAME = gql`
+  query GetStopPlaceName($stopPlaceNetexId: String!) {
+    stop_registry {
+      stopPlace(id: $stopPlaceNetexId, onlyMonomodalStopPlaces: true) {
+        id
+
+        name {
+          lang
+          value
+        }
+
+        alternativeNames {
+          nameType
+          name {
+            lang
+            value
+          }
+        }
+      }
+    }
+  }
+`;
+
+function findName(
+  names: ReadonlyArray<StopRegistryEmbeddableMultilingualString>,
+  lang: string,
+): string | null | undefined {
+  return names.find((name) => name.lang === lang)?.value;
+}
+
+type GetStopPlaceNameLoading = {
+  readonly loading: true;
+  readonly stopPlaceName: null;
+};
+
+type GetStopPlaceNameLoaded = {
+  readonly loading: false;
+  readonly stopPlaceName: StopPlaceName;
+};
+
+export function useGetStopPlaceName(
+  stopPlaceNetexId: string | null,
+): GetStopPlaceNameLoading | GetStopPlaceNameLoaded {
+  const { data, loading } = useGetStopPlaceNameQuery(
+    stopPlaceNetexId ? { variables: { stopPlaceNetexId } } : { skip: true },
+  );
+
+  const stopPlace = data?.stop_registry?.stopPlace?.at(0);
+  const stopPlaceName: StopPlaceName = useMemo(() => {
+    if (!stopPlace) {
+      return {
+        name: '',
+        nameSwe: '',
+      };
+    }
+
+    const names = compact([
+      stopPlace.name,
+      ...compact(stopPlace.alternativeNames).map((it) => it.name),
+    ]);
+
+    return {
+      name: findName(names, 'fin') ?? '',
+      nameSwe: findName(names, 'swe') ?? '',
+    };
+  }, [stopPlace]);
+
+  if (loading || !stopPlaceNetexId) {
+    return { loading: true, stopPlaceName: null };
+  }
+
+  return { loading: false, stopPlaceName };
+}

--- a/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersionPageInfo.ts
+++ b/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersionPageInfo.ts
@@ -1,0 +1,63 @@
+import { StopPlaceName, StopVersion, StopVersionStatus } from '../types';
+import { useGetStopPlaceName } from './useGetStopPlaceName';
+import { useGetStopVersions } from './useGetStopVersions';
+
+function active(stopVersion: StopVersion) {
+  return stopVersion.status === StopVersionStatus.ACTIVE;
+}
+
+function properVersion(stopVersion: StopVersion) {
+  return (
+    stopVersion.status === StopVersionStatus.STANDARD ||
+    stopVersion.status === StopVersionStatus.TEMPORARY
+  );
+}
+
+function resolveStopPlaceId(
+  stopVersions: ReadonlyArray<StopVersion> | null,
+): string | null {
+  if (!stopVersions || stopVersions.length === 0) {
+    return null;
+  }
+
+  const activeStopVersion = stopVersions.find(active);
+  if (activeStopVersion) {
+    return activeStopVersion.stop_place_netex_id;
+  }
+
+  const lastProperVersion = stopVersions.findLast(properVersion);
+  if (lastProperVersion) {
+    return lastProperVersion.stop_place_netex_id;
+  }
+
+  return stopVersions[stopVersions.length - 1].stop_place_netex_id;
+}
+
+type GetStopVersionPageInfoLoading = {
+  readonly loading: true;
+  readonly stopVersions: null;
+  readonly stopPlaceName: null;
+};
+
+type GetStopVersionPageInfoLoaded = {
+  readonly loading: false;
+  readonly stopVersions: ReadonlyArray<StopVersion>;
+  readonly stopPlaceName: StopPlaceName;
+};
+
+export function useGetStopVersionPageInfo(
+  publicCode: string,
+): GetStopVersionPageInfoLoading | GetStopVersionPageInfoLoaded {
+  const { stopVersions, loading: loadingStopVersions } =
+    useGetStopVersions(publicCode);
+
+  const stopPlaceId = resolveStopPlaceId(stopVersions);
+  const { stopPlaceName, loading: loadingStopPlaceName } =
+    useGetStopPlaceName(stopPlaceId);
+
+  if (loadingStopVersions || loadingStopPlaceName) {
+    return { loading: true, stopVersions: null, stopPlaceName: null };
+  }
+
+  return { loading: false, stopVersions, stopPlaceName };
+}

--- a/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersions.ts
+++ b/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersions.ts
@@ -1,0 +1,156 @@
+import { gql } from '@apollo/client';
+import { DateTime } from 'luxon';
+import { useMemo } from 'react';
+import {
+  StopVersionInfoFragment,
+  useGetQuayVersionsQuery,
+} from '../../../../../generated/graphql';
+import { parseDate } from '../../../../../time';
+import { Priority } from '../../../../../types/enums';
+import { getGeometryPoint, numberEnumValues } from '../../../../../utils';
+import { StopVersion, StopVersionStatus } from '../types';
+
+const GQL_GET_QUAY_VERSIONS = gql`
+  query GetQuayVersions($publicCode: String!) {
+    stops_database {
+      quays: stops_database_quay_newest_version(
+        where: { public_code: { _eq: $publicCode } }
+        order_by: [{ validity_start: asc }, { priority: asc }]
+      ) {
+        ...StopVersionInfo
+      }
+    }
+  }
+
+  fragment StopVersionInfo on stops_database_quay_newest_version {
+    id
+    netex_id
+
+    stop_place {
+      id
+      netex_id
+    }
+
+    validity_start
+    validity_end
+    priority
+
+    centroid
+
+    created
+    changed
+    changed_by
+    version_comment
+  }
+`;
+
+const knownPriorityNumbers: ReadonlyArray<number> = numberEnumValues(Priority);
+
+function parsePriority(prioStr: string | null | undefined): Priority {
+  const prioNumber = Number(prioStr);
+  return knownPriorityNumbers.includes(prioNumber)
+    ? (prioNumber as Priority)
+    : Priority.Standard;
+}
+
+function mapPriorityToStopVersionStatus(priority: Priority): StopVersionStatus {
+  switch (priority) {
+    case Priority.Draft:
+      return StopVersionStatus.DRAFT;
+    case Priority.Temporary:
+      return StopVersionStatus.TEMPORARY;
+    default:
+      return StopVersionStatus.STANDARD;
+  }
+}
+
+function requireValue<T>(
+  nullable: T | undefined | null,
+): Exclude<T, undefined | null> {
+  if (nullable === undefined || nullable === null) {
+    throw new Error(
+      `Expected non nullable value but it was: ${String(nullable)}`,
+    );
+  }
+
+  return nullable as Exclude<T, undefined | null>;
+}
+
+function mapQuayToStopVersionInfoItem(
+  rawQuay: StopVersionInfoFragment,
+  activeVersionId: number | null,
+): StopVersion {
+  const priority = parsePriority(rawQuay.priority);
+  const status =
+    rawQuay.id === activeVersionId
+      ? StopVersionStatus.ACTIVE
+      : mapPriorityToStopVersionStatus(priority);
+
+  return {
+    id: rawQuay.id,
+    netex_id: requireValue(rawQuay.netex_id),
+    stop_place_netex_id: requireValue(rawQuay.stop_place?.netex_id),
+    validity_start: requireValue(parseDate(rawQuay.validity_start)),
+    validity_end: parseDate(rawQuay.validity_end) ?? null,
+    priority,
+    status,
+    location: requireValue(getGeometryPoint(rawQuay.centroid)),
+    changed: requireValue(parseDate(rawQuay.changed ?? rawQuay.created)),
+    changed_by: rawQuay.changed_by ?? '',
+    version_comment: rawQuay.version_comment ?? '',
+  };
+}
+
+function resolveActiveVersionId(
+  rawQuays: ReadonlyArray<StopVersionInfoFragment>,
+): number | null {
+  const today = DateTime.now().toISODate();
+
+  // prettier-ignore
+  const quay = rawQuays.findLast((rawQuay) =>
+    // Is Standard or Temporary
+    (Number(rawQuay.priority) < Priority.Draft) &&
+    // Started before or at today
+    (rawQuay.validity_start && rawQuay.validity_start <= today) &&
+    // Has not ended yet
+    (!rawQuay.validity_end || rawQuay.validity_end >= today)
+  );
+
+  return quay?.id ?? null;
+}
+
+type GetStopVersionsLoading = {
+  readonly loading: true;
+  readonly stopVersions: null;
+};
+
+type GetStopVersionsLoaded = {
+  readonly loading: false;
+  readonly stopVersions: ReadonlyArray<StopVersion>;
+};
+
+export function useGetStopVersions(
+  publicCode: string,
+): GetStopVersionsLoading | GetStopVersionsLoaded {
+  const { data, loading } = useGetQuayVersionsQuery({
+    variables: { publicCode },
+  });
+
+  const rawQuays = data?.stops_database?.quays;
+  const stopVersions = useMemo(() => {
+    if (!rawQuays) {
+      return [];
+    }
+
+    const activeVersionId = resolveActiveVersionId(rawQuays);
+    return rawQuays.map((rawQuay) =>
+      mapQuayToStopVersionInfoItem(rawQuay, activeVersionId),
+    );
+  }, [rawQuays]);
+
+  if (loading) {
+    return { loading: true, stopVersions: null };
+  }
+
+  return { loading: false, stopVersions };
+}

--- a/ui/src/components/stop-registry/stops/versions/types/ActionMenuStop.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/ActionMenuStop.ts
@@ -1,0 +1,6 @@
+import { DateTime } from 'luxon';
+import { LocatableStop } from '../../../types';
+
+export type ActionMenuStop = LocatableStop & {
+  readonly startDate: DateTime;
+};

--- a/ui/src/components/stop-registry/stops/versions/types/StopPlaceName.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/StopPlaceName.ts
@@ -1,0 +1,4 @@
+export type StopPlaceName = {
+  readonly name: string;
+  readonly nameSwe: string;
+};

--- a/ui/src/components/stop-registry/stops/versions/types/StopVersion.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/StopVersion.ts
@@ -1,0 +1,18 @@
+import { DateTime } from 'luxon';
+import { Point } from '../../../../../types';
+import { Priority } from '../../../../../types/enums';
+import { StopVersionStatus } from './StopVersionStatus';
+
+export type StopVersion = {
+  readonly id: number;
+  readonly netex_id: string;
+  readonly stop_place_netex_id: string;
+  readonly validity_start: DateTime;
+  readonly validity_end: DateTime | null;
+  readonly priority: Priority;
+  readonly status: StopVersionStatus;
+  readonly location: Point;
+  readonly changed: DateTime;
+  readonly changed_by: string;
+  readonly version_comment: string;
+};

--- a/ui/src/components/stop-registry/stops/versions/types/StopVersionStatus.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/StopVersionStatus.ts
@@ -1,0 +1,6 @@
+export enum StopVersionStatus {
+  ACTIVE = 'ACTIVE',
+  STANDARD = 'STANDARD',
+  TEMPORARY = 'TEMPORARY',
+  DRAFT = 'DRAFT',
+}

--- a/ui/src/components/stop-registry/stops/versions/types/StopVersionTableColumn.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/StopVersionTableColumn.ts
@@ -1,0 +1,7 @@
+export type StopVersionTableColumn =
+  | 'STATUS'
+  | 'VALIDITY_START'
+  | 'VALIDITY_END'
+  | 'VERSION_COMMENT'
+  | 'CHANGED'
+  | 'CHANGED_BY';

--- a/ui/src/components/stop-registry/stops/versions/types/StopVersionTableSortingInfo.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/StopVersionTableSortingInfo.ts
@@ -1,0 +1,7 @@
+import { SortOrder } from '../../../../../types';
+import { StopVersionTableColumn } from './StopVersionTableColumn';
+
+export type StopVersionTableSortingInfo = {
+  readonly sortBy: StopVersionTableColumn;
+  readonly sortOrder: SortOrder;
+};

--- a/ui/src/components/stop-registry/stops/versions/types/index.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/index.ts
@@ -1,0 +1,3 @@
+export * from './StopPlaceName';
+export * from './StopVersion';
+export * from './StopVersionStatus';

--- a/ui/src/components/stop-registry/stops/versions/types/index.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/index.ts
@@ -1,3 +1,5 @@
 export * from './StopPlaceName';
 export * from './StopVersion';
 export * from './StopVersionStatus';
+export * from './StopVersionTableColumn';
+export * from './StopVersionTableSortingInfo';

--- a/ui/src/components/stop-registry/stops/versions/utils/getAccordionClassNames.ts
+++ b/ui/src/components/stop-registry/stops/versions/utils/getAccordionClassNames.ts
@@ -1,0 +1,8 @@
+import { twJoin } from 'tailwind-merge';
+
+export function getAccordionClassNames(expanded: boolean) {
+  return twJoin(
+    'mt-2 transition-[max-height] overflow-hidden',
+    expanded ? 'max-h-screen' : 'max-h-0',
+  );
+}

--- a/ui/src/components/stop-registry/stops/versions/utils/index.ts
+++ b/ui/src/components/stop-registry/stops/versions/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './trStatus';

--- a/ui/src/components/stop-registry/stops/versions/utils/index.ts
+++ b/ui/src/components/stop-registry/stops/versions/utils/index.ts
@@ -1,1 +1,3 @@
+export * from './getAccordionClassNames';
 export * from './trStatus';
+export * from './useSortedStopVersions';

--- a/ui/src/components/stop-registry/stops/versions/utils/trStatus.ts
+++ b/ui/src/components/stop-registry/stops/versions/utils/trStatus.ts
@@ -1,0 +1,21 @@
+import { TFunction } from 'i18next';
+import { StopVersionStatus } from '../types';
+
+export function trStatus(t: TFunction, status: StopVersionStatus): string {
+  switch (status) {
+    case StopVersionStatus.ACTIVE:
+      return t('stopVersion.status.active');
+
+    case StopVersionStatus.STANDARD:
+      return t('stopVersion.status.standard');
+
+    case StopVersionStatus.TEMPORARY:
+      return t('stopVersion.status.temporary');
+
+    case StopVersionStatus.DRAFT:
+      return t('stopVersion.status.draft');
+
+    default:
+      return '';
+  }
+}

--- a/ui/src/components/stop-registry/stops/versions/utils/useSortedStopVersions.ts
+++ b/ui/src/components/stop-registry/stops/versions/utils/useSortedStopVersions.ts
@@ -1,0 +1,77 @@
+import { DateTime } from 'luxon';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SortOrder } from '../../../../../types';
+import {
+  StopVersion,
+  StopVersionTableColumn,
+  StopVersionTableSortingInfo,
+} from '../types';
+import { trStatus } from './trStatus';
+
+type Comparator = (versionA: StopVersion, versionB: StopVersion) => number;
+
+function compareDates(dateA: DateTime | null, dateB: DateTime | null): number {
+  if (dateA === null && dateB === null) {
+    return 0;
+  }
+
+  if (dateA === null) {
+    return -1;
+  }
+
+  if (dateB === null) {
+    return 1;
+  }
+
+  return dateA.valueOf() - dateB.valueOf();
+}
+
+function useComparator(orderBy: StopVersionTableColumn): Comparator {
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
+
+  const collator = useMemo(() => new Intl.Collator(language), [language]);
+
+  switch (orderBy) {
+    case 'STATUS':
+      return (a, b) =>
+        collator.compare(trStatus(t, a.status), trStatus(t, b.status));
+
+    case 'VALIDITY_START':
+      return (a, b) => compareDates(a.validity_start, b.validity_start);
+
+    case 'VALIDITY_END':
+      return (a, b) => compareDates(a.validity_end, b.validity_end);
+
+    case 'VERSION_COMMENT':
+      return (a, b) => collator.compare(a.version_comment, b.version_comment);
+
+    case 'CHANGED':
+      return (a, b) => compareDates(a.changed, b.changed);
+
+    case 'CHANGED_BY':
+      return (a, b) => collator.compare(a.changed_by, b.changed_by);
+
+    default:
+      return () => 0;
+  }
+}
+
+export function useSortedStopVersions(
+  sortingInfo: StopVersionTableSortingInfo,
+  stopVersions: ReadonlyArray<StopVersion>,
+): ReadonlyArray<StopVersion> {
+  const comparator = useComparator(sortingInfo.sortBy);
+
+  return useMemo(() => {
+    const orderedComparator: Comparator =
+      sortingInfo.sortOrder === SortOrder.ASCENDING
+        ? comparator
+        : (a, b) => -comparator(a, b);
+
+    return stopVersions.toSorted(orderedComparator);
+  }, [sortingInfo, comparator, stopVersions]);
+}

--- a/ui/src/components/stop-registry/types/LocatableStopProps.ts
+++ b/ui/src/components/stop-registry/types/LocatableStopProps.ts
@@ -1,6 +1,16 @@
+import { DateTime } from 'luxon';
 import { LocatableStop } from './LocatableStop';
 
 export type LocatableStopProps = {
   readonly className?: string;
   readonly stop: LocatableStop;
 };
+
+export type LocatableStopWithObservationDateProps = LocatableStopProps & {
+  readonly observationDate?: DateTime;
+};
+
+export type LocatableStopWithObserveOnValidityStartProps =
+  LocatableStopProps & {
+    readonly observeOnStopValidityStartDate?: boolean;
+  };

--- a/ui/src/components/stop-registry/utils/useShowStopOnMap.ts
+++ b/ui/src/components/stop-registry/utils/useShowStopOnMap.ts
@@ -23,7 +23,10 @@ export function useShowStopOnMap() {
   const { openMapWithParameters } = useMapQueryParams();
   const getStopPointForQuay = useGetStopPointForQuay();
 
-  return ({ netextId, location }: LocatableStop) => {
+  return (
+    { netextId, location }: LocatableStop,
+    observeOnStopValidityStartDate: boolean = false,
+  ) => {
     Promise.all([
       netextId ? getStopPointForQuay(netextId) : Promise.resolve(null),
       dispatch(resetMapState()),
@@ -40,13 +43,18 @@ export function useShowStopOnMap() {
         }),
       );
 
+      const observeOn =
+        (observeOnStopValidityStartDate
+          ? stopPoint?.validity_start
+          : observationDate) ?? observationDate;
+
       openMapWithParameters({
         viewPortParams: {
           latitude: location.latitude,
           longitude: location.longitude,
           zoom: 15,
         },
-        observationDate,
+        observationDate: observeOn,
         displayedRouteParams: {},
       });
     });

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -70291,6 +70291,104 @@ export type ResolveExistingStopValidityRangesQuery = {
   }>;
 };
 
+export type GetStopPlaceNameQueryVariables = Exact<{
+  stopPlaceNetexId: Scalars['String']['input'];
+}>;
+
+export type GetStopPlaceNameQuery = {
+  __typename?: 'query_root';
+  stop_registry?: {
+    __typename?: 'stop_registryStopPlaceRegister';
+    stopPlace?: Array<
+      | {
+          __typename?: 'stop_registry_ParentStopPlace';
+          id?: string | null;
+          name?: {
+            __typename?: 'stop_registry_EmbeddableMultilingualString';
+            lang?: string | null;
+            value?: string | null;
+          } | null;
+          alternativeNames?: Array<{
+            __typename?: 'stop_registry_AlternativeName';
+            nameType: StopRegistryNameType;
+            name: {
+              __typename?: 'stop_registry_EmbeddableMultilingualString';
+              lang?: string | null;
+              value?: string | null;
+            };
+          } | null> | null;
+        }
+      | {
+          __typename?: 'stop_registry_StopPlace';
+          id?: string | null;
+          name?: {
+            __typename?: 'stop_registry_EmbeddableMultilingualString';
+            lang?: string | null;
+            value?: string | null;
+          } | null;
+          alternativeNames?: Array<{
+            __typename?: 'stop_registry_AlternativeName';
+            nameType: StopRegistryNameType;
+            name: {
+              __typename?: 'stop_registry_EmbeddableMultilingualString';
+              lang?: string | null;
+              value?: string | null;
+            };
+          } | null> | null;
+        }
+      | null
+    > | null;
+  } | null;
+};
+
+export type GetQuayVersionsQueryVariables = Exact<{
+  publicCode: Scalars['String']['input'];
+}>;
+
+export type GetQuayVersionsQuery = {
+  __typename?: 'query_root';
+  stops_database?: {
+    __typename?: 'stops_database_stops_database_query';
+    quays: Array<{
+      __typename?: 'stops_database_quay_newest_version';
+      id?: any | null;
+      netex_id?: string | null;
+      validity_start?: string | null;
+      validity_end?: string | null;
+      priority?: string | null;
+      centroid?: GeoJSON.Geometry | null;
+      created?: any | null;
+      changed?: any | null;
+      changed_by?: string | null;
+      version_comment?: string | null;
+      stop_place?: {
+        __typename?: 'stops_database_stop_place';
+        id: any;
+        netex_id?: string | null;
+      } | null;
+    }>;
+  } | null;
+};
+
+export type StopVersionInfoFragment = {
+  __typename?: 'stops_database_quay_newest_version';
+  id?: any | null;
+  netex_id?: string | null;
+  validity_start?: string | null;
+  validity_end?: string | null;
+  priority?: string | null;
+  centroid?: GeoJSON.Geometry | null;
+  created?: any | null;
+  changed?: any | null;
+  changed_by?: string | null;
+  version_comment?: string | null;
+  stop_place?: {
+    __typename?: 'stops_database_stop_place';
+    id: any;
+    netex_id?: string | null;
+  } | null;
+};
+
 export type VehicleJourneyByStopFragment = {
   __typename?: 'timetables_vehicle_journey_vehicle_journey';
   journey_pattern_ref_id: UUID;
@@ -76507,6 +76605,24 @@ export const StopPlaceDetailsFragmentDoc = gql`
   ${TopographicPlaceDetailsFragmentDoc}
   ${FareZoneDetailsFragmentDoc}
 `;
+export const StopVersionInfoFragmentDoc = gql`
+  fragment StopVersionInfo on stops_database_quay_newest_version {
+    id
+    netex_id
+    stop_place {
+      id
+      netex_id
+    }
+    validity_start
+    validity_end
+    priority
+    centroid
+    created
+    changed
+    changed_by
+    version_comment
+  }
+`;
 export const InfraLinkMatchingFieldsFragmentDoc = gql`
   fragment infra_link_matching_fields on infrastructure_network_infrastructure_link {
     external_link_id
@@ -79142,6 +79258,189 @@ export type ResolveExistingStopValidityRangesSuspenseQueryHookResult =
 export type ResolveExistingStopValidityRangesQueryResult = Apollo.QueryResult<
   ResolveExistingStopValidityRangesQuery,
   ResolveExistingStopValidityRangesQueryVariables
+>;
+export const GetStopPlaceNameDocument = gql`
+  query GetStopPlaceName($stopPlaceNetexId: String!) {
+    stop_registry {
+      stopPlace(id: $stopPlaceNetexId, onlyMonomodalStopPlaces: true) {
+        id
+        name {
+          lang
+          value
+        }
+        alternativeNames {
+          nameType
+          name {
+            lang
+            value
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useGetStopPlaceNameQuery__
+ *
+ * To run a query within a React component, call `useGetStopPlaceNameQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStopPlaceNameQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetStopPlaceNameQuery({
+ *   variables: {
+ *      stopPlaceNetexId: // value for 'stopPlaceNetexId'
+ *   },
+ * });
+ */
+export function useGetStopPlaceNameQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetStopPlaceNameQuery,
+    GetStopPlaceNameQueryVariables
+  > &
+    (
+      | { variables: GetStopPlaceNameQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetStopPlaceNameQuery, GetStopPlaceNameQueryVariables>(
+    GetStopPlaceNameDocument,
+    options,
+  );
+}
+export function useGetStopPlaceNameLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetStopPlaceNameQuery,
+    GetStopPlaceNameQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetStopPlaceNameQuery,
+    GetStopPlaceNameQueryVariables
+  >(GetStopPlaceNameDocument, options);
+}
+export function useGetStopPlaceNameSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetStopPlaceNameQuery,
+        GetStopPlaceNameQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetStopPlaceNameQuery,
+    GetStopPlaceNameQueryVariables
+  >(GetStopPlaceNameDocument, options);
+}
+export type GetStopPlaceNameQueryHookResult = ReturnType<
+  typeof useGetStopPlaceNameQuery
+>;
+export type GetStopPlaceNameLazyQueryHookResult = ReturnType<
+  typeof useGetStopPlaceNameLazyQuery
+>;
+export type GetStopPlaceNameSuspenseQueryHookResult = ReturnType<
+  typeof useGetStopPlaceNameSuspenseQuery
+>;
+export type GetStopPlaceNameQueryResult = Apollo.QueryResult<
+  GetStopPlaceNameQuery,
+  GetStopPlaceNameQueryVariables
+>;
+export const GetQuayVersionsDocument = gql`
+  query GetQuayVersions($publicCode: String!) {
+    stops_database {
+      quays: stops_database_quay_newest_version(
+        where: { public_code: { _eq: $publicCode } }
+        order_by: [{ validity_start: asc }, { priority: asc }]
+      ) {
+        ...StopVersionInfo
+      }
+    }
+  }
+  ${StopVersionInfoFragmentDoc}
+`;
+
+/**
+ * __useGetQuayVersionsQuery__
+ *
+ * To run a query within a React component, call `useGetQuayVersionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetQuayVersionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetQuayVersionsQuery({
+ *   variables: {
+ *      publicCode: // value for 'publicCode'
+ *   },
+ * });
+ */
+export function useGetQuayVersionsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetQuayVersionsQuery,
+    GetQuayVersionsQueryVariables
+  > &
+    (
+      | { variables: GetQuayVersionsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<GetQuayVersionsQuery, GetQuayVersionsQueryVariables>(
+    GetQuayVersionsDocument,
+    options,
+  );
+}
+export function useGetQuayVersionsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetQuayVersionsQuery,
+    GetQuayVersionsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetQuayVersionsQuery,
+    GetQuayVersionsQueryVariables
+  >(GetQuayVersionsDocument, options);
+}
+export function useGetQuayVersionsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetQuayVersionsQuery,
+        GetQuayVersionsQueryVariables
+      >,
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetQuayVersionsQuery,
+    GetQuayVersionsQueryVariables
+  >(GetQuayVersionsDocument, options);
+}
+export type GetQuayVersionsQueryHookResult = ReturnType<
+  typeof useGetQuayVersionsQuery
+>;
+export type GetQuayVersionsLazyQueryHookResult = ReturnType<
+  typeof useGetQuayVersionsLazyQuery
+>;
+export type GetQuayVersionsSuspenseQueryHookResult = ReturnType<
+  typeof useGetQuayVersionsSuspenseQuery
+>;
+export type GetQuayVersionsQueryResult = Apollo.QueryResult<
+  GetQuayVersionsQuery,
+  GetQuayVersionsQueryVariables
 >;
 export const GetRouteWithJourneyPatternDocument = gql`
   query GetRouteWithJourneyPattern($routeId: uuid!) {

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -17,6 +17,7 @@ export * from './useDebouncedString';
 export * from './useGetJourneyPatternIdsByRouteLabel';
 export * from './useGetTimetableVersions';
 export * from './useRequiredParams';
+export * from './useSafeBackNavigation';
 export * from './useShowRoutesOnModal';
 export * from './useToggle';
 export * from './useTypedUrlState';

--- a/ui/src/hooks/useSafeBackNavigation.ts
+++ b/ui/src/hooks/useSafeBackNavigation.ts
@@ -1,0 +1,113 @@
+import {
+  NavigateOptions,
+  To,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
+
+export function isBackNavigationSafe(state: unknown): boolean {
+  return !!(
+    state &&
+    typeof state === 'object' &&
+    'safeToNavigateBack' in state &&
+    state.safeToNavigateBack
+  );
+}
+
+type SafeToNavigateBackState = { readonly safeToNavigateBack: true };
+
+const safeState: SafeToNavigateBackState = { safeToNavigateBack: true };
+
+export function makeBackNavigationIsSafeState(): SafeToNavigateBackState;
+export function makeBackNavigationIsSafeState<
+  State extends Record<string, unknown>,
+>(otherStateBits: State): State & SafeToNavigateBackState;
+export function makeBackNavigationIsSafeState<
+  State extends Record<string, unknown>,
+>(
+  otherStateBits?: State,
+): (State & SafeToNavigateBackState) | SafeToNavigateBackState {
+  if (otherStateBits) {
+    return { ...otherStateBits, safeToNavigateBack: true };
+  }
+
+  return safeState;
+}
+
+type SafeBackNavigationFn = (to: To, options?: NavigateOptions) => void;
+
+/**
+ * Allows navigating to previous page, while preventing cross domain navigation.
+ *
+ *
+ * Preface: React Router's navigation is directly tied to the {@link History}
+ *          API. React Router does "hijack" and abstract over the API,
+ *          but ultimately all React Router navigation boil down the
+ *          {@link History.pushState}, {@link History.replaceState} and
+ *          {@link History.go} API methods.
+ *
+ *
+ * Problem: Say the user is initially on another domain (even on browser homepage)
+ *          and then navigates to __Jore__ with link, e.g. from Teams or bookmark,
+ *          the History stack will look like `[domain.fi, jore.fi/page]`. <p/>
+ *          Now navigating back one page will take the user back to __domain.fi__.
+ *          So if we have a '*Go back*'-button on the page that simply pops the
+ *          last entry from the stack, could result in unexpected cross domain
+ *          navigation.
+ *
+ *
+ * Simple solution: Never do index based navigation, i.e. no real'*Go back*' or
+ * '*Go forward*'-buttons. While simple this can result in non-optimal browser
+ * History stacks. For example in the case of Stop Version Page's '*Go back*'
+ * -button we could have the 2 to scenarios. § in front of the path shall
+ * refer to the active page. <p/>
+ * Initial History stack: `[/…/search/, /…/stops/A1, §/…/stops/A1/versions]`
+ *
+ * 1. Navigating "back" with simple pushState would result in history stack:
+ *    `[/…/search/, /…/stops/A1, /…/stops/A1/versions, §/…/stops/A1]`, thus if
+ *    the user was to then press the browsers Back-button they would end up
+ *    back on the Versions page instead of the assumed Stop Search page.
+ *    Also, if the user was to press the browsers Forward-button nothing would
+ *    happen, as the user is already on the latest page.
+ *
+ * 2. Navigating "back" with replaceState would result in history stack:
+ *    `[/…/search/, §/…/stops/A1]`. This time a browser Back-button would take
+ *    the user to the assumed Stop Search page. But now the temporary navigation
+ *    to Versions page has been completely erased from the navigation history.
+ *    If the user was to press the browsers Forward-button nothing would happen,
+ *    as the user is already on the latest page.
+ *
+ *
+ * Proper solution: Determine if the previous page in the stack belongs to the
+ * same domain, if so navigate back `navigate(-1)` else perform the navigation
+ * somehow else, in not so optimal manner.
+ *
+ * Problem: The History API does not expose any info about previous or "upcoming"
+ * pages to current page. E.g. the is no `history.peek()` method. Thus, the
+ * "safeness" of the back navigation needs to be somehow encoded in the current
+ * page's {@link History.state} value.
+ *
+ *
+ * In React Router V7 the `useLocation().key` property will be set to `default`
+ * on the initial location. Once we upgrade to V7 we can use that to safely
+ * and consistently determine whether we are on the 1st page of the App or
+ * if we have already done in App page navigation.
+ *
+ * But for now we have to encode the info manually at the point where we expose
+ * a navigation into a page, that need support for safe back navigation.
+ * See {@link makeBackNavigationIsSafeState} and {@link isBackNavigationSafe}
+ *
+ * @return {SafeBackNavigationFn}
+ */
+export function useNavigateBackSafely(): SafeBackNavigationFn {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+
+  return (fallback: To, options) => {
+    if (isBackNavigationSafe(state)) {
+      navigate(-1);
+    } else {
+      navigate(fallback, options);
+    }
+  };
+}

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -388,6 +388,7 @@
       }
     },
     "actions": {
+      "showVersions": "Versions",
       "extra": {
         "copy": "Make a new copy"
       }

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -1030,5 +1030,37 @@
       "topic": "Temporary version will change",
       "description": "Validity will end within 20 days."
     }
+  },
+  "stopVersion": {
+    "title": "Versions | Stop {{publicCode}}",
+    "titleWithName": "Versions | Stop {{publicCode}} {{name}}",
+    "loading": "Loading version information",
+    "goBack": "Go back",
+    "scheduled": {
+      "title": "Scheduled",
+      "show": "Show scheduled",
+      "hide": "Hide scheduled",
+      "noVersions": "No scheduled versions in the selected time range."
+    },
+    "drafts": {
+      "title": "Drafts",
+      "show": "Show drafts",
+      "hide": "Hide drafts",
+      "noVersions": "The stop has no draft verisons."
+    },
+    "header": {
+      "status": "Status",
+      "validity_start": "Valid from",
+      "validity_end": "Valid to",
+      "version_comment": "Version name",
+      "changed": "Changed",
+      "changed_by": "Changed by"
+    },
+    "status": {
+      "active": "Active",
+      "standard": "$t(priority.standard)",
+      "temporary": "$t(priority.temporary)",
+      "draft": "$t(priority.draft)"
+    }
   }
 }

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -388,6 +388,7 @@
       }
     },
     "actions": {
+      "showVersions": "Versiot",
       "extra": {
         "copy": "Kopioi uudeksi versioksi"
       }

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -1030,5 +1030,37 @@
       "topic": "Väliaikainen versio vaihtuu",
       "description": "Voimassaolo päättyy 20 päivän sisällä."
     }
+  },
+  "stopVersion": {
+    "title": "Versiot | Pysäkki {{publicCode}}",
+    "titleWithName": "Versiot | Pysäkki {{publicCode}} {{name}}",
+    "loading": "Ladataan versiotietoja",
+    "goBack": "Palaa",
+    "scheduled": {
+      "title": "Kalenteroidut",
+      "show": "Näytä kalenteroidut",
+      "hide": "Piilota kalenteroidut",
+      "noVersions": "Valitulla aikavälillä ei ole yhtään kalenteroitua pysäkkiversiota."
+    },
+    "drafts": {
+      "title": "Luonnokset",
+      "show": "Näytä luonnokset",
+      "hide": "Piilota luonnokset",
+      "noVersions": "Pysäkiin ei liity yhtään luonnosta."
+    },
+    "header": {
+      "status": "Status",
+      "validity_start": "Alkaa",
+      "validity_end": "Päättyy",
+      "version_comment": "Version nimi",
+      "changed": "Muokattu",
+      "changed_by": "Muokkaaja"
+    },
+    "status": {
+      "active": "Voimassa",
+      "standard": "$t(priority.standard)",
+      "temporary": "$t(priority.temporary)",
+      "draft": "$t(priority.draft)"
+    }
   }
 }

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -21,6 +21,7 @@ import {
   StopSearchResultPage,
 } from '../components/stop-registry';
 import { StopAreaDetailsPage } from '../components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage';
+import { StopVersionsPage } from '../components/stop-registry/stops/versions';
 import {
   SubstituteDaySettingsPage,
   TimetablesMainPage,
@@ -149,6 +150,11 @@ export const Router: FC = () => {
       _routerRoute: Path.stopDetails,
       protected: true,
       element: <StopDetailsPage />,
+    },
+    [Path.stopVersions]: {
+      _routerRoute: Path.stopVersions,
+      protected: true,
+      element: <StopVersionsPage />,
     },
     [Path.stopAreaDetails]: {
       _routerRoute: Path.stopAreaDetails,

--- a/ui/src/router/routeDetails.ts
+++ b/ui/src/router/routeDetails.ts
@@ -21,7 +21,7 @@ export enum Path {
   // Stop registry
   stopSearch = '/stop-registry/search',
   stopDetails = '/stop-registry/stops/:label',
-  // stopVersions = '/stop-registry/stops/:label/versions',
+  stopVersions = '/stop-registry/stops/:label/versions',
   // stopChangeHistory = '/stop-registry/stops/:label/history',
   // terminalDetails = '/stop-registry/terminals/:id',
   stopAreaDetails = '/stop-registry/stop-areas/:id',
@@ -119,6 +119,10 @@ export const routeDetails: Record<Path, RouteDetail> = {
   },
   [Path.stopDetails]: {
     getLink: (label: string) => Path.stopDetails.replace(':label', label),
+    includeInNav: false,
+  },
+  [Path.stopVersions]: {
+    getLink: (label: string) => Path.stopVersions.replace(':label', label),
     includeInNav: false,
   },
   [Path.stopAreaDetails]: {

--- a/ui/src/uiComponents/CloseIconButton.tsx
+++ b/ui/src/uiComponents/CloseIconButton.tsx
@@ -1,25 +1,28 @@
-interface Props {
-  onClick: () => void;
-  className?: string;
-  label?: string;
-  testId: string;
-}
+import { FC, ReactNode } from 'react';
+import { twJoin } from 'tailwind-merge';
+import { TextAndIconButton } from './TextAndIconButton';
 
-export const CloseIconButton = ({
-  onClick,
-  className = '',
+type CloseIconButtonProps = {
+  readonly className?: string;
+  readonly label?: ReactNode;
+  readonly onClick: () => void;
+  readonly testId: string;
+};
+
+export const CloseIconButton: FC<CloseIconButtonProps> = ({
+  className,
   label,
+  onClick,
   testId,
-}: Props): React.ReactElement => {
+}) => {
   return (
-    <button
-      className={className}
-      type="button"
-      onClick={onClick}
+    <TextAndIconButton
+      className={twJoin('gap-4', className)}
       data-testid={testId}
-    >
-      {label}
-      <i className="icon-close-large ml-4 text-lg" />
-    </button>
+      icon={<i className="icon-close-large text-lg" />}
+      onClick={onClick}
+      text={label}
+      type="button"
+    />
   );
 };

--- a/ui/src/uiComponents/SimpleButton.tsx
+++ b/ui/src/uiComponents/SimpleButton.tsx
@@ -1,35 +1,38 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import React, { FC, ReactNode } from 'react';
+import { Link, To } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 
-interface CommonButtonProps {
-  id?: string;
-  className?: string;
-  testId?: string;
-  inverted?: boolean;
-  selected?: boolean;
-  disabled?: boolean;
-  children?: ReactNode;
-  containerClassName?: string;
-  invertedClassName?: string;
-  tooltip?: string;
-  disabledTooltip?: string;
-  ariaSelected?: boolean;
-  role?: string;
-  ariaControls?: string;
-}
+type CommonButtonProps = {
+  readonly id?: string;
+  readonly className?: string;
+  readonly testId?: string;
+  readonly inverted?: boolean;
+  readonly selected?: boolean;
+  readonly disabled?: boolean;
+  readonly children?: ReactNode;
+  readonly containerClassName?: string;
+  readonly invertedClassName?: string;
+  readonly tooltip?: string;
+  readonly disabledTooltip?: string;
+  readonly ariaSelected?: boolean;
+  readonly role?: string;
+  readonly ariaControls?: string;
+};
 
-interface ButtonProps {
-  onClick?: () => void;
-  type?: 'button' | 'reset' | 'submit' | undefined;
-  href?: never;
-}
-interface LinkButtonProps {
-  onClick?: never;
-  type?: never;
-  href: string;
-}
+type ButtonProps = {
+  readonly onClick?: () => void;
+  readonly type?: 'button' | 'reset' | 'submit' | undefined;
+  readonly href?: never;
+  readonly state?: never;
+};
+
+type LinkButtonProps = {
+  readonly onClick?: never;
+  readonly type?: never;
+  readonly href: To;
+  readonly state?: unknown;
+};
 
 type Props = CommonButtonProps & (ButtonProps | LinkButtonProps);
 
@@ -49,7 +52,7 @@ const getHoverStyles = (inverted = false, disabled = false) => {
     : `${hoverStyle} hover:bg-opacity-50`;
 };
 
-export const SimpleButton: React.FC<Props> = ({
+export const SimpleButton: FC<Props> = ({
   id,
   className = '',
   inverted,
@@ -67,6 +70,7 @@ export const SimpleButton: React.FC<Props> = ({
   type = 'button',
   onClick,
   href,
+  state,
 }) => {
   const colorClassNames = inverted
     ? `text-brand bg-white border border-grey active:border-brand ${invertedClassName}`
@@ -94,6 +98,7 @@ export const SimpleButton: React.FC<Props> = ({
           type="button"
           // @ts-expect-error we want to pass undefined as href for disabled buttons
           to={disabled ? undefined : href}
+          state={state}
           aria-disabled={disabled}
           tabIndex={disabled ? -1 : undefined}
           data-testid={testId}


### PR DESCRIPTION
### Stop Versions: Define base data types


### Stop Versions: Add queries to fecth verion page data


### Stop Versions: Add new translation strings


### Stop Versions: Add components to implement `<StopVersionTable>`


### Stop Versions: Include proper observationDate on menus & action buttons


### Stop Versions: Implement the actual page


### Stop Versions: Include stop versions page in the navigation


### Stop Versions: Implement back navigation from Versions Page
* Reimplement `<CloseIconButton>` with `<TextAndIconButton>`.
* Allow `<SimpleButton>` to accept React Router state value in link mode.
* Implement hook for safely navigating back to previous page, without
  fear of ending up on another domain.
* Add 'Go back' button to Stop Versions Page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1025)
<!-- Reviewable:end -->
