### PR TITLE
Always visualize closest point on a Infra link when working with stops on the map

### DIFF
--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -8,6 +8,7 @@ import {
 import { Column, Visible } from '../../layoutComponents';
 import {
   Mode,
+  selectHasDraftLocation,
   selectHasDraftRouteGeometry,
   selectIsCreateStopAreaModeEnabled,
   selectIsCreateStopModeEnabled,
@@ -60,6 +61,7 @@ export const MapComponent = (
 
   const { drawingMode } = useAppSelector(selectMapRouteEditor);
   const hasDraftRouteGeometry = useAppSelector(selectHasDraftRouteGeometry);
+  const hasDraftStopLocation = useAppSelector(selectHasDraftLocation);
   const { showMapEntityTypeFilterOverlay } = useAppSelector(selectMapFilter);
 
   const dispatch = useAppDispatch();
@@ -197,7 +199,10 @@ export const MapComponent = (
       <EditRouteMetadataLayer />
       <InfraLinksVectorLayer
         enableInfraLinkLayer={
-          showInfraLinks || isCreateStopModeEnabled || isMoveStopModeEnabled
+          showInfraLinks ||
+          isCreateStopModeEnabled ||
+          isMoveStopModeEnabled ||
+          hasDraftStopLocation
         }
         showInfraLinks={showInfraLinks}
       />

--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -195,7 +195,12 @@ export const MapComponent = (
         </Column>
       </CustomOverlay>
       <EditRouteMetadataLayer />
-      {showInfraLinks && <InfraLinksVectorLayer />}
+      <InfraLinksVectorLayer
+        enableInfraLinkLayer={
+          showInfraLinks || isCreateStopModeEnabled || isMoveStopModeEnabled
+        }
+        showInfraLinks={showInfraLinks}
+      />
       {/**
        * Empty layer for dynamically ordering route layers
        * https://github.com/visgl/react-map-gl/issues/939#issuecomment-625290200

--- a/ui/src/components/map/network/InfraLinksVectorLayer.tsx
+++ b/ui/src/components/map/network/InfraLinksVectorLayer.tsx
@@ -4,7 +4,19 @@ import { theme } from '../../../generated/theme';
 
 const { colors } = theme;
 
-export const InfraLinksVectorLayer: React.FC = () => {
+type InfraLinksVectorLayerProps = {
+  readonly enableInfraLinkLayer: boolean;
+  readonly showInfraLinks: boolean;
+};
+
+export const InfraLinksVectorLayer: React.FC<InfraLinksVectorLayerProps> = ({
+  enableInfraLinkLayer,
+  showInfraLinks,
+}) => {
+  if (!enableInfraLinkLayer) {
+    return null;
+  }
+
   return (
     <Source
       type="vector"
@@ -23,7 +35,7 @@ export const InfraLinksVectorLayer: React.FC = () => {
           paint: {
             'line-color': colors.tweakedBrand,
             'line-width': 5,
-            'line-opacity': 0.6,
+            'line-opacity': showInfraLinks ? 0.6 : 0,
           },
         }}
       />

--- a/ui/src/components/map/stops/EditStopLayer.tsx
+++ b/ui/src/components/map/stops/EditStopLayer.tsx
@@ -137,7 +137,8 @@ export const EditStopLayer = forwardRef<EditStoplayerRef, EditStopLayerProps>(
 
     return (
       <>
-        {stopInfo && <LineToClosestInfraLink stop={stopInfo} />}
+        <LineToClosestInfraLink draftLocation={draftLocation} stop={stopInfo} />
+
         {draftLocation && (
           <Stop
             onClick={noop}

--- a/ui/src/components/map/stops/LineToClosestInfraLink.tsx
+++ b/ui/src/components/map/stops/LineToClosestInfraLink.tsx
@@ -1,24 +1,70 @@
 import type { LineString } from 'geojson';
 import { FC } from 'react';
+import { MapInstance } from 'react-map-gl/dist/maplibre';
+import { useMap } from 'react-map-gl/maplibre';
+import { Point } from '../../../types';
+import { findNearestPointOnARoad } from '../../../utils/map';
 import { StopInfoForEditingOnMap } from '../../forms/stop/utils/useGetStopInfoForEditingOnMap';
 import { LineRenderLayer } from '../routes';
 
-type LineToClosestInfraLinkProps = { readonly stop: StopInfoForEditingOnMap };
-
-export const LineToClosestInfraLink: FC<LineToClosestInfraLinkProps> = ({
-  stop,
-}) => {
-  if (!stop.closestPointOnInfraLink) {
+function linestringFromStop(
+  stop: StopInfoForEditingOnMap | null,
+): LineString | null {
+  if (!stop?.closestPointOnInfraLink) {
     return null;
   }
 
-  const lineToInfraLink: LineString = {
+  return {
     type: 'LineString',
     coordinates: [
       [stop.formState.longitude, stop.formState.latitude],
       stop.closestPointOnInfraLink.coordinates,
     ],
   };
+}
+
+function linestringFromDraftLocation(
+  map: MapInstance | undefined,
+
+  draftLocation: Point | null,
+): LineString | null {
+  if (!draftLocation) {
+    return null;
+  }
+
+  const pointOnInfraLink = findNearestPointOnARoad(map, draftLocation);
+
+  if (!pointOnInfraLink) {
+    return null;
+  }
+
+  return {
+    type: 'LineString',
+    coordinates: [
+      [draftLocation.longitude, draftLocation.latitude],
+      pointOnInfraLink.coordinates,
+    ],
+  };
+}
+
+type LineToClosestInfraLinkProps = {
+  readonly draftLocation: Point | null;
+  readonly stop: StopInfoForEditingOnMap | null;
+};
+
+export const LineToClosestInfraLink: FC<LineToClosestInfraLinkProps> = ({
+  draftLocation,
+  stop,
+}) => {
+  const { current: map } = useMap();
+
+  const lineToInfraLink: LineString | null =
+    linestringFromStop(stop) ??
+    linestringFromDraftLocation(map?.getMap(), draftLocation);
+
+  if (!lineToInfraLink) {
+    return null;
+  }
 
   return (
     <LineRenderLayer

--- a/ui/src/redux/selectors/mapStopEditor.ts
+++ b/ui/src/redux/selectors/mapStopEditor.ts
@@ -18,6 +18,11 @@ export const selectDraftLocation = createSelector(
   (mapStopEditor) => mapStopEditor.draftLocation,
 );
 
+export const selectHasDraftLocation = createSelector(
+  selectMapStopEditor,
+  (mapStopEditor) => !!mapStopEditor.draftLocation,
+);
+
 export const selectIsCreateStopModeEnabled = createSelector(
   selectMapStopEditor,
   (mapStopEditor) => mapStopEditor.isCreateStopModeEnabled,

--- a/ui/src/utils/map/lineFromStopToInfraLink.ts
+++ b/ui/src/utils/map/lineFromStopToInfraLink.ts
@@ -10,6 +10,7 @@ import {
   Point as MapLibrePoint,
 } from 'maplibre-gl';
 import { MapInstance } from 'react-map-gl/maplibre';
+import { Point as JorePoint } from '../../types';
 import { notNullish } from '../misc';
 import {
   Geometry,
@@ -141,6 +142,33 @@ export function addLineFromStopToInfraLink(
       },
     });
   }
+}
+
+export function findNearestPointOnARoad(
+  map: MapInstance | undefined,
+  to: JorePoint,
+): Point | null {
+  if (!map) {
+    return null;
+  }
+
+  const toCoordinates: [number, number] = [to.longitude, to.latitude];
+
+  const features: ReadonlyArray<MapGeoJSONFeature> =
+    findFeaturesForLayerWithRadius(
+      map,
+      ROAD_LAYER_ID,
+      map.project(toCoordinates),
+      SEARCH_RADIUS_IN_PIXELS,
+    );
+
+  return findNearestPointOnLineFeatures(
+    {
+      type: 'Point',
+      coordinates: toCoordinates,
+    },
+    features,
+  );
 }
 
 export function drawLineToClosestRoad(


### PR DESCRIPTION
### Enable InfraLink source/layer when editing stop location


### Visualize closest infra link for placed Draft stop

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1064)
<!-- Reviewable:end -->
