### PR TITLE
Stop Versions Page accessibility improvements & a sorting fix

### DIFF
--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionTableHeaderSortableCell.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionTableHeaderSortableCell.tsx
@@ -1,10 +1,21 @@
 import { TFunction } from 'i18next';
-import { Dispatch, FC, SetStateAction } from 'react';
+import { AriaAttributes, Dispatch, FC, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twJoin } from 'tailwind-merge';
 import { SortOrder } from '../../../../../types';
 import { ExpandButton } from '../../../../../uiComponents';
 import { StopVersionTableColumn, StopVersionTableSortingInfo } from '../types';
+
+function getAriaSortValue(
+  active: boolean,
+  ascending: boolean,
+): AriaAttributes['aria-sort'] {
+  if (active) {
+    return ascending ? 'ascending' : 'descending';
+  }
+
+  return undefined;
+}
 
 function trColumnName(t: TFunction, columnType: StopVersionTableColumn) {
   switch (columnType) {
@@ -61,11 +72,11 @@ export const StopVersionTableHeaderSortableCell: FC<
   };
 
   return (
-    <td className={tdClassName}>
+    <td aria-sort={getAriaSortValue(active, ascending)} className={tdClassName}>
       <ExpandButton
+        forSorting
         className={twJoin(active ? 'underline' : '', className)}
         iconClassName="text-base"
-        ariaControls="a"
         expanded={!ascending}
         expandedText={trColumnName(t, columnType)}
         onClick={onClick}

--- a/ui/src/components/stop-registry/stops/versions/utils/useSortedStopVersions.ts
+++ b/ui/src/components/stop-registry/stops/versions/utils/useSortedStopVersions.ts
@@ -11,17 +11,21 @@ import { trStatus } from './trStatus';
 
 type Comparator = (versionA: StopVersion, versionB: StopVersion) => number;
 
-function compareDates(dateA: DateTime | null, dateB: DateTime | null): number {
+function compareDates(
+  dateA: DateTime | null,
+  dateB: DateTime | null,
+  nullsLast: boolean = false,
+): number {
   if (dateA === null && dateB === null) {
     return 0;
   }
 
   if (dateA === null) {
-    return -1;
+    return nullsLast ? 1 : -1;
   }
 
   if (dateB === null) {
-    return 1;
+    return nullsLast ? -1 : 1;
   }
 
   return dateA.valueOf() - dateB.valueOf();
@@ -44,7 +48,7 @@ function useComparator(orderBy: StopVersionTableColumn): Comparator {
       return (a, b) => compareDates(a.validity_start, b.validity_start);
 
     case 'VALIDITY_END':
-      return (a, b) => compareDates(a.validity_end, b.validity_end);
+      return (a, b) => compareDates(a.validity_end, b.validity_end, true);
 
     case 'VERSION_COMMENT':
       return (a, b) => collator.compare(a.version_comment, b.version_comment);

--- a/ui/src/uiComponents/ExpandButton.tsx
+++ b/ui/src/uiComponents/ExpandButton.tsx
@@ -5,11 +5,15 @@ import { TextAndIconButton } from './TextAndIconButton';
 
 type AllowedButtonProps = Omit<
   React.JSX.IntrinsicElements['button'],
-  'aria-controls' | 'aria-expanded' | 'children' | 'onClick' | 'type'
+  | 'aria-controls'
+  | 'aria-expanded'
+  | 'aria-pressed'
+  | 'children'
+  | 'onClick'
+  | 'type'
 >;
 
 type CustomExpandButtonProps = {
-  readonly ariaControls: string;
   readonly className?: string;
   readonly iconClassName?: string;
   readonly expanded: boolean;
@@ -19,9 +23,22 @@ type CustomExpandButtonProps = {
   readonly testId?: string;
 };
 
-type ExpandButtonProps = AllowedButtonProps & CustomExpandButtonProps;
+type ForAccordionProps = {
+  readonly forSorting?: false;
+  readonly ariaControls: string;
+};
+
+type ForSortingProps = {
+  readonly forSorting: true;
+  readonly ariaControls?: never;
+};
+
+type ExpandButtonProps = AllowedButtonProps &
+  CustomExpandButtonProps &
+  (ForAccordionProps | ForSortingProps);
 
 export const ExpandButton: FC<ExpandButtonProps> = ({
+  forSorting = false,
   ariaControls,
   className,
   iconClassName,
@@ -48,8 +65,13 @@ export const ExpandButton: FC<ExpandButtonProps> = ({
       type="button"
       testId={testId}
       onClick={onClick}
-      aria-expanded={expanded}
-      aria-controls={ariaControls}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...(forSorting
+        ? { 'aria-pressed': expanded }
+        : {
+            'aria-expanded': expanded,
+            'aria-controls': ariaControls,
+          })}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...buttonProps}
     />


### PR DESCRIPTION
### Improve `<ExpandButton>` accessibility options
Allow using the button as an Accordion control or as aria-sort button.


### Stop Versions: Improve Stop version table header accessibility


### Stop Versions: Fix Validity end null (=∞) value sorting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1033)
<!-- Reviewable:end -->
