### PR TITLE
Fix dispatching Cypress after:run event to multiple plugins

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,7 +72,7 @@ jobs:
       azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   run_e2e_tests:
-    name: Run e2e tests
+    name: Run E2E tests
     needs:
       - publish_ui_docker_image_to_acr
       - publish_cypress_docker_image_to_acr

--- a/cypress/support/compositeEventHandler.ts
+++ b/cypress/support/compositeEventHandler.ts
@@ -1,0 +1,91 @@
+type AfterSpecHandlerFn = (
+  spec: Cypress.Spec,
+  results: CypressCommandLine.RunResult,
+) => void | Promise<void>;
+
+type AfterRunHandlerFn = (
+  results:
+    | CypressCommandLine.CypressRunResult
+    | CypressCommandLine.CypressFailedRunResult,
+) => void | Promise<void>;
+
+type BeforeRunHandlerFn = (
+  runDetails: Cypress.BeforeRunDetails,
+) => void | Promise<void>;
+
+// The compositeOn supports only events that are used by multiple plugins, i.e.
+// currently (2025-06) cypress-split and cypress-ctrf-json-reporter
+export class CompositeCypressEventHandler {
+  private compositeHandlers: {
+    'after:spec': AfterSpecHandlerFn[];
+    'before:run': BeforeRunHandlerFn[];
+    'after:run': AfterRunHandlerFn[];
+  };
+
+  constructor(on: Cypress.PluginEvents) {
+    this.compositeHandlers = {
+      'after:spec': [],
+      'after:run': [],
+      'before:run': [],
+    };
+
+    on('after:spec', this.onAfterSpec.bind(this));
+    on('before:run', this.onBeforeRun.bind(this));
+    on('after:run', this.onAfterRun.bind(this));
+  }
+
+  on(task: string, fn: unknown): void {
+    switch (task) {
+      case 'after:spec': {
+        this.compositeHandlers['after:spec'].push(fn as AfterSpecHandlerFn);
+        break;
+      }
+      case 'before:run': {
+        this.compositeHandlers['before:run'].push(fn as BeforeRunHandlerFn);
+        break;
+      }
+      case 'after:run': {
+        this.compositeHandlers['after:run'].push(fn as AfterRunHandlerFn);
+        break;
+      }
+      default: {
+        throw new Error(
+          `This compositeOn does not support handlers of type ${task}!`,
+        );
+      }
+    }
+  }
+
+  private async onAfterSpec(
+    spec: Cypress.Spec,
+    results: CypressCommandLine.RunResult,
+  ): Promise<void> {
+    await Promise.all(
+      this.compositeHandlers['after:spec'].map((handler) =>
+        handler.call(null, spec, results),
+      ),
+    );
+  }
+
+  private async onBeforeRun(
+    runDetails: Cypress.BeforeRunDetails,
+  ): Promise<void> {
+    await Promise.all(
+      this.compositeHandlers['before:run'].map((handler) =>
+        handler.call(null, runDetails),
+      ),
+    );
+  }
+
+  private async onAfterRun(
+    results:
+      | CypressCommandLine.CypressRunResult
+      | CypressCommandLine.CypressFailedRunResult,
+  ): Promise<void> {
+    await Promise.all(
+      this.compositeHandlers['after:run'].map((handler) =>
+        handler.call(null, results),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Both cypress-ctrf-json-reporter and cypress-split plugins are registering for this event currently. Because cypress-ctrf-json-reporter was the last to register for this event, cypress-split's after:run handler was not called which caused cypress-split not to write E2E test durations into a file for later use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1116)
<!-- Reviewable:end -->
