### PR TITLE
Fix saving stop area details not working if any quay doesn't have description

### DIFF
--- a/ui/src/components/forms/stop-area/stopAreaFormSchema.tsx
+++ b/ui/src/components/forms/stop-area/stopAreaFormSchema.tsx
@@ -7,8 +7,8 @@ import {
 } from '../common';
 
 const nameSchema = z.object({
-  value: requiredString,
-  lang: requiredString,
+  value: z.string().optional(),
+  lang: z.string().optional(),
 });
 
 const scheduledStopPointLabelSchema = z.object({

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaDetailsEdit.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import React, { ForwardRefRenderFunction, forwardRef, useMemo } from 'react';
+import { ForwardRefRenderFunction, forwardRef, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';


### PR DESCRIPTION
Make the name field (quay location) of the area's quays optional for saving stop area details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1124)
<!-- Reviewable:end -->
