### PR TITLE
Stop area add stop on map

### DIFF
--- a/cypress/e2e/map/editStopAreas.cy.ts
+++ b/cypress/e2e/map/editStopAreas.cy.ts
@@ -236,6 +236,8 @@ describe('Stop areas on map', mapViewport, () => {
     confirmationDialog.getConfirmButton().click();
     mapModal.map.waitForLoadToComplete();
     expectGraphQLCallToSucceed('@gqlUpsertStopArea');
+    mapModal.stopAreaPopup.getLabel().shouldBeVisible();
+    mapModal.stopAreaPopup.getCloseButton().click();
     mapModal.stopAreaPopup.getLabel().should('not.exist');
 
     // There should be nothing at the old position.

--- a/cypress/pageObjects/StopAreaPopup.ts
+++ b/cypress/pageObjects/StopAreaPopup.ts
@@ -22,4 +22,8 @@ export class StopAreaPopup {
   getMoveButton() {
     return cy.getByTestId('StopAreaPopup::moveButton');
   }
+
+  getAddStopButton() {
+    return cy.getByTestId('StopAreaPopup::addStopButton');
+  }
 }

--- a/cypress/pageObjects/StopForm.ts
+++ b/cypress/pageObjects/StopForm.ts
@@ -18,7 +18,7 @@ export interface BaseStopFormInfo
 
 export interface NewStopFormInfo extends BaseStopFormInfo {
   publicCode: string;
-  stopPlace: string;
+  stopPlace?: string;
 }
 
 export class StopForm {
@@ -120,8 +120,10 @@ export class StopForm {
   fillFormForNewStop(values: NewStopFormInfo) {
     this.getPublicCodeInput().clearAndType(values.publicCode);
 
-    this.getStopAreaInput().clearAndType(values.stopPlace);
-    this.getStopAreaResult(values.stopPlace).click();
+    if (values.stopPlace) {
+      this.getStopAreaInput().clearAndType(values.stopPlace);
+      this.getStopAreaResult(values.stopPlace).click();
+    }
 
     this.fillBaseForm(values);
   }

--- a/ui/src/components/forms/stop-area/useUpsertStopArea.ts
+++ b/ui/src/components/forms/stop-area/useUpsertStopArea.ts
@@ -123,7 +123,10 @@ const mapFormStateToInput = ({
 export const useUpsertStopArea = () => {
   const { t } = useTranslation();
   const tryHandleApolloError = useStopAreaDetailsApolloErrorHandler();
-  const [upsertStopAreaMutation] = useUpsertStopAreaMutation();
+  const [upsertStopAreaMutation] = useUpsertStopAreaMutation({
+    awaitRefetchQueries: true,
+    refetchQueries: ['GetStopAreasByLocation'],
+  });
 
   /**
    * Update an existing stop area, or create a new one.

--- a/ui/src/components/forms/stop-area/useUpsertStopArea.ts
+++ b/ui/src/components/forms/stop-area/useUpsertStopArea.ts
@@ -14,6 +14,7 @@ import {
   patchKeyValues,
   showDangerToast,
 } from '../../../utils';
+import { getEnrichedStopPlace } from '../../stop-registry/stop-areas/stop-area-details/useGetStopAreaDetails';
 import { StopAreaFormState } from './stopAreaFormSchema';
 import { useStopAreaDetailsApolloErrorHandler } from './util/stopAreaDetailsErrorHandler';
 
@@ -137,7 +138,9 @@ export const useUpsertStopArea = () => {
         variables: { input },
       });
 
-      return result.data?.stop_registry?.mutateStopPlace;
+      return getEnrichedStopPlace(
+        result.data?.stop_registry?.mutateStopPlace?.at(0),
+      );
     },
     [upsertStopAreaMutation],
   );

--- a/ui/src/components/forms/stop/StopForm.tsx
+++ b/ui/src/components/forms/stop/StopForm.tsx
@@ -330,7 +330,12 @@ const StopFormComponent: ForwardRefRenderFunction<HTMLFormElement, Props> = (
         onSubmit={handleSubmit(onFormSubmit)}
         ref={ref}
       >
-        <PublicCodeAndArea editing={editing} className="p-4" />
+        <PublicCodeAndArea
+          className="p-4"
+          publicCodeDisabled={editing}
+          // Either editing or stop creating was initiated from a Stip Area.
+          stopAreaDisabled={!!defaultValues.stopArea}
+        />
         <Location className="p-4" />
         <VersionInfo className="border-t border-light-grey p-4" />
 

--- a/ui/src/components/forms/stop/components/PublicCode.tsx
+++ b/ui/src/components/forms/stop/components/PublicCode.tsx
@@ -13,10 +13,10 @@ const testIds = {
 
 type PublicCodeProps = {
   readonly className?: string;
-  readonly editing: boolean;
+  readonly disabled: boolean;
 };
 
-export const PublicCode: FC<PublicCodeProps> = ({ className, editing }) => {
+export const PublicCode: FC<PublicCodeProps> = ({ className, disabled }) => {
   const { t } = useTranslation();
   const datalistId = useId();
 
@@ -33,7 +33,7 @@ export const PublicCode: FC<PublicCodeProps> = ({ className, editing }) => {
       latitude,
       longitude,
       query,
-      skip: editing,
+      skip: disabled,
     });
 
   useEffect(() => {
@@ -53,7 +53,7 @@ export const PublicCode: FC<PublicCodeProps> = ({ className, editing }) => {
         customTitlePath="stops.publicCode"
         testId={testIds.publicCode}
         placeholder={loading ? t('stops.loadingUsedPublicCodes') : undefined}
-        disabled={editing || loading}
+        disabled={disabled || loading}
       />
 
       <datalist id={datalistId}>

--- a/ui/src/components/forms/stop/components/PublicCodeAndArea.tsx
+++ b/ui/src/components/forms/stop/components/PublicCodeAndArea.tsx
@@ -8,19 +8,21 @@ import { StopAreaInfoSection } from './StopAreaInfoSection';
 
 type PublicCodeAndAreaProps = {
   readonly className?: string;
-  readonly editing: boolean;
+  readonly publicCodeDisabled: boolean;
+  readonly stopAreaDisabled: boolean;
 };
 
 export const PublicCodeAndArea: FC<PublicCodeAndAreaProps> = ({
   className,
-  editing,
+  publicCodeDisabled,
+  stopAreaDisabled,
 }) => {
   return (
     <FormColumn className={twMerge('bg-background', className)}>
       <div className="flex gap-4">
-        <PublicCode className="min-w-0" editing={editing} />
+        <PublicCode className="min-w-0" disabled={publicCodeDisabled} />
 
-        <FindStopArea className="w-full" disabled={editing} />
+        <FindStopArea className="w-full" disabled={stopAreaDisabled} />
       </div>
 
       <PublicCodePrefixMissmatchWarning />

--- a/ui/src/components/forms/stop/utils/useGetStopInfoForEditingOnMap.ts
+++ b/ui/src/components/forms/stop/utils/useGetStopInfoForEditingOnMap.ts
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client';
-import type { GeoJSON } from 'geojson';
 import compact from 'lodash/compact';
 import { useMemo } from 'react';
 import {

--- a/ui/src/components/map/Map.tsx
+++ b/ui/src/components/map/Map.tsx
@@ -7,15 +7,15 @@ import {
 } from '../../hooks';
 import { Column, Visible } from '../../layoutComponents';
 import {
+  MapEntityEditorViewState,
   Mode,
   selectHasDraftLocation,
   selectHasDraftRouteGeometry,
-  selectIsCreateStopAreaModeEnabled,
   selectIsCreateStopModeEnabled,
-  selectIsMoveStopAreaModeEnabled,
   selectIsMoveStopModeEnabled,
   selectMapFilter,
   selectMapRouteEditor,
+  selectMapStopAreaViewState,
   selectSelectedRouteId,
   setSelectedRouteIdAction,
 } from '../../redux';
@@ -76,12 +76,8 @@ export const MapComponent = (
 
   const isCreateStopModeEnabled = useAppSelector(selectIsCreateStopModeEnabled);
   const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
-  const isCreateStopAreaModeEnabled = useAppSelector(
-    selectIsCreateStopAreaModeEnabled,
-  );
-  const isMoveStopAreaModeEnabled = useAppSelector(
-    selectIsMoveStopAreaModeEnabled,
-  );
+
+  const mapStopAreaViewState = useAppSelector(selectMapStopAreaViewState);
 
   useImperativeHandle(externalRef, () => ({
     onDrawRoute: () => {
@@ -128,14 +124,17 @@ export const MapComponent = (
       onCreateStop(e);
       return;
     }
-    if (isCreateStopAreaModeEnabled) {
+
+    if (mapStopAreaViewState === MapEntityEditorViewState.PLACE) {
       onCreateStopArea(e);
       return;
     }
-    if (isMoveStopAreaModeEnabled) {
+
+    if (mapStopAreaViewState === MapEntityEditorViewState.MOVE) {
       onMoveStopArea(e);
       return;
     }
+
     if (isMoveStopModeEnabled) {
       onMoveStop(e);
     }

--- a/ui/src/components/map/MapFooter.tsx
+++ b/ui/src/components/map/MapFooter.tsx
@@ -4,17 +4,18 @@ import { MdDelete } from 'react-icons/md';
 import { useAppAction, useAppSelector } from '../../hooks';
 import { Row, Visible } from '../../layoutComponents';
 import {
+  MapEntityEditorViewState,
   Mode,
+  isEditorOpen,
   selectHasChangesInProgress,
   selectHasDraftRouteGeometry,
-  selectIsCreateStopAreaModeEnabled,
   selectIsCreateStopModeEnabled,
   selectIsInViewMode,
-  selectIsMoveStopAreaModeEnabled,
   selectIsMoveStopModeEnabled,
   selectMapRouteEditor,
-  setIsCreateStopAreaModeEnabledAction,
+  selectMapStopAreaViewState,
   setIsCreateStopModeEnabledAction,
+  setMapStopAreaViewStateAction,
 } from '../../redux';
 import { SimpleButton } from '../../uiComponents';
 import { MapFooterActionsDropdown } from './MapFooterActionsDropdown';
@@ -61,22 +62,15 @@ export const MapFooter: React.FC<Props> = ({
     setIsCreateStopModeEnabledAction,
   );
 
-  const isCreateStopAreaModeEnabled = useAppSelector(
-    selectIsCreateStopAreaModeEnabled,
-  );
-  const setIsCreateStopAreaModeEnabled = useAppAction(
-    setIsCreateStopAreaModeEnabledAction,
-  );
-  const isMoveStopAreaModeEnabled = useAppSelector(
-    selectIsMoveStopAreaModeEnabled,
-  );
+  const mapStopAreaViewState = useAppSelector(selectMapStopAreaViewState);
+  const setMapStopAreaViewState = useAppAction(setMapStopAreaViewStateAction);
 
   const onAddStops = () => {
     setIsCreateStopModeEnabled(!isCreateStopModeEnabled);
   };
 
   const onAddStopArea = () => {
-    setIsCreateStopAreaModeEnabled(!isCreateStopAreaModeEnabled);
+    setMapStopAreaViewState(MapEntityEditorViewState.PLACE);
   };
 
   return (
@@ -89,8 +83,7 @@ export const MapFooter: React.FC<Props> = ({
           creatingNewRoute ||
           isCreateStopModeEnabled ||
           isMoveStopModeEnabled ||
-          isCreateStopAreaModeEnabled ||
-          isMoveStopAreaModeEnabled
+          mapStopAreaViewState !== MapEntityEditorViewState.NONE
         }
         inverted={drawingMode !== Mode.Draw}
       >
@@ -111,8 +104,7 @@ export const MapFooter: React.FC<Props> = ({
         disabled={
           drawingMode !== undefined ||
           creatingNewRoute ||
-          isCreateStopAreaModeEnabled ||
-          isMoveStopAreaModeEnabled
+          isEditorOpen(mapStopAreaViewState)
         }
         inverted={!isCreateStopModeEnabled}
         testId={testIds.addStopButton}
@@ -127,9 +119,8 @@ export const MapFooter: React.FC<Props> = ({
           creatingNewRoute ||
           hasChangesInProgress ||
           isRouteMetadataFormOpen ||
-          isMoveStopAreaModeEnabled
+          mapStopAreaViewState !== MapEntityEditorViewState.NONE
         }
-        tooltip={t('map.footerActionsTooltip')}
         onCreateNewStopArea={onAddStopArea}
       />
       <SimpleButton

--- a/ui/src/components/map/MapFooter.tsx
+++ b/ui/src/components/map/MapFooter.tsx
@@ -9,13 +9,12 @@ import {
   isEditorOpen,
   selectHasChangesInProgress,
   selectHasDraftRouteGeometry,
-  selectIsCreateStopModeEnabled,
   selectIsInViewMode,
-  selectIsMoveStopModeEnabled,
   selectMapRouteEditor,
   selectMapStopAreaViewState,
-  setIsCreateStopModeEnabledAction,
+  selectMapStopViewState,
   setMapStopAreaViewStateAction,
+  setMapStopViewStateAction,
 } from '../../redux';
 import { SimpleButton } from '../../uiComponents';
 import { MapFooterActionsDropdown } from './MapFooterActionsDropdown';
@@ -56,17 +55,14 @@ export const MapFooter: React.FC<Props> = ({
   const hasChangesInProgress = useAppSelector(selectHasChangesInProgress);
   const isInViewMode = useAppSelector(selectIsInViewMode);
 
-  const isCreateStopModeEnabled = useAppSelector(selectIsCreateStopModeEnabled);
-  const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
-  const setIsCreateStopModeEnabled = useAppAction(
-    setIsCreateStopModeEnabledAction,
-  );
+  const mapStopViewState = useAppSelector(selectMapStopViewState);
+  const setMapStopViewState = useAppAction(setMapStopViewStateAction);
 
   const mapStopAreaViewState = useAppSelector(selectMapStopAreaViewState);
   const setMapStopAreaViewState = useAppAction(setMapStopAreaViewStateAction);
 
   const onAddStops = () => {
-    setIsCreateStopModeEnabled(!isCreateStopModeEnabled);
+    setMapStopViewState(MapEntityEditorViewState.PLACE);
   };
 
   const onAddStopArea = () => {
@@ -81,8 +77,7 @@ export const MapFooter: React.FC<Props> = ({
         disabled={
           !isInViewMode ||
           creatingNewRoute ||
-          isCreateStopModeEnabled ||
-          isMoveStopModeEnabled ||
+          mapStopViewState !== MapEntityEditorViewState.NONE ||
           mapStopAreaViewState !== MapEntityEditorViewState.NONE
         }
         inverted={drawingMode !== Mode.Draw}
@@ -106,7 +101,7 @@ export const MapFooter: React.FC<Props> = ({
           creatingNewRoute ||
           isEditorOpen(mapStopAreaViewState)
         }
-        inverted={!isCreateStopModeEnabled}
+        inverted={mapStopViewState === MapEntityEditorViewState.NONE}
         testId={testIds.addStopButton}
         disabledTooltip={t('dataModelRefactor.disabled')}
       >
@@ -114,7 +109,7 @@ export const MapFooter: React.FC<Props> = ({
       </SimpleButton>
       <MapFooterActionsDropdown
         disabled={
-          isCreateStopModeEnabled ||
+          mapStopViewState !== MapEntityEditorViewState.NONE ||
           drawingMode !== undefined ||
           creatingNewRoute ||
           hasChangesInProgress ||

--- a/ui/src/components/map/MapFooterActionsDropdown.tsx
+++ b/ui/src/components/map/MapFooterActionsDropdown.tsx
@@ -1,12 +1,14 @@
 import { Menu } from '@headlessui/react';
 import noop from 'lodash/noop';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdMoreVert } from 'react-icons/md';
-import { SimpleDropdownMenuItem, SimpleRoundButton } from '../../uiComponents';
 import {
   AlignDirection,
+  SimpleDropdownMenuItem,
   SimpleDropdownMenuItems,
-} from '../../uiComponents/SimpleDropdownMenuItems';
+  SimpleRoundButton,
+} from '../../uiComponents';
 
 const testIds = {
   menu: 'MapFooterActionsDropdown::menu',
@@ -14,17 +16,15 @@ const testIds = {
   createNewStopArea: 'MapFooterActionsDropdown::createNewStopArea',
 };
 
-interface Props {
-  tooltip: string;
-  disabled?: boolean;
-  onCreateNewStopArea: () => void;
-}
+type MapFooterActionsDropdownProps = {
+  readonly disabled?: boolean;
+  readonly onCreateNewStopArea: () => void;
+};
 
-export const MapFooterActionsDropdown = ({
-  tooltip,
+export const MapFooterActionsDropdown: FC<MapFooterActionsDropdownProps> = ({
   disabled,
   onCreateNewStopArea,
-}: Props): JSX.Element => {
+}) => {
   const { t } = useTranslation();
 
   return (
@@ -37,7 +37,7 @@ export const MapFooterActionsDropdown = ({
             className="flex justify-around"
           >
             <SimpleRoundButton
-              tooltip={tooltip}
+              tooltip={t('map.footerActionsTooltip')}
               disabled={disabled}
               onClick={noop}
               inverted={!open}

--- a/ui/src/components/map/MapModal.tsx
+++ b/ui/src/components/map/MapModal.tsx
@@ -4,7 +4,6 @@ import { useMapQueryParams } from '../../hooks';
 import { Map } from './Map';
 import { MapFooter } from './MapFooter';
 import { MapHeader } from './MapHeader';
-import { MapLoader } from './MapLoader';
 import { RouteEditorRef } from './refTypes';
 
 interface Props {
@@ -54,7 +53,6 @@ export const MapModal: React.FC<Props> = ({ className = '' }) => {
         onCancel={() => mapRef.current?.onCancel()}
         onSave={() => mapRef.current?.onSave()}
       />
-      <MapLoader />
     </Dialog>
   );
 };

--- a/ui/src/components/map/stop-areas/CreateStopAreaMarker.tsx
+++ b/ui/src/components/map/stop-areas/CreateStopAreaMarker.tsx
@@ -1,15 +1,18 @@
 import noop from 'lodash/noop';
-import React, { useCallback, useEffect } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
 import { MapLayerMouseEvent, useMap } from 'react-map-gl/maplibre';
-import { useDispatch } from 'react-redux';
 import { useCallbackOnKeyEscape } from '../../../hooks';
-import { resetEnabledStopAreaModesAction } from '../../../redux';
 import { Coords } from '../../../types';
 import { StopAreaMarker } from '../markers';
 
-export const CreateStopAreaMarker = (): JSX.Element => {
-  const [mouseCoords, setMouseCoords] = React.useState<Coords>();
-  const dispatch = useDispatch();
+type CreateStopAreaMarkerProps = {
+  readonly onCancel: () => void;
+};
+
+export const CreateStopAreaMarker: FC<CreateStopAreaMarkerProps> = ({
+  onCancel,
+}) => {
+  const [mouseCoords, setMouseCoords] = useState<Coords>();
   const { current: map } = useMap();
 
   const CREATE_STOP_AREA_MARKER_SIZE = 20;
@@ -27,11 +30,7 @@ export const CreateStopAreaMarker = (): JSX.Element => {
     };
   }, [map, onMouseMove]);
 
-  const resetModes = () => {
-    dispatch(resetEnabledStopAreaModesAction());
-  };
-
-  useCallbackOnKeyEscape(resetModes);
+  useCallbackOnKeyEscape(onCancel);
 
   return (
     <>

--- a/ui/src/components/map/stop-areas/EditStopAreaLayer.tsx
+++ b/ui/src/components/map/stop-areas/EditStopAreaLayer.tsx
@@ -14,6 +14,7 @@ import {
   selectMapStopViewState,
   setEditedStopAreaDataAction,
   setMapStopAreaViewStateAction,
+  setMapStopViewStateAction,
   setSelectedMapStopAreaIdAction,
 } from '../../../redux';
 import { EnrichedStopPlace } from '../../../types';
@@ -37,6 +38,8 @@ export const EditStopAreaLayer = forwardRef<
   const { t } = useTranslation();
 
   const mapStopViewState = useAppSelector(selectMapStopViewState);
+  const setMapStopViewState = useAppAction(setMapStopViewStateAction);
+
   const mapStopAreaViewState = useAppSelector(selectMapStopAreaViewState);
   const setMapStopAreaViewState = useAppAction(setMapStopAreaViewStateAction);
 
@@ -65,6 +68,10 @@ export const EditStopAreaLayer = forwardRef<
 
   const onStartMoveStopArea = () => {
     setMapStopAreaViewState(MapEntityEditorViewState.MOVE);
+  };
+
+  const onAddStop = () => {
+    setMapStopViewState(MapEntityEditorViewState.PLACE);
   };
 
   const onCloseEditors = () => {
@@ -157,6 +164,7 @@ export const EditStopAreaLayer = forwardRef<
         mapStopViewState === MapEntityEditorViewState.NONE && (
           <StopAreaPopup
             area={editedArea}
+            onAddStop={onAddStop}
             onDelete={openDeleteDialog}
             onEdit={onStartEditStopArea}
             onMove={onStartMoveStopArea}

--- a/ui/src/components/map/stop-areas/MemberStop.tsx
+++ b/ui/src/components/map/stop-areas/MemberStop.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next';
 import { Marker } from 'react-map-gl/maplibre';
 import { QuayDetailsFragment } from '../../../generated/graphql';
 import { theme } from '../../../generated/theme';
@@ -7,7 +6,7 @@ import {
   setSelectedMapStopAreaIdAction,
   setSelectedStopIdAction,
 } from '../../../redux';
-import { getGeometryPoint, showDangerToastWithError } from '../../../utils';
+import { getGeometryPoint } from '../../../utils';
 import { Circle } from '../markers';
 
 const testIds = {
@@ -20,8 +19,6 @@ type MemberStopProps = {
 };
 
 export const MemberStop = ({ stop }: MemberStopProps) => {
-  const { t } = useTranslation();
-
   const setSelectedMapStopAreaId = useAppAction(setSelectedMapStopAreaIdAction);
   const setSelectedStopId = useAppAction(setSelectedStopIdAction);
 
@@ -30,15 +27,8 @@ export const MemberStop = ({ stop }: MemberStopProps) => {
       return;
     }
 
-    try {
-      setSelectedMapStopAreaId(undefined);
-      setSelectedStopId(stop.id);
-    } catch (e) {
-      showDangerToastWithError(
-        t('stopArea.errors.failedToResolveScheduledStopPoint'),
-        e,
-      );
-    }
+    setSelectedMapStopAreaId(undefined);
+    setSelectedStopId(stop.id);
   };
 
   const point = getGeometryPoint(stop.geometry);

--- a/ui/src/components/map/stop-areas/MemberStop.tsx
+++ b/ui/src/components/map/stop-areas/MemberStop.tsx
@@ -1,9 +1,13 @@
 import { Marker } from 'react-map-gl/maplibre';
 import { QuayDetailsFragment } from '../../../generated/graphql';
 import { theme } from '../../../generated/theme';
-import { useAppAction } from '../../../hooks';
+import { useAppAction, useAppSelector } from '../../../hooks';
 import {
-  setSelectedMapStopAreaIdAction,
+  MapEntityEditorViewState,
+  selectMapStopViewState,
+  selectSelectedStopId,
+  setMapStopAreaViewStateAction,
+  setMapStopViewStateAction,
   setSelectedStopIdAction,
 } from '../../../redux';
 import { getGeometryPoint } from '../../../utils';
@@ -19,16 +23,22 @@ type MemberStopProps = {
 };
 
 export const MemberStop = ({ stop }: MemberStopProps) => {
-  const setSelectedMapStopAreaId = useAppAction(setSelectedMapStopAreaIdAction);
+  const mapStopViewState = useAppSelector(selectMapStopViewState);
+  const setMapStopViewState = useAppAction(setMapStopViewStateAction);
+
+  const setMapStopAreaViewState = useAppAction(setMapStopAreaViewStateAction);
+
+  const selectedStopId = useAppSelector(selectSelectedStopId);
   const setSelectedStopId = useAppAction(setSelectedStopIdAction);
 
   const onClick = async () => {
-    if (!stop.id) {
+    if (!stop.id || mapStopViewState !== MapEntityEditorViewState.NONE) {
       return;
     }
 
-    setSelectedMapStopAreaId(undefined);
     setSelectedStopId(stop.id);
+    setMapStopAreaViewState(MapEntityEditorViewState.NONE);
+    setMapStopViewState(MapEntityEditorViewState.POPUP);
   };
 
   const point = getGeometryPoint(stop.geometry);
@@ -43,6 +53,8 @@ export const MemberStop = ({ stop }: MemberStopProps) => {
         onClick={onClick}
         size={30}
         testId={testIds.memberStop(stop)}
+        centerDot={selectedStopId === stop.id}
+        centerDotSize={4.5}
       />
     </Marker>
   );

--- a/ui/src/components/map/stop-areas/StopArea.tsx
+++ b/ui/src/components/map/stop-areas/StopArea.tsx
@@ -1,7 +1,7 @@
+import { FC } from 'react';
 import { Marker } from 'react-map-gl/maplibre';
 import { StopAreaMinimalShowOnMapFieldsFragment } from '../../../generated/graphql';
-import { useAppSelector } from '../../../hooks';
-import { selectIsMoveStopAreaModeEnabled } from '../../../redux';
+import { MapEntityEditorViewState } from '../../../redux';
 import { getGeometryPoint } from '../../../utils';
 import { StopAreaMarker } from '../markers';
 
@@ -13,18 +13,22 @@ const testIds = {
 };
 
 type StopAreaProps = {
-  area: StopAreaMinimalShowOnMapFieldsFragment;
-  onClick: (area: StopAreaMinimalShowOnMapFieldsFragment) => void;
-  selected: boolean;
+  readonly area: StopAreaMinimalShowOnMapFieldsFragment;
+  readonly mapStopAreaViewState: MapEntityEditorViewState;
+  readonly onClick: (area: StopAreaMinimalShowOnMapFieldsFragment) => void;
+  readonly selected: boolean;
 };
 
-export const StopArea = ({ area, selected, onClick }: StopAreaProps) => {
-  const isMoveStopAreaModeEnabled = useAppSelector(
-    selectIsMoveStopAreaModeEnabled,
-  );
+export const StopArea: FC<StopAreaProps> = ({
+  area,
+  mapStopAreaViewState,
+  selected,
+  onClick,
+}) => {
   // If the stop area is being moved, we use different styles for the stop
   // to indicate the placeholder of the old location
-  const isPlaceholder = selected && isMoveStopAreaModeEnabled;
+  const isPlaceholder =
+    selected && mapStopAreaViewState === MapEntityEditorViewState.MOVE;
 
   const point = getGeometryPoint(area.centroid);
   if (!point) {

--- a/ui/src/components/map/stop-areas/StopAreaPopup.tsx
+++ b/ui/src/components/map/stop-areas/StopAreaPopup.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { MdDelete } from 'react-icons/md';
+import { MdAddCircle, MdDelete } from 'react-icons/md';
 import { Popup } from 'react-map-gl/maplibre';
 import { Column, Row } from '../../../layoutComponents';
 import { Path, routeDetails } from '../../../router/routeDetails';
@@ -19,10 +19,12 @@ const testIds = {
   deleteButton: 'StopAreaPopup::deleteButton',
   editButton: 'StopAreaPopup::editButton',
   moveButton: 'StopAreaPopup::moveButton',
+  addStopButton: 'StopAreaPopup::addStopButton',
 };
 
 type StopAreaPopupProps = {
   area: EnrichedStopPlace;
+  onAddStop: () => void;
   onDelete: () => void;
   onEdit: () => void;
   onMove: () => void;
@@ -31,6 +33,7 @@ type StopAreaPopupProps = {
 
 export const StopAreaPopup = ({
   area,
+  onAddStop,
   onDelete,
   onEdit,
   onMove,
@@ -99,6 +102,17 @@ export const StopAreaPopup = ({
           >
             <MdDelete aria-label={t('stopArea.delete')} className="text-xl" />
           </SimpleButton>
+
+          <SimpleButton
+            containerClassName="ml-1"
+            className="h-full !px-3"
+            inverted
+            onClick={onAddStop}
+            testId={testIds.addStopButton}
+          >
+            <MdAddCircle aria-label={t('map.addStop')} className="text-xl" />
+          </SimpleButton>
+
           <SimpleButton
             containerClassName="ml-auto"
             onClick={onMove}
@@ -106,6 +120,7 @@ export const StopAreaPopup = ({
           >
             {t('move')}
           </SimpleButton>
+
           <SimpleButton
             containerClassName="ml-2"
             onClick={onEdit}

--- a/ui/src/components/map/stops/CreateStopMarker.tsx
+++ b/ui/src/components/map/stops/CreateStopMarker.tsx
@@ -1,14 +1,15 @@
 import debounce from 'lodash/debounce';
+import { Point as MapLibrePoint } from 'maplibre-gl';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { MapLayerMouseEvent, useMap } from 'react-map-gl/maplibre';
 import { theme } from '../../../generated/theme';
 import { useCallbackOnKeyEscape } from '../../../hooks';
-import { Coords } from '../../../types';
 import {
   drawLineToClosestRoad,
   removeLineFromStopToInfraLink,
 } from '../../../utils/map';
 import { Circle } from '../markers';
+import { LineToActiveStopArea } from './LineToActiveStopArea';
 
 const { colors } = theme;
 
@@ -17,7 +18,8 @@ type CreateStopMarkerProps = {
 };
 
 export const CreateStopMarker: FC<CreateStopMarkerProps> = ({ onCancel }) => {
-  const [mouseCoords, setMouseCoords] = useState<Coords>();
+  const [mouseCoords, setMouseCoords] = useState<MapLibrePoint | null>(null);
+
   const { current: map } = useMap();
 
   const createStopMarkerSize = 20;
@@ -50,25 +52,29 @@ export const CreateStopMarker: FC<CreateStopMarkerProps> = ({ onCancel }) => {
 
   useCallbackOnKeyEscape(onCancel);
 
+  if (!mouseCoords) {
+    return null;
+  }
+
+  /* Display hovering bus stop while in create mode */
   return (
     <>
-      {/* Display hovering bus stop while in create mode */}
-      {mouseCoords && (
-        <div
-          style={{
-            pointerEvents: 'none',
-            position: 'absolute',
-            left: mouseCoords.x - createStopMarkerSize / 2,
-            top: mouseCoords.y - createStopMarkerSize / 2,
-          }}
-        >
-          <Circle
-            centerDot
-            borderColor={colors.hslRed}
-            size={createStopMarkerSize}
-          />
-        </div>
-      )}
+      <LineToActiveStopArea.FromMouse mouseCoords={mouseCoords} />
+
+      <div
+        style={{
+          pointerEvents: 'none',
+          position: 'absolute',
+          left: mouseCoords.x - createStopMarkerSize / 2,
+          top: mouseCoords.y - createStopMarkerSize / 2,
+        }}
+      >
+        <Circle
+          centerDot
+          borderColor={colors.hslRed}
+          size={createStopMarkerSize}
+        />
+      </div>
     </>
   );
 };

--- a/ui/src/components/map/stops/CreateStopMarker.tsx
+++ b/ui/src/components/map/stops/CreateStopMarker.tsx
@@ -1,10 +1,8 @@
 import debounce from 'lodash/debounce';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { MapLayerMouseEvent, useMap } from 'react-map-gl/maplibre';
-import { useDispatch } from 'react-redux';
 import { theme } from '../../../generated/theme';
 import { useCallbackOnKeyEscape } from '../../../hooks';
-import { resetEnabledModesAction } from '../../../redux';
 import { Coords } from '../../../types';
 import {
   drawLineToClosestRoad,
@@ -14,9 +12,12 @@ import { Circle } from '../markers';
 
 const { colors } = theme;
 
-export const CreateStopMarker = (): React.ReactElement => {
-  const [mouseCoords, setMouseCoords] = React.useState<Coords>();
-  const dispatch = useDispatch();
+type CreateStopMarkerProps = {
+  readonly onCancel: () => void;
+};
+
+export const CreateStopMarker: FC<CreateStopMarkerProps> = ({ onCancel }) => {
+  const [mouseCoords, setMouseCoords] = useState<Coords>();
   const { current: map } = useMap();
 
   const createStopMarkerSize = 20;
@@ -47,11 +48,7 @@ export const CreateStopMarker = (): React.ReactElement => {
     };
   }, [map, onMouseMove]);
 
-  const resetModes = () => {
-    dispatch(resetEnabledModesAction());
-  };
-
-  useCallbackOnKeyEscape(resetModes);
+  useCallbackOnKeyEscape(onCancel);
 
   return (
     <>

--- a/ui/src/components/map/stops/LineToActiveStopArea.tsx
+++ b/ui/src/components/map/stops/LineToActiveStopArea.tsx
@@ -1,0 +1,87 @@
+import { point } from '@turf/helpers';
+import { LineString, Position } from 'geojson';
+import { Point as MapLibrePoint } from 'maplibre-gl';
+import { FC } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+import { useAppSelector } from '../../../hooks';
+import { selectEditedStopAreaData } from '../../../redux';
+import { Point } from '../../../types';
+import { LineRenderLayer } from '../routes';
+
+type LineToActiveStopAreaProps = { readonly from: Position };
+
+const LineToActiveStopAreaImpl: FC<LineToActiveStopAreaProps> = ({ from }) => {
+  const editedStopAreaData = useAppSelector(selectEditedStopAreaData);
+
+  if (
+    editedStopAreaData?.locationLong === undefined ||
+    editedStopAreaData.locationLat === undefined
+  ) {
+    return null;
+  }
+
+  const lineToStopArea: LineString = {
+    type: 'LineString',
+    coordinates: [
+      from,
+      [editedStopAreaData.locationLong, editedStopAreaData.locationLat],
+    ],
+  };
+
+  if (!lineToStopArea) {
+    return null;
+  }
+
+  return (
+    <LineRenderLayer
+      layerId="LineToActiveStopArea"
+      geometry={lineToStopArea}
+      paint={{
+        'line-offset': 0,
+        'line-width': 4,
+      }}
+    />
+  );
+};
+
+type LineToActiveStopAreaFromMouseProps = {
+  readonly mouseCoords: MapLibrePoint;
+};
+
+const LineToActiveStopAreaFromMouse: FC<LineToActiveStopAreaFromMouseProps> = ({
+  mouseCoords,
+}) => {
+  const { current: map } = useMap();
+
+  if (!map) {
+    return null;
+  }
+
+  // convert cursor location from pixel coordinates to lat/lng
+  const cursorLocation = point(map.unproject(mouseCoords).toArray()).geometry;
+
+  return <LineToActiveStopAreaImpl from={cursorLocation.coordinates} />;
+};
+
+type LineToActiveStopAreaFromDraftProps = {
+  readonly draftLocation: Point | null;
+};
+
+const LineToActiveStopAreaFromDraft: FC<LineToActiveStopAreaFromDraftProps> = ({
+  draftLocation,
+}) => {
+  if (!draftLocation) {
+    return null;
+  }
+
+  return (
+    <LineToActiveStopAreaImpl
+      from={[draftLocation.longitude, draftLocation.latitude]}
+    />
+  );
+};
+
+export const LineToActiveStopArea = {
+  FromMouse: LineToActiveStopAreaFromMouse,
+  FromDraft: LineToActiveStopAreaFromDraft,
+} as const;

--- a/ui/src/components/map/stops/LineToClosestInfraLink.tsx
+++ b/ui/src/components/map/stops/LineToClosestInfraLink.tsx
@@ -68,7 +68,7 @@ export const LineToClosestInfraLink: FC<LineToClosestInfraLinkProps> = ({
 
   return (
     <LineRenderLayer
-      layerId="MemberLines"
+      layerId="LineToClosestInfraLink"
       geometry={lineToInfraLink}
       layout={{
         'line-cap': 'round',

--- a/ui/src/components/map/stops/Stop.tsx
+++ b/ui/src/components/map/stops/Stop.tsx
@@ -8,14 +8,8 @@ import { Circle } from '../markers';
 
 const { colors } = theme;
 
-type StopProps = {
-  readonly isHighlighted?: boolean;
-  readonly mapStopViewState: MapEntityEditorViewState;
-  readonly onClick: () => void;
-  readonly selected?: boolean;
-  readonly testId?: string;
-  readonly vehicleMode?: ReusableComponentsVehicleModeEnum;
-} & Point;
+const iconSize = 30;
+const selectedIconSize = 32;
 
 /** Stop map markers border color is determined in this function. There are
  * different aspects which are affecting this determination. These are
@@ -49,6 +43,15 @@ const determineBorderColor = (
   return colors.hslDark80;
 };
 
+type StopProps = {
+  readonly isHighlighted?: boolean;
+  readonly mapStopViewState: MapEntityEditorViewState;
+  readonly onClick: () => void;
+  readonly selected?: boolean;
+  readonly testId?: string;
+  readonly vehicleMode?: ReusableComponentsVehicleModeEnum;
+} & Point;
+
 export const Stop: FC<StopProps> = ({
   isHighlighted = false,
   latitude,
@@ -59,8 +62,6 @@ export const Stop: FC<StopProps> = ({
   testId,
   vehicleMode = undefined,
 }) => {
-  const iconSize = 30;
-  const selectedIconSize = 32;
   // If the stop is being moved, we use different styles for the stop
   // to indicate the placeholder of the old location
   const isPlaceholder =

--- a/ui/src/components/map/stops/Stop.tsx
+++ b/ui/src/components/map/stops/Stop.tsx
@@ -1,20 +1,21 @@
+import { FC } from 'react';
 import { Marker } from 'react-map-gl/maplibre';
 import { ReusableComponentsVehicleModeEnum } from '../../../generated/graphql';
 import { theme } from '../../../generated/theme';
-import { useAppSelector } from '../../../hooks';
-import { selectIsMoveStopModeEnabled } from '../../../redux';
+import { MapEntityEditorViewState } from '../../../redux';
 import { Point } from '../../../types';
 import { Circle } from '../markers';
 
 const { colors } = theme;
 
-interface Props extends Point {
-  testId?: string;
-  selected?: boolean;
-  onClick: () => void;
-  vehicleMode?: ReusableComponentsVehicleModeEnum;
-  isHighlighted?: boolean;
-}
+type StopProps = {
+  readonly isHighlighted?: boolean;
+  readonly mapStopViewState: MapEntityEditorViewState;
+  readonly onClick: () => void;
+  readonly selected?: boolean;
+  readonly testId?: string;
+  readonly vehicleMode?: ReusableComponentsVehicleModeEnum;
+} & Point;
 
 /** Stop map markers border color is determined in this function. There are
  * different aspects which are affecting this determination. These are
@@ -48,21 +49,22 @@ const determineBorderColor = (
   return colors.hslDark80;
 };
 
-export const Stop = ({
-  testId,
+export const Stop: FC<StopProps> = ({
+  isHighlighted = false,
   latitude,
   longitude,
+  mapStopViewState,
   onClick,
   selected = false,
+  testId,
   vehicleMode = undefined,
-  isHighlighted = false,
-}: Props): React.ReactElement => {
-  const isMoveStopModeEnabled = useAppSelector(selectIsMoveStopModeEnabled);
+}) => {
   const iconSize = 30;
   const selectedIconSize = 32;
   // If the stop is being moved, we use different styles for the stop
   // to indicate the placeholder of the old location
-  const isPlaceholder = selected && isMoveStopModeEnabled;
+  const isPlaceholder =
+    selected && mapStopViewState === MapEntityEditorViewState.MOVE;
   const iconBorderColor = determineBorderColor(
     isHighlighted,
     selected,

--- a/ui/src/components/map/stops/StopEditorViews.tsx
+++ b/ui/src/components/map/stops/StopEditorViews.tsx
@@ -1,5 +1,0 @@
-export enum StopEditorViews {
-  None = 'None',
-  Popup = 'Popup',
-  Modal = 'modal',
-}

--- a/ui/src/components/map/stops/Stops.tsx
+++ b/ui/src/components/map/stops/Stops.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useRef, useState } from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
 import { MapLayerMouseEvent } from 'react-map-gl/maplibre';
 import {
   useAppAction,
@@ -14,6 +14,7 @@ import {
   MapEntityType,
   Operation,
   isEditorOpen,
+  isNoneOrPopup,
   isPlacingOrMoving,
   selectDraftLocation,
   selectMapStopAreaViewState,
@@ -21,9 +22,10 @@ import {
   selectMapViewport,
   selectSelectedStopId,
   selectShowMapEntityTypes,
-  selectStopAreaEditorIsActive,
   setDraftLocationAction,
+  setEditedStopAreaDataAction,
   setMapStopViewStateAction,
+  setSelectedMapStopAreaIdAction,
   setSelectedStopIdAction,
 } from '../../../redux';
 import { Priority } from '../../../types/enums';
@@ -54,6 +56,8 @@ export const Stops = React.forwardRef((_props, ref) => {
   const mapStopViewState = useAppSelector(selectMapStopViewState);
   const setMapStopViewState = useAppAction(setMapStopViewStateAction);
 
+  const setSelectedMapStopAreaId = useAppAction(setSelectedMapStopAreaIdAction);
+  const setEditedStopAreaData = useAppAction(setEditedStopAreaDataAction);
   const setSelectedStopId = useAppAction(setSelectedStopIdAction);
   const setDraftStopLocation = useAppAction(setDraftLocationAction);
 
@@ -105,14 +109,18 @@ export const Stops = React.forwardRef((_props, ref) => {
   }));
 
   const onClickStop = (stop: MapStop) => {
-    if (mapStopViewState === MapEntityEditorViewState.NONE) {
+    if (isNoneOrPopup(mapStopViewState)) {
       setSelectedStopId(stop.netex_id);
+      setSelectedMapStopAreaId(stop.stop_place_netex_id);
+      setMapStopViewState(MapEntityEditorViewState.POPUP);
     }
   };
 
   const onPopupClose = () => {
     setSelectedStopId(undefined);
     setDraftStopLocation(undefined);
+    setSelectedMapStopAreaId(undefined);
+    setEditedStopAreaData(undefined);
   };
 
   const onEditingFinished = async (netextId: string | null) => {

--- a/ui/src/components/map/stops/Stops.tsx
+++ b/ui/src/components/map/stops/Stops.tsx
@@ -13,8 +13,10 @@ import {
   MapEntityEditorViewState,
   MapEntityType,
   Operation,
+  isEditorOpen,
   isPlacingOrMoving,
   selectDraftLocation,
+  selectMapStopAreaViewState,
   selectMapStopViewState,
   selectMapViewport,
   selectSelectedStopId,
@@ -43,7 +45,8 @@ export const Stops = React.forwardRef((_props, ref) => {
 
   const selectedStopId = useAppSelector(selectSelectedStopId);
   const draftLocation = useAppSelector(selectDraftLocation);
-  const stopAreaEditorIsActive = useAppSelector(selectStopAreaEditorIsActive);
+  const mapStopAreaViewState = useAppSelector(selectMapStopAreaViewState);
+
   const { [MapEntityType.Stop]: showStops } = useAppSelector(
     selectShowMapEntityTypes,
   );
@@ -61,10 +64,13 @@ export const Stops = React.forwardRef((_props, ref) => {
   const { getStopVehicleMode, getStopHighlighted } = useMapStops();
 
   const viewport = useAppSelector(selectMapViewport);
+
   // Skip initial 0 radius fetch and wait for the map to get loaded,
   // so that we have a proper viewport.
   const skipFetching =
-    !showStops || stopAreaEditorIsActive || viewport.radius <= 0;
+    !showStops ||
+    mapStopAreaViewState !== MapEntityEditorViewState.NONE ||
+    viewport.radius <= 0;
   const {
     stops: unfilteredStops,
     setFetchStopsLoadingState,
@@ -129,7 +135,7 @@ export const Stops = React.forwardRef((_props, ref) => {
     );
   };
 
-  if (stopAreaEditorIsActive) {
+  if (isEditorOpen(mapStopAreaViewState)) {
     return null;
   }
 

--- a/ui/src/components/map/stops/useEditStopUtils.tsx
+++ b/ui/src/components/map/stops/useEditStopUtils.tsx
@@ -1,7 +1,6 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MapLayerMouseEvent, useMap } from 'react-map-gl/maplibre';
-import { useDispatch } from 'react-redux';
 import { StopRegistryGeoJsonType } from '../../../generated/graphql';
 import {
   EditChanges,
@@ -11,10 +10,9 @@ import {
   useObservationDateQueryParam,
   usePrepareEdit,
 } from '../../../hooks';
-import { Operation, setIsMoveStopModeEnabledAction } from '../../../redux';
+import { MapEntityEditorViewState, Operation } from '../../../redux';
 import { mapLngLatToGeoJSON, showSuccessToast } from '../../../utils';
 import { StopInfoForEditingOnMap } from '../../forms/stop/utils/useGetStopInfoForEditingOnMap';
-import { StopEditorViews } from './StopEditorViews';
 import { useUpdateStopPriorityFilterIfNeeded } from './useUpdateStopPriorityFilterIfNeeded';
 
 type EditUtilsEditActive = {
@@ -39,11 +37,10 @@ type UseEditStopUtilsReturn = EditUtilsEditActive | EditUtilsEditInactive;
 
 export function useEditStopUtils(
   stopInfo: StopInfoForEditingOnMap | null,
-  setDisplayedEditor: Dispatch<SetStateAction<StopEditorViews>>,
+  setDisplayedEditor: (newViewState: MapEntityEditorViewState) => void,
   onFinishEditing: (netextId: string) => void,
 ): UseEditStopUtilsReturn {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
 
   const [editChanges, setEditChanges] = useState<EditChanges | null>(null);
 
@@ -76,7 +73,7 @@ export function useEditStopUtils(
       },
     });
 
-    setDisplayedEditor(StopEditorViews.Modal);
+    setDisplayedEditor(MapEntityEditorViewState.EDIT);
   };
 
   const onMoveStop = async (event: MapLayerMouseEvent) => {
@@ -145,7 +142,6 @@ export function useEditStopUtils(
       updateStopPriorityFilterIfNeeded(editChanges.editedStop.priority);
 
       onFinishEditing(editChanges.quayId);
-      dispatch(setIsMoveStopModeEnabledAction(false));
     } catch (err) {
       defaultErrorHandler(err as Error);
     } finally {
@@ -154,8 +150,7 @@ export function useEditStopUtils(
   };
 
   const onCancelEdit = () => {
-    dispatch(setIsMoveStopModeEnabledAction(false));
-    setDisplayedEditor(StopEditorViews.Popup);
+    setDisplayedEditor(MapEntityEditorViewState.POPUP);
     setEditChanges(null);
   };
 

--- a/ui/src/components/map/stops/useGetMapStops.ts
+++ b/ui/src/components/map/stops/useGetMapStops.ts
@@ -24,6 +24,7 @@ const GQL_GET_MAP_STOPS = gql`
         validity_end
         priority
         centroid
+        stop_place_netex_id
       }
     }
   }
@@ -32,6 +33,7 @@ const GQL_GET_MAP_STOPS = gql`
 export type MapStop = FilterableStopInfo & {
   readonly location: Point;
   readonly netex_id: string;
+  readonly stop_place_netex_id: string;
 };
 
 function viewportToWhere(
@@ -84,7 +86,8 @@ export function useGetMapStops({ skipFetching, viewport }: GetMapStopsOptions) {
       if (
         !rawStop?.label ||
         rawStop.centroid?.type !== 'Point' ||
-        !rawStop.netex_id
+        !rawStop.netex_id ||
+        !rawStop.stop_place_netex_id
       ) {
         return null;
       }
@@ -93,6 +96,7 @@ export function useGetMapStops({ skipFetching, viewport }: GetMapStopsOptions) {
         label: rawStop.label,
         location: rawStop.centroid,
         netex_id: rawStop.netex_id,
+        stop_place_netex_id: rawStop.stop_place_netex_id,
         priority: Number(rawStop.priority) as Priority,
         validity_start: parseDate(rawStop.validity_start),
         validity_end: parseDate(rawStop.validity_end),

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/useGetStopAreaDetails.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/useGetStopAreaDetails.ts
@@ -79,7 +79,7 @@ const GQL_GET_STOP_AREA_DETAILS = gql`
   }
 `;
 
-function getEnrichedStopPlace(
+export function getEnrichedStopPlace(
   stopPlace: StopPlaceDetailsFragment | null | undefined,
 ): EnrichedStopPlace | null {
   if (!stopPlace) {

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/useGetStopAreaDetails.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/useGetStopAreaDetails.ts
@@ -101,19 +101,26 @@ function getEnrichedStopPlaceDetailsFromQueryResult(
   return getEnrichedStopPlace(stopPlaces.at(0));
 }
 
-export function useGetStopPlaceDetails() {
-  const { id } = useRequiredParams<{ id: string }>();
+export function useGetStopPlaceDetailsById(id: string | null | undefined) {
+  const { data, ...rest } = useGetStopPlaceDetailsQuery(
+    id ? { variables: { id } } : { skip: true },
+  );
 
-  const { data, ...rest } = useGetStopPlaceDetailsQuery({
-    variables: { id },
-  });
-
+  const rawStopPlace = getStopPlacesFromQueryResult<StopPlaceDetailsFragment>(
+    data?.stop_registry?.stopPlace,
+  ).at(0);
   const stopPlaceDetails = useMemo(
-    () => getEnrichedStopPlaceDetailsFromQueryResult(data),
-    [data],
+    () => getEnrichedStopPlace(rawStopPlace),
+    [rawStopPlace],
   );
 
   return { ...rest, stopPlaceDetails };
+}
+
+export function useGetStopPlaceDetails() {
+  const { id } = useRequiredParams<{ id: string }>();
+
+  return useGetStopPlaceDetailsById(id);
 }
 
 export function useGetStopPlaceDetailsLazy() {

--- a/ui/src/components/stop-registry/stops/queries/useDeleteQuay.ts
+++ b/ui/src/components/stop-registry/stops/queries/useDeleteQuay.ts
@@ -26,7 +26,7 @@ export function useDeleteQuay() {
     (stopPlaceId: string, quayId: string) =>
       deleteQuay({
         variables: { stopPlaceId, quayId },
-        refetchQueries: ['GetMapStops'],
+        refetchQueries: ['GetMapStops', 'getStopPlaceDetails'],
         awaitRefetchQueries: true,
       }),
     [deleteQuay],

--- a/ui/src/components/stop-registry/utils/useShowStopAreaOnMap.ts
+++ b/ui/src/components/stop-registry/utils/useShowStopAreaOnMap.ts
@@ -5,7 +5,9 @@ import {
 } from '../../../hooks';
 import {
   FilterType,
+  MapEntityEditorViewState,
   resetMapState,
+  setMapStopAreaViewStateAction,
   setSelectedMapStopAreaIdAction,
   setStopFilterAction,
 } from '../../../redux';
@@ -23,6 +25,7 @@ export function useShowStopAreaOnMap() {
   return (id: string | undefined, point: Point) => {
     dispatch(resetMapState()).then(() => {
       dispatch(setSelectedMapStopAreaIdAction(id));
+      dispatch(setMapStopAreaViewStateAction(MapEntityEditorViewState.POPUP));
       dispatch(
         setStopFilterAction({
           filterType: FilterType.ShowAllBusStops,

--- a/ui/src/components/stop-registry/utils/useShowStopOnMap.ts
+++ b/ui/src/components/stop-registry/utils/useShowStopOnMap.ts
@@ -6,7 +6,9 @@ import {
 } from '../../../hooks';
 import {
   FilterType,
+  MapEntityEditorViewState,
   resetMapState,
+  setMapStopViewStateAction,
   setSelectedStopIdAction,
   setStopFilterAction,
 } from '../../../redux';
@@ -29,6 +31,7 @@ export function useShowStopOnMap() {
     dispatch(resetMapState()).then(() => {
       if (netextId) {
         dispatch(setSelectedStopIdAction(netextId));
+        dispatch(setMapStopViewStateAction(MapEntityEditorViewState.POPUP));
       }
 
       dispatch(

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -67555,6 +67555,7 @@ export type GetMapStopsQuery = {
       validity_end?: string | null,
       priority?: string | null,
       centroid?: GeoJSON.Geometry | null,
+      stop_place_netex_id?: string | null,
       label?: string | null
     }>
   } | null
@@ -76433,6 +76434,7 @@ export const GetMapStopsDocument = gql`
       validity_end
       priority
       centroid
+      stop_place_netex_id
     }
   }
 }

--- a/ui/src/hooks/redux.ts
+++ b/ui/src/hooks/redux.ts
@@ -5,6 +5,7 @@ import {
   ActionCreatorWithoutPayload,
   PayloadAction,
 } from '@reduxjs/toolkit';
+import { useCallback } from 'react';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { AppDispatch, RootState } from '../redux';
 
@@ -55,5 +56,8 @@ export function useAppAction<
 
 export function useAppAction(action: ExplicitAny): ExplicitAny {
   const dispatch = useAppDispatch();
-  return (...params: ExplicitAny[]) => dispatch(action(...params));
+  return useCallback(
+    (...params: ExplicitAny[]) => dispatch(action(...params)),
+    [dispatch, action],
+  );
 }

--- a/ui/src/hooks/stop-registry/stop-areas/useDeleteStopArea.ts
+++ b/ui/src/hooks/stop-registry/stop-areas/useDeleteStopArea.ts
@@ -10,7 +10,10 @@ const GQL_DELETE_STOP_AREA = gql`
 `;
 
 export const useDeleteStopArea = () => {
-  const [deleteStopAreaFunction] = useDeleteStopAreaMutation();
+  const [deleteStopAreaFunction] = useDeleteStopAreaMutation({
+    awaitRefetchQueries: true,
+    refetchQueries: ['GetStopAreasByLocation'],
+  });
 
   const deleteStopArea = async (stopPlaceId: string) => {
     return deleteStopAreaFunction({ variables: { stopPlaceId } });

--- a/ui/src/hooks/stops/useCreateStop.ts
+++ b/ui/src/hooks/stops/useCreateStop.ts
@@ -140,8 +140,10 @@ export function useCheckIsLocationValidForStop() {
 
 export function useCreateStop() {
   const [insertStopPointMutation] = useInsertStopPointMutation();
-  const [insertQuayIntoStopPlaceMutation] =
-    useInsertQuayIntoStopPlaceMutation();
+  const [insertQuayIntoStopPlaceMutation] = useInsertQuayIntoStopPlaceMutation({
+    awaitRefetchQueries: true,
+    refetchQueries: ['getStopPlaceDetails', 'GetStopInfoForEditingOnMap'],
+  });
 
   return async ({ stopPlaceId, quay, stopPoint }: CreateChanges) => {
     const insertQuayResult = await insertQuayIntoStopPlaceMutation({

--- a/ui/src/hooks/stops/useEditStop.ts
+++ b/ui/src/hooks/stops/useEditStop.ts
@@ -3,7 +3,6 @@ import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
 import { wrapErrors } from '../../components/stop-registry/stops/stop-details/stop-version/utils/wrapErrors';
 import {
   EditStopMutationVariables,
@@ -26,7 +25,6 @@ import {
   mapGetRoutesBrokenByStopChangeResult,
   mapStopResultToStop,
 } from '../../graphql';
-import { setIsMoveStopModeEnabledAction } from '../../redux';
 import {
   DirectionNotResolvedError,
   EditRouteTerminalStopsError,
@@ -478,7 +476,6 @@ export function usePrepareEdit() {
 // in case an exception is thrown
 export function useDefaultErrorHandler() {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
 
   return (err: Error) => {
     if (err instanceof LinkNotResolvedError) {
@@ -504,7 +501,6 @@ export function useDefaultErrorHandler() {
     }
 
     if (err instanceof TimingPlaceRequiredError) {
-      dispatch(setIsMoveStopModeEnabledAction(false));
       return showDangerToast(
         t('stops.timingPlaceRequired', { routeLabels: err.message }),
       );

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -140,7 +140,6 @@
     "checkingNamesFailed": "Failed to check the consistency of names <RefetchButton>Try again</RefetchButton>",
     "editSuccess": "Stop area edited",
     "errors": {
-      "failedToResolveScheduledStopPoint": "Failed to resolve Scheduled Stop Point! Reason",
       "expandToSeeErrors": "Expand Language versions and abbreviations to see errors"
     }
   },

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -140,7 +140,6 @@
     "checkingNamesFailed": "Nimien tarkastus epäonnistui <RefetchButton>Yritä uudelleen</RefetchButton>",
     "editSuccess": "Pysäkkialue muokattu",
     "errors": {
-      "failedToResolveScheduledStopPoint": "Pysäkin tietojen selvitys epäonnistui! Syy",
       "expandToSeeErrors": "Avaa Kieliversiot ja lyhenteet nähdäksesi virheet"
     }
   },

--- a/ui/src/redux/index.ts
+++ b/ui/src/redux/index.ts
@@ -14,3 +14,4 @@ export * from './slices/modals';
 export * from './slices/user';
 export * from './store';
 export * from './thunks';
+export * from './types/MapEntityEditorViewState';

--- a/ui/src/redux/selectors/mapStopAreaEditor.ts
+++ b/ui/src/redux/selectors/mapStopAreaEditor.ts
@@ -23,12 +23,7 @@ export const selectEditedStopAreaData = createSelector(
   (mapStopAreaEditor) => mapStopAreaEditor.editedStopAreaData,
 );
 
-export const selectIsCreateStopAreaModeEnabled = createSelector(
+export const selectMapStopAreaViewState = createSelector(
   selectMapStopAreaEditor,
-  (mapStopAreEditor) => mapStopAreEditor.isCreateStopAreaModeEnabled,
-);
-
-export const selectIsMoveStopAreaModeEnabled = createSelector(
-  selectMapStopAreaEditor,
-  (mapStopAreEditor) => mapStopAreEditor.isMoveStopAreaModeEnabled,
+  (mapStopAreEditor) => mapStopAreEditor.viewState,
 );

--- a/ui/src/redux/selectors/mapStopAreaEditor.ts
+++ b/ui/src/redux/selectors/mapStopAreaEditor.ts
@@ -13,11 +13,6 @@ export const selectSelectedStopAreaId = createSelector(
   (mapStopAreEditor) => mapStopAreEditor.selectedStopAreaId,
 );
 
-export const selectStopAreaEditorIsActive = createSelector(
-  selectMapStopAreaEditor,
-  (mapStopAreEditor) => mapStopAreEditor.selectedStopAreaId !== undefined,
-);
-
 export const selectEditedStopAreaData = createSelector(
   selectMapStopAreaEditor,
   (mapStopAreaEditor) => mapStopAreaEditor.editedStopAreaData,

--- a/ui/src/redux/selectors/mapStopEditor.ts
+++ b/ui/src/redux/selectors/mapStopEditor.ts
@@ -23,12 +23,7 @@ export const selectHasDraftLocation = createSelector(
   (mapStopEditor) => !!mapStopEditor.draftLocation,
 );
 
-export const selectIsCreateStopModeEnabled = createSelector(
+export const selectMapStopViewState = createSelector(
   selectMapStopEditor,
-  (mapStopEditor) => mapStopEditor.isCreateStopModeEnabled,
-);
-
-export const selectIsMoveStopModeEnabled = createSelector(
-  selectMapStopEditor,
-  (mapStopEditor) => mapStopEditor.isMoveStopModeEnabled,
+  (mapStopEditor) => mapStopEditor.viewState,
 );

--- a/ui/src/redux/slices/mapStopAreaEditor.ts
+++ b/ui/src/redux/slices/mapStopAreaEditor.ts
@@ -1,12 +1,12 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { EnrichedStopPlace } from '../../types';
 import { StoreType, mapToStoreType } from '../mappers';
+import { MapEntityEditorViewState } from '../types';
 
 export type MapStopAreaEditor = {
   readonly selectedStopAreaId?: string;
   readonly editedStopAreaData?: EnrichedStopPlace;
-  readonly isCreateStopAreaModeEnabled: boolean;
-  readonly isMoveStopAreaModeEnabled: boolean;
+  readonly viewState: MapEntityEditorViewState;
 };
 
 type IState = StoreType<MapStopAreaEditor>;
@@ -14,8 +14,7 @@ type IState = StoreType<MapStopAreaEditor>;
 const initialState: IState = {
   selectedStopAreaId: undefined,
   editedStopAreaData: undefined,
-  isCreateStopAreaModeEnabled: false,
-  isMoveStopAreaModeEnabled: false,
+  viewState: MapEntityEditorViewState.NONE,
 };
 
 const slice = createSlice({
@@ -39,15 +38,11 @@ const slice = createSlice({
         payload: stopArea ? mapToStoreType(stopArea) : undefined,
       }),
     },
-    setIsCreateStopAreaModeEnabled: (state, action: PayloadAction<boolean>) => {
-      state.isCreateStopAreaModeEnabled = action.payload;
-    },
-    setIsMoveStopAreaModeEnabled: (state, action: PayloadAction<boolean>) => {
-      state.isMoveStopAreaModeEnabled = action.payload;
-    },
-    resetEnabledStopAreaModes: (state) => {
-      state.isCreateStopAreaModeEnabled = false;
-      state.isMoveStopAreaModeEnabled = false;
+    setMapStopAreaViewState: (
+      state,
+      action: PayloadAction<MapEntityEditorViewState>,
+    ) => {
+      state.viewState = action.payload;
     },
     reset: () => initialState,
   },
@@ -56,9 +51,7 @@ const slice = createSlice({
 export const {
   setSelectedStopAreaId: setSelectedMapStopAreaIdAction,
   setEditedStopAreaData: setEditedStopAreaDataAction,
-  setIsCreateStopAreaModeEnabled: setIsCreateStopAreaModeEnabledAction,
-  setIsMoveStopAreaModeEnabled: setIsMoveStopAreaModeEnabledAction,
-  resetEnabledStopAreaModes: resetEnabledStopAreaModesAction,
+  setMapStopAreaViewState: setMapStopAreaViewStateAction,
   reset: resetMapStopAreaEditorAction,
 } = slice.actions;
 

--- a/ui/src/redux/slices/mapStopEditor.ts
+++ b/ui/src/redux/slices/mapStopEditor.ts
@@ -1,21 +1,20 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { Point } from '../../types';
-import { StoreType } from '../mappers/storeType';
+import { StoreType } from '../mappers';
+import { MapEntityEditorViewState } from '../types';
 
-export interface MapStopEditorState {
-  selectedStopId?: string;
-  draftLocation?: Point;
-  isCreateStopModeEnabled: boolean;
-  isMoveStopModeEnabled: boolean;
-}
+export type MapStopEditorState = {
+  readonly selectedStopId?: string;
+  readonly draftLocation?: Point;
+  readonly viewState: MapEntityEditorViewState;
+};
 
 type IState = StoreType<MapStopEditorState>;
 
 const initialState: IState = {
   selectedStopId: undefined,
   draftLocation: undefined,
-  isCreateStopModeEnabled: false,
-  isMoveStopModeEnabled: false,
+  viewState: MapEntityEditorViewState.NONE,
 };
 
 const slice = createSlice({
@@ -25,21 +24,17 @@ const slice = createSlice({
     setSelectedStopId: (state, action: PayloadAction<string | undefined>) => {
       state.selectedStopId = action.payload;
     },
-    setIsCreateStopModeEnabled: (state, action: PayloadAction<boolean>) => {
-      state.isCreateStopModeEnabled = action.payload;
-    },
-    setIsMoveStopModeEnabled: (state, action: PayloadAction<boolean>) => {
-      state.isMoveStopModeEnabled = action.payload;
-    },
-    resetEnabledModes: (state) => {
-      state.isMoveStopModeEnabled = false;
-      state.isCreateStopModeEnabled = false;
-    },
     setDraftLocation: (
       state,
       action: PayloadAction<StoreType<Point> | undefined>,
     ) => {
       state.draftLocation = action.payload;
+    },
+    setMapStopViewState: (
+      state,
+      action: PayloadAction<MapEntityEditorViewState>,
+    ) => {
+      state.viewState = action.payload;
     },
     reset: () => {
       return initialState;
@@ -49,10 +44,8 @@ const slice = createSlice({
 
 export const {
   setSelectedStopId: setSelectedStopIdAction,
-  setIsCreateStopModeEnabled: setIsCreateStopModeEnabledAction,
-  setIsMoveStopModeEnabled: setIsMoveStopModeEnabledAction,
-  resetEnabledModes: resetEnabledModesAction,
   setDraftLocation: setDraftLocationAction,
+  setMapStopViewState: setMapStopViewStateAction,
   reset: resetMapStopEditorStateAction,
 } = slice.actions;
 

--- a/ui/src/redux/types/MapEntityEditorViewState.ts
+++ b/ui/src/redux/types/MapEntityEditorViewState.ts
@@ -1,0 +1,63 @@
+export enum MapEntityEditorViewState {
+  NONE = 'NONE',
+  PLACE = 'PLACE',
+  CREATE = 'CREATE',
+  POPUP = 'POPUP',
+  EDIT = 'EDIT',
+  MOVE = 'MOVE',
+}
+
+type NonEditingViewState =
+  | MapEntityEditorViewState.NONE
+  | MapEntityEditorViewState.POPUP;
+
+type MoveOrPlaceViewState =
+  | MapEntityEditorViewState.PLACE
+  | MapEntityEditorViewState.MOVE;
+
+type ModalOpenViewState =
+  | MapEntityEditorViewState.CREATE
+  | MapEntityEditorViewState.EDIT;
+
+type EditingViewState = MoveOrPlaceViewState | ModalOpenViewState;
+type StaticPositionViewState = NonEditingViewState | ModalOpenViewState;
+type ModalClosedViewState = NonEditingViewState | MoveOrPlaceViewState;
+
+export function isNoneOrPopup(viewState: NonEditingViewState): true;
+export function isNoneOrPopup(viewState: EditingViewState): false;
+export function isNoneOrPopup(viewState: MapEntityEditorViewState): boolean;
+export function isNoneOrPopup(viewState: MapEntityEditorViewState): boolean {
+  return (
+    viewState === MapEntityEditorViewState.NONE ||
+    viewState === MapEntityEditorViewState.POPUP
+  );
+}
+
+export function isEditorOpen(viewState: NonEditingViewState): false;
+export function isEditorOpen(viewState: EditingViewState): true;
+export function isEditorOpen(viewState: MapEntityEditorViewState): boolean;
+export function isEditorOpen(viewState: MapEntityEditorViewState): boolean {
+  return !isNoneOrPopup(viewState);
+}
+
+export function isPlacingOrMoving(viewState: MoveOrPlaceViewState): true;
+export function isPlacingOrMoving(viewState: StaticPositionViewState): false;
+export function isPlacingOrMoving(viewState: MapEntityEditorViewState): boolean;
+export function isPlacingOrMoving(
+  viewState: MapEntityEditorViewState,
+): boolean {
+  return (
+    viewState === MapEntityEditorViewState.PLACE ||
+    viewState === MapEntityEditorViewState.MOVE
+  );
+}
+
+export function isModalOpen(viewState: ModalOpenViewState): true;
+export function isModalOpen(viewState: ModalClosedViewState): false;
+export function isModalOpen(viewState: MapEntityEditorViewState): boolean;
+export function isModalOpen(viewState: MapEntityEditorViewState): boolean {
+  return (
+    viewState === MapEntityEditorViewState.CREATE ||
+    viewState === MapEntityEditorViewState.EDIT
+  );
+}

--- a/ui/src/redux/types/index.ts
+++ b/ui/src/redux/types/index.ts
@@ -1,2 +1,3 @@
 export * from './mapModal';
 export * from './mapRouteEditor';
+export * from './MapEntityEditorViewState';

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { getUserInfo } from '../api/user';
 import { PageTitle } from '../components/common';
 import { MainPage } from '../components/main/MainPage';
-import { MapModal } from '../components/map';
+import { MapLoader, MapModal } from '../components/map';
 import { JoreLoader } from '../components/map/JoreLoader';
 import { Navbar } from '../components/navbar';
 import { CreateNewLinePage } from '../components/routes-and-lines/create-line/CreateNewLinePage';
@@ -221,6 +221,7 @@ export const Router: FC = () => {
       </Routes>
       <ProtectedRoute>
         <MapModal />
+        <MapLoader />
       </ProtectedRoute>
       <JoreLoader />
       <JoreErrorModal />

--- a/ui/src/uiComponents/LoadingOverlay.tsx
+++ b/ui/src/uiComponents/LoadingOverlay.tsx
@@ -1,3 +1,4 @@
+import { Portal } from '@headlessui/react';
 import React, { useEffect, useRef, useState } from 'react';
 import PulseLoader from 'react-spinners/PulseLoader';
 import { theme } from '../generated/theme';
@@ -100,16 +101,18 @@ export const LoadingOverlay: React.FC<Props> = ({
   }
 
   return (
-    <div
-      className="fixed left-1/2 top-1/2 z-50 flex h-32 -translate-x-1/2 -translate-y-1/2 cursor-wait rounded border border-light-grey bg-background px-20 shadow-lg"
-      data-testid={testId}
-    >
-      <PulseLoader
-        color={theme.colors.brand}
-        size={25}
-        cssOverride={{ margin: 'auto auto' }}
-        speedMultiplier={0.7}
-      />
-    </div>
+    <Portal>
+      <div
+        className="fixed left-1/2 top-1/2 z-20 flex h-32 -translate-x-1/2 -translate-y-1/2 cursor-wait rounded border border-light-grey bg-background px-20 shadow-lg"
+        data-testid={testId}
+      >
+        <PulseLoader
+          color={theme.colors.brand}
+          size={25}
+          cssOverride={{ margin: 'auto auto' }}
+          speedMultiplier={0.7}
+        />
+      </div>
+    </Portal>
   );
 };


### PR DESCRIPTION
### Drop unused import from useGetStopInfoForEditingOnMap


### Make useAppAction stable


### Fix MapLoader being hidden under dialogs
* Wrap `<LoadingOverlay>` in Headless UI Portal.
* Move `<MapLoader>` out of MapModal, so the new portal does it not get nested inside the map "Dialog".


### Change LineToClosestInfraLink layer ID


### Centralize StopArea map view state
* Use single variable in Redux store to tell the state of StopArea "editing":
  - Nothing active
  - Popup open
  - Placing new stop area
  - Modal open for new area
  - Modal open for existing stop area
  - Moving exsting area


### Centralize Stop map view state.

Use single Redux state to store the view state. Like was done for StopAreas in the previous commit.


### Drop unneeded StopPoint error handling from MemberStop


### Replace stopAreaEditorIsActive state with mapStopAreaViewState


### Allow getting StopPlace details by external id


### Fetch StopPlace NetexID for map stops


### Return updated EnrichedStopPlace from useUpsertStopArea


### Refetch data on Map Entity mutations


### Add `<LineToActiveStopArea>` component
Draws a line between the selected StopArea and another given point, mouse location or the draft location of a new Stop.


### Add stop to active Area & ensure proper Stop⋄Area state transitions

Classic case of: I need to refactor and fix these 20 bugs, before I can implement this new Feature, without introducing 10 new bugs.

Most of the refactoring work has been extracted to separate commits, but due to multiple things having changed, it is no more clear which commit these changes would or even could belong to.

* Add support for adding a new Stop on the map to an StopArea, by having the StopArea selected and active, when clicking the "Add new stop" -button. StopArea details will be preselected on the Stop details form.
* Ensure that related Stop and StopArea are viasually connected to each other on the map.
* Ensure only valid state transitions between Stop/StopArea view states are permitted.


### Add "Add new stop" -button to StopAreaPopup


### Add test for adding stop with preselected StopArea

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1088)
<!-- Reviewable:end -->
