### PR TITLE
Implement popover notifying user about future stop area versions when moving a stop

### DIFF
--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -347,12 +347,12 @@ describe('Stop area details', () => {
       assertBasicDetails(newBasicDetails);
     });
 
-    it('should allow adding member stops', () => {
+    it('should allow moving member stop to the stop area', () => {
       stopAreaDetailsPage.memberStops.getAddStopButton().click();
       stopAreaDetailsPage.memberStops.modal.modal().shouldBeVisible();
       selectMemberStopsDropdown.dropdownButton().click();
-      selectMemberStopsDropdown.getInput().click({ force: true });
-      selectMemberStopsDropdown.getInput().clear().type('E2E003');
+      selectMemberStopsDropdown.getInput().click();
+      selectMemberStopsDropdown.getInput().clearAndType('E2E003');
       selectMemberStopsDropdown.getMemberOptions().should('have.length', 1);
       selectMemberStopsDropdown
         .getMemberOptions()
@@ -378,6 +378,16 @@ describe('Stop area details', () => {
       stopAreaDetailsPage.memberStops.getStopRow('E2E001').shouldBeVisible();
       stopAreaDetailsPage.memberStops.getStopRow('E2E003').shouldBeVisible();
       stopAreaDetailsPage.memberStops.getStopRow('E2E009').shouldBeVisible();
+    });
+
+    it('should not find member stop to move to the stop area if it already is in the stop area', () => {
+      stopAreaDetailsPage.memberStops.getAddStopButton().click();
+      stopAreaDetailsPage.memberStops.modal.modal().shouldBeVisible();
+      selectMemberStopsDropdown.dropdownButton().click();
+      selectMemberStopsDropdown.getInput().click();
+      selectMemberStopsDropdown.getInput().clearAndType('E2E001');
+      selectMemberStopsDropdown.getMemberOptions().should('have.length', 0);
+      stopAreaDetailsPage.memberStops.modal.saveButton().should('be.disabled');
     });
 
     it('should handle unique name exception', () => {

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
@@ -37,14 +37,15 @@ export function sortByPublicCode(
 type SelectMemberStopsDropdownProps = {
   readonly className?: string;
   readonly disabled?: boolean;
-  readonly value: SelectedStop | undefined;
+  readonly value: SelectedStop | null;
   readonly onSelectionChange: (
-    newValue: SelectedStop | undefined,
-    currentValue: SelectedStop | undefined,
+    newValue: SelectedStop | null,
+    currentValue: SelectedStop | null,
     options: SelectedStop[],
   ) => void;
   readonly testId?: string;
   readonly inputAriaLabel?: string;
+  readonly areaId?: string;
 };
 
 export const SelectMemberStopsDropdownArea: FC<
@@ -56,6 +57,7 @@ export const SelectMemberStopsDropdownArea: FC<
   testId,
   onSelectionChange,
   inputAriaLabel,
+  areaId,
 }) => {
   const [query, setQuery] = useState('');
   const [isInputFocused, setIsInputFocused] = useState(false);
@@ -64,12 +66,14 @@ export const SelectMemberStopsDropdownArea: FC<
   const { options, loading, allFetched, fetchNextPage } =
     useFindQuaysByQuery(cleanQuery);
 
-  const unselectedOptions = useMemo(
-    () => options.filter((stop) => stop.stopPlaceId !== value?.stopPlaceId),
-    [value?.stopPlaceId, options],
-  );
+  const unselectedOptions = useMemo(() => {
+    return options.filter(
+      (stop) =>
+        stop.stopPlaceId !== value?.stopPlaceId && stop.stopPlaceId !== areaId,
+    );
+  }, [options, value?.stopPlaceId, areaId]);
 
-  const handleSelectionChange = (newValue: SelectedStop | undefined) => {
+  const handleSelectionChange = (newValue: SelectedStop | null) => {
     if (newValue === FETCH_MORE_OPTION) {
       fetchNextPage().catch((error) =>
         log.error('Failed to fetch next page:', error),

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/FutureVersionsAlertPopover.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/FutureVersionsAlertPopover.tsx
@@ -1,0 +1,38 @@
+import { Popover } from '@headlessui/react';
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IoAlertSharp } from 'react-icons/io5';
+import { twMerge } from 'tailwind-merge';
+import { getHoverStyles } from '../../../../../uiComponents';
+
+type FutureVersionsAlertPopoverProps = {
+  readonly className?: string;
+};
+
+export const FutureVersionsAlertPopover: FC<
+  FutureVersionsAlertPopoverProps
+> = ({ className }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Popover>
+      <Popover.Button
+        className={twMerge(
+          'h-8 w-8',
+          'flex items-center justify-center',
+          'rounded-full border-2 border-brand',
+          'disabled:pointer-events-none disabled:bg-background disabled:opacity-70',
+          getHoverStyles(),
+          className,
+        )}
+      >
+        <IoAlertSharp className="text-2xl text-brand" />
+      </Popover.Button>
+      <Popover.Panel className="absolute z-20 ml-2 mt-2 inline-flex w-52 flex-row items-start rounded-lg border border-light-grey bg-white p-2 drop-shadow-md">
+        <p className="text-xs">
+          {t('stopAreaDetails.memberStops.futureVersionsAlert')}
+        </p>
+      </Popover.Panel>
+    </Popover>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopModal.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopModal.tsx
@@ -131,12 +131,11 @@ export const StopAreaMemberStopModal: FC<StopAreaMemberStopModalProps> = ({
 
   const handleStopSelection = useCallback(
     (
-      newValue: SelectedStop | undefined,
-      formOnChange?: (value: SelectedStop | undefined) => void,
+      newValue: SelectedStop | null,
+      formOnChange?: (value: SelectedStop | null) => void,
     ) => {
-      const stopValue = newValue ?? null;
       updateState({
-        selectedStop: stopValue,
+        selectedStop: newValue,
         showVersions: false,
       });
 
@@ -184,11 +183,12 @@ export const StopAreaMemberStopModal: FC<StopAreaMemberStopModalProps> = ({
             {t('stopAreaDetails.memberStops.getStop')}
           </div>
           <SelectMemberStopsDropdownArea
-            value={selectedStop ?? undefined}
+            value={selectedStop ?? null}
             testId={testIds.selectMemberStops}
             onSelectionChange={(newValue) =>
               handleStopSelection(newValue, undefined)
             }
+            areaId={areaId}
           />
         </div>
 

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStops.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStops.tsx
@@ -14,7 +14,7 @@ export const StopAreaMemberStops: FC<EditableStopAreaComponentProps> = ({
       <div className="flex items-center gap-4">
         <h2>{t('stopAreaDetails.memberStops.title')}</h2>
 
-        {area.id && <StopAreaMemberStopsHeader areaId={area.id} />}
+        <StopAreaMemberStopsHeader area={area} />
       </div>
 
       <StopAreaMemberStopRows area={area} />

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsHeader.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsHeader.tsx
@@ -1,5 +1,6 @@
-import React, { FC, useState } from 'react';
+import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { EnrichedStopPlace } from '../../../../../types';
 import { SlimSimpleButton } from '../../../stops/stop-details/layout';
 import { StopAreaMemberStopModal } from './StopAreaMemberStopModal';
 
@@ -8,11 +9,11 @@ const testIds = {
 };
 
 type StopAreaMemberStopsHeaderProps = {
-  readonly areaId: string;
+  readonly area: EnrichedStopPlace;
 };
 
 export const StopAreaMemberStopsHeader: FC<StopAreaMemberStopsHeaderProps> = ({
-  areaId,
+  area,
 }) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -24,6 +25,10 @@ export const StopAreaMemberStopsHeader: FC<StopAreaMemberStopsHeaderProps> = ({
   const handleCloseModal = () => {
     setIsModalOpen(false);
   };
+
+  if (!area.id || !area.privateCode?.value) {
+    return null;
+  }
 
   return (
     <>
@@ -42,7 +47,8 @@ export const StopAreaMemberStopsHeader: FC<StopAreaMemberStopsHeaderProps> = ({
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         onSave={handleCloseModal}
-        areaId={areaId}
+        areaId={area.id}
+        areaPrivateCode={area.privateCode.value}
       />
     </>
   );

--- a/ui/src/components/stop-registry/stop-areas/versions/queries/useGetStopAreaVersions.ts
+++ b/ui/src/components/stop-registry/stop-areas/versions/queries/useGetStopAreaVersions.ts
@@ -1,0 +1,96 @@
+import { gql } from '@apollo/client';
+import { useMemo } from 'react';
+import {
+  StopAreaVersionInfoFragment,
+  useGetStopPlaceVersionsQuery,
+} from '../../../../../generated/graphql';
+import { parseDate } from '../../../../../time';
+import { getGeometryPoint, requireValue } from '../../../../../utils';
+import { StopAreaVersion } from '../types';
+
+const GQL_GET_STOP_PLACE_VERSIONS = gql`
+  query GetStopPlaceVersions($privateCode: String!) {
+    stops_database {
+      stopAreas: stops_database_stop_place_newest_version(
+        where: { private_code_value: { _eq: $privateCode } }
+        order_by: [{ validity_start: asc }, { priority: asc }]
+      ) {
+        ...StopAreaVersionInfo
+      }
+    }
+  }
+
+  fragment StopAreaVersionInfo on stops_database_stop_place_newest_version {
+    id
+    netex_id
+    private_code_type
+    private_code_value
+    name_value
+
+    validity_start
+    validity_end
+
+    centroid
+
+    created
+    changed
+    changed_by
+    version_comment
+  }
+`;
+
+function mapRawStopAreaToStopAreaVersion(
+  rawStopArea: StopAreaVersionInfoFragment,
+): StopAreaVersion {
+  return {
+    id: rawStopArea.id,
+    netex_id: requireValue(rawStopArea.netex_id),
+    private_code: requireValue(rawStopArea.private_code_value),
+    name: rawStopArea.name_value ?? '',
+
+    validity_start: requireValue(parseDate(rawStopArea.validity_start)),
+    validity_end: parseDate(rawStopArea.validity_end) ?? null,
+
+    location: requireValue(getGeometryPoint(rawStopArea.centroid)),
+
+    created: requireValue(parseDate(rawStopArea.created)),
+    changed: requireValue(parseDate(rawStopArea.changed)),
+    changed_by: rawStopArea.changed_by ?? '',
+    version_comment: rawStopArea.version_comment ?? '',
+  };
+}
+
+type GetStopAreaVersionsLoading = {
+  readonly loading: true;
+  readonly stopAreaVersions: null;
+};
+
+type GetStopAreaVersionsLoaded = {
+  readonly loading: false;
+  readonly stopAreaVersions: ReadonlyArray<StopAreaVersion>;
+};
+
+export function useGetStopAreaVersions(
+  privateCode: string,
+): GetStopAreaVersionsLoading | GetStopAreaVersionsLoaded {
+  const { data, loading } = useGetStopPlaceVersionsQuery({
+    variables: { privateCode },
+    skip: !privateCode,
+  });
+
+  const rawStopAreas = data?.stops_database?.stopAreas;
+
+  const stopAreaVersions: ReadonlyArray<StopAreaVersion> = useMemo(() => {
+    if (!rawStopAreas) {
+      return [];
+    }
+
+    return rawStopAreas.map(mapRawStopAreaToStopAreaVersion);
+  }, [rawStopAreas]);
+
+  if (loading) {
+    return { loading: true, stopAreaVersions: null };
+  }
+
+  return { loading: false, stopAreaVersions };
+}

--- a/ui/src/components/stop-registry/stop-areas/versions/types/StopAreaVersion.ts
+++ b/ui/src/components/stop-registry/stop-areas/versions/types/StopAreaVersion.ts
@@ -1,0 +1,19 @@
+import { DateTime } from 'luxon';
+import { Point } from '../../../../../types';
+
+export type StopAreaVersion = {
+  readonly id: number;
+  readonly netex_id: string;
+  readonly private_code: string;
+  readonly name: string;
+
+  readonly validity_start: DateTime;
+  readonly validity_end: DateTime | null;
+
+  readonly location: Point;
+
+  readonly created: DateTime;
+  readonly changed: DateTime;
+  readonly changed_by: string;
+  readonly version_comment: string;
+};

--- a/ui/src/components/stop-registry/stop-areas/versions/types/index.ts
+++ b/ui/src/components/stop-registry/stop-areas/versions/types/index.ts
@@ -1,0 +1,1 @@
+export * from './StopAreaVersion';

--- a/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersions.ts
+++ b/ui/src/components/stop-registry/stops/versions/queries/useGetStopVersions.ts
@@ -131,6 +131,7 @@ export function useGetStopVersions(
 ): GetStopVersionsLoading | GetStopVersionsLoaded {
   const { data, loading } = useGetQuayVersionsQuery({
     variables: { publicCode },
+    skip: !publicCode,
   });
 
   const rawQuays = data?.stops_database?.quays;

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -69357,6 +69357,49 @@ export type StopPlaceDetailsFragment = {
   } | null> | null
 };
 
+export type GetStopPlaceVersionsQueryVariables = Exact<{
+  privateCode: Scalars['String']['input'];
+}>;
+
+
+export type GetStopPlaceVersionsQuery = {
+  readonly __typename?: 'query_root',
+  readonly stops_database?: {
+    readonly __typename?: 'stops_database_stops_database_query',
+    readonly stopAreas: ReadonlyArray<{
+      readonly __typename?: 'stops_database_stop_place_newest_version',
+      readonly id?: any | null,
+      readonly netex_id?: string | null,
+      readonly private_code_type?: string | null,
+      readonly private_code_value?: string | null,
+      readonly name_value?: string | null,
+      readonly validity_start?: string | null,
+      readonly validity_end?: string | null,
+      readonly centroid?: GeoJSON.Geometry | null,
+      readonly created?: any | null,
+      readonly changed?: any | null,
+      readonly changed_by?: string | null,
+      readonly version_comment?: string | null
+    }>
+  } | null
+};
+
+export type StopAreaVersionInfoFragment = {
+  readonly __typename?: 'stops_database_stop_place_newest_version',
+  readonly id?: any | null,
+  readonly netex_id?: string | null,
+  readonly private_code_type?: string | null,
+  readonly private_code_value?: string | null,
+  readonly name_value?: string | null,
+  readonly validity_start?: string | null,
+  readonly validity_end?: string | null,
+  readonly centroid?: GeoJSON.Geometry | null,
+  readonly created?: any | null,
+  readonly changed?: any | null,
+  readonly changed_by?: string | null,
+  readonly version_comment?: string | null
+};
+
 export type DeleteQuayMutationVariables = Exact<{
   stopPlaceId: Scalars['String']['input'];
   quayId: Scalars['String']['input'];
@@ -76849,6 +76892,22 @@ ${QuayDetailsFragmentDoc}
 ${AccessibilityAssessmentDetailsFragmentDoc}
 ${TopographicPlaceDetailsFragmentDoc}
 ${FareZoneDetailsFragmentDoc}`;
+export const StopAreaVersionInfoFragmentDoc = gql`
+    fragment StopAreaVersionInfo on stops_database_stop_place_newest_version {
+  id
+  netex_id
+  private_code_type
+  private_code_value
+  name_value
+  validity_start
+  validity_end
+  centroid
+  created
+  changed
+  changed_by
+  version_comment
+}
+    `;
 export const StopPointDetailsFragmentDoc = gql`
     fragment StopPointDetails on service_pattern_scheduled_stop_point {
   stop_place_ref
@@ -78744,6 +78803,51 @@ export type GetStopPlaceDetailsQueryHookResult = ReturnType<typeof useGetStopPla
 export type GetStopPlaceDetailsLazyQueryHookResult = ReturnType<typeof useGetStopPlaceDetailsLazyQuery>;
 export type GetStopPlaceDetailsSuspenseQueryHookResult = ReturnType<typeof useGetStopPlaceDetailsSuspenseQuery>;
 export type GetStopPlaceDetailsQueryResult = Apollo.QueryResult<GetStopPlaceDetailsQuery, GetStopPlaceDetailsQueryVariables>;
+export const GetStopPlaceVersionsDocument = gql`
+    query GetStopPlaceVersions($privateCode: String!) {
+  stops_database {
+    stopAreas: stops_database_stop_place_newest_version(
+      where: {private_code_value: {_eq: $privateCode}}
+      order_by: [{validity_start: asc}, {priority: asc}]
+    ) {
+      ...StopAreaVersionInfo
+    }
+  }
+}
+    ${StopAreaVersionInfoFragmentDoc}`;
+
+/**
+ * __useGetStopPlaceVersionsQuery__
+ *
+ * To run a query within a React component, call `useGetStopPlaceVersionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetStopPlaceVersionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetStopPlaceVersionsQuery({
+ *   variables: {
+ *      privateCode: // value for 'privateCode'
+ *   },
+ * });
+ */
+export function useGetStopPlaceVersionsQuery(baseOptions: Apollo.QueryHookOptions<GetStopPlaceVersionsQuery, GetStopPlaceVersionsQueryVariables> & ({ variables: GetStopPlaceVersionsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetStopPlaceVersionsQuery, GetStopPlaceVersionsQueryVariables>(GetStopPlaceVersionsDocument, options);
+      }
+export function useGetStopPlaceVersionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetStopPlaceVersionsQuery, GetStopPlaceVersionsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetStopPlaceVersionsQuery, GetStopPlaceVersionsQueryVariables>(GetStopPlaceVersionsDocument, options);
+        }
+export function useGetStopPlaceVersionsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetStopPlaceVersionsQuery, GetStopPlaceVersionsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<GetStopPlaceVersionsQuery, GetStopPlaceVersionsQueryVariables>(GetStopPlaceVersionsDocument, options);
+        }
+export type GetStopPlaceVersionsQueryHookResult = ReturnType<typeof useGetStopPlaceVersionsQuery>;
+export type GetStopPlaceVersionsLazyQueryHookResult = ReturnType<typeof useGetStopPlaceVersionsLazyQuery>;
+export type GetStopPlaceVersionsSuspenseQueryHookResult = ReturnType<typeof useGetStopPlaceVersionsSuspenseQuery>;
+export type GetStopPlaceVersionsQueryResult = Apollo.QueryResult<GetStopPlaceVersionsQuery, GetStopPlaceVersionsQueryVariables>;
 export const DeleteQuayDocument = gql`
     mutation DeleteQuay($stopPlaceId: String!, $quayId: String!) {
   stop_registry {

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -187,7 +187,8 @@
       "statusTag": {
         "added": "Added",
         "removed": "Removed"
-      }
+      },
+      "futureVersionsAlert": "The stop area has future versions. After the move, this stop belongs only to the stop area version it was moved to. The stop does not automatically belong to future stop area versions. Create a copy of the stop for future area versions if necessary."
     },
     "errors": {
       "stopPlacesUniqueName": "Stop area should have unique name but {{name}} is already in use!",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -187,7 +187,8 @@
       "statusTag": {
         "added": "Lisätty",
         "removed": "poistettu"
-      }
+      },
+      "futureVersionsAlert": "Pysäkkialuella on tulevia versioita. Siirron jälkeen, tämä pysäkki kuuluu vain ja ainoastaan siihen pysäkkialueen versioon, johon se on siirretty. Pysäkki ei automaattisesti kuulu tuleviin pysäkkialueen versioihin. Luo pysäkistä kopio tuleviin alueen versioihin tarpeen vaatiessa."
     },
     "errors": {
       "stopPlacesUniqueName": "Pysäkkialueella tulee olla uniikki nimi, mutta nimi {{name}} on jo jonkin toisen alueen käytössä!",


### PR DESCRIPTION
- Implement a popover notifying the user about future stop area versions when moving a stop
- Fix existing issues with the stop search dropdown
  - Dropdown going from uncontrolled to controlled
  - Search returning stops that are already part of the stop area

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1150)
<!-- Reviewable:end -->
