### PR TITLE
Copy stop: Ensure other Quays are not updated

### DIFF
--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useCopyStop.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useCopyStop.ts
@@ -64,7 +64,7 @@ function useGetStopPlaceUpdateInput() {
         existingQuays,
         stopPlaceInput: {
           id: getStopPlaceId(originalStop),
-          quays: existingQuays.concat(quayCopy),
+          quays: [...existingQuays, quayCopy],
         },
       };
     },

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useResolveExistingQuays.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useResolveExistingQuays.ts
@@ -13,20 +13,12 @@ const GQL_RESOLVE_EXISTING_QUAYS = gql`
       ) {
         id
         netex_id
-        description_lang
-        description_value
       }
     }
   }
 `;
 
-// We need to allways pass the same description in.
-// Leaving it empty in the input, will result in Timat setting
-// the field to null otherwise.
-export type ExistingQuayInput = Pick<
-  StopRegistryQuayInput,
-  'id' | 'description'
->;
+export type ExistingQuayInput = Pick<StopRegistryQuayInput, 'id'>;
 
 export function useResolveExistingQuays() {
   const [resolveExistingQuaysLazyQuery] = useResolveExistingQuaysLazyQuery();
@@ -44,13 +36,7 @@ export function useResolveExistingQuays() {
           );
         }
 
-        return {
-          id: rawQuay.netex_id,
-          description: {
-            lang: rawQuay.description_lang,
-            value: rawQuay.description_value,
-          },
-        };
+        return { id: rawQuay.netex_id };
       });
     },
     [resolveExistingQuaysLazyQuery],

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -70142,8 +70142,6 @@ export type ResolveExistingQuaysQuery = {
       __typename?: 'stops_database_quay_newest_version';
       id?: any | null;
       netex_id?: string | null;
-      description_lang?: string | null;
-      description_value?: string | null;
     }>;
   } | null;
 };
@@ -78700,8 +78698,6 @@ export const ResolveExistingQuaysDocument = gql`
       ) {
         id
         netex_id
-        description_lang
-        description_value
       }
     }
   }


### PR DESCRIPTION
Thanks to recent Tiamat change we no longer need to always pass in the Description field. Passing that in to the quays causes all quays of the Stop Place to be updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1027)
<!-- Reviewable:end -->
