### PR TITLE
Make old terminal location icon correct style when moving terminal

### DIFF
--- a/ui/src/components/map/markers/TerminalMarker.tsx
+++ b/ui/src/components/map/markers/TerminalMarker.tsx
@@ -25,13 +25,16 @@ export const TerminalMarker: FC<TerminalMarkerProps> = ({
       data-placeholder={isPlaceholder}
       data-selected={selected}
       data-testid={testId}
-      className="flex cursor-pointer items-center justify-center rounded bg-tweaked-brand text-white hover:bg-tweaked-brand-darker30 data-[placeholder=true]:bg-dark-grey data-[selected=true]:bg-background-hsl-button-selected"
+      className="flex cursor-pointer items-center justify-center rounded bg-tweaked-brand text-white hover:bg-tweaked-brand-darker30 data-[placeholder=true]:border data-[placeholder=true]:border-dashed data-[placeholder=true]:border-grey data-[placeholder=true]:bg-white data-[selected=true]:bg-background-hsl-button-selected"
       style={{ width, height: width, fontSize }}
       aria-hidden
       onClick={onClick}
       title={title}
     >
-      <i className="icon-bus" />
+      <i
+        data-placeholder={isPlaceholder}
+        className="icon-bus data-[placeholder=true]:text-grey"
+      />
     </div>
   );
 };


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1144)
<!-- Reviewable:end -->
