### PR TITLE
Dont use global i18n instance

### DIFF
--- a/ui/src/components/forms/line/LineTypeDropdown.tsx
+++ b/ui/src/components/forms/line/LineTypeDropdown.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { RouteTypeOfLineEnum } from '../../../generated/graphql';
 import { mapLineTypeToUiName } from '../../../i18n/uiNameMappings';
 import { FormInputProps } from '../../../uiComponents';
+import { AllOptionEnum } from '../../../utils';
 import { EnumDropdown } from '../common';
 
 interface Props extends FormInputProps {
@@ -19,12 +20,12 @@ export const LineTypeDropdown = ({
   const { t } = useTranslation();
 
   return (
-    <EnumDropdown
+    <EnumDropdown<RouteTypeOfLineEnum | AllOptionEnum.All>
       id={id}
       testId={testId}
       enumType={RouteTypeOfLineEnum}
       placeholder={t('lines.chooseTypeOfLine')}
-      uiNameMapper={mapLineTypeToUiName}
+      uiNameMapper={(value) => mapLineTypeToUiName(t, value)}
       includeAllOption={!!includeAllOption}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...formInputProps}

--- a/ui/src/components/forms/line/TransportTargetDropdown.tsx
+++ b/ui/src/components/forms/line/TransportTargetDropdown.tsx
@@ -19,7 +19,7 @@ export const TransportTargetDropdown = ({
       testId={testId}
       enumType={HslRouteTransportTargetEnum}
       placeholder={t('lines.transportTarget')}
-      uiNameMapper={mapTransportTargetToUiName}
+      uiNameMapper={(value) => mapTransportTargetToUiName(t, value)}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...formInputProps}
     />

--- a/ui/src/components/forms/line/VehicleModeDropdown.tsx
+++ b/ui/src/components/forms/line/VehicleModeDropdown.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { ReusableComponentsVehicleModeEnum } from '../../../generated/graphql';
 import { mapVehicleModeToUiName } from '../../../i18n/uiNameMappings';
 import { FormInputProps } from '../../../uiComponents';
+import { AllOptionEnum } from '../../../utils';
 import { EnumDropdown } from '../common/EnumDropdown';
 
 interface Props extends FormInputProps {
@@ -22,12 +23,12 @@ export const VehicleModeDropdown = ({
   const { t } = useTranslation();
 
   return (
-    <EnumDropdown
+    <EnumDropdown<ReusableComponentsVehicleModeEnum | AllOptionEnum.All>
       id={id}
       testId={testId}
       enumType={ReusableComponentsVehicleModeEnum}
       placeholder={t('lines.chooseVehicleMode')}
-      uiNameMapper={mapVehicleModeToUiName}
+      uiNameMapper={(value) => mapVehicleModeToUiName(t, value)}
       includeAllOption={!!includeAllOption}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...formInputProps}

--- a/ui/src/components/forms/timetables/LineTypeMultiSelectDropdown.tsx
+++ b/ui/src/components/forms/timetables/LineTypeMultiSelectDropdown.tsx
@@ -17,12 +17,12 @@ export const LineTypeMultiSelectDropdown = ({
   const { t } = useTranslation();
 
   return (
-    <EnumMultiSelectDropdown
+    <EnumMultiSelectDropdown<RouteTypeOfLineEnum>
       id={id}
       testId={testId}
       enumType={RouteTypeOfLineEnum}
       placeholder={t('lines.chooseTypeOfLine')}
-      uiNameMapper={mapLineTypeToUiName}
+      uiNameMapper={(value) => mapLineTypeToUiName(t, value)}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...formInputProps}
     />

--- a/ui/src/components/forms/timetables/SubstituteDayOfWeekDropdown.tsx
+++ b/ui/src/components/forms/timetables/SubstituteDayOfWeekDropdown.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { mapSubstituteDayOfWeekToUiName } from '../../../i18n/uiNameMappings';
 import { SubstituteDayOfWeek } from '../../../types/enums';
 import { FormInputProps } from '../../../uiComponents';
+import { AllOptionEnum } from '../../../utils';
 import { EnumDropdown } from '../common';
 
 interface Props extends FormInputProps {
@@ -18,12 +19,12 @@ export const SubstituteDayOfWeekDropdown = ({
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
   return (
-    <EnumDropdown
+    <EnumDropdown<SubstituteDayOfWeek | AllOptionEnum.All>
       id={id}
       testId={testId}
       enumType={SubstituteDayOfWeek}
       placeholder={t('timetables.chooseSubstituteDay')}
-      uiNameMapper={mapSubstituteDayOfWeekToUiName}
+      uiNameMapper={(value) => mapSubstituteDayOfWeekToUiName(t, value)}
       includeAllOption={!!includeAllOption}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...formInputProps}

--- a/ui/src/components/map/MapFilterPanel.tsx
+++ b/ui/src/components/map/MapFilterPanel.tsx
@@ -1,5 +1,4 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { FilterType, selectMapFilter, setStopFilterAction } from '../../redux';
 import { FilterPanel, placeholderToggles } from '../../uiComponents';
@@ -19,8 +18,6 @@ export const MapFilterPanel: FC<MapFilterPanelProps> = ({
   setShowInfraLinks,
   setShowRoute,
 }) => {
-  const { t } = useTranslation();
-
   const dispatch = useAppDispatch();
   const { stopFilters } = useAppSelector(selectMapFilter);
 
@@ -33,7 +30,7 @@ export const MapFilterPanel: FC<MapFilterPanelProps> = ({
           onToggle: setShowRoute,
           disabled: !routeDisplayed,
           testId: 'FilterPanel::toggleShowBusRoutes',
-          tooltip: t('vehicleModeEnum.bus'),
+          tooltip: (t) => t('vehicleModeEnum.bus'),
         },
         // We want to show placeholder toggles of unimplemented features for visual purposes
         ...placeholderToggles,
@@ -50,7 +47,7 @@ export const MapFilterPanel: FC<MapFilterPanelProps> = ({
               }),
             ),
           testId: 'FilterPanel::toggleShowAllBusStops',
-          tooltip: t('vehicleModeEnum.bus'),
+          tooltip: (t) => t('vehicleModeEnum.bus'),
         },
         ...placeholderToggles,
       ]}

--- a/ui/src/components/map/PriorityBadge.tsx
+++ b/ui/src/components/map/PriorityBadge.tsx
@@ -17,7 +17,7 @@ export const PriorityBadge = ({
 }) => {
   const { t } = useTranslation();
 
-  const title = `${mapPriorityToUiName(priority)}: ${mapToValidityPeriod(
+  const title = `${mapPriorityToUiName(t, priority)}: ${mapToValidityPeriod(
     t,
     validityStart,
     validityEnd,

--- a/ui/src/components/navbar/LanguageDropdown.spec.tsx
+++ b/ui/src/components/navbar/LanguageDropdown.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
-import { i18n } from '../../i18n';
+import { illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance as i18n } from '../../i18n';
 import { render } from '../../utils/test-utils';
 import { LanguageDropdown, testIds } from './LanguageDropdown';
 

--- a/ui/src/components/navbar/LanguageDropdown.spec.tsx
+++ b/ui/src/components/navbar/LanguageDropdown.spec.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, screen } from '@testing-library/react';
+import i18n from 'i18next';
 import React from 'react';
-import { illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance as i18n } from '../../i18n';
 import { render } from '../../utils/test-utils';
+import '../../i18n';
 import { LanguageDropdown, testIds } from './LanguageDropdown';
 
 describe('<LanguageDropdown />', () => {

--- a/ui/src/components/routes-and-lines/common/ConflictResolverModal.tsx
+++ b/ui/src/components/routes-and-lines/common/ConflictResolverModal.tsx
@@ -85,7 +85,7 @@ const ConflictItemRow = ({
       className="[&>td]:border [&>td]:border-light-grey [&>td]:p-5"
       key={item.id}
     >
-      <td>{mapPriorityToUiName(item.priority)}</td>
+      <td>{mapPriorityToUiName(t, item.priority)}</td>
       <td>
         {mapToShortDate(item.validityStart) ?? t('saveChangesModal.indefinite')}
       </td>

--- a/ui/src/components/routes-and-lines/line-details/AdditionalInformation.tsx
+++ b/ui/src/components/routes-and-lines/line-details/AdditionalInformation.tsx
@@ -50,7 +50,7 @@ export const AdditionalInformation: React.FC<Props> = ({
         <FieldValue
           className="w-1/2"
           fieldName={t('lines.primaryVehicleMode')}
-          value={mapVehicleModeToUiName(line.primary_vehicle_mode)}
+          value={mapVehicleModeToUiName(t, line.primary_vehicle_mode)}
           testId={testIds.primaryVehicleMode}
         />
       </Row>
@@ -64,13 +64,13 @@ export const AdditionalInformation: React.FC<Props> = ({
         <FieldValue
           className="w-1/4"
           fieldName={t('lines.typeOfLine')}
-          value={mapLineTypeToUiName(line.type_of_line)}
+          value={mapLineTypeToUiName(t, line.type_of_line)}
           testId={testIds.typeOfLine}
         />
         <FieldValue
           className="w-1/2"
           fieldName={t('lines.transportTarget')}
-          value={mapTransportTargetToUiName(line.transport_target)}
+          value={mapTransportTargetToUiName(t, line.transport_target)}
           testId={testIds.transportTarget}
         />
       </Row>

--- a/ui/src/components/routes-and-lines/line-details/LineValidityPeriod.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineValidityPeriod.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { LineDefaultFieldsFragment } from '../../../generated/graphql';
 import { mapPriorityToUiName } from '../../../i18n/uiNameMappings';
 import { Row } from '../../../layoutComponents';
@@ -19,6 +20,8 @@ export const LineValidityPeriod: React.FC<Props> = ({
   className = '',
   line,
 }) => {
+  const { t } = useTranslation();
+
   const buildValidityPeriod = (
     validityStart?: DateLike | null,
     validityEnd?: DateLike | null,
@@ -35,7 +38,7 @@ export const LineValidityPeriod: React.FC<Props> = ({
       {line.priority !== Priority.Standard && (
         <>
           <span className="font-bold" data-testid={testIds.priority}>
-            {mapPriorityToUiName(line.priority)}
+            {mapPriorityToUiName(t, line.priority)}
           </span>
           <span className="mx-1">|</span>
         </>

--- a/ui/src/components/routes-and-lines/line-details/RouteRow.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteRow.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../generated/graphql';
 import { useAlertsAndHighLights, useShowRoutesOnModal } from '../../../hooks';
 import { mapDirectionToSymbol } from '../../../i18n/uiNameMappings';
-import { parseI18nField } from '../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../i18n/utils';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import {
   MAX_DATE,
@@ -59,6 +59,8 @@ export const RouteRow: FC<PropsWithChildren<Props>> = ({
   controls,
 }) => {
   const { t } = useTranslation();
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const { showRouteOnMap } = useShowRoutesOnModal();
 
   const { getAlertStatus, getAlertStyle } = useAlertsAndHighLights();
@@ -93,7 +95,7 @@ export const RouteRow: FC<PropsWithChildren<Props>> = ({
         </span>
       </div>
       <span className="col-span-8 text-xl" data-testid={testIds.name}>
-        {parseI18nField(route.name_i18n)}
+        {getLocalizedTextFromDbBlob(route.name_i18n)}
       </span>
       <EditButton
         href={routeDetails[Path.editRoute].getLink(

--- a/ui/src/components/stop-registry/search/components/StopSearchBar/PriorityFilter.tsx
+++ b/ui/src/components/stop-registry/search/components/StopSearchBar/PriorityFilter.tsx
@@ -1,6 +1,7 @@
 import without from 'lodash/without';
 import React, { FC } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { mapPriorityToUiName } from '../../../../../i18n/uiNameMappings';
 import { Column, Row } from '../../../../../layoutComponents';
 import { Priority, knownPriorityValues } from '../../../../../types/enums';
@@ -17,6 +18,8 @@ type PriorityFilterProps = {
 };
 
 export const PriorityFilter: FC<PriorityFilterProps> = ({ className }) => {
+  const { t } = useTranslation();
+
   const {
     field: { onChange, value, disabled, onBlur, ref },
   } = useController<StopSearchFilters, 'priorities'>({
@@ -44,7 +47,7 @@ export const PriorityFilter: FC<PriorityFilterProps> = ({ className }) => {
         {knownPriorityValues.map((priority) => (
           <LabeledCheckbox
             key={priority}
-            label={mapPriorityToUiName(priority)}
+            label={mapPriorityToUiName(t, priority)}
             onBlur={onBlur}
             onClick={togglePriority(priority)}
             disabled={!!disabled || notForStops}

--- a/ui/src/components/stop-registry/stops/stop-details/StopHeaderSummaryRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopHeaderSummaryRow.tsx
@@ -55,7 +55,7 @@ export const StopHeaderSummaryRow: React.FC<Props> = ({
           />
           {stopState && stopState !== StopPlaceState.InOperation && (
             <div className="rounded-md bg-dark-grey px-4 py-1 text-center text-sm uppercase leading-normal text-white">
-              {mapStopPlaceStateToUiName(stopState)}
+              {mapStopPlaceStateToUiName(t, stopState)}
             </div>
           )}
         </div>

--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsStopFields.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsStopFields.tsx
@@ -34,11 +34,11 @@ export const StopDetailsSection = ({ stop }: Props) => {
   const { t } = useTranslation();
 
   const stopState =
-    stop.quay?.stopState && mapStopPlaceStateToUiName(stop.quay?.stopState);
+    stop.quay?.stopState && mapStopPlaceStateToUiName(t, stop.quay.stopState);
 
   const transportMode =
     stop.stop_place?.transportMode &&
-    mapStopRegistryTransportModeTypeToUiName(stop.stop_place?.transportMode);
+    mapStopRegistryTransportModeTypeToUiName(t, stop.stop_place.transportMode);
 
   return (
     <>
@@ -88,7 +88,7 @@ export const StopDetailsSection = ({ stop }: Props) => {
         <div className="flex items-center gap-4">
           <LabeledDetail
             title={t('stopDetails.basicDetails.stopType')}
-            detail={stop.quay && translateStopTypes(stop.quay)}
+            detail={stop.quay && translateStopTypes(t, stop.quay)}
             testId={testIds.stopType}
           />
           <MainLineWarning

--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopLabelAndLocationFormRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopLabelAndLocationFormRow.tsx
@@ -66,7 +66,7 @@ export const StopLabelAndLocationFormRow = () => {
               <EnumDropdown<StopPlaceState>
                 enumType={StopPlaceState}
                 placeholder={t('stopDetails.basicDetails.stopState')}
-                uiNameMapper={mapStopPlaceStateToUiName}
+                uiNameMapper={(value) => mapStopPlaceStateToUiName(t, value)}
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...props}
               />

--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopOtherDetailsFormRow.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/basic-details-form/StopOtherDetailsFormRow.tsx
@@ -39,7 +39,9 @@ export const StopOtherDetailsFormRow = ({
             <EnumDropdown<JoreStopRegistryTransportModeType>
               enumType={JoreStopRegistryTransportModeType}
               placeholder={t('stopDetails.basicDetails.transportMode')}
-              uiNameMapper={mapStopRegistryTransportModeTypeToUiName}
+              uiNameMapper={(value) =>
+                mapStopRegistryTransportModeTypeToUiName(t, value)
+              }
               disabled={isRailReplacement}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...props}

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/InfoSpotDetails.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/InfoSpotDetails.tsx
@@ -25,7 +25,7 @@ export const InfoSpotDetails: FC<Props> = ({ infoSpot }) => {
       />
       <LabeledDetail
         title={t('stopDetails.infoSpots.backlight')}
-        detail={optionalBooleanToUiText(infoSpot.backlight)}
+        detail={optionalBooleanToUiText(t, infoSpot.backlight)}
         testId={testIds.backlight}
       />
     </>

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/InfoSpotDetailsDynamic.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/InfoSpotDetailsDynamic.tsx
@@ -29,7 +29,7 @@ export const InfoSpotDetailsDynamic: FC<Props> = ({ infoSpot }) => {
       />
       <LabeledDetail
         title={t('stopDetails.infoSpots.speechProperty')}
-        detail={optionalBooleanToUiText(infoSpot.speechProperty)}
+        detail={optionalBooleanToUiText(t, infoSpot.speechProperty)}
         testId={testIds.speechProperty}
       />
     </>

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/InfoSpotsSection.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/InfoSpotsSection.tsx
@@ -77,6 +77,7 @@ const InfoSpotTitle: FC<{
         {t('stopDetails.infoSpots.shelterTypeSubtitle', {
           index: shelterNumber,
           shelterType: mapStopRegistryShelterTypeEnumToUiName(
+            t,
             shelter.shelterType ?? NullOptionEnum.Null,
           ),
         })}

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsFormFields.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsFormFields.tsx
@@ -108,7 +108,9 @@ export const InfoSpotFormFields: FC<Props> = ({
               <EnumDropdown<StopRegistryPosterPlaceSize>
                 enumType={StopRegistryPosterPlaceSize}
                 placeholder={t('unknown')}
-                uiNameMapper={mapStopRegistryPosterPlaceSizeEnumToUiName}
+                uiNameMapper={(value) =>
+                  mapStopRegistryPosterPlaceSizeEnumToUiName(t, value)
+                }
                 buttonClassName="min-w-36"
                 includeNullOption
                 // eslint-disable-next-line react/jsx-props-no-spreading

--- a/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsFormPosters.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/info-spots/info-spots-form/InfoSpotsFormPosters.tsx
@@ -55,7 +55,9 @@ export const InfoSpotsFormPosters: FC<Props> = ({
             <EnumDropdown<StopRegistryPosterPlaceSize>
               enumType={StopRegistryPosterPlaceSize}
               placeholder={t('unknown')}
-              uiNameMapper={mapStopRegistryPosterPlaceSizeEnumToUiName}
+              uiNameMapper={(value) =>
+                mapStopRegistryPosterPlaceSizeEnumToUiName(t, value)
+              }
               buttonClassName="min-w-36"
               includeNullOption
               disabled={toBeDeletedPoster}

--- a/ui/src/components/stop-registry/stops/stop-details/measurements/AccessibilityLevelIcon.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/measurements/AccessibilityLevelIcon.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { StopRegistryAccessibilityLevel } from '../../../../../generated/graphql';
 import { mapStopAccessibilityLevelToUiName } from '../../../../../i18n/uiNameMappings';
 
@@ -18,8 +19,10 @@ const iconFiles: Record<AccessibilityLevelWithIcon, string> = {
 };
 
 export const AccessibilityLevelIcon = ({ level }: Props) => {
+  const { t } = useTranslation();
+
   const iconFile = iconFiles[level];
-  const title = mapStopAccessibilityLevelToUiName(level);
+  const title = mapStopAccessibilityLevelToUiName(t, level);
 
   return (
     <i

--- a/ui/src/components/stop-registry/stops/stop-details/measurements/AccessibilityLevelInfo.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/measurements/AccessibilityLevelInfo.tsx
@@ -29,7 +29,7 @@ export const AccessibilityLevelInfo: React.FC<Props> = ({ stop }) => {
         onClick={toggleIsModalOpen}
       >
         <span data-testid={testIds.accessibilityLevel}>
-          {mapStopAccessibilityLevelToUiName(accessibilityLevel)}
+          {mapStopAccessibilityLevelToUiName(t, accessibilityLevel)}
         </span>
         <i className="icon-info text-xl text-brand" />
       </button>

--- a/ui/src/components/stop-registry/stops/stop-details/measurements/MeasurementsForm.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/measurements/MeasurementsForm.tsx
@@ -86,7 +86,9 @@ const MeasurementsFormComponent = (
                 <EnumDropdown<StopRegistryStopType>
                   enumType={StopRegistryStopType}
                   placeholder={t('unknown')}
-                  uiNameMapper={mapStopRegistryStopTypeToUiName}
+                  uiNameMapper={(value) =>
+                    mapStopRegistryStopTypeToUiName(t, value)
+                  }
                   includeNullOption
                   // eslint-disable-next-line react/jsx-props-no-spreading
                   {...props}
@@ -116,7 +118,9 @@ const MeasurementsFormComponent = (
                 <EnumDropdown<StopRegistryShelterWidthType>
                   enumType={StopRegistryShelterWidthType}
                   placeholder={t('unknown')}
-                  uiNameMapper={mapStopRegistryShelterWidthTypeToUiName}
+                  uiNameMapper={(value) =>
+                    mapStopRegistryShelterWidthTypeToUiName(t, value)
+                  }
                   includeNullOption
                   // eslint-disable-next-line react/jsx-props-no-spreading
                   {...props}
@@ -262,7 +266,9 @@ const MeasurementsFormComponent = (
                 <EnumDropdown<StopRegistryGuidanceType>
                   enumType={StopRegistryGuidanceType}
                   placeholder={t('unknown')}
-                  uiNameMapper={mapStopRegistryGuidanceTypeToUiName}
+                  uiNameMapper={(value) =>
+                    mapStopRegistryGuidanceTypeToUiName(t, value)
+                  }
                   includeNullOption
                   buttonClassName="min-w-32"
                   // eslint-disable-next-line react/jsx-props-no-spreading
@@ -293,7 +299,9 @@ const MeasurementsFormComponent = (
                 <EnumDropdown<StopRegistryMapType>
                   enumType={StopRegistryMapType}
                   placeholder={t('unknown')}
-                  uiNameMapper={mapStopRegistryMapTypeToUiName}
+                  uiNameMapper={(value) =>
+                    mapStopRegistryMapTypeToUiName(t, value)
+                  }
                   includeNullOption
                   buttonClassName="min-w-32"
                   // eslint-disable-next-line react/jsx-props-no-spreading
@@ -347,8 +355,8 @@ const MeasurementsFormComponent = (
                 <EnumDropdown<StopRegistryPedestrianCrossingRampType>
                   enumType={StopRegistryPedestrianCrossingRampType}
                   placeholder={t('unknown')}
-                  uiNameMapper={
-                    mapStopRegistryPedestrianCrossingRampTypeToUiName
+                  uiNameMapper={(value) =>
+                    mapStopRegistryPedestrianCrossingRampTypeToUiName(t, value)
                   }
                   includeNullOption
                   // eslint-disable-next-line react/jsx-props-no-spreading

--- a/ui/src/components/stop-registry/stops/stop-details/measurements/MeasurementsViewCard.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/measurements/MeasurementsViewCard.tsx
@@ -10,6 +10,7 @@ import { StopWithDetails } from '../../../../../types';
 import { DetailRow, LabeledDetail } from '../layout';
 import {
   extractRelevantAccessibilityAssessment,
+  optionalBooleanToCustomUiText,
   optionalBooleanToUiText,
 } from '../utils';
 
@@ -57,21 +58,22 @@ export const MeasurementsViewCard = ({ stop }: Props): React.ReactElement => {
 
   const stopType =
     accessibilityProps?.stopType &&
-    mapStopRegistryStopTypeToUiName(accessibilityProps.stopType);
+    mapStopRegistryStopTypeToUiName(t, accessibilityProps.stopType);
   const shelterType =
     accessibilityProps?.shelterType &&
-    mapStopRegistryShelterWidthTypeToUiName(accessibilityProps.shelterType);
+    mapStopRegistryShelterWidthTypeToUiName(t, accessibilityProps.shelterType);
   const pedestrianCrossingRampType =
     accessibilityProps?.pedestrianCrossingRampType &&
     mapStopRegistryPedestrianCrossingRampTypeToUiName(
+      t,
       accessibilityProps.pedestrianCrossingRampType,
     );
   const guidanceType =
     accessibilityProps?.guidanceType &&
-    mapStopRegistryGuidanceTypeToUiName(accessibilityProps.guidanceType);
+    mapStopRegistryGuidanceTypeToUiName(t, accessibilityProps.guidanceType);
   const mapType =
     accessibilityProps?.mapType &&
-    mapStopRegistryMapTypeToUiName(accessibilityProps.mapType);
+    mapStopRegistryMapTypeToUiName(t, accessibilityProps.mapType);
 
   return (
     <div data-testid={testIds.container}>
@@ -83,7 +85,7 @@ export const MeasurementsViewCard = ({ stop }: Props): React.ReactElement => {
         />
         <LabeledDetail
           title={t('stopDetails.measurements.curvedStop')}
-          detail={optionalBooleanToUiText(accessibilityProps?.curvedStop)}
+          detail={optionalBooleanToUiText(t, accessibilityProps?.curvedStop)}
           testId={testIds.curvedStop}
         />
         <LabeledDetail
@@ -138,6 +140,7 @@ export const MeasurementsViewCard = ({ stop }: Props): React.ReactElement => {
         <LabeledDetail
           title={t('stopDetails.measurements.platformEdgeWarningArea')}
           detail={optionalBooleanToUiText(
+            t,
             accessibilityProps?.platformEdgeWarningArea,
           )}
           testId={testIds.platformEdgeWarningArea}
@@ -145,18 +148,23 @@ export const MeasurementsViewCard = ({ stop }: Props): React.ReactElement => {
         <LabeledDetail
           title={t('stopDetails.measurements.sidewalkAccessibleConnection')}
           detail={optionalBooleanToUiText(
+            t,
             accessibilityProps?.sidewalkAccessibleConnection,
           )}
           testId={testIds.sidewalkAccessibleConnection}
         />
         <LabeledDetail
           title={t('stopDetails.measurements.guidanceStripe')}
-          detail={optionalBooleanToUiText(accessibilityProps?.guidanceStripe)}
+          detail={optionalBooleanToUiText(
+            t,
+            accessibilityProps?.guidanceStripe,
+          )}
           testId={testIds.guidanceStripe}
         />
         <LabeledDetail
           title={t('stopDetails.measurements.serviceAreaStripes')}
           detail={optionalBooleanToUiText(
+            t,
             accessibilityProps?.serviceAreaStripes,
           )}
           testId={testIds.serviceAreaStripes}
@@ -168,7 +176,7 @@ export const MeasurementsViewCard = ({ stop }: Props): React.ReactElement => {
         />
         <LabeledDetail
           title={t('stopDetails.measurements.guidanceTiles')}
-          detail={optionalBooleanToUiText(accessibilityProps?.guidanceTiles)}
+          detail={optionalBooleanToUiText(t, accessibilityProps?.guidanceTiles)}
           testId={testIds.guidanceTiles}
         />
         <LabeledDetail
@@ -205,12 +213,10 @@ export const MeasurementsViewCard = ({ stop }: Props): React.ReactElement => {
         />
         <LabeledDetail
           title={t('stopDetails.measurements.stopAreaSurroundingsAccessible')}
-          detail={optionalBooleanToUiText(
+          detail={optionalBooleanToCustomUiText(
             accessibilityProps?.stopAreaSurroundingsAccessible,
-            {
-              true: t('stopDetails.measurements.accessible'),
-              false: t('stopDetails.measurements.inaccessible'),
-            },
+            t('stopDetails.measurements.accessible'),
+            t('stopDetails.measurements.inaccessible'),
           )}
           testId={testIds.stopAreaSurroundingsAccessible}
         />

--- a/ui/src/components/stop-registry/stops/stop-details/shelters/ShelterFormFields.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/shelters/ShelterFormFields.tsx
@@ -96,7 +96,9 @@ export const ShelterFormFields = ({
             <EnumDropdown<StopRegistryShelterType>
               enumType={StopRegistryShelterType}
               placeholder={t('unknown')}
-              uiNameMapper={mapStopRegistryShelterTypeEnumToUiName}
+              uiNameMapper={(value) =>
+                mapStopRegistryShelterTypeEnumToUiName(t, value)
+              }
               buttonClassName="min-w-36"
               includeNullOption
               disabled={toBeDeleted}
@@ -114,7 +116,9 @@ export const ShelterFormFields = ({
             <EnumDropdown<StopRegistryShelterElectricity>
               enumType={StopRegistryShelterElectricity}
               placeholder={t('unknown')}
-              uiNameMapper={mapStopRegistryShelterElectricityEnumToUiName}
+              uiNameMapper={(value) =>
+                mapStopRegistryShelterElectricityEnumToUiName(t, value)
+              }
               buttonClassName="min-w-44"
               includeNullOption
               disabled={toBeDeleted}
@@ -147,7 +151,9 @@ export const ShelterFormFields = ({
             <EnumDropdown<StopRegistryShelterCondition>
               enumType={StopRegistryShelterCondition}
               placeholder={t('unknown')}
-              uiNameMapper={mapStopRegistryShelterConditionEnumToUiName}
+              uiNameMapper={(value) =>
+                mapStopRegistryShelterConditionEnumToUiName(t, value)
+              }
               includeNullOption
               disabled={toBeDeleted}
               buttonClassName="min-w-32"

--- a/ui/src/components/stop-registry/stops/stop-details/shelters/ShelterViewCard.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/shelters/ShelterViewCard.tsx
@@ -33,13 +33,16 @@ export const ShelterViewCard = ({ shelter }: Props) => {
 
   const shelterType =
     shelter.shelterType &&
-    mapStopRegistryShelterTypeEnumToUiName(shelter.shelterType);
+    mapStopRegistryShelterTypeEnumToUiName(t, shelter.shelterType);
   const shelterCondition =
     shelter.shelterCondition &&
-    mapStopRegistryShelterConditionEnumToUiName(shelter.shelterCondition);
+    mapStopRegistryShelterConditionEnumToUiName(t, shelter.shelterCondition);
   const shelterElectricity =
     shelter.shelterElectricity &&
-    mapStopRegistryShelterElectricityEnumToUiName(shelter.shelterElectricity);
+    mapStopRegistryShelterElectricityEnumToUiName(
+      t,
+      shelter.shelterElectricity,
+    );
 
   return (
     <div data-testid={testIds.container}>
@@ -66,7 +69,7 @@ export const ShelterViewCard = ({ shelter }: Props) => {
         />
         <LabeledDetail
           title={t('stopDetails.shelters.shelterLighting')}
-          detail={optionalBooleanToUiText(shelter.shelterLighting)}
+          detail={optionalBooleanToUiText(t, shelter.shelterLighting)}
           testId={testIds.shelterLighting}
         />
         <LabeledDetail
@@ -83,32 +86,32 @@ export const ShelterViewCard = ({ shelter }: Props) => {
       <DetailRow>
         <LabeledDetail
           title={t('stopDetails.shelters.trashCan')}
-          detail={optionalBooleanToUiText(shelter.trashCan)}
+          detail={optionalBooleanToUiText(t, shelter.trashCan)}
           testId={testIds.trashCan}
         />
         <LabeledDetail
           title={t('stopDetails.shelters.shelterHasDisplay')}
-          detail={optionalBooleanToUiText(shelter.shelterHasDisplay)}
+          detail={optionalBooleanToUiText(t, shelter.shelterHasDisplay)}
           testId={testIds.shelterHasDisplay}
         />
         <LabeledDetail
           title={t('stopDetails.shelters.bicycleParking')}
-          detail={optionalBooleanToUiText(shelter.bicycleParking)}
+          detail={optionalBooleanToUiText(t, shelter.bicycleParking)}
           testId={testIds.bicycleParking}
         />
         <LabeledDetail
           title={t('stopDetails.shelters.leaningRail')}
-          detail={optionalBooleanToUiText(shelter.leaningRail)}
+          detail={optionalBooleanToUiText(t, shelter.leaningRail)}
           testId={testIds.leaningRail}
         />
         <LabeledDetail
           title={t('stopDetails.shelters.outsideBench')}
-          detail={optionalBooleanToUiText(shelter.outsideBench)}
+          detail={optionalBooleanToUiText(t, shelter.outsideBench)}
           testId={testIds.outsideBench}
         />
         <LabeledDetail
           title={t('stopDetails.shelters.shelterFasciaBoardTaping')}
-          detail={optionalBooleanToUiText(shelter.shelterFasciaBoardTaping)}
+          detail={optionalBooleanToUiText(t, shelter.shelterFasciaBoardTaping)}
           testId={testIds.shelterFasciaBoardTaping}
         />
       </DetailRow>

--- a/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsForm.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsForm.tsx
@@ -59,7 +59,9 @@ const SignageDetailsFormComponent = (
                   <EnumDropdown<StopPlaceSignType>
                     enumType={StopPlaceSignType}
                     placeholder={t('stopDetails.signs.signType')}
-                    uiNameMapper={mapStopPlaceSignTypeToUiName}
+                    uiNameMapper={(value) =>
+                      mapStopPlaceSignTypeToUiName(t, value)
+                    }
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...props}
                   />

--- a/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsViewCard.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/signage-details/SignageDetailsViewCard.tsx
@@ -29,7 +29,8 @@ export const SignageDetailsViewCard = ({ stop }: Props): React.ReactElement => {
   const signType =
     generalSign?.privateCode?.value &&
     mapStopPlaceSignTypeToUiName(
-      generalSign?.privateCode?.value as StopPlaceSignType,
+      t,
+      generalSign.privateCode.value as StopPlaceSignType,
     );
 
   return (
@@ -55,13 +56,13 @@ export const SignageDetailsViewCard = ({ stop }: Props): React.ReactElement => {
       <DetailRow>
         <LabeledDetail
           title={t('stopDetails.signs.lineSignage')}
-          detail={optionalBooleanToUiText(generalSign?.lineSignage)}
+          detail={optionalBooleanToUiText(t, generalSign?.lineSignage)}
           testId={testIds.lineSignage}
         />
         <div className="flex items-center gap-4">
           <LabeledDetail
             title={t('stopDetails.signs.mainLineSign')}
-            detail={optionalBooleanToUiText(generalSign?.mainLineSign)}
+            detail={optionalBooleanToUiText(t, generalSign?.mainLineSign)}
             testId={testIds.mainLineSign}
           />
           <MainLineWarning
@@ -73,7 +74,7 @@ export const SignageDetailsViewCard = ({ stop }: Props): React.ReactElement => {
         </div>
         <LabeledDetail
           title={t('stopDetails.signs.replacesRailSign')}
-          detail={optionalBooleanToUiText(generalSign?.replacesRailSign)}
+          detail={optionalBooleanToUiText(t, generalSign?.replacesRailSign)}
           testId={testIds.replacesRailSign}
         />
       </DetailRow>

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopBoilerPlate.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/CopyStopBoilerPlate.tsx
@@ -29,7 +29,7 @@ export const CopyStopBoilerPlate: FC<CopyStopBoilerPlateProps> = ({
       </p>
       <p className="mt-1" data-testid={testIds.validity}>
         <span className="font-bold">
-          {mapPriorityToUiName(originalStop.priority)}
+          {mapPriorityToUiName(t, originalStop.priority)}
         </span>
         <span className="mx-2">|</span>
         <span>

--- a/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
@@ -1,3 +1,4 @@
+import { i18n } from '../../../../i18n';
 import { optionalBooleanToUiText, translateStopTypes } from './utils';
 
 describe('Stop registry utils', () => {
@@ -11,7 +12,7 @@ describe('Stop registry utils', () => {
           virtual: false,
         },
       };
-      const result = translateStopTypes(stopPlace);
+      const result = translateStopTypes(i18n.t, stopPlace);
       expect(result).toBe('Raideliikennettä korvaava');
     });
 
@@ -24,7 +25,7 @@ describe('Stop registry utils', () => {
           virtual: true,
         },
       };
-      const result = translateStopTypes(stopPlace);
+      const result = translateStopTypes(i18n.t, stopPlace);
       expect(result).toBe(
         'Runkolinja, vaihtopysäkki, raideliikennettä korvaava, virtuaalipysäkki',
       );
@@ -39,29 +40,29 @@ describe('Stop registry utils', () => {
           virtual: false,
         },
       };
-      const result = translateStopTypes(stopPlace);
+      const result = translateStopTypes(i18n.t, stopPlace);
       expect(result).toBe('');
     });
   });
 
   describe('optionalBooleanToUiText', () => {
     it('should translate true', () => {
-      const result = optionalBooleanToUiText(true);
+      const result = optionalBooleanToUiText(i18n.t, true);
       expect(result).toBe('Kyllä');
     });
 
     it('should translate false', () => {
-      const result = optionalBooleanToUiText(false);
+      const result = optionalBooleanToUiText(i18n.t, false);
       expect(result).toBe('Ei');
     });
 
     it('should not translate undefined', () => {
-      const result = optionalBooleanToUiText(undefined);
+      const result = optionalBooleanToUiText(i18n.t, undefined);
       expect(result).toBe(undefined);
     });
 
     it('should not translate null', () => {
-      const result = optionalBooleanToUiText(null);
+      const result = optionalBooleanToUiText(i18n.t, null);
       expect(result).toBe(undefined);
     });
   });

--- a/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
@@ -1,4 +1,5 @@
-import { illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance as i18n } from '../../../../i18n';
+import i18n from 'i18next';
+import '../../../../i18n';
 import { optionalBooleanToUiText, translateStopTypes } from './utils';
 
 describe('Stop registry utils', () => {

--- a/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
@@ -1,4 +1,4 @@
-import { i18n } from '../../../../i18n';
+import { illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance as i18n } from '../../../../i18n';
 import { optionalBooleanToUiText, translateStopTypes } from './utils';
 
 describe('Stop registry utils', () => {

--- a/ui/src/components/stop-registry/stops/stop-details/utils.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/utils.ts
@@ -5,20 +5,24 @@ import {
   StopRegistryDisplayType,
   StopRegistryInfoSpotType,
 } from '../../../../generated/graphql';
-import { i18n } from '../../../../i18n';
 import { EnrichedQuay, StopWithDetails } from '../../../../types';
 
 /**
  * Returns a translated string that includes all stop types of a given stop place.
  */
 export const translateStopTypes = (
+  t: TFunction,
   quay?: Pick<EnrichedQuay, 'stopType'> | null | undefined,
 ) => {
+  if (!quay) {
+    return '';
+  }
+
   const result = compact([
-    quay?.stopType.mainLine && i18n.t('stopPlaceTypes.mainLine'),
-    quay?.stopType.interchange && i18n.t('stopPlaceTypes.interchange'),
-    quay?.stopType.railReplacement && i18n.t('stopPlaceTypes.railReplacement'),
-    quay?.stopType.virtual && i18n.t('stopPlaceTypes.virtual'),
+    quay.stopType.mainLine && t('stopPlaceTypes.mainLine'),
+    quay.stopType.interchange && t('stopPlaceTypes.interchange'),
+    quay.stopType.railReplacement && t('stopPlaceTypes.railReplacement'),
+    quay.stopType.virtual && t('stopPlaceTypes.virtual'),
   ])
     // Uncapitalize each translation.
     .map((stopType) => stopType.charAt(0).toLowerCase() + stopType.slice(1))
@@ -34,18 +38,38 @@ export const translateStopTypes = (
  * Missing values are NOT translated.
  */
 export const optionalBooleanToUiText = (
+  t: TFunction,
   value: boolean | undefined | null,
-  translations: { true: string; false: string } = {
-    true: i18n.t('yes'),
-    false: i18n.t('no'),
-  },
 ) => {
   if (value) {
-    return translations.true;
+    return t('yes');
   }
+
   if (value === false) {
-    return translations.false;
+    return t('no');
   }
+
+  return undefined;
+};
+
+/**
+ * Maps a boolean to a custom text values.
+ *
+ * Missing values are NOT translated.
+ */
+export const optionalBooleanToCustomUiText = (
+  value: boolean | undefined | null,
+  ifTrue: string,
+  ifFalse: string,
+) => {
+  if (value) {
+    return ifTrue;
+  }
+
+  if (value === false) {
+    return ifFalse;
+  }
+
   return undefined;
 };
 

--- a/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
+++ b/ui/src/components/timetables/common/VehicleJourneyGroupInfo.tsx
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
 import { VehicleJourneyWithServiceFragment } from '../../../generated/graphql';
 import { useAppDispatch } from '../../../hooks';
-import { parseI18nField } from '../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../i18n/utils';
 import { Row } from '../../../layoutComponents';
 import { openChangeTimetableValidityModalAction } from '../../../redux';
 import { mapDurationToShortTime, mapToShortDate } from '../../../time';
@@ -41,6 +41,8 @@ export const VehicleJourneyGroupInfo = ({
   className = '',
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const dispatch = useAppDispatch();
 
   const changeVehicleScheduleFrameValidity = () => {
@@ -68,7 +70,7 @@ export const VehicleJourneyGroupInfo = ({
     >
       <IconButton
         tooltip={t('accessibility:timetables.changeValidityPeriod', {
-          dayType: parseI18nField(dayTypeNameI18n),
+          dayType: getLocalizedTextFromDbBlob(dayTypeNameI18n),
         })}
         className={`mr-2 h-8 w-16 rounded-sm border border-light-grey bg-white text-base ${
           isDisabled ? 'text-light-grey' : hoverStyle

--- a/ui/src/components/timetables/import/ImportTimetablesPage.tsx
+++ b/ui/src/components/timetables/import/ImportTimetablesPage.tsx
@@ -91,6 +91,7 @@ export const ImportTimetablesPage = (): React.ReactElement => {
             return {
               errorTitle: t('import.fileUploadFailed', { filename }),
               details: mapHastusErrorTypeToErrorMessage(
+                t,
                 extractErrorType(getImportErrorBody(failure.error)),
               ),
               additionalDetails: failure.error.response?.data?.reason ?? '',

--- a/ui/src/components/timetables/import/contents-view/BlockVehicleJourneysTable.tsx
+++ b/ui/src/components/timetables/import/contents-view/BlockVehicleJourneysTable.tsx
@@ -5,7 +5,7 @@ import {
   VehicleServiceWithJourneysFragment,
 } from '../../../../generated/graphql';
 import { useToggle } from '../../../../hooks';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { Row, Visible } from '../../../../layoutComponents';
 import { AccordionButton } from '../../../../uiComponents';
 import { VehicleJourneyRow } from './VehicleJourneyRow';
@@ -39,8 +39,12 @@ export const BlockVehicleJourneysTable = ({
   vehicleScheduleFrameLabel,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const [isOpen, toggleIsOpen] = useToggle();
+
   const identifier = `${vehicleScheduleFrameLabel} ${blockLabel}`;
+
   return (
     <table
       className="border-brand-gray w-full border"
@@ -63,7 +67,7 @@ export const BlockVehicleJourneysTable = ({
               <p data-testid={testIds.vehicleType}>
                 {vehicleType &&
                   t('timetablesPreview.vehicleType', {
-                    vehicleTypeName: parseI18nField(
+                    vehicleTypeName: getLocalizedTextFromDbBlob(
                       vehicleType.description_i18n,
                     ),
                   })}

--- a/ui/src/components/timetables/import/contents-view/VehicleJourneyRow.tsx
+++ b/ui/src/components/timetables/import/contents-view/VehicleJourneyRow.tsx
@@ -2,7 +2,7 @@ import {
   VehicleJourneyWithRouteInfoFragment,
   VehicleServiceWithJourneysFragment,
 } from '../../../../generated/graphql';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { Row } from '../../../../layoutComponents';
 import { mapDurationToShortTime } from '../../../../time';
 import { getRouteLabelVariantText } from '../../../../utils';
@@ -25,6 +25,8 @@ export const VehicleJourneyRow = ({
   vehicleJourney: VehicleJourneyWithRouteInfoFragment;
   vehicleService: VehicleServiceWithJourneysFragment;
 }): React.ReactElement => {
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const route =
     vehicleJourney.journey_pattern_ref.journey_pattern_instance
       ?.journey_pattern_route;
@@ -54,7 +56,7 @@ export const VehicleJourneyRow = ({
         </Row>
       </td>
       <td data-testid={testIds.dayTypeName}>
-        {parseI18nField(vehicleService.day_type.name_i18n)}
+        {getLocalizedTextFromDbBlob(vehicleService.day_type.name_i18n)}
       </td>
       <td data-testid={testIds.startTime}>
         {vehicleJourney.start_time

--- a/ui/src/components/timetables/import/contents-view/VehicleScheduleFrameBlocksView.tsx
+++ b/ui/src/components/timetables/import/contents-view/VehicleScheduleFrameBlocksView.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { VehicleScheduleFrameWithRouteInfoFragment } from '../../../../generated/graphql';
 import { useToggle } from '../../../../hooks';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { Row, Visible } from '../../../../layoutComponents';
 import { mapToShortDate } from '../../../../time';
 import { AccordionButton } from '../../../../uiComponents';
@@ -26,11 +26,13 @@ export const VehicleScheduleFrameBlocksView = ({
   vehicleScheduleFrame,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const [isOpen, toggleIsOpen] = useToggle(true);
 
   const blocks = vehicleScheduleFrame.vehicle_services.flatMap((service) =>
     service.blocks.map((block) => ({
-      label: parseI18nField(service.name_i18n),
+      label: getLocalizedTextFromDbBlob(service.name_i18n),
       service,
       block,
     })),

--- a/ui/src/components/timetables/import/duplicate-journeys/VehicleJourneyRow.tsx
+++ b/ui/src/components/timetables/import/duplicate-journeys/VehicleJourneyRow.tsx
@@ -1,5 +1,5 @@
 import { VehicleJourneyInfo } from '../../../../hooks';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { mapDurationToShortTime, mapToShortDate } from '../../../../time';
 
 interface Props {
@@ -7,6 +7,8 @@ interface Props {
 }
 
 export const VehicleJourneyRow = ({ vehicleJourneyInfo }: Props) => {
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   return (
     <tr className="border odd:bg-white even:bg-hsl-neutral-blue [&>td]:border-light-grey [&>td]:px-8 [&>td]:py-2">
       <td className="border-r font-bold">{vehicleJourneyInfo.uniqueLabel}</td>
@@ -14,7 +16,7 @@ export const VehicleJourneyRow = ({ vehicleJourneyInfo }: Props) => {
         {mapDurationToShortTime(vehicleJourneyInfo.startTime)}
       </td>
       <td className="border-r">
-        {parseI18nField(vehicleJourneyInfo.dayTypeName)}
+        {getLocalizedTextFromDbBlob(vehicleJourneyInfo.dayTypeName)}
       </td>
       <td className="!pr-0">
         {mapToShortDate(vehicleJourneyInfo.validityStart)}

--- a/ui/src/components/timetables/import/missing-route-deviations/RouteDeviationLink.tsx
+++ b/ui/src/components/timetables/import/missing-route-deviations/RouteDeviationLink.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { VehicleScheduleFrameInfo } from '../../../../hooks';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { routeDetails } from '../../../../router/routeDetails';
 import { DirectionBadge } from '../../../routes-and-lines/line-details/DirectionBadge';
 
@@ -20,11 +20,14 @@ export const RouteDeviationLink = ({
   isLast,
   testIdPrefix,
 }: Props) => {
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const { lineId, uniqueLabel, direction } = deviation;
+
   return (
     <Link
       to={routeDetails['/timetables/lines/:id'].getLink(lineId, uniqueLabel)}
-      title={parseI18nField(deviation.routeName)}
+      title={getLocalizedTextFromDbBlob(deviation.routeName)}
       data-testid={testIds.link(testIdPrefix)}
     >
       <div className="flex items-center">

--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopSection.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopSection.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { pipe, unique } from 'remeda';
 import { RouteWithJourneyPatternStopsFragment } from '../../../generated/graphql';
 import { VehicleJourneyGroup, useTimetablesViewState } from '../../../hooks';
-import { parseI18nField } from '../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../i18n/utils';
 import { Row } from '../../../layoutComponents';
 import { TimetablePriority } from '../../../types/enums';
 import { VehicleJourneyGroupInfo } from '../common/VehicleJourneyGroupInfo';
@@ -28,8 +28,10 @@ export const PassingTimesByStopSection = ({
   vehicleJourneyGroups,
   route,
 }: Props): React.ReactElement => {
-  const { dayType, setDayType } = useTimetablesViewState();
   const { t } = useTranslation();
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
+  const { dayType, setDayType } = useTimetablesViewState();
 
   const vehicleJourneyGroupsToDisplay =
     vehicleJourneyGroups?.filter(
@@ -47,7 +49,7 @@ export const PassingTimesByStopSection = ({
     return pipe(
       dayTypes.find((type) => type.label === dayTypeLabel),
       (type) => type?.name_i18n,
-      parseI18nField,
+      getLocalizedTextFromDbBlob,
     );
   };
 

--- a/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingMinute.tsx
+++ b/ui/src/components/timetables/passing-times-by-stop/PassingTimesByStopTableRowPassingMinute.tsx
@@ -1,7 +1,7 @@
 import { twMerge } from 'tailwind-merge';
 import { PassingTimeByStopFragment } from '../../../generated/graphql';
 import { useAppSelector } from '../../../hooks';
-import { parseI18nField } from '../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../i18n/utils';
 import { Visible } from '../../../layoutComponents';
 import { selectTimetable } from '../../../redux';
 import { mapDurationToShortTime, padToTwoDigits } from '../../../time';
@@ -33,6 +33,8 @@ export const PassingTimesByStopTableRowPassingMinute = ({
   selectedPassingTime,
   setSelectedPassingTime,
 }: Props): React.ReactElement => {
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const { showArrivalTimes } = useAppSelector(selectTimetable);
   const passing = passingTime.passing_time;
 
@@ -93,7 +95,7 @@ export const PassingTimesByStopTableRowPassingMinute = ({
       <Visible visible={isSelected}>
         <VehicleJourneyPopover
           passingTime={passing}
-          vehicleTypeDescription={parseI18nField(
+          vehicleTypeDescription={getLocalizedTextFromDbBlob(
             passingTime.vehicle_journey.block.vehicle_type?.description_i18n,
           )}
           onClose={() => setSelectedPassingTime(undefined)}

--- a/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/RouteTimetablesSection.tsx
@@ -9,7 +9,7 @@ import {
   useTimetablesViewState,
   useToggle,
 } from '../../../hooks';
-import { parseI18nField } from '../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../i18n/utils';
 import { Row, Visible } from '../../../layoutComponents';
 import { LoadingState, selectLoader, selectTimetable } from '../../../redux';
 import { DayType } from '../../../types/enums';
@@ -45,10 +45,14 @@ export const RouteTimetablesSection = ({
   initiallyOpen = true,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
-  const { showAllValid } = useAppSelector(selectTimetable);
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const [isOpen, toggleIsOpen] = useToggle(initiallyOpen);
-  const { activeView, setShowPassingTimesByStop } = useTimetablesViewState();
+
+  const { showAllValid } = useAppSelector(selectTimetable);
   const { fetchRouteTimetables } = useAppSelector(selectLoader);
+
+  const { activeView, setShowPassingTimesByStop } = useTimetablesViewState();
   const routeResult = useGetRouteWithJourneyPatternQuery({
     variables: { routeId },
   });
@@ -73,7 +77,7 @@ export const RouteTimetablesSection = ({
       (item) => DayType[item.dayType.label as keyof typeof DayType],
     ]);
   })();
-  const routeName = parseI18nField(route.name_i18n);
+  const routeName = getLocalizedTextFromDbBlob(route.name_i18n);
   const sectionIdentifier = `${route.direction}-${route.label}-route-timetables-section`;
 
   return (

--- a/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
+++ b/ui/src/components/timetables/vehicle-schedule-details/vehicle-service-table/VehicleServiceTable.tsx
@@ -3,7 +3,7 @@ import { MdHistory } from 'react-icons/md';
 import { groupBy, pipe } from 'remeda';
 import { twMerge } from 'tailwind-merge';
 import { VehicleJourneyGroup } from '../../../../hooks';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { Column, Visible } from '../../../../layoutComponents';
 import { mapToShortDateTime } from '../../../../time';
 import { TimetablePriority } from '../../../../types/enums';
@@ -50,6 +50,7 @@ export const VehicleServiceTable = ({
   onClick,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
 
   const { vehicleJourneys, priority, dayType, createdAt } = vehicleJourneyGroup;
 
@@ -97,7 +98,7 @@ export const VehicleServiceTable = ({
         data-testid={testIds.timetableHeadingButton}
       >
         <Column className="mr-auto">
-          <h4>{parseI18nField(dayType.name_i18n)}</h4>
+          <h4>{getLocalizedTextFromDbBlob(dayType.name_i18n)}</h4>
         </Column>
         <Column className="justify-center">
           <p className="text-sm">

--- a/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
@@ -96,11 +96,14 @@ export const TimetableVersionTableRow = ({
 
   const statusText = data.inEffect
     ? t('timetables.inEffect')
-    : mapTimetablePriorityToUiName(data.vehicleScheduleFrame.priority);
+    : mapTimetablePriorityToUiName(t, data.vehicleScheduleFrame.priority);
 
   const substituteDayOperatingText = data.substituteDay?.substituteDayOfWeek
     ? t('timetables.operatedLike', {
-        dayOfWeek: mapDayOfWeekToUiName(data.substituteDay.substituteDayOfWeek),
+        dayOfWeek: mapDayOfWeekToUiName(
+          t,
+          data.substituteDay.substituteDayOfWeek,
+        ),
       })
     : t('timetables.noService');
 

--- a/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
+++ b/ui/src/components/timetables/versions/TimetableVersionTableRow.tsx
@@ -5,7 +5,7 @@ import {
   mapDayOfWeekToUiName,
   mapTimetablePriorityToUiName,
 } from '../../../i18n/uiNameMappings';
-import { parseI18nField } from '../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../i18n/utils';
 import { Visible } from '../../../layoutComponents';
 import {
   openDeleteTimetableModalAction,
@@ -71,6 +71,8 @@ export const TimetableVersionTableRow = ({
   data,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const dispatch = useAppDispatch();
 
   const onClick = () => {
@@ -111,10 +113,11 @@ export const TimetableVersionTableRow = ({
     data.vehicleScheduleFrame.priority,
   )} bg-opacity-25`;
 
-  const dayType = parseI18nField(data.dayType.nameI18n);
-  const vehicleScheduleFrameName = parseI18nField(
+  const dayType = getLocalizedTextFromDbBlob(data.dayType.nameI18n);
+  const vehicleScheduleFrameName = getLocalizedTextFromDbBlob(
     data.vehicleScheduleFrame.nameI18n,
   );
+
   return (
     <tr
       className="h-14 text-center [&>td]:border [&>td]:border-light-grey"

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/RouteTimetableCard.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/RouteTimetableCard.tsx
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { RouteTimetableRowInfo } from '../../../../hooks';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { VehicleJourneyGroupInfo } from '../../common/VehicleJourneyGroupInfo';
 import { VehicleServiceRow } from '../../vehicle-schedule-details';
 import { ExpandableRouteTimetableRow } from './ExpandableRouteTimetableRow';
@@ -17,14 +17,17 @@ export const RouteTimetableCard: React.FC<Props> = ({
   dayTypeNameI18n,
   createdAt,
 }) => {
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
   const sectionIdentifier = `ExpandableRouteTimetableRow.${routeTimetableRowInfo.label}.${routeTimetableRowInfo.direction}`;
+
   return (
     <ExpandableRouteTimetableRow
       className="mb-4"
       key={`${routeTimetableRowInfo.label}.${routeTimetableRowInfo.direction}`}
       routeLabel={routeTimetableRowInfo.label}
       direction={routeTimetableRowInfo.direction}
-      routeName={parseI18nField(routeTimetableRowInfo.nameI18n)}
+      routeName={getLocalizedTextFromDbBlob(routeTimetableRowInfo.nameI18n)}
       sectionIdentifier={sectionIdentifier}
     >
       <div className="mt-4 space-y-2" id={sectionIdentifier}>

--- a/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableHeading.tsx
+++ b/ui/src/components/timetables/versions/timetable-version-details-panel/TimetableHeading.tsx
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { MdHistory } from 'react-icons/md';
 import { twMerge } from 'tailwind-merge';
-import { parseI18nField } from '../../../../i18n/utils';
+import { useGetLocalizedTextFromDbBlob } from '../../../../i18n/utils';
 import { Column, Row } from '../../../../layoutComponents';
 import { mapToShortDateTime } from '../../../../time';
 import { TimetablePriority } from '../../../../types/enums';
@@ -12,22 +12,28 @@ export const TimetableHeading: React.FC<{
   dayTypeI18n?: LocalizedString;
   createdAt?: DateTime;
   className?: string;
-}> = ({ priority, dayTypeI18n, createdAt, className = '' }) => (
-  <Row
-    className={twMerge(
-      'justify-between rounded-md border-2 border-transparent bg-opacity-50 px-4 py-1',
-      getTimetableHeadingBgColor(priority),
-      className,
-    )}
-  >
-    <Column>
-      <span className="text-lg font-bold">{parseI18nField(dayTypeI18n)}</span>
-    </Column>
-    <Column className="justify-center">
-      <p className="text-sm">
-        {mapToShortDateTime(createdAt)}
-        <MdHistory className="ml-2 inline" />
-      </p>
-    </Column>
-  </Row>
-);
+}> = ({ priority, dayTypeI18n, createdAt, className = '' }) => {
+  const getLocalizedTextFromDbBlob = useGetLocalizedTextFromDbBlob();
+
+  return (
+    <Row
+      className={twMerge(
+        'justify-between rounded-md border-2 border-transparent bg-opacity-50 px-4 py-1',
+        getTimetableHeadingBgColor(priority),
+        className,
+      )}
+    >
+      <Column>
+        <span className="text-lg font-bold">
+          {getLocalizedTextFromDbBlob(dayTypeI18n)}
+        </span>
+      </Column>
+      <Column className="justify-center">
+        <p className="text-sm">
+          {mapToShortDateTime(createdAt)}
+          <MdHistory className="ml-2 inline" />
+        </p>
+      </Column>
+    </Row>
+  );
+};

--- a/ui/src/hooks/routes/useExportRoutes.ts
+++ b/ui/src/hooks/routes/useExportRoutes.ts
@@ -83,6 +83,7 @@ export const useExportRoutes = () => {
       });
 
       const filename = `${routeLabels[0]}_${mapPriorityToUiName(
+        t,
         priorities[0],
       )}_${observationDate.toISODate()}.csv`;
 
@@ -98,6 +99,7 @@ export const useExportRoutes = () => {
           errorModalTitle: t('export.hastusErrorTitle'),
           errorDetails: {
             details: mapHastusErrorTypeToErrorMessage(
+              t,
               extractErrorType(errorResponseBody),
             ),
             additionalDetails: errorResponseBody?.reason ?? '',

--- a/ui/src/hooks/timetables-import/deviations/missing-routes/useReplaceDeviations.spec.ts
+++ b/ui/src/hooks/timetables-import/deviations/missing-routes/useReplaceDeviations.spec.ts
@@ -2,6 +2,8 @@ import { act, renderHook } from '@testing-library/react';
 import { RouteDirectionEnum } from '../../../../generated/graphql';
 import { VehicleScheduleVehicleScheduleFrameWithRoutes } from '../useVehicleScheduleFrameWithRouteLabelAndLineId';
 import { useReplaceDeviations } from './useReplaceDeviations';
+// Make sure I18Next is initialized
+import '../../../../i18n';
 
 jest.mock('../../../../utils/toastService', () => ({
   showDangerToastWithError: jest.fn(),

--- a/ui/src/i18n.ts
+++ b/ui/src/i18n.ts
@@ -30,16 +30,5 @@ i18next.use(initReactI18next).init({
   },
 });
 
-/**
- * Global refence to the I18Next objects should never be used in React code.
- * Function calls employing the global instance cannot react to changes in
- * language, translations or other state bits stored in the I18Next object.
- * Instead, one should always retrieve the active version/state of the I18Next
- * object with the help of `useContext(import('react-18next').I18NextContext)`
- * or `useTranslation` hooks.
- */
-export const illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance =
-  i18next;
-
 // All the translation key paths as strings (e.g. "navigation.logout")
 export type TranslationKey = Paths<typeof translationsJson>;

--- a/ui/src/i18n.ts
+++ b/ui/src/i18n.ts
@@ -30,7 +30,16 @@ i18next.use(initReactI18next).init({
   },
 });
 
-export const i18n = i18next;
+/**
+ * Global refence to the I18Next objects should never be used in React code.
+ * Function calls employing the global instance cannot react to changes in
+ * language, translations or other state bits stored in the I18Next object.
+ * Instead, one should always retrieve the active version/state of the I18Next
+ * object with the help of `useContext(import('react-18next').I18NextContext)`
+ * or `useTranslation` hooks.
+ */
+export const illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance =
+  i18next;
 
 // All the translation key paths as strings (e.g. "navigation.logout")
 export type TranslationKey = Paths<typeof translationsJson>;

--- a/ui/src/i18n/hastusErrorMappings.ts
+++ b/ui/src/i18n/hastusErrorMappings.ts
@@ -1,38 +1,39 @@
+import { TFunction } from 'i18next';
 import { HastusApiErrorType } from '../api/hastus';
-import { i18n } from '../i18n';
 
 export const mapHastusErrorTypeToErrorMessage = (
+  t: TFunction,
   errorType: HastusApiErrorType,
 ): string => {
   switch (errorType) {
     case HastusApiErrorType.CannotFindJourneyPatternRefByRouteLabelAndDirectionError:
-      return i18n.t(
+      return t(
         'hastusApiErrors.cannotFindJourneyPatternRefByRouteLabelAndDirectionError',
       );
     case HastusApiErrorType.CannotFindJourneyPatternRefByStopPointLabelsError:
-      return i18n.t(
+      return t(
         'hastusApiErrors.cannotFindJourneyPatternRefByStopPointLabelsError',
       );
     case HastusApiErrorType.CannotFindJourneyPatternRefByTimingPlaceLabelsError:
-      return i18n.t(
+      return t(
         'hastusApiErrors.cannotFindJourneyPatternRefByTimingPlaceLabelsError',
       );
     case HastusApiErrorType.ErrorWhileProcessingHastusDataError:
-      return i18n.t('hastusApiErrors.errorWhileProcessingHastusDataError');
+      return t('hastusApiErrors.errorWhileProcessingHastusDataError');
     case HastusApiErrorType.FirstStopNotTimingPointError:
-      return i18n.t('hastusApiErrors.firstStopNotTimingPointError');
+      return t('hastusApiErrors.firstStopNotTimingPointError');
     case HastusApiErrorType.GraphQLAuthenticationFailedError:
-      return i18n.t('hastusApiErrors.graphQLAuthenticationFailedError');
+      return t('hastusApiErrors.graphQLAuthenticationFailedError');
     case HastusApiErrorType.IllegalArgumentError:
-      return i18n.t('hastusApiErrors.illegalArgumentError');
+      return t('hastusApiErrors.illegalArgumentError');
     case HastusApiErrorType.InvalidHastusDataError:
-      return i18n.t('hastusApiErrors.invalidHastusDataError');
+      return t('hastusApiErrors.invalidHastusDataError');
     case HastusApiErrorType.LastStopNotTimingPointError:
-      return i18n.t('hastusApiErrors.lastStopNotTimingPointError');
+      return t('hastusApiErrors.lastStopNotTimingPointError');
     case HastusApiErrorType.TooFewStopPointsError:
-      return i18n.t('hastusApiErrors.tooFewStopPointsError');
+      return t('hastusApiErrors.tooFewStopPointsError');
     case HastusApiErrorType.UnknownError:
     default:
-      return i18n.t('hastusApiErrors.unknownError');
+      return t('hastusApiErrors.unknownError');
   }
 };

--- a/ui/src/i18n/uiNameMappings.ts
+++ b/ui/src/i18n/uiNameMappings.ts
@@ -5,9 +5,7 @@ import {
   RouteDirectionEnum,
   RouteTypeOfLineEnum,
   StopRegistryAccessibilityLevel,
-  StopRegistryDisplayType,
   StopRegistryGuidanceType,
-  StopRegistryInfoSpotType,
   StopRegistryMapType,
   StopRegistryPedestrianCrossingRampType,
   StopRegistryPosterPlaceSize,
@@ -18,11 +16,9 @@ import {
   StopRegistryStopType,
   StopRegistryTransportModeType,
 } from '../generated/graphql';
-import { i18n } from '../i18n';
 import {
   DayOfWeek,
   Priority,
-  StopRegistryMunicipality,
   SubstituteDayOfWeek,
   TimetablePriority,
 } from '../types/enums';
@@ -33,231 +29,358 @@ import {
 } from '../types/stop-registry';
 import { AllOptionEnum, NullOptionEnum } from '../utils';
 
-export const mapPriorityToUiName = (key: Priority) => {
-  const uiStrings: Record<Priority, string> = {
-    [Priority.Standard]: i18n.t('priority.standard'),
-    [Priority.Temporary]: i18n.t('priority.temporary'),
-    [Priority.Draft]: i18n.t('priority.draft'),
-  };
-  return uiStrings[key];
-};
-
-export const mapTimetablePriorityToUiName = (key: TimetablePriority) => {
-  const uiStrings: Record<TimetablePriority, string> = {
-    [TimetablePriority.Standard]: i18n.t('priority.standard'),
-    [TimetablePriority.Temporary]: i18n.t('priority.temporary'),
-    [TimetablePriority.Draft]: i18n.t('priority.draft'),
-    [TimetablePriority.SubstituteByLineType]: i18n.t('priority.substitute'),
-    [TimetablePriority.Special]: i18n.t('priority.special'),
-    [TimetablePriority.Staging]: '', // NOTE: staging priorities are not intented to be shown in UI
-  };
-  return uiStrings[key];
-};
-
-export const mapDayOfWeekToUiName = (key: DayOfWeek) => {
-  const uiStrings: Record<DayOfWeek, string> = {
-    [DayOfWeek.Monday]: i18n.t('dayOfWeek.monday'),
-    [DayOfWeek.Tuesday]: i18n.t('dayOfWeek.tuesday'),
-    [DayOfWeek.Wednesday]: i18n.t('dayOfWeek.wednesday'),
-    [DayOfWeek.Thursday]: i18n.t('dayOfWeek.thursday'),
-    [DayOfWeek.Friday]: i18n.t('dayOfWeek.friday'),
-    [DayOfWeek.Saturday]: i18n.t('dayOfWeek.saturday'),
-    [DayOfWeek.Sunday]: i18n.t('dayOfWeek.sunday'),
-  };
-  return uiStrings[key];
-};
-
-export const mapVehicleModeToUiName = (
-  key: ReusableComponentsVehicleModeEnum | AllOptionEnum.All,
-) => i18n.t(key === AllOptionEnum.All ? 'all' : `vehicleModeEnum.${key}`);
-
-export const mapStopRegistryTransportModeTypeToUiName = (
-  key: StopRegistryTransportModeType | JoreStopRegistryTransportModeType,
-) => i18n.t(`stopRegistryTransportModeTypeEnum.${key}`);
-
-export const mapStopPlaceStateToUiName = (key: StopPlaceState) =>
-  i18n.t(`stopPlaceStateEnum.${key}`);
-
-export const mapStopPlaceSignTypeToUiName = (key: StopPlaceSignType) =>
-  i18n.t(`stopPlaceSignTypeEnum.${key}`);
-
-export const mapStopRegistryStopTypeToUiName = (
-  key: StopRegistryStopType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null ? 'unknown' : `stopRegistryStopTypeEnum.${key}`,
-  );
-
-export const mapStopRegistryShelterWidthTypeToUiName = (
-  key: StopRegistryShelterWidthType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopRegistryShelterWidthTypeEnum.${key}`,
-  );
-
-export const mapStopRegistryPedestrianCrossingRampTypeToUiName = (
-  key: StopRegistryPedestrianCrossingRampType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopRegistryPedestrianCrossingRampTypeEnum.${key}`,
-  );
-
-export const mapStopRegistryGuidanceTypeToUiName = (
-  key: StopRegistryGuidanceType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopRegistryGuidanceTypeEnum.${key}`,
-  );
-
-export const mapStopRegistryMapTypeToUiName = (
-  key: StopRegistryMapType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null ? 'unknown' : `stopRegistryMapTypeEnum.${key}`,
-  );
-
-export const mapStopRegistryShelterConditionEnumToUiName = (
-  key: StopRegistryShelterCondition | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopRegistryShelterConditionEnum.${key}`,
-  );
-
-export const mapStopRegistryShelterElectricityEnumToUiName = (
-  key: StopRegistryShelterElectricity | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopRegistryShelterElectricityEnum.${key}`,
-  );
-
-export const mapStopRegistryShelterTypeEnumToUiName = (
-  key: StopRegistryShelterType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopRegistryShelterTypeEnum.${key}`,
-  );
-
-export const mapStopRegistryInfoSpotTypeEnumToUiName = (
-  key: StopRegistryInfoSpotType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopDetails.infoSpots.type.${key}`,
-  );
-
-export const mapStopRegistryDisplayTypeEnumToUiName = (
-  key: StopRegistryDisplayType | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopDetails.infoSpots.displayTypes.${key}`,
-  );
-
-export const mapStopRegistryPosterPlaceSizeEnumToUiName = (
-  key: StopRegistryPosterPlaceSize | NullOptionEnum,
-) =>
-  i18n.t(
-    key === NullOptionEnum.Null
-      ? 'unknown'
-      : `stopDetails.infoSpots.posterPlaceSizes.${key}`,
-  );
-
-export const mapStopAccessibilityLevelToUiName = (
-  key: StopRegistryAccessibilityLevel,
-) => i18n.t(`stopAccessibilityLevelEnum.${key}`);
-
-export const mapLineTypeToUiName = (
-  key: RouteTypeOfLineEnum | AllOptionEnum.All,
-) => i18n.t(key === AllOptionEnum.All ? 'all' : `lineTypeEnum.${key}`);
-
-export function mapDirectionToUiName(
-  t: TFunction,
-  direction: RouteDirectionEnum,
-) {
-  switch (direction) {
-    case RouteDirectionEnum.Inbound:
-      return t(`directionEnum.inbound`);
-
-    case RouteDirectionEnum.Outbound:
-      return t(`directionEnum.outbound`);
-
-    default:
-      return `? - ${direction}`;
+class UnknownTranslationRequestedError extends Error {
+  constructor(value: unknown) {
+    super(
+      `Requested translation for value (${value}), but no mapper or defaultValue was found for it!`,
+    );
   }
 }
 
-export function mapDirectionToSymbol(
-  t: TFunction,
-  direction: RouteDirectionEnum,
-) {
-  switch (direction) {
-    case RouteDirectionEnum.Inbound:
-      return t(`directionEnum.symbol.inbound`);
+function genTranslationMapper<
+  MappedValue extends string | number | symbol,
+  InputValue extends string | number | symbol = MappedValue,
+>(
+  mapping: Readonly<Record<MappedValue, (t: TFunction) => string>>,
+): (t: TFunction, value: InputValue) => string;
 
-    case RouteDirectionEnum.Outbound:
-      return t(`directionEnum.symbol.outbound`);
+function genTranslationMapper<
+  MappedValue extends string | number | symbol,
+  InputValue extends string | number | symbol = MappedValue,
+  DefaultOutputValue = string,
+>(
+  mapping: Readonly<Record<MappedValue, (t: TFunction) => string>>,
+  defaultValue: (t: TFunction, value: InputValue) => DefaultOutputValue,
+): (t: TFunction, value: InputValue) => string | DefaultOutputValue;
 
-    default:
-      return '?';
-  }
-}
+function genTranslationMapper<
+  MappedValue extends string | number | symbol,
+  InputValue extends string | number | symbol = MappedValue,
+  DefaultOutputValue = string,
+>(
+  mapping: Readonly<Record<MappedValue, (t: TFunction) => string>>,
+  defaultValue?: (t: TFunction, value: InputValue) => DefaultOutputValue,
+): (t: TFunction, value: InputValue) => string | DefaultOutputValue {
+  return (t: TFunction, value: InputValue): string | DefaultOutputValue => {
+    if (value in mapping) {
+      return mapping[value as unknown as MappedValue](t);
+    }
 
-export function mapDirectionToLabel(
-  t: TFunction,
-  direction: RouteDirectionEnum,
-) {
-  switch (direction) {
-    case RouteDirectionEnum.Inbound:
-      return t(`directionEnum.label.inbound`);
+    if (defaultValue) {
+      return defaultValue(t, value);
+    }
 
-    case RouteDirectionEnum.Outbound:
-      return t(`directionEnum.label.outbound`);
-
-    default:
-      return String(direction);
-  }
-}
-
-export const mapTransportTargetToUiName = (key: HslRouteTransportTargetEnum) =>
-  i18n.t(`transportTargetEnum.${key}`);
-
-export const mapSubstituteDayOfWeekToUiName = (
-  key: SubstituteDayOfWeek | AllOptionEnum,
-) => {
-  if (key === AllOptionEnum.All) {
-    return i18n.t('all');
-  }
-
-  const uiStrings: Record<SubstituteDayOfWeek, string> = {
-    [SubstituteDayOfWeek.NoTraffic]: i18n.t('timetableDayEnum.noTraffic'),
-    [SubstituteDayOfWeek.Monday]: i18n.t('timetableDayEnum.monday'),
-    [SubstituteDayOfWeek.Tuesday]: i18n.t('timetableDayEnum.tuesday'),
-    [SubstituteDayOfWeek.Wednesday]: i18n.t('timetableDayEnum.wednesday'),
-    [SubstituteDayOfWeek.Thursday]: i18n.t('timetableDayEnum.thursday'),
-    [SubstituteDayOfWeek.Friday]: i18n.t('timetableDayEnum.friday'),
-    [SubstituteDayOfWeek.Saturday]: i18n.t('timetableDayEnum.saturday'),
-    [SubstituteDayOfWeek.Sunday]: i18n.t('timetableDayEnum.sunday'),
+    throw new UnknownTranslationRequestedError(value);
   };
+}
 
-  return uiStrings[key];
-};
+export const mapPriorityToUiName = genTranslationMapper<Priority>({
+  [Priority.Standard]: (t) => t('priority.standard'),
+  [Priority.Temporary]: (t) => t('priority.temporary'),
+  [Priority.Draft]: (t) => t('priority.draft'),
+});
 
-export const mapMunicipalityToUiName = (
-  key: StopRegistryMunicipality | AllOptionEnum,
-) => {
-  return key === AllOptionEnum.All ? i18n.t('all') : key.toString();
-};
+export const mapTimetablePriorityToUiName =
+  genTranslationMapper<TimetablePriority>({
+    [TimetablePriority.Standard]: (t) => t('priority.standard'),
+    [TimetablePriority.Temporary]: (t) => t('priority.temporary'),
+    [TimetablePriority.Draft]: (t) => t('priority.draft'),
+    [TimetablePriority.SubstituteByLineType]: (t) => t('priority.substitute'),
+    [TimetablePriority.Special]: (t) => t('priority.special'),
+    [TimetablePriority.Staging]: () => '', // NOTE: staging priorities are not intented to be shown in UI
+  });
+
+export const mapDayOfWeekToUiName = genTranslationMapper<DayOfWeek>({
+  [DayOfWeek.Monday]: (t) => t('dayOfWeek.monday'),
+  [DayOfWeek.Tuesday]: (t) => t('dayOfWeek.tuesday'),
+  [DayOfWeek.Wednesday]: (t) => t('dayOfWeek.wednesday'),
+  [DayOfWeek.Thursday]: (t) => t('dayOfWeek.thursday'),
+  [DayOfWeek.Friday]: (t) => t('dayOfWeek.friday'),
+  [DayOfWeek.Saturday]: (t) => t('dayOfWeek.saturday'),
+  [DayOfWeek.Sunday]: (t) => t('dayOfWeek.sunday'),
+});
+
+export const mapVehicleModeToUiName = genTranslationMapper<
+  ReusableComponentsVehicleModeEnum | AllOptionEnum.All
+>({
+  [AllOptionEnum.All]: (t) => t('all'),
+  [ReusableComponentsVehicleModeEnum.Bus]: (t) => t('vehicleModeEnum.bus'),
+  [ReusableComponentsVehicleModeEnum.Ferry]: (t) => t('vehicleModeEnum.ferry'),
+  [ReusableComponentsVehicleModeEnum.Metro]: (t) => t('vehicleModeEnum.metro'),
+  [ReusableComponentsVehicleModeEnum.Train]: (t) => t('vehicleModeEnum.train'),
+  [ReusableComponentsVehicleModeEnum.Tram]: (t) => t('vehicleModeEnum.tram'),
+});
+
+export const mapStopRegistryTransportModeTypeToUiName = genTranslationMapper<
+  JoreStopRegistryTransportModeType,
+  JoreStopRegistryTransportModeType | StopRegistryTransportModeType
+>({
+  [JoreStopRegistryTransportModeType.Bus]: (t) =>
+    t('stopRegistryTransportModeTypeEnum.bus'),
+  [JoreStopRegistryTransportModeType.Metro]: (t) =>
+    t('stopRegistryTransportModeTypeEnum.metro'),
+  [JoreStopRegistryTransportModeType.Rail]: (t) =>
+    t('stopRegistryTransportModeTypeEnum.rail'),
+  [JoreStopRegistryTransportModeType.Tram]: (t) =>
+    t('stopRegistryTransportModeTypeEnum.tram'),
+  [JoreStopRegistryTransportModeType.Water]: (t) =>
+    t('stopRegistryTransportModeTypeEnum.water'),
+});
+
+export const mapStopPlaceStateToUiName = genTranslationMapper<StopPlaceState>({
+  [StopPlaceState.InOperation]: (t) => t('stopPlaceStateEnum.InOperation'),
+  [StopPlaceState.OutOfOperation]: (t) =>
+    t('stopPlaceStateEnum.OutOfOperation'),
+  [StopPlaceState.PermanentlyOutOfOperation]: (t) =>
+    t('stopPlaceStateEnum.PermanentlyOutOfOperation'),
+  [StopPlaceState.Removed]: (t) => t('stopPlaceStateEnum.Removed'),
+});
+
+export const mapStopPlaceSignTypeToUiName =
+  genTranslationMapper<StopPlaceSignType>({
+    [StopPlaceSignType.None]: (t) => t('stopPlaceSignTypeEnum.None'),
+    [StopPlaceSignType.StopSign]: (t) => t('stopPlaceSignTypeEnum.StopSign'),
+    [StopPlaceSignType.CanopyFrame]: (t) =>
+      t('stopPlaceSignTypeEnum.CanopyFrame'),
+    [StopPlaceSignType.PoleSign]: (t) => t('stopPlaceSignTypeEnum.PoleSign'),
+    [StopPlaceSignType.JokerSign]: (t) => t('stopPlaceSignTypeEnum.JokerSign'),
+  });
+
+export const mapStopRegistryStopTypeToUiName = genTranslationMapper<
+  StopRegistryStopType | NullOptionEnum
+>({
+  [NullOptionEnum.Null]: (t) => t('unknown'),
+  [StopRegistryStopType.BusBulb]: (t) => t('stopRegistryStopTypeEnum.busBulb'),
+  [StopRegistryStopType.InLane]: (t) => t('stopRegistryStopTypeEnum.inLane'),
+  [StopRegistryStopType.Other]: (t) => t('stopRegistryStopTypeEnum.other'),
+  [StopRegistryStopType.PullOut]: (t) => t('stopRegistryStopTypeEnum.pullOut'),
+});
+
+export const mapStopRegistryShelterWidthTypeToUiName = genTranslationMapper<
+  StopRegistryShelterWidthType | NullOptionEnum
+>({
+  [NullOptionEnum.Null]: (t) => t('unknown'),
+  [StopRegistryShelterWidthType.Narrow]: (t) =>
+    t('stopRegistryShelterWidthTypeEnum.narrow'),
+  [StopRegistryShelterWidthType.Other]: (t) =>
+    t('stopRegistryShelterWidthTypeEnum.other'),
+  [StopRegistryShelterWidthType.Wide]: (t) =>
+    t('stopRegistryShelterWidthTypeEnum.wide'),
+});
+
+export const mapStopRegistryPedestrianCrossingRampTypeToUiName =
+  genTranslationMapper<StopRegistryPedestrianCrossingRampType | NullOptionEnum>(
+    {
+      [NullOptionEnum.Null]: (t) => t('unknown'),
+      [StopRegistryPedestrianCrossingRampType.Lr]: (t) =>
+        t('stopRegistryPedestrianCrossingRampTypeEnum.LR'),
+      [StopRegistryPedestrianCrossingRampType.Rk4]: (t) =>
+        t('stopRegistryPedestrianCrossingRampTypeEnum.RK4'),
+      [StopRegistryPedestrianCrossingRampType.Rk4Lr]: (t) =>
+        t('stopRegistryPedestrianCrossingRampTypeEnum.RK4_LR'),
+      [StopRegistryPedestrianCrossingRampType.Other]: (t) =>
+        t('stopRegistryPedestrianCrossingRampTypeEnum.other'),
+    },
+  );
+
+export const mapStopRegistryGuidanceTypeToUiName = genTranslationMapper<
+  StopRegistryGuidanceType | NullOptionEnum
+>({
+  [NullOptionEnum.Null]: (t) => t('unknown'),
+  [StopRegistryGuidanceType.Braille]: (t) =>
+    t('stopRegistryGuidanceTypeEnum.braille'),
+  [StopRegistryGuidanceType.None]: (t) =>
+    t('stopRegistryGuidanceTypeEnum.none'),
+  [StopRegistryGuidanceType.Other]: (t) =>
+    t('stopRegistryGuidanceTypeEnum.other'),
+});
+
+export const mapStopRegistryMapTypeToUiName = genTranslationMapper<
+  StopRegistryMapType | NullOptionEnum
+>({
+  [NullOptionEnum.Null]: (t) => t('unknown'),
+  [StopRegistryMapType.None]: (t) => t('stopRegistryMapTypeEnum.none'),
+  [StopRegistryMapType.Other]: (t) => t('stopRegistryMapTypeEnum.other'),
+  [StopRegistryMapType.Tactile]: (t) => t('stopRegistryMapTypeEnum.tactile'),
+});
+
+export const mapStopRegistryShelterConditionEnumToUiName = genTranslationMapper<
+  StopRegistryShelterCondition | NullOptionEnum
+>({
+  [NullOptionEnum.Null]: (t) => t('unknown'),
+  [StopRegistryShelterCondition.Bad]: (t) =>
+    t('stopRegistryShelterConditionEnum.bad'),
+  [StopRegistryShelterCondition.Good]: (t) =>
+    t('stopRegistryShelterConditionEnum.good'),
+  [StopRegistryShelterCondition.Mediocre]: (t) =>
+    t('stopRegistryShelterConditionEnum.mediocre'),
+});
+
+export const mapStopRegistryShelterElectricityEnumToUiName =
+  genTranslationMapper<StopRegistryShelterElectricity | NullOptionEnum>({
+    [NullOptionEnum.Null]: (t) => t('unknown'),
+    [StopRegistryShelterElectricity.Continuous]: (t) =>
+      t('stopRegistryShelterElectricityEnum.continuous'),
+    [StopRegistryShelterElectricity.ContinuousPlanned]: (t) =>
+      t('stopRegistryShelterElectricityEnum.continuousPlanned'),
+    [StopRegistryShelterElectricity.ContinuousUnderConstruction]: (t) =>
+      t('stopRegistryShelterElectricityEnum.continuousUnderConstruction'),
+    [StopRegistryShelterElectricity.Light]: (t) =>
+      t('stopRegistryShelterElectricityEnum.light'),
+    [StopRegistryShelterElectricity.None]: (t) =>
+      t('stopRegistryShelterElectricityEnum.none'),
+    [StopRegistryShelterElectricity.TemporarilyOff]: (t) =>
+      t('stopRegistryShelterElectricityEnum.temporarilyOff'),
+  });
+
+export const mapStopRegistryShelterTypeEnumToUiName = genTranslationMapper<
+  StopRegistryShelterType | NullOptionEnum
+>({
+  [NullOptionEnum.Null]: (t) => t('unknown'),
+  [StopRegistryShelterType.Concrete]: (t) =>
+    t('stopRegistryShelterTypeEnum.concrete'),
+  [StopRegistryShelterType.Glass]: (t) =>
+    t('stopRegistryShelterTypeEnum.glass'),
+  [StopRegistryShelterType.Post]: (t) => t('stopRegistryShelterTypeEnum.post'),
+  [StopRegistryShelterType.Steel]: (t) =>
+    t('stopRegistryShelterTypeEnum.steel'),
+  [StopRegistryShelterType.Urban]: (t) =>
+    t('stopRegistryShelterTypeEnum.urban'),
+  [StopRegistryShelterType.Virtual]: (t) =>
+    t('stopRegistryShelterTypeEnum.virtual'),
+  [StopRegistryShelterType.Wooden]: (t) =>
+    t('stopRegistryShelterTypeEnum.wooden'),
+});
+
+export const mapStopRegistryPosterPlaceSizeEnumToUiName = genTranslationMapper<
+  StopRegistryPosterPlaceSize | NullOptionEnum
+>({
+  [NullOptionEnum.Null]: (t) => t('unknown'),
+  [StopRegistryPosterPlaceSize.A3]: (t) =>
+    t('stopDetails.infoSpots.posterPlaceSizes.a3'),
+  [StopRegistryPosterPlaceSize.A4]: (t) =>
+    t('stopDetails.infoSpots.posterPlaceSizes.a4'),
+  [StopRegistryPosterPlaceSize.Cm80x120]: (t) =>
+    t('stopDetails.infoSpots.posterPlaceSizes.cm80x120'),
+});
+
+export const mapStopAccessibilityLevelToUiName =
+  genTranslationMapper<StopRegistryAccessibilityLevel>({
+    [StopRegistryAccessibilityLevel.FullyAccessible]: (t) =>
+      t('stopAccessibilityLevelEnum.fullyAccessible'),
+    [StopRegistryAccessibilityLevel.Inaccessible]: (t) =>
+      t('stopAccessibilityLevelEnum.inaccessible'),
+    [StopRegistryAccessibilityLevel.MostlyAccessible]: (t) =>
+      t('stopAccessibilityLevelEnum.mostlyAccessible'),
+    [StopRegistryAccessibilityLevel.PartiallyInaccessible]: (t) =>
+      t('stopAccessibilityLevelEnum.partiallyInaccessible'),
+    [StopRegistryAccessibilityLevel.Unknown]: (t) =>
+      t('stopAccessibilityLevelEnum.unknown'),
+  });
+
+export const mapLineTypeToUiName = genTranslationMapper<
+  RouteTypeOfLineEnum | AllOptionEnum
+>({
+  [AllOptionEnum.All]: (t) => t('all'),
+  [RouteTypeOfLineEnum.CityTramService]: (t) =>
+    t('lineTypeEnum.city_tram_service'),
+  [RouteTypeOfLineEnum.DemandAndResponseBusService]: (t) =>
+    t('lineTypeEnum.demand_and_response_bus_service'),
+  [RouteTypeOfLineEnum.ExpressBusService]: (t) =>
+    t('lineTypeEnum.express_bus_service'),
+  [RouteTypeOfLineEnum.FerryService]: (t) => t('lineTypeEnum.ferry_service'),
+  [RouteTypeOfLineEnum.MetroService]: (t) => t('lineTypeEnum.metro_service'),
+  [RouteTypeOfLineEnum.RegionalBusService]: (t) =>
+    t('lineTypeEnum.regional_bus_service'),
+  [RouteTypeOfLineEnum.RegionalRailService]: (t) =>
+    t('lineTypeEnum.regional_rail_service'),
+  [RouteTypeOfLineEnum.RegionalTramService]: (t) =>
+    t('lineTypeEnum.regional_tram_service'),
+  [RouteTypeOfLineEnum.SpecialNeedsBus]: (t) =>
+    t('lineTypeEnum.special_needs_bus'),
+  [RouteTypeOfLineEnum.StoppingBusService]: (t) =>
+    t('lineTypeEnum.stopping_bus_service'),
+  [RouteTypeOfLineEnum.SuburbanRailway]: (t) =>
+    t('lineTypeEnum.suburban_railway'),
+});
+
+export const mapDirectionToUiName = genTranslationMapper<
+  RouteDirectionEnum.Inbound | RouteDirectionEnum.Outbound,
+  RouteDirectionEnum
+>(
+  {
+    [RouteDirectionEnum.Inbound]: (t) => t('directionEnum.inbound'),
+    [RouteDirectionEnum.Outbound]: (t) => t('directionEnum.outbound'),
+  },
+  (_, direction) => `? - ${direction}`,
+);
+
+export const mapDirectionToSymbol = genTranslationMapper<
+  RouteDirectionEnum.Inbound | RouteDirectionEnum.Outbound,
+  RouteDirectionEnum
+>(
+  {
+    [RouteDirectionEnum.Inbound]: (t) => t('directionEnum.symbol.inbound'),
+    [RouteDirectionEnum.Outbound]: (t) => t('directionEnum.symbol.outbound'),
+  },
+  () => '?',
+);
+
+export const mapDirectionToLabel = genTranslationMapper<
+  RouteDirectionEnum.Inbound | RouteDirectionEnum.Outbound,
+  RouteDirectionEnum
+>(
+  {
+    [RouteDirectionEnum.Inbound]: (t) => t('directionEnum.label.inbound'),
+    [RouteDirectionEnum.Outbound]: (t) => t('directionEnum.label.outbound'),
+  },
+  (_, direction) => String(direction),
+);
+
+export const mapTransportTargetToUiName =
+  genTranslationMapper<HslRouteTransportTargetEnum>({
+    [HslRouteTransportTargetEnum.EspooAndKauniainenInternalTraffic]: (t) =>
+      t('transportTargetEnum.espoo_and_kauniainen_internal_traffic'),
+    [HslRouteTransportTargetEnum.EspooRegionalTraffic]: (t) =>
+      t('transportTargetEnum.espoo_regional_traffic'),
+    [HslRouteTransportTargetEnum.HelsinkiInternalTraffic]: (t) =>
+      t('transportTargetEnum.helsinki_internal_traffic'),
+    [HslRouteTransportTargetEnum.KeravaInternalTraffic]: (t) =>
+      t('transportTargetEnum.kerava_internal_traffic'),
+    [HslRouteTransportTargetEnum.KeravaRegionalTraffic]: (t) =>
+      t('transportTargetEnum.kerava_regional_traffic'),
+    [HslRouteTransportTargetEnum.KirkkonummiInternalTraffic]: (t) =>
+      t('transportTargetEnum.kirkkonummi_internal_traffic'),
+    [HslRouteTransportTargetEnum.KirkkonummiRegionalTraffic]: (t) =>
+      t('transportTargetEnum.kirkkonummi_regional_traffic'),
+    [HslRouteTransportTargetEnum.SipooInternalTraffic]: (t) =>
+      t('transportTargetEnum.sipoo_internal_traffic'),
+    [HslRouteTransportTargetEnum.SiuntioInternalTraffic]: (t) =>
+      t('transportTargetEnum.siuntio_internal_traffic'),
+    [HslRouteTransportTargetEnum.SiuntioRegionalTraffic]: (t) =>
+      t('transportTargetEnum.siuntio_regional_traffic'),
+    [HslRouteTransportTargetEnum.TransverseRegional]: (t) =>
+      t('transportTargetEnum.transverse_regional'),
+    [HslRouteTransportTargetEnum.TuusulaInternalTraffic]: (t) =>
+      t('transportTargetEnum.tuusula_internal_traffic'),
+    [HslRouteTransportTargetEnum.TuusulaRegionalTraffic]: (t) =>
+      t('transportTargetEnum.tuusula_regional_traffic'),
+    [HslRouteTransportTargetEnum.VantaaInternalTraffic]: (t) =>
+      t('transportTargetEnum.vantaa_internal_traffic'),
+    [HslRouteTransportTargetEnum.VantaaRegionalTraffic]: (t) =>
+      t('transportTargetEnum.vantaa_regional_traffic'),
+  });
+
+export const mapSubstituteDayOfWeekToUiName = genTranslationMapper<
+  SubstituteDayOfWeek | AllOptionEnum
+>({
+  [AllOptionEnum.All]: (t) => t('all'),
+  [SubstituteDayOfWeek.NoTraffic]: (t) => t('timetableDayEnum.noTraffic'),
+  [SubstituteDayOfWeek.Monday]: (t) => t('timetableDayEnum.monday'),
+  [SubstituteDayOfWeek.Tuesday]: (t) => t('timetableDayEnum.tuesday'),
+  [SubstituteDayOfWeek.Wednesday]: (t) => t('timetableDayEnum.wednesday'),
+  [SubstituteDayOfWeek.Thursday]: (t) => t('timetableDayEnum.thursday'),
+  [SubstituteDayOfWeek.Friday]: (t) => t('timetableDayEnum.friday'),
+  [SubstituteDayOfWeek.Saturday]: (t) => t('timetableDayEnum.saturday'),
+  [SubstituteDayOfWeek.Sunday]: (t) => t('timetableDayEnum.sunday'),
+});

--- a/ui/src/i18n/utils.ts
+++ b/ui/src/i18n/utils.ts
@@ -12,6 +12,10 @@ function debugValue(value: unknown): string {
  * is assumed to contain locale-to-translations pairs such as
  * `{ "fi_FI": "Käännös teksti" }`. Throws if the given value
  * is not an object or if non-string data is stored under the key.
+ *
+ * For compatability an empty string is returned if the given blob
+ * is undefined or null.
+ *
  */
 export function useGetLocalizedTextFromDbBlob(): (
   blob: unknown,
@@ -25,7 +29,11 @@ export function useGetLocalizedTextFromDbBlob(): (
 
   return useCallback(
     (blob: unknown, fallbackField: string = 'fi_FI') => {
-      if (typeof blob !== 'object' || blob === null) {
+      if (blob === undefined || blob === null) {
+        return '';
+      }
+
+      if (typeof blob !== 'object') {
         throw new Error(
           `Given blob is not an JS object! Blob: ${debugValue(blob)}`,
         );

--- a/ui/src/i18n/utils.ts
+++ b/ui/src/i18n/utils.ts
@@ -1,13 +1,65 @@
-import { illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance as i18n } from '../i18n';
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 
-export const parseI18nField = (i18nField: ExplicitAny) => {
-  if (!i18nField) {
-    return 'Missing i18n object';
-  }
+function debugValue(value: unknown): string {
+  return `typeof(${typeof value}) | String(${value}) | Json(${JSON.stringify(value, null, 0)})`;
+}
+
+/**
+ * Returns a function that reacts to changes in the locale and
+ * which return a localized string from an JSON object stored
+ * as untyped JSON or JSONB blob in the database. The object
+ * is assumed to contain locale-to-translations pairs such as
+ * `{ "fi_FI": "Käännös teksti" }`. Throws if the given value
+ * is not an object or if non-string data is stored under the key.
+ */
+export function useGetLocalizedTextFromDbBlob(): (
+  blob: unknown,
+  fallbackField?: string,
+) => string {
+  const { i18n } = useTranslation();
+
   // we have defined locales to our i18n library like 'fi-FI',
-  // but api returns those as 'fi_FI'.
+  // but the API (which API are we actually talking about?) returns those as 'fi_FI'.
   const locale = i18n.language.replace('-', '_');
-  const requestedtranslation = i18nField[locale];
-  const fallbackTranslation = i18nField.fi_FI ?? '';
-  return requestedtranslation ?? fallbackTranslation;
-};
+
+  return useCallback(
+    (blob: unknown, fallbackField: string = 'fi_FI') => {
+      if (typeof blob !== 'object' || blob === null) {
+        throw new Error(
+          `Given blob is not an JS object! Blob: ${debugValue(blob)}`,
+        );
+      }
+      const typedBlob = blob as Record<string, unknown>;
+
+      if (locale in typedBlob) {
+        const value = typedBlob[locale];
+
+        if (typeof value !== 'string') {
+          throw new Error(
+            `Given blob does contain the locale key (${locale}) but its not a string! Value: ${debugValue(value)}`,
+          );
+        }
+
+        return value;
+      }
+
+      if (fallbackField in typedBlob) {
+        const value = typedBlob[fallbackField];
+
+        if (typeof value !== 'string') {
+          throw new Error(
+            `Given blob does contain the fallback field (${fallbackField}) but its not a string! Value: ${debugValue(value)}`,
+          );
+        }
+
+        return value;
+      }
+
+      throw new Error(
+        `Given blob does not contain the locale (${locale}) nor the fallback field (${fallbackField})! Blob: ${debugValue(typedBlob)}`,
+      );
+    },
+    [locale],
+  );
+}

--- a/ui/src/i18n/utils.ts
+++ b/ui/src/i18n/utils.ts
@@ -1,4 +1,4 @@
-import { i18n } from '../i18n';
+import { illegalExportDoNotUseOrYouWillRegretItI18NextGlobalInstance as i18n } from '../i18n';
 
 export const parseI18nField = (i18nField: ExplicitAny) => {
   if (!i18nField) {

--- a/ui/src/time.spec.ts
+++ b/ui/src/time.spec.ts
@@ -2,12 +2,12 @@ import { DateTime } from 'luxon';
 import {
   findEarliestTime,
   findLatestTime,
-  formatDate,
+  formatDateWithLocale,
   mapToISODate,
   parseDate,
 } from './time';
 
-describe(`${formatDate.name}()`, () => {
+describe(`${formatDateWithLocale.name}()`, () => {
   // These tests temporariry disabled as we had to hard-code
   // used date and datetime formats instead of using localized
   // ones in order to do temporary workaround for flaky

--- a/ui/src/time.ts
+++ b/ui/src/time.ts
@@ -2,7 +2,6 @@ import isString from 'lodash/isString';
 import padStart from 'lodash/padStart';
 import { DateTime, Duration, Interval, Settings } from 'luxon';
 import { Maybe, ValidityPeriod } from './generated/graphql';
-import { i18n } from './i18n';
 
 Settings.defaultZone = 'Europe/Helsinki';
 
@@ -50,29 +49,25 @@ export function parseDate(date?: DateLike | null) {
 }
 
 // date formats known by luxon: https://moment.github.io/luxon/#/formatting?id=presets
-export const formatDate = (
+export const formatDateWithLocale = (
+  format: string,
+  locale: string,
+  date?: DateLike | null,
+): string | undefined => parseDate(date)?.setLocale(locale).toFormat(format);
+
+// date formats known by luxon: https://moment.github.io/luxon/#/formatting?id=presets
+export const formatDateWithoutLocale = (
   format: string,
   date?: DateLike | null,
-  locale?: string,
-) => {
-  const dateTime = parseDate(date);
-  if (!dateTime) {
-    return undefined;
-  }
+): string | undefined => parseDate(date)?.toFormat(format);
 
-  // if not explicitly defined, the i18n locale is used
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const dateLocale = locale || i18n.language;
+// "shortDate" means format "D.M.YYYY"
+export const mapToShortDate = (date?: DateLike | null) =>
+  formatDateWithoutLocale('d.L.yyyy', date);
 
-  return dateTime.setLocale(dateLocale).toFormat(format);
-};
-
-// "shortDate" means format DD.MM.YYYY
-export const mapToShortDate = (date?: DateLike | null, locale?: string) =>
-  formatDate('d.L.yyyy', date, locale);
-
-export const mapToShortDateTime = (date?: DateLike | null, locale?: string) =>
-  formatDate('d.L.yyyy t', date, locale);
+// "shortDateTime" means format "D.M.YYYY H.mm"
+export const mapToShortDateTime = (date?: DateLike | null) =>
+  formatDateWithoutLocale('d.L.yyyy H.mm', date);
 
 export const mapToISODate = (date?: DateLike | null) =>
   parseDate(date)?.toISODate();

--- a/ui/src/uiComponents/FilterPanel.tsx
+++ b/ui/src/uiComponents/FilterPanel.tsx
@@ -1,43 +1,38 @@
+import { TFunction } from 'i18next';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { i18n } from '../i18n';
 import { Row } from '../layoutComponents';
 import { Card } from './Card';
 import { IconToggle } from './IconToggle';
 
-interface Toggle {
-  // eslint gives errors for "react/no-unused-prop-types" even though these are actually used (and these aren't `PropTypes` anyway, we are not using those with TypeScript!). Seems like this linter rule gets confused because these aren't inlined in props interface definition? (And we don't want to do that as these are used in more than one place.)
-  active: boolean; // eslint-disable-line react/no-unused-prop-types
-  onToggle: (active: boolean) => void; // eslint-disable-line react/no-unused-prop-types
-  testId: string; // eslint-disable-line react/no-unused-prop-types
-}
+type Toggle = {
+  readonly active: boolean;
+  readonly onToggle: (active: boolean) => void;
+  readonly testId: string;
+};
 
-interface IconToggle extends Toggle {
-  iconClassName: string; // eslint-disable-line react/no-unused-prop-types
-  disabled?: boolean; // eslint-disable-line react/no-unused-prop-types
-  tooltip: string; // eslint-disable-line react/no-unused-prop-types
-}
+type IconToggle = Toggle & {
+  readonly iconClassName: string;
+  readonly disabled?: boolean;
+  readonly tooltip: (t: TFunction) => string;
+};
 
-interface ToggleRowProps {
-  toggles: IconToggle[];
-}
+type ToggleRowProps = {
+  readonly toggles: ReadonlyArray<IconToggle>;
+};
 
-const ToggleRow = ({ toggles }: ToggleRowProps): React.ReactElement => {
+const ToggleRow: FC<ToggleRowProps> = ({ toggles }) => {
+  const { t } = useTranslation();
+
   return (
     <Row className="mt-2">
       {toggles.map(
         (
-          {
-            active,
-            onToggle,
-            iconClassName,
-            disabled,
-            testId,
-            tooltip,
-          }: IconToggle,
+          { active, onToggle, iconClassName, disabled, testId, tooltip },
           index: number,
         ) => (
           <IconToggle
-            // We don'thave proper id's to use as key here.
+            // We don't have proper ids to use as keys here.
             // This shouldn't matter as this array isn't dynamic.
             key={index} // eslint-disable-line react/no-array-index-key
             iconClassName={iconClassName}
@@ -46,7 +41,7 @@ const ToggleRow = ({ toggles }: ToggleRowProps): React.ReactElement => {
             onToggle={onToggle}
             disabled={disabled}
             testId={testId}
-            tooltip={tooltip}
+            tooltip={tooltip(t)}
           />
         ),
       )}
@@ -64,7 +59,7 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
-    tooltip: i18n.t('vehicleModeEnum.tram'),
+    tooltip: (t) => t('vehicleModeEnum.tram'),
   },
   {
     iconClassName: 'icon-train',
@@ -72,7 +67,7 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
-    tooltip: i18n.t('vehicleModeEnum.train'),
+    tooltip: (t) => t('vehicleModeEnum.train'),
   },
   {
     iconClassName: 'icon-ferry',
@@ -80,7 +75,7 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
-    tooltip: i18n.t('vehicleModeEnum.ferry'),
+    tooltip: (t) => t('vehicleModeEnum.ferry'),
   },
   {
     iconClassName: 'icon-metro',
@@ -88,23 +83,23 @@ export const placeholderToggles: IconToggle[] = [
     onToggle: noop,
     disabled: true,
     testId: 'placeholder',
-    tooltip: i18n.t('vehicleModeEnum.metro'),
+    tooltip: (t) => t('vehicleModeEnum.metro'),
   },
 ];
 
-interface Props {
-  routes: IconToggle[];
-  stops: IconToggle[];
-  infraLinks: Toggle;
-  className?: string;
-}
+type FilterPanelProps = {
+  readonly routes: ReadonlyArray<IconToggle>;
+  readonly stops: ReadonlyArray<IconToggle>;
+  readonly infraLinks: Toggle;
+  readonly className?: string;
+};
 
-export const FilterPanel = ({
+export const FilterPanel: FC<FilterPanelProps> = ({
   routes,
   stops,
   infraLinks,
   className = '',
-}: Props): React.ReactElement => {
+}) => {
   const { t } = useTranslation();
   const headingClassName = 'text-sm font-bold';
   return (
@@ -113,10 +108,12 @@ export const FilterPanel = ({
         <h6 className={headingClassName}>{t('map.showRoutes')}</h6>
         <ToggleRow toggles={routes} />
       </Card>
+
       <Card className="flex-col rounded-none !border-t-0">
         <h6 className={headingClassName}>{t('map.showStops')}</h6>
         <ToggleRow toggles={stops} />
       </Card>
+
       <Card className="flex-col rounded-t-none !px-5 !py-2.5">
         <label htmlFor="show-network" className="inline-flex font-normal">
           <input

--- a/ui/src/utils/test-utils/renderer.tsx
+++ b/ui/src/utils/test-utils/renderer.tsx
@@ -5,6 +5,8 @@ import { RenderOptions, render } from '@testing-library/react';
 import React, { FC, PropsWithChildren } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { ReduxProvider } from '../../redux';
+// Make sure I18Next is initialized
+import '../../i18n';
 
 const AllTheProviders: FC<PropsWithChildren> = ({ children }) => {
   // Add "providers" or "wrappers" that are needed in all DOM render tests here


### PR DESCRIPTION
### Rewrite Enum To Translation mappers not to use global I18Next


### Make basic date[time] formatting locale independent
Instead of relying on the global I18Next instance to always inject the current locale into the DateTime object before formatting, a single fixed format is used for all languages.

The formatting already had a fixed format for the date portion, but the time portion was dependent on the active locale. The time portion has now been fixed to the same format that was already used for when Finnish as the active locale 'H.mm'. This format also aligns the recent decision to prefer UK formats in English language texts, and UK people are aware of the 24H clock system.

Additional helper function have been provided to allow for proper locale aware DateTime formatting in the future, but for that the locale must be properly retrieved and provided from the calling scope.


### ~Illegalize the use of the global I18Next export~
~Renamed the global export and added documentation comment.~


### Replace `parseI18nField` with reactive alternative
Old `parseI18nField` got the locale from a global reference to the I18Next object instance, and thus was not reactive within React scope. This function has been replaced with another implementation, that takes React's context and state into account and returns correct translations. Additionally the function has been made more robust and to not assume that the input data is valid.


### Completely drop the custom re-export of global I18Next instance



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1073)
<!-- Reviewable:end -->
