### PR TITLE
Add support for displaying a specific version of stops on the Details page

### DIFF
--- a/cypress/e2e/stop-registry/stopVersions.cy.ts
+++ b/cypress/e2e/stop-registry/stopVersions.cy.ts
@@ -588,6 +588,10 @@ describe('Stop Versions Page', () => {
       stopDetailsPage.loadingStopDetails().should('not.exist');
 
       stopDetailsPage.titleRow.label().shouldHaveText('E2E001');
+      stopDetailsPage
+        .returnToDateBasedVersionSelection()
+        .shouldBeVisible()
+        .click();
       stopDetailsPage.observationDateControl
         .getObservationDateInput()
         .should('have.attr', 'value', '2020-03-20');

--- a/cypress/pageObjects/stop-registry/StopDetailsPage.ts
+++ b/cypress/pageObjects/stop-registry/StopDetailsPage.ts
@@ -71,4 +71,10 @@ export class StopDetailsPage {
   loadingStopDetails() {
     return cy.getByTestId('StopDetailsPage::loadingStopDetails');
   }
+
+  returnToDateBasedVersionSelection() {
+    return cy.getByTestId(
+      'StopDetailsVersion::returnToDateBasedVersionSelection',
+    );
+  }
 }

--- a/ui/src/components/stop-registry/components/MenuItems/OpenDetailsPage.tsx
+++ b/ui/src/components/stop-registry/components/MenuItems/OpenDetailsPage.tsx
@@ -3,6 +3,7 @@ import { ForwardRefRenderFunction, forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Path, routeDetails } from '../../../../router/routeDetails';
+import { Priority } from '../../../../types/enums';
 import { SimpleDropdownMenuItem } from '../../../../uiComponents';
 import { LocatableStopWithObservationDateProps } from '../../types';
 
@@ -10,16 +11,20 @@ const testIds = {
   showStopDetails: 'StopTableRow::ActionMenu::ShowStopDetails',
 };
 
+type OpenDetailsPageProps = LocatableStopWithObservationDateProps & {
+  readonly priority?: Priority;
+};
+
 const OpenDetailsPageImpl: ForwardRefRenderFunction<
   HTMLButtonElement,
-  LocatableStopWithObservationDateProps
-> = ({ className, observationDate, stop }, ref) => {
+  OpenDetailsPageProps
+> = ({ className, observationDate, priority, stop }, ref) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
   const pathname = routeDetails[Path.stopDetails].getLink(stop.label);
   const search = qs.stringify(
-    { observationDate: observationDate?.toISODate() },
+    { observationDate: observationDate?.toISODate(), priority },
     { addQueryPrefix: true },
   );
 

--- a/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
@@ -1,17 +1,10 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdWarning } from 'react-icons/md';
-import {
-  makeBackNavigationIsSafeState,
-  useGetStopDetails,
-  useRequiredParams,
-} from '../../../../hooks';
-import { Container, Row, Visible } from '../../../../layoutComponents';
-import { Path, routeDetails } from '../../../../router/routeDetails';
+import { useGetStopDetails, useRequiredParams } from '../../../../hooks';
+import { Container, Visible } from '../../../../layoutComponents';
 import { mapToShortDate } from '../../../../time';
-import { SimpleButton } from '../../../../uiComponents';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
-import { ObservationDateControl } from '../../../common/ObservationDateControl';
 import { BasicDetailsSection } from './basic-details/BasicDetailsSection';
 import {
   DetailTabSelector,
@@ -24,6 +17,7 @@ import { MaintenanceSection } from './maintenance';
 import { MeasurementsSection } from './measurements';
 import { SheltersSection } from './shelters';
 import { SignageDetailsSection } from './signage-details/SignageDetailsSection';
+import { StopDetailsVersion } from './StopDetailsVersion';
 import { StopHeaderSummaryRow } from './StopHeaderSummaryRow';
 import { StopTitleRow } from './title-row/StopTitleRow';
 
@@ -49,17 +43,8 @@ export const StopDetailsPage = (): React.ReactElement => {
     <Container testId={testIds.page}>
       <StopTitleRow stopDetails={stopDetails} label={label} />
       <StopHeaderSummaryRow className="my-2" stopDetails={stopDetails} />
-      <Row className="items-end justify-end gap-4">
-        {/* TODO: Stop/Announcement/Breakroom/Lines tabs */}
-        <ObservationDateControl className="col-start-6" />
-        <SimpleButton
-          inverted
-          href={{ pathname: routeDetails[Path.stopVersions].getLink(label) }}
-          state={makeBackNavigationIsSafeState()}
-        >
-          {t('stopDetails.actions.showVersions')}
-        </SimpleButton>
-      </Row>
+      {/* TODO: Stop/Announcement/Breakroom/Lines tabs */}
+      <StopDetailsVersion label={label} />
       <hr className="my-4" />
       <div className="my-4 flex items-center">
         <h2 className="">{t('stopDetails.stopDetails')}</h2>

--- a/ui/src/components/stop-registry/stops/stop-details/StopDetailsVersion.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopDetailsVersion.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { makeBackNavigationIsSafeState, useUrlQuery } from '../../../../hooks';
+import { Row } from '../../../../layoutComponents';
+import { Path, routeDetails } from '../../../../router/routeDetails';
+import { CloseIconButton, SimpleButton } from '../../../../uiComponents';
+import { ObservationDateControl } from '../../../common/ObservationDateControl';
+
+const testIds = {
+  returnToDateBasedVersionSelection:
+    'StopDetailsVersion::returnToDateBasedVersionSelection',
+};
+
+type StopDetailsVersionProps = { readonly label: string };
+
+export const StopDetailsVersion: FC<StopDetailsVersionProps> = ({ label }) => {
+  const { t } = useTranslation();
+
+  const {
+    queryParams: { priority },
+    deleteFromUrlQuery,
+  } = useUrlQuery();
+
+  return (
+    <Row className="items-end justify-end gap-4">
+      {priority ? (
+        <Row className="mx-auto items-center rounded bg-city-bicycle-yellow px-4 py-2">
+          <span className="mr-4 font-bold">
+            {t('stopDetails.selectedVersion.showingSelected')}
+          </span>
+          <CloseIconButton
+            className="underline"
+            label={t('stopDetails.selectedVersion.showByDate')}
+            onClick={() =>
+              deleteFromUrlQuery({ paramName: 'priority', replace: true })
+            }
+            testId={testIds.returnToDateBasedVersionSelection}
+          />
+        </Row>
+      ) : (
+        <ObservationDateControl className="col-start-6" />
+      )}
+      <SimpleButton
+        inverted
+        href={{ pathname: routeDetails[Path.stopVersions].getLink(label) }}
+        state={makeBackNavigationIsSafeState()}
+      >
+        {t('stopDetails.actions.showVersions')}
+      </SimpleButton>
+    </Row>
+  );
+};

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionActionMenu.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionActionMenu.tsx
@@ -31,7 +31,11 @@ export const StopVersionActionMenu: FC<StopVersionActionMenuProps> = ({
       testId={testIds.actionMenu}
     >
       <ShowOnMap stop={stop} observeOnStopValidityStartDate />
-      <OpenDetailsPage stop={stop} observationDate={stop.startDate} />
+      <OpenDetailsPage
+        stop={stop}
+        observationDate={stop.startDate}
+        priority={stop.priority}
+      />
     </SimpleDropdownMenu>
   );
 };

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
@@ -54,6 +54,7 @@ export const StopVersionRow: FC<StopVersionRowProps> = ({
     netextId: stopVersion.netex_id,
     location: stopVersion.location,
     startDate: stopVersion.validity_start,
+    priority: stopVersion.priority,
   };
 
   return (

--- a/ui/src/components/stop-registry/stops/versions/types/ActionMenuStop.ts
+++ b/ui/src/components/stop-registry/stops/versions/types/ActionMenuStop.ts
@@ -1,6 +1,8 @@
 import { DateTime } from 'luxon';
+import { Priority } from '../../../../../types/enums';
 import { LocatableStop } from '../../../types';
 
 export type ActionMenuStop = LocatableStop & {
   readonly startDate: DateTime;
+  readonly priority: Priority;
 };

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -73833,12 +73833,11 @@ export type ScheduledStopPointDetailFieldsFragment = {
   }>;
 };
 
-export type GetHighestPriorityStopDetailsByLabelAndDateQueryVariables = Exact<{
-  label: Scalars['String']['input'];
-  observationDate: Scalars['date']['input'];
+export type GetStopDetailsQueryVariables = Exact<{
+  where?: InputMaybe<ServicePatternScheduledStopPointBoolExp>;
 }>;
 
-export type GetHighestPriorityStopDetailsByLabelAndDateQuery = {
+export type GetStopDetailsQuery = {
   __typename?: 'query_root';
   service_pattern_scheduled_stop_point: Array<{
     __typename?: 'service_pattern_scheduled_stop_point';
@@ -82692,33 +82691,10 @@ export type UpdateInfoSpotMutationOptions = Apollo.BaseMutationOptions<
   UpdateInfoSpotMutation,
   UpdateInfoSpotMutationVariables
 >;
-export const GetHighestPriorityStopDetailsByLabelAndDateDocument = gql`
-  query GetHighestPriorityStopDetailsByLabelAndDate(
-    $label: String!
-    $observationDate: date!
-  ) {
+export const GetStopDetailsDocument = gql`
+  query GetStopDetails($where: service_pattern_scheduled_stop_point_bool_exp) {
     service_pattern_scheduled_stop_point(
-      where: {
-        _and: [
-          { label: { _eq: $label } }
-          {
-            _and: [
-              {
-                _or: [
-                  { validity_start: { _lte: $observationDate } }
-                  { validity_start: { _is_null: true } }
-                ]
-              }
-              {
-                _or: [
-                  { validity_end: { _gte: $observationDate } }
-                  { validity_end: { _is_null: true } }
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      where: $where
       order_by: { priority: desc }
       limit: 1
     ) {
@@ -82733,59 +82709,51 @@ export const GetHighestPriorityStopDetailsByLabelAndDateDocument = gql`
 `;
 
 /**
- * __useGetHighestPriorityStopDetailsByLabelAndDateQuery__
+ * __useGetStopDetailsQuery__
  *
- * To run a query within a React component, call `useGetHighestPriorityStopDetailsByLabelAndDateQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetHighestPriorityStopDetailsByLabelAndDateQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetStopDetailsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStopDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetHighestPriorityStopDetailsByLabelAndDateQuery({
+ * const { data, loading, error } = useGetStopDetailsQuery({
  *   variables: {
- *      label: // value for 'label'
- *      observationDate: // value for 'observationDate'
+ *      where: // value for 'where'
  *   },
  * });
  */
-export function useGetHighestPriorityStopDetailsByLabelAndDateQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetHighestPriorityStopDetailsByLabelAndDateQuery,
-    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
-  > &
-    (
-      | {
-          variables: GetHighestPriorityStopDetailsByLabelAndDateQueryVariables;
-          skip?: boolean;
-        }
-      | { skip: boolean }
-    ),
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetHighestPriorityStopDetailsByLabelAndDateQuery,
-    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
-  >(GetHighestPriorityStopDetailsByLabelAndDateDocument, options);
-}
-export function useGetHighestPriorityStopDetailsByLabelAndDateLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetHighestPriorityStopDetailsByLabelAndDateQuery,
-    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
+export function useGetStopDetailsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetStopDetailsQuery,
+    GetStopDetailsQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetHighestPriorityStopDetailsByLabelAndDateQuery,
-    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
-  >(GetHighestPriorityStopDetailsByLabelAndDateDocument, options);
+  return Apollo.useQuery<GetStopDetailsQuery, GetStopDetailsQueryVariables>(
+    GetStopDetailsDocument,
+    options,
+  );
 }
-export function useGetHighestPriorityStopDetailsByLabelAndDateSuspenseQuery(
+export function useGetStopDetailsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetStopDetailsQuery,
+    GetStopDetailsQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<GetStopDetailsQuery, GetStopDetailsQueryVariables>(
+    GetStopDetailsDocument,
+    options,
+  );
+}
+export function useGetStopDetailsSuspenseQuery(
   baseOptions?:
     | Apollo.SkipToken
     | Apollo.SuspenseQueryHookOptions<
-        GetHighestPriorityStopDetailsByLabelAndDateQuery,
-        GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
+        GetStopDetailsQuery,
+        GetStopDetailsQueryVariables
       >,
 ) {
   const options =
@@ -82793,23 +82761,23 @@ export function useGetHighestPriorityStopDetailsByLabelAndDateSuspenseQuery(
       ? baseOptions
       : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
-    GetHighestPriorityStopDetailsByLabelAndDateQuery,
-    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
-  >(GetHighestPriorityStopDetailsByLabelAndDateDocument, options);
+    GetStopDetailsQuery,
+    GetStopDetailsQueryVariables
+  >(GetStopDetailsDocument, options);
 }
-export type GetHighestPriorityStopDetailsByLabelAndDateQueryHookResult =
-  ReturnType<typeof useGetHighestPriorityStopDetailsByLabelAndDateQuery>;
-export type GetHighestPriorityStopDetailsByLabelAndDateLazyQueryHookResult =
-  ReturnType<typeof useGetHighestPriorityStopDetailsByLabelAndDateLazyQuery>;
-export type GetHighestPriorityStopDetailsByLabelAndDateSuspenseQueryHookResult =
-  ReturnType<
-    typeof useGetHighestPriorityStopDetailsByLabelAndDateSuspenseQuery
-  >;
-export type GetHighestPriorityStopDetailsByLabelAndDateQueryResult =
-  Apollo.QueryResult<
-    GetHighestPriorityStopDetailsByLabelAndDateQuery,
-    GetHighestPriorityStopDetailsByLabelAndDateQueryVariables
-  >;
+export type GetStopDetailsQueryHookResult = ReturnType<
+  typeof useGetStopDetailsQuery
+>;
+export type GetStopDetailsLazyQueryHookResult = ReturnType<
+  typeof useGetStopDetailsLazyQuery
+>;
+export type GetStopDetailsSuspenseQueryHookResult = ReturnType<
+  typeof useGetStopDetailsSuspenseQuery
+>;
+export type GetStopDetailsQueryResult = Apollo.QueryResult<
+  GetStopDetailsQuery,
+  GetStopDetailsQueryVariables
+>;
 export const UpsertOrganisationDocument = gql`
   mutation UpsertOrganisation($objects: [stop_registry_OrganisationInput]) {
     stop_registry {

--- a/ui/src/hooks/stop-registry/useEditStopInfoSpots.ts
+++ b/ui/src/hooks/stop-registry/useEditStopInfoSpots.ts
@@ -5,7 +5,7 @@ import {
   InfoSpotsFormState,
 } from '../../components/stop-registry/stops/stop-details/info-spots/info-spots-form/schema';
 import {
-  GetHighestPriorityStopDetailsByLabelAndDateDocument,
+  GetStopDetailsDocument,
   StopRegistryDisplayType,
   StopRegistryInfoSpotType,
   StopRegistryPosterInput,
@@ -88,7 +88,7 @@ const prepareEditForTiamatDb = ({ state }: EditTiamatParams) => {
 export const useEditStopInfoSpots = () => {
   const { t } = useTranslation();
   const [updateInfoSpotMutation] = useUpdateInfoSpotMutation({
-    refetchQueries: [GetHighestPriorityStopDetailsByLabelAndDateDocument],
+    refetchQueries: [GetStopDetailsDocument],
   });
 
   const clearLocationsForDeletedInfoSpots = (infoSpots: InfoSpotState[]) => {

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -179,6 +179,10 @@
   "stopDetails": {
     "stopDetails": "Stop details",
     "notValidOnObservationDate": "Stop is not valid on chosen date.",
+    "selectedVersion": {
+      "showingSelected": "Showing selected version",
+      "showByDate": "Return to observation date"
+    },
     "detailTabs": {
       "basic": "Basic information",
       "technical": "Technical features",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -179,6 +179,10 @@
   "stopDetails": {
     "stopDetails": "Pysäkkitiedot",
     "notValidOnObservationDate": "Pysäkki ei ole voimassa valittuna päivänä.",
+    "selectedVersion": {
+      "showingSelected": "Näytetään valittu versio",
+      "showByDate": "Palaa tarkasteluhetkeen"
+    },
     "detailTabs": {
       "basic": "Perustiedot",
       "technical": "Tekniset ominaisuudet",


### PR DESCRIPTION
### Add support for opening specific priority version of a stop details


### Open up the specified prio version of a Stop from Stop Version row link

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1036)
<!-- Reviewable:end -->
