### PR TITLE
Only invalidate ui build layer when NEXT_PUBLIC_GIT value changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ COPY ./ui/public ./ui/public
 COPY ./ui/tsconfig.json ./ui/next.config.js ./ui/next-env.d.ts ./ui/tailwind.config.js ./ui/postcss.config.js ./ui/convert-theme-to-ts.js ./ui/theme.js ./ui/graphql.schema.json ./ui/
 COPY ./test-db-manager/rollup.config.mjs ./test-db-manager/tsconfig.json ./test-db-manager/
 
-ARG NEXT_PUBLIC_GIT_HASH=unknown
 RUN yarn ws:db run build
+ARG NEXT_PUBLIC_GIT_HASH=unknown
 RUN yarn ws:ui run build
 
 FROM nginx:1.24.0-alpine


### PR DESCRIPTION
Previously also the db build layer was invalidated even if the NEXT_PUBLIC_GIT is not used there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1152)
<!-- Reviewable:end -->
