### PR TITLE
Only query monomodal StopPlaces in Quay queries

### DIFF
--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/utils/queries.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/utils/queries.ts
@@ -76,7 +76,7 @@ const GQL_UPDATE_STOP_POINT = gql`
 const GQL_GET_ORIGINAL_QUAYS = gql`
   query GetOriginalQuays($quayId: String!) {
     stop_registry {
-      stopPlace(query: $quayId) {
+      stopPlace(query: $quayId, onlyMonomodalStopPlaces: true) {
         ... on stop_registry_StopPlace {
           quays {
             id

--- a/ui/src/components/stop-registry/stops/queries/useGetQuay.ts
+++ b/ui/src/components/stop-registry/stops/queries/useGetQuay.ts
@@ -3,7 +3,7 @@ import { gql } from '@apollo/client';
 const GQL_GET_QUAY = gql`
   query GetQuay($quayId: String!) {
     stop_registry {
-      stopPlace(query: $quayId) {
+      stopPlace(query: $quayId, onlyMonomodalStopPlaces: true) {
         ... on stop_registry_StopPlace {
           id
           quays {

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useGetShelterResolver.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useGetShelterResolver.ts
@@ -11,7 +11,7 @@ import { FailedToResolveNewShelters } from '../errors';
 const GQL_RESOLVE_STOP_SHELTERS = gql`
   query ResolveStopShelters($netexId: String!) {
     stop_registry {
-      stopPlace(query: $netexId) {
+      stopPlace(query: $netexId, onlyMonomodalStopPlaces: true) {
         id
 
         ... on stop_registry_StopPlace {

--- a/ui/src/generated/graphql.tsx
+++ b/ui/src/generated/graphql.tsx
@@ -79480,7 +79480,7 @@ export type UpdateStopPointMutationOptions = Apollo.BaseMutationOptions<UpdateSt
 export const GetOriginalQuaysDocument = gql`
     query GetOriginalQuays($quayId: String!) {
   stop_registry {
-    stopPlace(query: $quayId) {
+    stopPlace(query: $quayId, onlyMonomodalStopPlaces: true) {
       ... on stop_registry_StopPlace {
         quays {
           id
@@ -79752,7 +79752,7 @@ export type EditScheduledStopPointValidityMutationOptions = Apollo.BaseMutationO
 export const GetQuayDocument = gql`
     query GetQuay($quayId: String!) {
   stop_registry {
-    stopPlace(query: $quayId) {
+    stopPlace(query: $quayId, onlyMonomodalStopPlaces: true) {
       ... on stop_registry_StopPlace {
         id
         quays {
@@ -80157,7 +80157,7 @@ export type GetOverlappingStopVersionsIndefiniteQueryResult = Apollo.QueryResult
 export const ResolveStopSheltersDocument = gql`
     query ResolveStopShelters($netexId: String!) {
   stop_registry {
-    stopPlace(query: $netexId) {
+    stopPlace(query: $netexId, onlyMonomodalStopPlaces: true) {
       id
       ... on stop_registry_StopPlace {
         quays {


### PR DESCRIPTION
When fetching Quay info trough Tiamat StopPlace we need to add `onlyMonomodalStopPlaces: true` query param, or else the query could return the associated terminal on the top level, instead of the actual StopPlace (StopArea).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1177)
<!-- Reviewable:end -->
