### PR TITLE
Optimize Stop Public Code recommendation queries

### DIFF
--- a/ui/src/components/forms/stop/utils/useGetPublicCodeCanditates.ts
+++ b/ui/src/components/forms/stop/utils/useGetPublicCodeCanditates.ts
@@ -26,10 +26,7 @@ const GQL_GET_EXISTING_PUBLIC_CODES = gql`
         name: name_value
       }
 
-      usedPublicCodes: stops_database_quay(
-        distinct_on: [public_code]
-        order_by: [{ public_code: asc }]
-      ) {
+      usedPublicCodes: stops_database_quay(distinct_on: [public_code]) {
         id
         publicCode: public_code
       }
@@ -44,7 +41,6 @@ const GQL_GET_EXISTING_PUBLIC_CODES = gql`
           }
         }
         distinct_on: [public_code]
-        order_by: [{ public_code: asc }]
       ) {
         id
         publicCode: public_code

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -75936,17 +75936,13 @@ export const GetExistingQuayPublicCodesDocument = gql`
       id
       name: name_value
     }
-    usedPublicCodes: stops_database_quay(
-      distinct_on: [public_code]
-      order_by: [{public_code: asc}]
-    ) {
+    usedPublicCodes: stops_database_quay(distinct_on: [public_code]) {
       id
       publicCode: public_code
     }
     nearbyStops: stops_database_quay(
       where: {centroid: {_st_d_within: {distance: $distanceToNearbyStops, from: $newStopLocation}}}
       distinct_on: [public_code]
-      order_by: [{public_code: asc}]
     ) {
       id
       publicCode: public_code


### PR DESCRIPTION
* No need to sort `usedPublicCodes` by the Public Code value those got stored in a `Set` in the final implementation. So order does not matter.
* No need to sort `nearbyStops` by the Pulic Code value, those got sorted by the distance to new stop's location on client side on the final implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1068)
<!-- Reviewable:end -->
