### PR TITLE
Fix more issues with moving stop to a stop place

### DIFF
--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/SelectMemberStopsDropdown.tsx
@@ -68,10 +68,9 @@ export const SelectMemberStopsDropdownArea: FC<
 
   const unselectedOptions = useMemo(() => {
     return options.filter(
-      (stop) =>
-        stop.stopPlaceId !== value?.stopPlaceId && stop.stopPlaceId !== areaId,
+      (stop) => stop.quayId !== value?.quayId && stop.stopPlaceId !== areaId,
     );
-  }, [options, value?.stopPlaceId, areaId]);
+  }, [options, value?.quayId, areaId]);
 
   const handleSelectionChange = (newValue: SelectedStop | null) => {
     if (newValue === FETCH_MORE_OPTION) {

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/useMoveQuayToStopPlace.ts
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/useMoveQuayToStopPlace.ts
@@ -9,7 +9,7 @@ import {
 import { showDangerToastWithError } from '../../../../utils';
 import {
   createAndInsertStopPoint,
-  createQuayMapping,
+  createQuayMappingForCopiedQuay,
   executeQuayMove,
   extractQuayValidityEnd,
   extractStopPlaceQuays,
@@ -62,7 +62,11 @@ export const useMoveQuayToStopPlace = () => {
       const movedStopPlace = await executeQuayMove(params, moveQuayMutation);
 
       const newQuays = extractStopPlaceQuays(movedStopPlace);
-      const quayMapping = createQuayMapping(originalQuays, newQuays);
+      const quayMapping = createQuayMappingForCopiedQuay(
+        originalQuays,
+        newQuays,
+        params.moveQuayFromDate,
+      );
 
       const originalQuayId = stopPointNeedingUpdate.stop_place_ref;
       if (!originalQuayId) {

--- a/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/utils/types.ts
+++ b/ui/src/components/forms/stop-area/SelectMemberStopsDropdown/utils/types.ts
@@ -11,6 +11,7 @@ export type MoveQuayParams = {
 export type QuayInfo = {
   id: string;
   publicCode: string;
+  validityStart?: string;
 };
 
 export type StopPointInfo =

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopModal.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopModal.tsx
@@ -34,6 +34,7 @@ type StopAreaMemberStopModalProps = {
   readonly onSave: () => void;
   readonly areaId: string;
   readonly areaPrivateCode: string;
+  readonly refetch: () => Promise<unknown>;
 };
 
 type ModalState = {
@@ -92,6 +93,7 @@ export const StopAreaMemberStopModal: FC<StopAreaMemberStopModalProps> = ({
   onSave,
   areaId,
   areaPrivateCode,
+  refetch,
 }) => {
   const { t } = useTranslation();
   const [state, setState] = useState<ModalState>(initialState);
@@ -156,6 +158,7 @@ export const StopAreaMemberStopModal: FC<StopAreaMemberStopModalProps> = ({
 
     try {
       await moveQuayToStopPlace(saveParams);
+      await refetch();
 
       onSave();
       handleClose();

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStops.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStops.tsx
@@ -6,6 +6,7 @@ import { StopAreaMemberStopsHeader } from './StopAreaMemberStopsHeader';
 
 export const StopAreaMemberStops: FC<EditableStopAreaComponentProps> = ({
   area,
+  refetch,
 }) => {
   const { t } = useTranslation();
 
@@ -14,7 +15,7 @@ export const StopAreaMemberStops: FC<EditableStopAreaComponentProps> = ({
       <div className="flex items-center gap-4">
         <h2>{t('stopAreaDetails.memberStops.title')}</h2>
 
-        <StopAreaMemberStopsHeader area={area} />
+        <StopAreaMemberStopsHeader area={area} refetch={refetch} />
       </div>
 
       <StopAreaMemberStopRows area={area} />

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsHeader.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaMemberStopsHeader.tsx
@@ -10,10 +10,12 @@ const testIds = {
 
 type StopAreaMemberStopsHeaderProps = {
   readonly area: EnrichedStopPlace;
+  readonly refetch: () => Promise<unknown>;
 };
 
 export const StopAreaMemberStopsHeader: FC<StopAreaMemberStopsHeaderProps> = ({
   area,
+  refetch,
 }) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -49,6 +51,7 @@ export const StopAreaMemberStopsHeader: FC<StopAreaMemberStopsHeaderProps> = ({
         onSave={handleCloseModal}
         areaId={area.id}
         areaPrivateCode={area.privateCode.value}
+        refetch={refetch}
       />
     </>
   );


### PR DESCRIPTION
- Refetch area stops after moving a stop
- Improve stop search
- Fix moving stop back to the original stop area after copying it to another area first

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1158)
<!-- Reviewable:end -->
