### PR TITLE
Small improvements and changes made as part of Stop Form revamp

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'cypress';
 import * as tasks from './e2e/utils/tasks';
-import { onLaunchBrowser } from './support/setHeadlessScreenSize';
+import { onLaunchBrowser } from './support/launchBrowser';
 
 // eslint-disable-next-line import/no-default-export
 export default defineConfig({

--- a/cypress/e2e/map/createRoute.cy.ts
+++ b/cypress/e2e/map/createRoute.cy.ts
@@ -96,18 +96,11 @@ describe('Route creation', mapViewport, () => {
           swedishName: 'Test destination SWE',
           swedishShortName: 'Test destination SWE shortName',
         },
+        priority: Priority.Standard,
+        validityStartISODate: '2022-01-01',
+        validityEndISODate: '2025-12-01',
       });
 
-      mapModal.routePropertiesForm.changeValidityForm.setPriority(
-        Priority.Standard,
-      );
-
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setStartDate(
-        '2022-01-01',
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setEndDate(
-        '2025-12-01',
-      );
       mapModal.editRouteModal.save();
 
       // Create a geometry for route that includes dataset stops E2E001,
@@ -172,17 +165,11 @@ describe('Route creation', mapViewport, () => {
           swedishName: 'Test destination SWE',
           swedishShortName: 'Test destination SWE shortName',
         },
+        priority: Priority.Standard,
+        validityStartISODate: '2022-01-01',
+        validityEndISODate: '2025-12-01',
       });
 
-      mapModal.routePropertiesForm.changeValidityForm.setPriority(
-        Priority.Standard,
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setStartDate(
-        '2022-01-01',
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setEndDate(
-        '2025-12-01',
-      );
       mapModal.editRouteModal.save();
 
       // Create a geometry for route that includes dataset stops E2E001 - E2E004
@@ -249,18 +236,11 @@ describe('Route creation', mapViewport, () => {
           swedishName: 'Test destination SWE',
           swedishShortName: 'Test destination SWE shortName',
         },
+        priority: Priority.Standard,
+        validityStartISODate: '2022-01-01',
+        validityEndISODate: '2025-12-01',
       });
 
-      mapModal.routePropertiesForm.changeValidityForm.setPriority(
-        Priority.Standard,
-      );
-
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setStartDate(
-        '2022-01-01',
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setEndDate(
-        '2025-12-01',
-      );
       mapModal.editRouteModal.save();
 
       // Create a geometry for route that includes dataset stops E2E001 and E2E002
@@ -316,17 +296,11 @@ describe('Route creation', mapViewport, () => {
           swedishName: 'Test destination SWE',
           swedishShortName: 'Test destination SWE shortName',
         },
+        priority: Priority.Standard,
+        validityStartISODate: '2022-01-01',
+        validityEndISODate: undefined, // == indefinite
       });
 
-      mapModal.routePropertiesForm.changeValidityForm.setPriority(
-        Priority.Standard,
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setStartDate(
-        '2022-01-01',
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm
-        .getIndefiniteCheckbox()
-        .click();
       mapModal.editRouteModal.save();
 
       // Create a geometry for route that includes dataset stops E2E001
@@ -371,6 +345,9 @@ describe('Route creation', mapViewport, () => {
           swedishName: 'Test destination SWE',
           swedishShortName: 'Test destination SWE shortName',
         },
+        priority: Priority.Standard,
+        validityStartISODate: '2022-01-01',
+        validityEndISODate: '2025-12-01',
       });
 
       // Use standard route 901 from dataset as template
@@ -379,16 +356,6 @@ describe('Route creation', mapViewport, () => {
         priority: Priority.Standard,
         label: '901',
       });
-
-      mapModal.routePropertiesForm.changeValidityForm.setPriority(
-        Priority.Standard,
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setStartDate(
-        '2022-01-01',
-      );
-      mapModal.routePropertiesForm.changeValidityForm.validityPeriodForm.setEndDate(
-        '2025-12-01',
-      );
 
       mapModal.editRouteModal.save();
 

--- a/cypress/pageObjects/Map.ts
+++ b/cypress/pageObjects/Map.ts
@@ -81,10 +81,10 @@ export class Map {
     return cy.getByTestId(`Map::StopArea::stopArea::${id}`);
   }
 
-  visit(params?: { zoom?: number; lat: number; lng: number }) {
+  visit(params?: { zoom?: number; lat: number; lng: number; path?: string }) {
     if (params) {
       cy.visit(
-        `/routes?${qs.stringify({
+        `${params.path ?? '/routes'}?${qs.stringify({
           z: params.zoom ?? 13, // 13 is default zoom level
           mapOpen: true,
           lat: params.lat,

--- a/cypress/support/launchBrowser.ts
+++ b/cypress/support/launchBrowser.ts
@@ -15,7 +15,7 @@
  * @param browser
  * @param launchOptions
  */
-function launchHeadlessBrowserWithScreenSize(
+function setHeadlessBrowserScreenSizeLaunchOptions(
   width: number,
   height: number,
   browser: Cypress.Browser,
@@ -56,7 +56,7 @@ function launchHeadlessBrowserWithScreenSize(
   return launchOptions;
 }
 
-export function onLaunchBrowser(
+function applyScreenSizeOptions(
   browser: Cypress.Browser,
   launchOptions: Cypress.BeforeBrowserLaunchOptions,
 ): Cypress.BeforeBrowserLaunchOptions {
@@ -67,7 +67,7 @@ export function onLaunchBrowser(
   );
 
   if (!browser.isHeadless) {
-    console.log('Not headless - Launching with default options!');
+    console.log('Not headless - Launching with default screen size options!');
     return launchOptions;
   }
 
@@ -80,7 +80,7 @@ export function onLaunchBrowser(
     console.log(
       'Headless - Found proper width and height - Launching with custom size!',
     );
-    return launchHeadlessBrowserWithScreenSize(
+    return setHeadlessBrowserScreenSizeLaunchOptions(
       width,
       height,
       browser,
@@ -94,8 +94,44 @@ export function onLaunchBrowser(
     );
   }
 
-  console.log('Headless - Launching with default options!');
+  console.log('Headless - Launching with default screen size options!');
   return launchOptions;
+}
+
+// Set the browser into reduced motion mode.
+// Prevents flakyness in map tests by disabling map panning/zooming animations.
+function applyReducedMotionOptions(
+  browser: Cypress.Browser,
+  launchOptions: Cypress.BeforeBrowserLaunchOptions,
+): Cypress.BeforeBrowserLaunchOptions {
+  if (browser.name === 'chrome') {
+    return {
+      ...launchOptions,
+      args: launchOptions.args.concat('--force-prefers-reduced-motion'),
+    };
+  }
+
+  if (browser.name === 'firefox') {
+    return {
+      ...launchOptions,
+      preferences: {
+        ...launchOptions.preferences,
+        'ui.prefersReducedMotion': 1,
+      },
+    };
+  }
+
+  return launchOptions;
+}
+
+export function onLaunchBrowser(
+  browser: Cypress.Browser,
+  launchOptions: Cypress.BeforeBrowserLaunchOptions,
+): Cypress.BeforeBrowserLaunchOptions {
+  const withScreenSize = applyScreenSizeOptions(browser, launchOptions);
+  const withReducedMotion = applyReducedMotionOptions(browser, withScreenSize);
+
+  return withReducedMotion;
 }
 
 export function registerBrowserLaunchHook() {

--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -10,7 +10,7 @@ services:
     # The :hsl-tag contains the desired version of hsl specific hasura.
     # Waiting for merging feature-branch to main in hasura-repo
     # Note: also update jore4-hasura-e2e in docker-compose.e2e when changing this.
-    image: 'hsldevcom/jore4-hasura:hsl-main--20250317-60eaf1217447890591ca3bbe262c96f2cc68ba57'
+    image: 'hsldevcom/jore4-hasura:hsl-main--20250409-b796f446100fe537a664aab187749de256ebe176'
     # Waiting for database to be ready to avoid startup delay due to hasura crashing at startup if db is offline
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:
@@ -38,7 +38,7 @@ services:
   jore4-tiamat:
     # Pin tiamat to a compatible version.
     # Note: also update jore4-tiamat-e2e in docker-compose.e2e when changing this.
-    image: "hsldevcom/jore4-tiamat:main--20250326-6df1009f53721e605e20caab5563dac5f67f8d76"
+    image: "hsldevcom/jore4-tiamat:main--20250403-fbcdfc5147fb8dfb508c249c3201bccdbc4b58cb"
 
   jore4-timetablesapi:
     # Pin timetables api to a compatible version.

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -11,7 +11,7 @@ services:
     extends:
       file: docker-compose.base.yml
       service: jore4-tiamat-base
-    image: "hsldevcom/jore4-tiamat:main--20250326-6df1009f53721e605e20caab5563dac5f67f8d76"
+    image: "hsldevcom/jore4-tiamat:main--20250403-fbcdfc5147fb8dfb508c249c3201bccdbc4b58cb"
     container_name: "tiamat-e2e"
     environment:
       - TIAMAT_DB_URL=jdbc:postgresql://jore4-testdb-e2e:5432/stopdb?stringtype=unspecified
@@ -43,7 +43,7 @@ services:
     extends:
       file: docker-compose.base.yml
       service: jore4-hasura-base
-    image: 'hsldevcom/jore4-hasura:hsl-main--20250317-60eaf1217447890591ca3bbe262c96f2cc68ba57'
+    image: 'hsldevcom/jore4-hasura:hsl-main--20250409-b796f446100fe537a664aab187749de256ebe176'
     container_name: "hasura-e2e"
     ports:
       - "127.0.0.1:3211:8080"

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -38890,6 +38890,9 @@ export type StopsDatabaseQuayNewestVersion = {
   /** An object relationship */
   stop_place?: Maybe<StopsDatabaseStopPlace>;
   stop_place_id?: Maybe<Scalars['bigint']['output']>;
+  stop_place_netex_id?: Maybe<Scalars['String']['output']>;
+  /** An object relationship */
+  stop_place_newest_version?: Maybe<StopsDatabaseStopPlaceNewestVersion>;
   stop_place_version?: Maybe<Scalars['bigint']['output']>;
   street_address?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
@@ -39028,6 +39031,8 @@ export type StopsDatabaseQuayNewestVersionBoolExp = {
   site_ref_version?: InputMaybe<StringComparisonExp>;
   stop_place?: InputMaybe<StopsDatabaseStopPlaceBoolExp>;
   stop_place_id?: InputMaybe<BigintComparisonExp>;
+  stop_place_netex_id?: InputMaybe<StringComparisonExp>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionBoolExp>;
   stop_place_version?: InputMaybe<BigintComparisonExp>;
   street_address?: InputMaybe<StringComparisonExp>;
   to_date?: InputMaybe<TimestampComparisonExp>;
@@ -39072,6 +39077,7 @@ export type StopsDatabaseQuayNewestVersionMaxFields = {
   site_ref?: Maybe<Scalars['String']['output']>;
   site_ref_version?: Maybe<Scalars['String']['output']>;
   stop_place_id?: Maybe<Scalars['bigint']['output']>;
+  stop_place_netex_id?: Maybe<Scalars['String']['output']>;
   stop_place_version?: Maybe<Scalars['bigint']['output']>;
   street_address?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
@@ -39116,6 +39122,7 @@ export type StopsDatabaseQuayNewestVersionMinFields = {
   site_ref?: Maybe<Scalars['String']['output']>;
   site_ref_version?: Maybe<Scalars['String']['output']>;
   stop_place_id?: Maybe<Scalars['bigint']['output']>;
+  stop_place_netex_id?: Maybe<Scalars['String']['output']>;
   stop_place_version?: Maybe<Scalars['bigint']['output']>;
   street_address?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
@@ -39165,6 +39172,8 @@ export type StopsDatabaseQuayNewestVersionOrderBy = {
   site_ref_version?: InputMaybe<OrderBy>;
   stop_place?: InputMaybe<StopsDatabaseStopPlaceOrderBy>;
   stop_place_id?: InputMaybe<OrderBy>;
+  stop_place_netex_id?: InputMaybe<OrderBy>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionOrderBy>;
   stop_place_version?: InputMaybe<OrderBy>;
   street_address?: InputMaybe<OrderBy>;
   to_date?: InputMaybe<OrderBy>;
@@ -39244,6 +39253,8 @@ export enum StopsDatabaseQuayNewestVersionSelectColumn {
   SiteRefVersion = 'site_ref_version',
   /** column name */
   StopPlaceId = 'stop_place_id',
+  /** column name */
+  StopPlaceNetexId = 'stop_place_netex_id',
   /** column name */
   StopPlaceVersion = 'stop_place_version',
   /** column name */
@@ -39346,6 +39357,7 @@ export type StopsDatabaseQuayNewestVersionStreamCursorValueInput = {
   site_ref?: InputMaybe<Scalars['String']['input']>;
   site_ref_version?: InputMaybe<Scalars['String']['input']>;
   stop_place_id?: InputMaybe<Scalars['bigint']['input']>;
+  stop_place_netex_id?: InputMaybe<Scalars['String']['input']>;
   stop_place_version?: InputMaybe<Scalars['bigint']['input']>;
   street_address?: InputMaybe<Scalars['String']['input']>;
   to_date?: InputMaybe<Scalars['timestamp']['input']>;
@@ -42529,7 +42541,6 @@ export type StopsDatabaseStopPlaceNewestVersion = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
-  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   scheduled_stop_point_instance?: Maybe<ServicePatternScheduledStopPoint>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
@@ -42844,7 +42855,6 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   private_code_type?: InputMaybe<StringComparisonExp>;
   private_code_value?: InputMaybe<StringComparisonExp>;
   public_code?: InputMaybe<StringComparisonExp>;
-  quay_public_code?: InputMaybe<StringComparisonExp>;
   rail_submode?: InputMaybe<StringComparisonExp>;
   short_name_lang?: InputMaybe<StringComparisonExp>;
   short_name_value?: InputMaybe<StringComparisonExp>;
@@ -42910,7 +42920,6 @@ export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
-  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;
@@ -42965,7 +42974,6 @@ export type StopsDatabaseStopPlaceNewestVersionMaxFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
-  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
@@ -43013,7 +43021,6 @@ export type StopsDatabaseStopPlaceNewestVersionMinFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
-  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
@@ -43070,7 +43077,6 @@ export type StopsDatabaseStopPlaceNewestVersionOrderBy = {
   private_code_type?: InputMaybe<OrderBy>;
   private_code_value?: InputMaybe<OrderBy>;
   public_code?: InputMaybe<OrderBy>;
-  quay_public_code?: InputMaybe<OrderBy>;
   rail_submode?: InputMaybe<OrderBy>;
   short_name_lang?: InputMaybe<OrderBy>;
   short_name_value?: InputMaybe<OrderBy>;
@@ -43158,8 +43164,6 @@ export enum StopsDatabaseStopPlaceNewestVersionSelectColumn {
   PrivateCodeValue = 'private_code_value',
   /** column name */
   PublicCode = 'public_code',
-  /** column name */
-  QuayPublicCode = 'quay_public_code',
   /** column name */
   RailSubmode = 'rail_submode',
   /** column name */
@@ -43270,7 +43274,6 @@ export type StopsDatabaseStopPlaceNewestVersionStreamCursorValueInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
-  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;

--- a/ui/src/components/forms/common/FormRow.tsx
+++ b/ui/src/components/forms/common/FormRow.tsx
@@ -1,4 +1,5 @@
 import React, { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 interface Props {
   className?: string;
@@ -25,7 +26,10 @@ export const FormRow: FC<Props> = ({
 
   return (
     <div
-      className={`${className} ${baseClassName} ${lgClassName} ${mdClassName} ${smClassName}`}
+      className={twMerge(
+        `${baseClassName} ${lgClassName} ${mdClassName} ${smClassName}`,
+        className,
+      )}
       data-testid={testId}
     >
       {children}

--- a/ui/src/components/forms/common/InputField.tsx
+++ b/ui/src/components/forms/common/InputField.tsx
@@ -1,4 +1,8 @@
-import React, { HTMLInputTypeAttribute, InputHTMLAttributes } from 'react';
+import React, {
+  HTMLInputTypeAttribute,
+  InputHTMLAttributes,
+  TextareaHTMLAttributes,
+} from 'react';
 import { FieldValues, Path } from 'react-hook-form';
 import { TranslationKey } from '../../../i18n';
 import { Column } from '../../../layoutComponents';
@@ -11,25 +15,33 @@ import { InputLabel } from './InputLabel';
 import { ValidationErrorList } from './ValidationErrorList';
 
 interface CommonInputProps<FormState extends FieldValues> {
-  className?: string;
-  inputClassName?: string;
-  fieldPath: Path<FormState>;
-  translationPrefix: TranslationKey;
-  customTitlePath?: TranslationKey;
-  testId: string;
+  readonly className?: string;
+  readonly inputClassName?: string;
+  readonly fieldPath: Path<FormState>;
+  readonly translationPrefix: TranslationKey;
+  readonly customTitlePath?: TranslationKey;
+  readonly testId: string;
 }
 
 interface ControlledInputProps {
-  inputElementRenderer: (props: InputElementRenderProps) => React.ReactElement;
-  type?: never;
+  readonly inputElementRenderer: (
+    props: InputElementRenderProps,
+  ) => React.ReactElement;
+  readonly type?: never;
 }
-interface HTMLInputProps extends InputHTMLAttributes<Element> {
-  inputElementRenderer?: never;
-  type: HTMLInputTypeAttribute;
+interface HTMLInputProps
+  extends Readonly<InputHTMLAttributes<HTMLInputElement>> {
+  readonly inputElementRenderer?: never;
+  readonly type: HTMLInputTypeAttribute;
+}
+interface HTMLTextAreaProps
+  extends Readonly<TextareaHTMLAttributes<HTMLTextAreaElement>> {
+  readonly inputElementRenderer?: never;
+  readonly type: 'textarea';
 }
 
 type Props<FormState extends FieldValues> = CommonInputProps<FormState> &
-  (ControlledInputProps | HTMLInputProps);
+  (ControlledInputProps | HTMLInputProps | HTMLTextAreaProps);
 
 export const InputField = <FormState extends FieldValues>({
   className = '',
@@ -68,16 +80,16 @@ export const InputField = <FormState extends FieldValues>({
           testId={testId}
         />
       ) : (
-        <InputElement
-          type={
-            type! /* eslint-disable-line @typescript-eslint/no-non-null-assertion */
-          }
+        <InputElement<FormState>
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...(inputHTMLAttributes as typeof type extends 'textarea'
+            ? HTMLTextAreaProps
+            : HTMLInputProps)}
+          type={type}
           fieldPath={fieldPath}
           id={id}
           testId={testId}
           className={inputClassName}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...inputHTMLAttributes}
         />
       )}
       <ValidationErrorList fieldPath={fieldPath} />

--- a/ui/src/components/forms/common/StopRegistryNamedEntityFormFields.tsx
+++ b/ui/src/components/forms/common/StopRegistryNamedEntityFormFields.tsx
@@ -1,0 +1,68 @@
+import React, { FC } from 'react';
+import { InputField } from './InputField';
+import { StopRegistryNamedEntityFormState } from './StopRegistryNamedEntitySchema';
+
+const testIds = {
+  nameFin: 'StopRegistryNamedEntityFormFields::nameFin',
+  nameSwe: 'StopRegistryNamedEntityFormFields::nameSwe',
+  locationFin: 'StopRegistryNamedEntityFormFields::locationFin',
+  locationSwe: 'StopRegistryNamedEntityFormFields::locationSwe',
+  nameLongFin: 'StopRegistryNamedEntityFormFields::nameLongFin',
+  nameLongSwe: 'StopRegistryNamedEntityFormFields::nameLongSwe',
+  abbreviationFin: 'StopRegistryNamedEntityFormFields::abbreviationFin',
+  abbreviationSwe: 'StopRegistryNamedEntityFormFields::abbreviationSwe',
+};
+
+// Was not needed for the Stop Modal. But will be needed to the Stop Area modal.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const StopRegistryNamedEntityFormFields: FC = () => {
+  return (
+    <fieldset>
+      <InputField<StopRegistryNamedEntityFormState>
+        type="text"
+        translationPrefix="stopRegistryNamedEntity"
+        fieldPath="nameSwe"
+        testId={testIds.nameSwe}
+      />
+
+      <InputField<StopRegistryNamedEntityFormState>
+        type="text"
+        translationPrefix="stopRegistryNamedEntity"
+        fieldPath="locationFin"
+        testId={testIds.locationFin}
+      />
+      <InputField<StopRegistryNamedEntityFormState>
+        type="text"
+        translationPrefix="stopRegistryNamedEntity"
+        fieldPath="locationFin"
+        testId={testIds.locationSwe}
+      />
+
+      <InputField<StopRegistryNamedEntityFormState>
+        type="text"
+        translationPrefix="stopRegistryNamedEntity"
+        fieldPath="nameLongFin"
+        testId={testIds.nameLongFin}
+      />
+      <InputField<StopRegistryNamedEntityFormState>
+        type="text"
+        translationPrefix="stopRegistryNamedEntity"
+        fieldPath="nameLongSwe"
+        testId={testIds.nameLongSwe}
+      />
+
+      <InputField<StopRegistryNamedEntityFormState>
+        type="text"
+        translationPrefix="stopRegistryNamedEntity"
+        fieldPath="abbreviationFin"
+        testId={testIds.abbreviationFin}
+      />
+      <InputField<StopRegistryNamedEntityFormState>
+        type="text"
+        translationPrefix="stopRegistryNamedEntity"
+        fieldPath="abbreviationSwe"
+        testId={testIds.abbreviationSwe}
+      />
+    </fieldset>
+  );
+};

--- a/ui/src/components/forms/common/StopRegistryNamedEntitySchema.ts
+++ b/ui/src/components/forms/common/StopRegistryNamedEntitySchema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { requiredString } from './customZodSchemas';
+
+export const stopRegistryNamedEntitySchema = z.object({
+  nameFin: requiredString,
+  nameSwe: z.string().optional(),
+  locationFin: z.string().optional(),
+  locationSwe: z.string().optional(),
+  nameLongFin: z.string().optional(),
+  nameLongSwe: z.string().optional(),
+  abbreviationFin: z.string().optional(),
+  abbreviationSwe: z.string().optional(),
+});
+
+export type StopRegistryNamedEntityFormState = z.infer<
+  typeof stopRegistryNamedEntitySchema
+>;

--- a/ui/src/components/forms/common/ValidityPeriodForm.tsx
+++ b/ui/src/components/forms/common/ValidityPeriodForm.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
@@ -27,15 +28,19 @@ const testIds = {
   indefiniteCheckbox: 'ValidityPeriodForm::indefiniteCheckbox',
 };
 
-interface Props {
-  className?: string;
-}
+type ValidityPeriodFormProps = {
+  readonly className?: string;
+  readonly dateInputRowClassName?: string;
+};
 
 /**
  * Component for selecting validity period for an entity (e.g. line, route, stop).
  * Can be merged with other forms.
  */
-export const ValidityPeriodForm = ({ className = '' }: Props): JSX.Element => {
+export const ValidityPeriodForm: FC<ValidityPeriodFormProps> = ({
+  className,
+  dateInputRowClassName,
+}) => {
   const { t } = useTranslation();
   const { register, watch } = useFormContext<ValidityPeriodFormState>();
 
@@ -44,7 +49,7 @@ export const ValidityPeriodForm = ({ className = '' }: Props): JSX.Element => {
   return (
     <div className={className}>
       <FormColumn>
-        <FormRow mdColumns={2}>
+        <FormRow className={dateInputRowClassName} mdColumns={2}>
           <InputField<ValidityPeriodFormState>
             type="date"
             translationPrefix="validityPeriod"

--- a/ui/src/components/map/CustomOverlay.tsx
+++ b/ui/src/components/map/CustomOverlay.tsx
@@ -79,8 +79,11 @@ const CustomOverlayComponent = ({
   const ctrlElement = ctrl.getElement();
   const map = ctrl.getMap();
 
+  // Prevent assigning "map" as a prop/attr on raw HTML elements
+  const newChildProps = typeof children.type === 'string' ? {} : { map };
+
   return map && ctrlElement
-    ? createPortal(cloneElement(children, { map }), ctrlElement)
+    ? createPortal(cloneElement(children, newChildProps), ctrlElement)
     : null;
 };
 

--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -172,6 +172,7 @@ export const Maplibre: FC<Props> = ({
       onClick={onClick}
       mapStyle={style as ExplicitAny}
       onMove={(event) => onViewportChange(event.viewState)}
+      onMoveEnd={(event) => onViewportChange(event.viewState)}
       doubleClickZoom={false}
       ref={mapRef}
       onLoad={onLoad}

--- a/ui/src/components/map/modal/Modal.tsx
+++ b/ui/src/components/map/modal/Modal.tsx
@@ -1,5 +1,6 @@
-import { FC, PropsWithChildren, ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
 import { useCallbackOnKeyEscape } from '../../../hooks';
 import { Row } from '../../../layoutComponents';
 import { SimpleButton } from '../../../uiComponents';
@@ -10,23 +11,25 @@ const testIds = {
   saveButton: 'Modal::saveButton',
 };
 
-const HeaderFooterContainer: FC<PropsWithChildren> = ({ children }) => {
-  return (
-    <div className="border border-light-grey bg-background px-14 py-7">
-      {children}
-    </div>
-  );
+type ModalFooterProps = {
+  readonly className?: string;
+  readonly onCancel: () => void;
+  readonly onSave: () => void;
 };
 
-interface FooterProps {
-  onCancel: () => void;
-  onSave: () => void;
-}
-
-const ModalFooter = ({ onCancel, onSave }: FooterProps): React.ReactElement => {
+const ModalFooter: FC<ModalFooterProps> = ({
+  className,
+  onCancel,
+  onSave,
+}: ModalFooterProps) => {
   const { t } = useTranslation();
   return (
-    <HeaderFooterContainer>
+    <div
+      className={twMerge(
+        'border border-light-grey bg-background px-14 py-7',
+        className,
+      )}
+    >
       <Row className="space-x-4">
         <SimpleButton containerClassName="ml-auto" onClick={onCancel} inverted>
           {t('cancel')}
@@ -35,20 +38,28 @@ const ModalFooter = ({ onCancel, onSave }: FooterProps): React.ReactElement => {
           {t('save')}
         </SimpleButton>
       </Row>
-    </HeaderFooterContainer>
+    </div>
   );
 };
 
-interface Props {
-  testId?: string;
-  heading: string;
-  onClose: () => void;
-  onCancel: () => void;
-  onSave: () => void;
-  children: ReactNode;
-}
+type ModalProps = {
+  readonly className?: string;
+  readonly headerClassName?: string;
+  readonly bodyClassName?: string;
+  readonly footerClassName?: string;
+  readonly testId?: string;
+  readonly heading: ReactNode;
+  readonly onClose: () => void;
+  readonly onCancel: () => void;
+  readonly onSave: () => void;
+  readonly children: ReactNode;
+};
 
-export const Modal: FC<Props> = ({
+export const Modal: FC<ModalProps> = ({
+  className,
+  headerClassName,
+  bodyClassName,
+  footerClassName,
   testId,
   heading,
   onClose,
@@ -59,10 +70,23 @@ export const Modal: FC<Props> = ({
   useCallbackOnKeyEscape(onClose);
 
   return (
-    <div data-testid={testId} className="overflow-auto bg-white">
-      <ModalHeader onClose={onClose} heading={heading} />
-      <ModalBody>{children}</ModalBody>
-      <ModalFooter onCancel={onCancel} onSave={onSave} />
+    <div
+      data-testid={testId}
+      className={twMerge('overflow-hidden bg-white', className)}
+    >
+      <ModalHeader
+        className={headerClassName}
+        onClose={onClose}
+        heading={heading}
+      />
+      <ModalBody className={twMerge('overflow-auto', bodyClassName)}>
+        {children}
+      </ModalBody>
+      <ModalFooter
+        className={footerClassName}
+        onCancel={onCancel}
+        onSave={onSave}
+      />
     </div>
   );
 };

--- a/ui/src/components/map/modal/ModalBody.tsx
+++ b/ui/src/components/map/modal/ModalBody.tsx
@@ -1,10 +1,11 @@
 import { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 
-interface Props {
-  className?: string;
-  children: ReactNode;
-}
+type ModalBodyProps = {
+  readonly className?: string;
+  readonly children: ReactNode;
+};
 
-export const ModalBody: FC<Props> = ({ className = '', children }) => {
-  return <div className={`mx-12 my-8 ${className}`}>{children}</div>;
+export const ModalBody: FC<ModalBodyProps> = ({ className = '', children }) => {
+  return <div className={twMerge(`mx-12 my-8`, className)}>{children}</div>;
 };

--- a/ui/src/components/map/modal/ModalHeader.tsx
+++ b/ui/src/components/map/modal/ModalHeader.tsx
@@ -1,3 +1,5 @@
+import { FC, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 import { Row } from '../../../layoutComponents';
 import { CloseIconButton } from '../../../uiComponents';
 
@@ -5,17 +7,24 @@ const testIds = {
   closeButton: 'ModalHeader::closeButton',
 };
 
-interface Props {
-  onClose: () => void;
-  heading: string;
-}
+type ModalHeaderProps = {
+  readonly className?: string;
+  readonly onClose: () => void;
+  readonly heading: ReactNode;
+};
 
-export const ModalHeader = ({
+export const ModalHeader: FC<ModalHeaderProps> = ({
+  className,
   onClose,
   heading,
-}: Props): React.ReactElement => {
+}) => {
   return (
-    <Row className="border border-light-grey bg-background px-10 py-7">
+    <Row
+      className={twMerge(
+        'border border-light-grey bg-background px-10 py-7',
+        className,
+      )}
+    >
       <h2>{heading}</h2>
       <CloseIconButton
         className="ml-auto"

--- a/ui/src/components/map/routes/LineRenderLayer.tsx
+++ b/ui/src/components/map/routes/LineRenderLayer.tsx
@@ -1,44 +1,48 @@
+import { FC } from 'react';
 import { Layer, Source } from 'react-map-gl/maplibre';
 import { theme } from '../../../generated/theme';
 import { mapGeoJSONtoFeature } from '../../../utils';
 
-export interface LinePaint {
-  'line-color': string;
-  'line-width': number;
-  'line-offset': number;
-}
+export type LinePaint = {
+  readonly 'line-color': string;
+  readonly 'line-dasharray'?: number[];
+  readonly 'line-offset': number;
+  readonly 'line-opacity'?: number;
+  readonly 'line-width': number;
+};
 
-interface LineLayout {
-  'line-join': 'round' | 'bevel' | 'miter' | undefined;
-  'line-cap': 'round' | 'butt' | 'square' | undefined;
-}
-interface Props {
-  layerId: string;
-  geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
-  beforeId?: string;
-  layout?: Partial<LineLayout>;
-  paint?: Partial<LinePaint>;
-}
+type LineLayout = {
+  readonly 'line-join': 'round' | 'bevel' | 'miter' | undefined;
+  readonly 'line-cap': 'round' | 'butt' | 'square' | undefined;
+};
+
+type LineRenderLayerProps = {
+  readonly layerId: string;
+  readonly geometry: GeoJSON.LineString | GeoJSON.MultiLineString;
+  readonly beforeId?: string;
+  readonly layout?: Partial<LineLayout>;
+  readonly paint?: Partial<LinePaint>;
+};
+
+const defaultLayout: LineLayout = {
+  'line-join': 'round',
+  'line-cap': 'round',
+};
+
+const defaultPaint = {
+  'line-color': theme.colors.routes.bus,
+  'line-width': 8,
+  'line-offset': 6,
+};
 
 // this layer renders a static line
-export const LineRenderLayer = ({
+export const LineRenderLayer: FC<LineRenderLayerProps> = ({
   layerId,
   geometry,
   beforeId,
   layout,
   paint,
-}: Props) => {
-  const defaultLayout: LineLayout = {
-    'line-join': 'round',
-    'line-cap': 'round',
-  };
-
-  const defaultPaint = {
-    'line-color': theme.colors.routes.bus,
-    'line-width': 8,
-    'line-offset': 6,
-  };
-
+}) => {
   return (
     <Source type="geojson" data={mapGeoJSONtoFeature(geometry)}>
       <Layer

--- a/ui/src/components/map/stops/EditStopLayer.tsx
+++ b/ui/src/components/map/stops/EditStopLayer.tsx
@@ -214,8 +214,7 @@ export const EditStopLayer = forwardRef<EditStoplayerRef, Props>(
         const stopResult = await insertStopMutation(variables);
 
         const scheduledStopPointId =
-          stopResult.data?.insert_service_pattern_scheduled_stop_point_one
-            ?.scheduled_stop_point_id;
+          stopResult.data?.stopPoint?.scheduled_stop_point_id;
 
         if (!scheduledStopPointId) {
           // if for some reason the insert fails but does not throw an error

--- a/ui/src/components/stop-registry/stops/queries/useDeleteQuay.ts
+++ b/ui/src/components/stop-registry/stops/queries/useDeleteQuay.ts
@@ -1,0 +1,33 @@
+import { gql } from '@apollo/client';
+import { useCallback } from 'react';
+import { useDeleteQuayMutation } from '../../../../generated/graphql';
+
+const GQL_DELETE_QUAY_MUTATION = gql`
+  mutation DeleteQuay($stopPlaceId: String!, $quayId: String!) {
+    stop_registry {
+      deleteQuay(stopPlaceId: $stopPlaceId, quayId: $quayId) {
+        id
+        version
+        ... on stop_registry_StopPlace {
+          quays {
+            id
+            version
+          }
+        }
+      }
+    }
+  }
+`;
+
+export function useDeleteQuay() {
+  const [deleteQuay] = useDeleteQuayMutation();
+
+  return useCallback(
+    (stopPlaceId: string, quayId: string) =>
+      deleteQuay({
+        variables: { stopPlaceId, quayId },
+        awaitRefetchQueries: true,
+      }),
+    [deleteQuay],
+  );
+}

--- a/ui/src/components/stop-registry/stops/queries/useInsertQuayIntoStopPlace.ts
+++ b/ui/src/components/stop-registry/stops/queries/useInsertQuayIntoStopPlace.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client';
+
+const GQL_INSERT_QUAY_INTO_STOP_PLACE = gql`
+  mutation InsertQuayIntoStopPlace(
+    $stopPlaceId: String!
+    $quayInput: stop_registry_QuayInput!
+  ) {
+    stop_registry {
+      mutateStopPlace(StopPlace: { id: $stopPlaceId, quays: [$quayInput] }) {
+        id
+        quays {
+          id
+
+          # Get keyValues to match the inserted Quay based on the 'imported-id'
+          keyValues {
+            key
+            values
+          }
+        }
+      }
+    }
+  }
+`;

--- a/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersions.ts
+++ b/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersions.ts
@@ -7,7 +7,11 @@ import {
 } from '../../../../../generated/graphql';
 import { parseDate } from '../../../../../time';
 import { Priority } from '../../../../../types/enums';
-import { getGeometryPoint, numberEnumValues } from '../../../../../utils';
+import {
+  getGeometryPoint,
+  numberEnumValues,
+  requireValue,
+} from '../../../../../utils';
 import { StopVersion, StopVersionStatus } from '../types';
 
 const GQL_GET_QUAY_VERSIONS = gql`
@@ -62,18 +66,6 @@ function mapPriorityToStopVersionStatus(priority: Priority): StopVersionStatus {
     default:
       return StopVersionStatus.STANDARD;
   }
-}
-
-function requireValue<T>(
-  nullable: T | undefined | null,
-): Exclude<T, undefined | null> {
-  if (nullable === undefined || nullable === null) {
-    throw new Error(
-      `Expected non nullable value but it was: ${String(nullable)}`,
-    );
-  }
-
-  return nullable as Exclude<T, undefined | null>;
 }
 
 function mapQuayToStopVersionInfoItem(

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -68520,6 +68520,59 @@ export type StopPlaceDetailsFragment = {
   } | null> | null
 };
 
+export type DeleteQuayMutationVariables = Exact<{
+  stopPlaceId: Scalars['String']['input'];
+  quayId: Scalars['String']['input'];
+}>;
+
+
+export type DeleteQuayMutation = {
+  __typename?: 'mutation_root',
+  stop_registry?: {
+    __typename?: 'stop_registryStopPlaceMutation',
+    deleteQuay?: {
+      __typename?: 'stop_registry_ParentStopPlace',
+      id?: string | null,
+      version?: string | null
+    } | {
+      __typename?: 'stop_registry_StopPlace',
+      id?: string | null,
+      version?: string | null,
+      quays?: Array<{
+        __typename?: 'stop_registry_Quay',
+        id?: string | null,
+        version?: string | null
+      } | null> | null
+    } | null
+  } | null
+};
+
+export type InsertQuayIntoStopPlaceMutationVariables = Exact<{
+  stopPlaceId: Scalars['String']['input'];
+  quayInput: StopRegistryQuayInput;
+}>;
+
+
+export type InsertQuayIntoStopPlaceMutation = {
+  __typename?: 'mutation_root',
+  stop_registry?: {
+    __typename?: 'stop_registryStopPlaceMutation',
+    mutateStopPlace?: Array<{
+      __typename?: 'stop_registry_StopPlace',
+      id?: string | null,
+      quays?: Array<{
+        __typename?: 'stop_registry_Quay',
+        id?: string | null,
+        keyValues?: Array<{
+          __typename?: 'stop_registry_KeyValues',
+          key?: string | null,
+          values?: Array<string | null> | null
+        } | null> | null
+      } | null> | null
+    } | null> | null
+  } | null
+};
+
 export type FindExistingPosterNamesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -72903,14 +72956,14 @@ export type PatchScheduledStopPointTimingSettingsMutation = {
   } | null
 };
 
-export type InsertStopMutationVariables = Exact<{
-  object: ServicePatternScheduledStopPointInsertInput;
+export type InsertStopPointMutationVariables = Exact<{
+  stopPoint: ServicePatternScheduledStopPointInsertInput;
 }>;
 
 
-export type InsertStopMutation = {
+export type InsertStopPointMutation = {
   __typename?: 'mutation_root',
-  insert_service_pattern_scheduled_stop_point_one?: {
+  stopPoint?: {
     __typename?: 'service_pattern_scheduled_stop_point',
     scheduled_stop_point_id: UUID,
     located_on_infrastructure_link_id: UUID,
@@ -76333,6 +76386,92 @@ export type GetStopPlaceDetailsQueryHookResult = ReturnType<typeof useGetStopPla
 export type GetStopPlaceDetailsLazyQueryHookResult = ReturnType<typeof useGetStopPlaceDetailsLazyQuery>;
 export type GetStopPlaceDetailsSuspenseQueryHookResult = ReturnType<typeof useGetStopPlaceDetailsSuspenseQuery>;
 export type GetStopPlaceDetailsQueryResult = Apollo.QueryResult<GetStopPlaceDetailsQuery, GetStopPlaceDetailsQueryVariables>;
+export const DeleteQuayDocument = gql`
+    mutation DeleteQuay($stopPlaceId: String!, $quayId: String!) {
+  stop_registry {
+    deleteQuay(stopPlaceId: $stopPlaceId, quayId: $quayId) {
+      id
+      version
+      ... on stop_registry_StopPlace {
+        quays {
+          id
+          version
+        }
+      }
+    }
+  }
+}
+    `;
+export type DeleteQuayMutationFn = Apollo.MutationFunction<DeleteQuayMutation, DeleteQuayMutationVariables>;
+
+/**
+ * __useDeleteQuayMutation__
+ *
+ * To run a mutation, you first call `useDeleteQuayMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteQuayMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deleteQuayMutation, { data, loading, error }] = useDeleteQuayMutation({
+ *   variables: {
+ *      stopPlaceId: // value for 'stopPlaceId'
+ *      quayId: // value for 'quayId'
+ *   },
+ * });
+ */
+export function useDeleteQuayMutation(baseOptions?: Apollo.MutationHookOptions<DeleteQuayMutation, DeleteQuayMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteQuayMutation, DeleteQuayMutationVariables>(DeleteQuayDocument, options);
+      }
+export type DeleteQuayMutationHookResult = ReturnType<typeof useDeleteQuayMutation>;
+export type DeleteQuayMutationResult = Apollo.MutationResult<DeleteQuayMutation>;
+export type DeleteQuayMutationOptions = Apollo.BaseMutationOptions<DeleteQuayMutation, DeleteQuayMutationVariables>;
+export const InsertQuayIntoStopPlaceDocument = gql`
+    mutation InsertQuayIntoStopPlace($stopPlaceId: String!, $quayInput: stop_registry_QuayInput!) {
+  stop_registry {
+    mutateStopPlace(StopPlace: {id: $stopPlaceId, quays: [$quayInput]}) {
+      id
+      quays {
+        id
+        keyValues {
+          key
+          values
+        }
+      }
+    }
+  }
+}
+    `;
+export type InsertQuayIntoStopPlaceMutationFn = Apollo.MutationFunction<InsertQuayIntoStopPlaceMutation, InsertQuayIntoStopPlaceMutationVariables>;
+
+/**
+ * __useInsertQuayIntoStopPlaceMutation__
+ *
+ * To run a mutation, you first call `useInsertQuayIntoStopPlaceMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useInsertQuayIntoStopPlaceMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [insertQuayIntoStopPlaceMutation, { data, loading, error }] = useInsertQuayIntoStopPlaceMutation({
+ *   variables: {
+ *      stopPlaceId: // value for 'stopPlaceId'
+ *      quayInput: // value for 'quayInput'
+ *   },
+ * });
+ */
+export function useInsertQuayIntoStopPlaceMutation(baseOptions?: Apollo.MutationHookOptions<InsertQuayIntoStopPlaceMutation, InsertQuayIntoStopPlaceMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<InsertQuayIntoStopPlaceMutation, InsertQuayIntoStopPlaceMutationVariables>(InsertQuayIntoStopPlaceDocument, options);
+      }
+export type InsertQuayIntoStopPlaceMutationHookResult = ReturnType<typeof useInsertQuayIntoStopPlaceMutation>;
+export type InsertQuayIntoStopPlaceMutationResult = Apollo.MutationResult<InsertQuayIntoStopPlaceMutation>;
+export type InsertQuayIntoStopPlaceMutationOptions = Apollo.BaseMutationOptions<InsertQuayIntoStopPlaceMutation, InsertQuayIntoStopPlaceMutationVariables>;
 export const FindExistingPosterNamesDocument = gql`
     query findExistingPosterNames {
   stops_database {
@@ -78592,9 +78731,9 @@ export function usePatchScheduledStopPointTimingSettingsMutation(baseOptions?: A
 export type PatchScheduledStopPointTimingSettingsMutationHookResult = ReturnType<typeof usePatchScheduledStopPointTimingSettingsMutation>;
 export type PatchScheduledStopPointTimingSettingsMutationResult = Apollo.MutationResult<PatchScheduledStopPointTimingSettingsMutation>;
 export type PatchScheduledStopPointTimingSettingsMutationOptions = Apollo.BaseMutationOptions<PatchScheduledStopPointTimingSettingsMutation, PatchScheduledStopPointTimingSettingsMutationVariables>;
-export const InsertStopDocument = gql`
-    mutation InsertStop($object: service_pattern_scheduled_stop_point_insert_input!) {
-  insert_service_pattern_scheduled_stop_point_one(object: $object) {
+export const InsertStopPointDocument = gql`
+    mutation InsertStopPoint($stopPoint: service_pattern_scheduled_stop_point_insert_input!) {
+  stopPoint: insert_service_pattern_scheduled_stop_point_one(object: $stopPoint) {
     scheduled_stop_point_id
     located_on_infrastructure_link_id
     direction
@@ -78606,32 +78745,32 @@ export const InsertStopDocument = gql`
   }
 }
     `;
-export type InsertStopMutationFn = Apollo.MutationFunction<InsertStopMutation, InsertStopMutationVariables>;
+export type InsertStopPointMutationFn = Apollo.MutationFunction<InsertStopPointMutation, InsertStopPointMutationVariables>;
 
 /**
- * __useInsertStopMutation__
+ * __useInsertStopPointMutation__
  *
- * To run a mutation, you first call `useInsertStopMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useInsertStopMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useInsertStopPointMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useInsertStopPointMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [insertStopMutation, { data, loading, error }] = useInsertStopMutation({
+ * const [insertStopPointMutation, { data, loading, error }] = useInsertStopPointMutation({
  *   variables: {
- *      object: // value for 'object'
+ *      stopPoint: // value for 'stopPoint'
  *   },
  * });
  */
-export function useInsertStopMutation(baseOptions?: Apollo.MutationHookOptions<InsertStopMutation, InsertStopMutationVariables>) {
+export function useInsertStopPointMutation(baseOptions?: Apollo.MutationHookOptions<InsertStopPointMutation, InsertStopPointMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<InsertStopMutation, InsertStopMutationVariables>(InsertStopDocument, options);
+        return Apollo.useMutation<InsertStopPointMutation, InsertStopPointMutationVariables>(InsertStopPointDocument, options);
       }
-export type InsertStopMutationHookResult = ReturnType<typeof useInsertStopMutation>;
-export type InsertStopMutationResult = Apollo.MutationResult<InsertStopMutation>;
-export type InsertStopMutationOptions = Apollo.BaseMutationOptions<InsertStopMutation, InsertStopMutationVariables>;
+export type InsertStopPointMutationHookResult = ReturnType<typeof useInsertStopPointMutation>;
+export type InsertStopPointMutationResult = Apollo.MutationResult<InsertStopPointMutation>;
+export type InsertStopPointMutationOptions = Apollo.BaseMutationOptions<InsertStopPointMutation, InsertStopPointMutationVariables>;
 export const UpdateScheduledStopPointStopPlaceRefDocument = gql`
     mutation updateScheduledStopPointStopPlaceRef($scheduled_stop_point_id: uuid!, $stop_place_ref: String) {
   update_service_pattern_scheduled_stop_point_by_pk(

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -38893,6 +38893,9 @@ export type StopsDatabaseQuayNewestVersion = {
   /** An object relationship */
   stop_place?: Maybe<StopsDatabaseStopPlace>;
   stop_place_id?: Maybe<Scalars['bigint']['output']>;
+  stop_place_netex_id?: Maybe<Scalars['String']['output']>;
+  /** An object relationship */
+  stop_place_newest_version?: Maybe<StopsDatabaseStopPlaceNewestVersion>;
   stop_place_version?: Maybe<Scalars['bigint']['output']>;
   street_address?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
@@ -39031,6 +39034,8 @@ export type StopsDatabaseQuayNewestVersionBoolExp = {
   site_ref_version?: InputMaybe<StringComparisonExp>;
   stop_place?: InputMaybe<StopsDatabaseStopPlaceBoolExp>;
   stop_place_id?: InputMaybe<BigintComparisonExp>;
+  stop_place_netex_id?: InputMaybe<StringComparisonExp>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionBoolExp>;
   stop_place_version?: InputMaybe<BigintComparisonExp>;
   street_address?: InputMaybe<StringComparisonExp>;
   to_date?: InputMaybe<TimestampComparisonExp>;
@@ -39075,6 +39080,7 @@ export type StopsDatabaseQuayNewestVersionMaxFields = {
   site_ref?: Maybe<Scalars['String']['output']>;
   site_ref_version?: Maybe<Scalars['String']['output']>;
   stop_place_id?: Maybe<Scalars['bigint']['output']>;
+  stop_place_netex_id?: Maybe<Scalars['String']['output']>;
   stop_place_version?: Maybe<Scalars['bigint']['output']>;
   street_address?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
@@ -39119,6 +39125,7 @@ export type StopsDatabaseQuayNewestVersionMinFields = {
   site_ref?: Maybe<Scalars['String']['output']>;
   site_ref_version?: Maybe<Scalars['String']['output']>;
   stop_place_id?: Maybe<Scalars['bigint']['output']>;
+  stop_place_netex_id?: Maybe<Scalars['String']['output']>;
   stop_place_version?: Maybe<Scalars['bigint']['output']>;
   street_address?: Maybe<Scalars['String']['output']>;
   to_date?: Maybe<Scalars['timestamp']['output']>;
@@ -39168,6 +39175,8 @@ export type StopsDatabaseQuayNewestVersionOrderBy = {
   site_ref_version?: InputMaybe<OrderBy>;
   stop_place?: InputMaybe<StopsDatabaseStopPlaceOrderBy>;
   stop_place_id?: InputMaybe<OrderBy>;
+  stop_place_netex_id?: InputMaybe<OrderBy>;
+  stop_place_newest_version?: InputMaybe<StopsDatabaseStopPlaceNewestVersionOrderBy>;
   stop_place_version?: InputMaybe<OrderBy>;
   street_address?: InputMaybe<OrderBy>;
   to_date?: InputMaybe<OrderBy>;
@@ -39247,6 +39256,8 @@ export enum StopsDatabaseQuayNewestVersionSelectColumn {
   SiteRefVersion = 'site_ref_version',
   /** column name */
   StopPlaceId = 'stop_place_id',
+  /** column name */
+  StopPlaceNetexId = 'stop_place_netex_id',
   /** column name */
   StopPlaceVersion = 'stop_place_version',
   /** column name */
@@ -39349,6 +39360,7 @@ export type StopsDatabaseQuayNewestVersionStreamCursorValueInput = {
   site_ref?: InputMaybe<Scalars['String']['input']>;
   site_ref_version?: InputMaybe<Scalars['String']['input']>;
   stop_place_id?: InputMaybe<Scalars['bigint']['input']>;
+  stop_place_netex_id?: InputMaybe<Scalars['String']['input']>;
   stop_place_version?: InputMaybe<Scalars['bigint']['input']>;
   street_address?: InputMaybe<Scalars['String']['input']>;
   to_date?: InputMaybe<Scalars['timestamp']['input']>;
@@ -42532,7 +42544,6 @@ export type StopsDatabaseStopPlaceNewestVersion = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
-  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   scheduled_stop_point_instance?: Maybe<ServicePatternScheduledStopPoint>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
@@ -42847,7 +42858,6 @@ export type StopsDatabaseStopPlaceNewestVersionBoolExp = {
   private_code_type?: InputMaybe<StringComparisonExp>;
   private_code_value?: InputMaybe<StringComparisonExp>;
   public_code?: InputMaybe<StringComparisonExp>;
-  quay_public_code?: InputMaybe<StringComparisonExp>;
   rail_submode?: InputMaybe<StringComparisonExp>;
   short_name_lang?: InputMaybe<StringComparisonExp>;
   short_name_value?: InputMaybe<StringComparisonExp>;
@@ -42913,7 +42923,6 @@ export type StopsDatabaseStopPlaceNewestVersionInsertInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
-  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;
@@ -42968,7 +42977,6 @@ export type StopsDatabaseStopPlaceNewestVersionMaxFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
-  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
@@ -43016,7 +43024,6 @@ export type StopsDatabaseStopPlaceNewestVersionMinFields = {
   private_code_type?: Maybe<Scalars['String']['output']>;
   private_code_value?: Maybe<Scalars['String']['output']>;
   public_code?: Maybe<Scalars['String']['output']>;
-  quay_public_code?: Maybe<Scalars['String']['output']>;
   rail_submode?: Maybe<Scalars['String']['output']>;
   short_name_lang?: Maybe<Scalars['String']['output']>;
   short_name_value?: Maybe<Scalars['String']['output']>;
@@ -43073,7 +43080,6 @@ export type StopsDatabaseStopPlaceNewestVersionOrderBy = {
   private_code_type?: InputMaybe<OrderBy>;
   private_code_value?: InputMaybe<OrderBy>;
   public_code?: InputMaybe<OrderBy>;
-  quay_public_code?: InputMaybe<OrderBy>;
   rail_submode?: InputMaybe<OrderBy>;
   short_name_lang?: InputMaybe<OrderBy>;
   short_name_value?: InputMaybe<OrderBy>;
@@ -43161,8 +43167,6 @@ export enum StopsDatabaseStopPlaceNewestVersionSelectColumn {
   PrivateCodeValue = 'private_code_value',
   /** column name */
   PublicCode = 'public_code',
-  /** column name */
-  QuayPublicCode = 'quay_public_code',
   /** column name */
   RailSubmode = 'rail_submode',
   /** column name */
@@ -43273,7 +43277,6 @@ export type StopsDatabaseStopPlaceNewestVersionStreamCursorValueInput = {
   private_code_type?: InputMaybe<Scalars['String']['input']>;
   private_code_value?: InputMaybe<Scalars['String']['input']>;
   public_code?: InputMaybe<Scalars['String']['input']>;
-  quay_public_code?: InputMaybe<Scalars['String']['input']>;
   rail_submode?: InputMaybe<Scalars['String']['input']>;
   short_name_lang?: InputMaybe<Scalars['String']['input']>;
   short_name_value?: InputMaybe<Scalars['String']['input']>;

--- a/ui/src/hooks/stops/useCreateStop.ts
+++ b/ui/src/hooks/stops/useCreateStop.ts
@@ -1,10 +1,10 @@
 import { gql } from '@apollo/client';
 import flow from 'lodash/flow';
 import {
-  InsertStopMutationVariables,
+  InsertStopPointMutationVariables,
   ScheduledStopPointDefaultFieldsFragment,
   ServicePatternScheduledStopPointInsertInput,
-  useInsertStopMutation,
+  useInsertStopPointMutation,
   useUpdateScheduledStopPointStopPlaceRefMutation,
 } from '../../generated/graphql';
 import { StopWithLocation } from '../../graphql';
@@ -35,11 +35,13 @@ export interface CreateChanges {
   conflicts?: ScheduledStopPointDefaultFieldsFragment[];
 }
 
-const GQL_INSERT_STOP = gql`
-  mutation InsertStop(
-    $object: service_pattern_scheduled_stop_point_insert_input!
+const GQL_INSERT_STOP_POINT = gql`
+  mutation InsertStopPoint(
+    $stopPoint: service_pattern_scheduled_stop_point_insert_input!
   ) {
-    insert_service_pattern_scheduled_stop_point_one(object: $object) {
+    stopPoint: insert_service_pattern_scheduled_stop_point_one(
+      object: $stopPoint
+    ) {
       scheduled_stop_point_id
       located_on_infrastructure_link_id
       direction
@@ -72,20 +74,22 @@ const GQL_UPDATE_SCHEDULED_STOP_POINT_STOP_PLACE_REF = gql`
 `;
 
 export const useCreateStop = () => {
-  const [mutateFunction] = useInsertStopMutation();
+  const [mutateFunction] = useInsertStopPointMutation();
   const [updateScheduledStopPointStopPlaceRefMutation] =
     useUpdateScheduledStopPointStopPlaceRefMutation();
   const [getStopLinkAndDirection] = useGetStopLinkAndDirection();
   const { getConflictingStops } = useCheckValidityAndPriorityConflicts();
   const getRoutesBrokenByStopChange = useGetRoutesBrokenByStopChange();
 
-  const insertStopMutation = async (variables: InsertStopMutationVariables) => {
+  const insertStopMutation = async (
+    variables: InsertStopPointMutationVariables,
+  ) => {
     return mutateFunction({
       variables,
       update(cache) {
         removeFromApolloCache(cache, {
           infrastructure_link_id:
-            variables.object.located_on_infrastructure_link_id,
+            variables.stopPoint.located_on_infrastructure_link_id,
           __typename: 'infrastructure_network_infrastructure_link',
         });
       },
@@ -163,8 +167,8 @@ export const useCreateStop = () => {
   };
 
   const mapCreateChangesToVariables = (changes: CreateChanges) => {
-    const variables: InsertStopMutationVariables = {
-      object: changes.stopToCreate,
+    const variables: InsertStopPointMutationVariables = {
+      stopPoint: changes.stopToCreate,
     };
     return variables;
   };

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -493,6 +493,16 @@
       "byStopArea": "By stop"
     }
   },
+  "stopRegistryNamedEntity": {
+    "nameFin": "Name (Finnish)",
+    "nameSwe": "Name (Swedish)",
+    "locationFin": "Location (Finnish)",
+    "locationSwe": "Location (Swedish)",
+    "nameLongFin": "Long name (Finnish)",
+    "nameLongSwe": "Long name (Swedish)",
+    "abbreviationFin": "Abbreviation (Finnish)",
+    "abbreviationSwe": "Abbreviation (Swedish)"
+  },
   "timingPlaces": {
     "label": "New Hastus place",
     "description": {

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -492,6 +492,16 @@
       "byStopArea": "Pysäkkialueen mukaan"
     }
   },
+  "stopRegistryNamedEntity": {
+    "nameFin": "Nimi (suomi)",
+    "nameSwe": "Nimi (ruotsi)",
+    "locationFin": "Sijainti (suomi)",
+    "locationSwe": "Sijainti (ruotsi)",
+    "nameLongFin": "Pitkänimi (suomi)",
+    "nameLongSwe": "Pitkänimi (ruotsi)",
+    "abbreviationFin": "Lyhenne (suomi)",
+    "abbreviationSwe": "Lyhenne (ruotsi)"
+  },
   "timingPlaces": {
     "label": "Uusi Hastus-paikka",
     "description": {

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -10,13 +10,23 @@ a:focus {
   outline-offset: 0.2em;
 }
 
+:root {
+  --input-height: 44px;
+}
+
 input,
 textarea {
-  height: 44px;
   padding: 12px 10px 12px 10px;
   border: 1px solid #888888;
   border-radius: 5px;
   background-color: white;
+}
+
+input {
+  height: var(--input-height);
+}
+textarea {
+  min-height: var(--input-height);
 }
 
 input:disabled,
@@ -30,7 +40,8 @@ textarea:disabled {
   color: #666666;
 }
 
-label {
+label,
+legend {
   font-weight: 700;
   font-size: 14px;
   margin-bottom: 4px;

--- a/ui/src/time.ts
+++ b/ui/src/time.ts
@@ -23,7 +23,12 @@ export function isDateLike(input?: unknown): input is DateLike {
   return DateTime.isDateTime(input) || isString(input);
 }
 
-export const parseDate = (date?: DateLike | null) => {
+export function parseDate(date: DateLike): DateTime;
+export function parseDate(date: null | undefined): undefined;
+export function parseDate(
+  date: DateLike | null | undefined,
+): DateTime | undefined;
+export function parseDate(date?: DateLike | null) {
   // if null/undefined, return undefined
   if (!date) {
     return undefined;
@@ -42,7 +47,7 @@ export const parseDate = (date?: DateLike | null) => {
   }
 
   throw new Error(`Invalid date input: ${date}`);
-};
+}
 
 // date formats known by luxon: https://moment.github.io/luxon/#/formatting?id=presets
 export const formatDate = (

--- a/ui/src/types/KeyHelpers.ts
+++ b/ui/src/types/KeyHelpers.ts
@@ -2,6 +2,11 @@
 export type RequiredKeys<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
 
+// Make given keys of a type required, leave the rest as-is
+export type RequiredNonNullableKeys<T, K extends keyof T> = Omit<T, K> & {
+  [P in K]-?: Exclude<T[P], null | undefined>;
+};
+
 // Make given keys of a type optional, leave the rest as-is
 export type OptionalKeys<T, K extends keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;

--- a/ui/src/utils/findKeyValue.ts
+++ b/ui/src/utils/findKeyValue.ts
@@ -1,7 +1,13 @@
-import { Maybe, StopRegistryKeyValues } from '../generated/graphql';
+import {
+  Maybe,
+  StopRegistryKeyValues,
+  StopRegistryKeyValuesInput,
+} from '../generated/graphql';
 
 type ElementWithKeyValues = {
-  readonly keyValues?: Maybe<Array<Maybe<StopRegistryKeyValues>>>;
+  readonly keyValues?: Maybe<
+    Array<Maybe<StopRegistryKeyValues | StopRegistryKeyValuesInput>>
+  >;
 };
 
 export function findKeyValue(

--- a/ui/src/utils/forms.ts
+++ b/ui/src/utils/forms.ts
@@ -19,4 +19,14 @@ export const mapDateInputToValidityStart = (isoDate: string) =>
 export const mapDateInputToValidityEnd = (
   isoDate?: string,
   isIndefinite = false,
-) => (isIndefinite ? null : parseDate(isoDate)?.endOf('day'));
+) => {
+  if (isIndefinite) {
+    return null;
+  }
+
+  if (!isoDate) {
+    throw new Error('End date must either be indefinite or set!');
+  }
+
+  return parseDate(isoDate).endOf('day');
+};

--- a/ui/src/utils/gis.ts
+++ b/ui/src/utils/gis.ts
@@ -40,16 +40,22 @@ export const mapPointToStopRegistryGeoJSON = ({
   };
 };
 
-export const mapLngLatToPoint = (lngLat: ReadonlyArray<number>): Point => {
+export const mapLngLatToPoint = (
+  lngLat: ReadonlyArray<number>,
+  maxPrecision?: number,
+): Point => {
   if (lngLat.length < 2 || lngLat.length > 3) {
     throw new Error(
       `Expected lngLat to be like [number, number] or [number, number, number] but got ${lngLat}`,
     );
   }
+
+  const [lon, lat, ele = 0] = lngLat;
+
   return {
-    longitude: lngLat[0],
-    latitude: lngLat[1],
-    elevation: lngLat[2] ?? 0,
+    longitude: maxPrecision ? Number(lon.toPrecision(maxPrecision)) : lon,
+    latitude: maxPrecision ? Number(lat.toPrecision(maxPrecision)) : lat,
+    elevation: maxPrecision ? Number(ele.toPrecision(maxPrecision)) : ele,
   };
 };
 
@@ -91,6 +97,12 @@ export function isValidGeoJSONPoint(
   );
 }
 
+export function getGeometryPoint(geometry: undefined): null;
+export function getGeometryPoint(geometry: null): null;
+export function getGeometryPoint(geometry: GeoJSON.Point): Point;
+export function getGeometryPoint(
+  geometry: GeoJSON.Geometry | StopRegistryGeoJson | null | undefined,
+): Point | null;
 export function getGeometryPoint(
   geometry: GeoJSON.Geometry | StopRegistryGeoJson | null | undefined,
 ): Point | null {

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -15,6 +15,7 @@ export * from './memoizeOne';
 export * from './misc';
 export * from './numberEnumHelpers';
 export * from './object';
+export * from './requireValue';
 export * from './route';
 export * from './routeShape';
 export * from './search';

--- a/ui/src/utils/requireValue.ts
+++ b/ui/src/utils/requireValue.ts
@@ -1,0 +1,11 @@
+export function requireValue<T>(
+  nullable: T | undefined | null,
+): Exclude<T, undefined | null> {
+  if (nullable === undefined || nullable === null) {
+    throw new Error(
+      `Expected non nullable value but it was: ${String(nullable)}`,
+    );
+  }
+
+  return nullable as Exclude<T, undefined | null>;
+}


### PR DESCRIPTION
### Handle programmatic map view state transitions
* MapLibre: Subscribe to MoveEnd event. Non animated state changes do not trigger a Move event, only MoveStart and MoveEnd.
* E2E: Launch the browser with Prefer reduced motion option enabled. This disables map animations and simply jumps the map straight to the new view state. Should reduce map related test flakyness.


### Update Timat & Hasura image refs


### Update global CSS styles
* Set textarea to have min-height of 44px instead of forcing the height prop to 44px. input elements still have hard height of 44px.

* Make legend element have identical style as label.


### Add function overloads for better typings in date parsing


### Preemptively add StopRegistryNamedEntitity form bits.
These were still needed in the initial iteration of for the new Stop creation modal, but were later dropped from the design. But these will be needed when we update the StopArea cration modal in the future. So as to not lose this already written valid code to /dev/null, the files are here now.


### Extract requireValue to be a generic utility function


### Allow finkdKeyValue util function to work with KeyValue inputs


### Update gis utility functions
* Allow limiting precision in mapLngLatToPoint.
* Add function overload to getGeometryPoint for better typings.


### Add RequiredNonNullableKeys helper type
Makes the requested keys of the type truly required:
  - Not optional
  - Not null
  - Not undefined


### Throw on invalid state in mapDateInputToValidityEnd


### E2E: Improve map/createRoute tests
Previously the form was filled in pieces: base details and then the priority and validity period were filled in manually afterwards. But the code in charge of filling in the base details also tries to fill in the priority and validity periods. This split resulted in the endDate/indefinite filds to flicker between states, sometimes resulting in test failures.

Now the form is filled-in in one swell swoop.


### E2E: Allow opening the map on top of any base route


### Map: Fix <CustomOverlay> to not inject JS obects into raw HTMLElements


### Improve the generic Modal component on the Map view
* Allow injecting custom CSS classes to the Header, Body and Footer sections of the modal.
* Allow Heading to receive a complex ReatNode for content as the title "string".
* Instead of having the full content of the modal be scrollable, only apply scrolling to the Body section and keep the Header and Footer always visible.


### Add proper merging/handling of CSS class names to <FormRow>


### Add support for rendering <InputField> as textarea element


### Allow passing in a CSS classname to the date input row in <ValidityPeriodForm>


### Improve <LineRenderLayer> component
* Add support for more paint properties.
* Make types readonly.
* Hoist const data to top level.


### Improve Stop copying
Coder's previous assumption was that one could alter the Quays included in a StopPlace by simply altering the contents of quays field in the mutation payload. But that is not case. Instead on Tiamat's end the quays field is always populated from the DB, and then any new quays are added from the mutation payload or existing ones changes, if there is a QuayInput fragment with a matching ID in the payload. Thus, omitting a Quay from the update payload, does not result in it getting deleted from StopPlace.

Instead to delete a Quay from a StopPlace a special `deleteQuay`
mutation must be called.

