### PR TITLE
Fix Map stop/Area queries \ Speed them up

### DIFF
--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -81,16 +81,26 @@ export const Maplibre: FC<PropsWithChildren<MaplibreProps>> = ({
 
   const updateMapDetailsDebounced = useMemo(
     () =>
-      debounce((latitude, longitude, zoom, radius) => {
-        dispatch(
-          setViewPortAction({
-            latitude,
-            longitude,
-            radius,
-          }),
-        );
-        setMapPosition(latitude, longitude, zoom);
-      }, 800),
+      debounce(
+        (
+          latitude: number,
+          longitude: number,
+          zoom: number,
+          radius: number,
+          bounds: [number, number][],
+        ) => {
+          dispatch(
+            setViewPortAction({
+              latitude,
+              longitude,
+              radius,
+              bounds,
+            }),
+          );
+          setMapPosition(latitude, longitude, zoom);
+        },
+        800,
+      ),
     [dispatch, setMapPosition],
   );
 
@@ -123,6 +133,7 @@ export const Maplibre: FC<PropsWithChildren<MaplibreProps>> = ({
         newViewport.longitude,
         newViewport.zoom,
         radius,
+        bounds.toArray(),
       );
     }
   };

--- a/ui/src/components/map/stops/useGetMapStops.ts
+++ b/ui/src/components/map/stops/useGetMapStops.ts
@@ -39,14 +39,21 @@ export type MapStop = FilterableStopInfo & {
 function viewportToWhere(
   viewport: Viewport,
 ): StopsDatabaseQuayNewestVersionBoolExp {
+  const [[west, south], [east, north]] = viewport.bounds;
+
   return {
     centroid: {
-      _st_d_within: {
-        from: {
-          type: 'Point',
-          coordinates: [viewport.longitude, viewport.latitude],
-        },
-        distance: viewport.radius,
+      _st_within: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [west, south],
+            [east, south],
+            [east, north],
+            [west, north],
+            [west, south],
+          ],
+        ],
       },
     },
   };

--- a/ui/src/redux/slices/mapModal.ts
+++ b/ui/src/redux/slices/mapModal.ts
@@ -1,26 +1,36 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { Viewport } from '../types';
 
+type Mutable<T> = { -readonly [P in keyof T]: Mutable<T[P]> };
+type MutableViewport = Mutable<Viewport>;
+
 export const HELSINKI_CITY_CENTER_COORDINATES = {
   latitude: 60.1716,
   longitude: 24.9409,
 };
 
-interface IState {
-  isOpen: boolean;
-  viewport: Viewport;
-}
+type IState = {
+  readonly isOpen: boolean;
+  readonly viewport: Viewport;
+};
 
 const initialState: IState = {
   isOpen: false,
-  viewport: { ...HELSINKI_CITY_CENTER_COORDINATES, radius: 0 },
+  viewport: {
+    ...HELSINKI_CITY_CENTER_COORDINATES,
+    radius: 0,
+    bounds: [
+      [0, 0],
+      [0, 0],
+    ],
+  },
 };
 
 const slice = createSlice({
   name: 'mapModal',
   initialState,
   reducers: {
-    setViewPort: (state: IState, action: PayloadAction<Viewport>) => {
+    setViewPort: (state, action: PayloadAction<MutableViewport>) => {
       state.viewport = action.payload;
     },
     reset: () => {

--- a/ui/src/redux/types/mapModal.ts
+++ b/ui/src/redux/types/mapModal.ts
@@ -1,5 +1,6 @@
-export interface Viewport {
-  latitude: number;
-  longitude: number;
-  radius: number;
-}
+export type Viewport = {
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly radius: number;
+  readonly bounds: ReadonlyArray<readonly [number, number]>;
+};

--- a/ui/src/utils/gql.ts
+++ b/ui/src/utils/gql.ts
@@ -172,15 +172,24 @@ export const buildWithinViewportGqlFilter = (
 
 export const buildWithinViewportGqlGeometryFilter = (
   viewport: Viewport,
-): GeometryComparisonExp => ({
-  _st_d_within: {
-    from: {
-      type: 'Point',
-      coordinates: [viewport.longitude, viewport.latitude],
+): GeometryComparisonExp => {
+  const [[west, south], [east, north]] = viewport.bounds;
+
+  return {
+    _st_within: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [west, south],
+          [east, south],
+          [east, north],
+          [west, north],
+          [west, south],
+        ],
+      ],
     },
-    distance: viewport.radius,
-  },
-});
+  };
+};
 
 /** Builds an object for gql to filter by primary_vehicle_mode */
 export const buildPrimaryVehicleModeGqlFilter = (


### PR DESCRIPTION
Why queries were slow: The map stored the "viewport radius" in meters in the Redux store, and then the queries asked for stops that were within a max distance of "radius" from the center point of the map screen. That might have worked correcly when we were fetching the stops based on the StopPoint, for witch the locaiton is stores as Geography type in the db, but on Tiamat side, that locations are stored as Geometry types, for witch the distance needs to be queried in "degrees" and not in meters. So in practice the old query always asked for every single stop within the known universe.

Instead of doing math on multiple ends (calculation "radius", converting that to "degrees" in UI and calculating distance per stop on db side) we can just store the actual corner coordinates, aka the "bounds" of the map, and query for points within that rectangle.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1091)
<!-- Reviewable:end -->
