### PR TITLE
Fix setting `HTTPS_PROXY` while fetching Digitransit key

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,11 +303,11 @@ Background map tiles are downloaded from the [Digitransit](https://digitransit.f
 require a subscription key to be included in each map tile request. The key is stored as a secret in
 Azure Key Vault, from where it is fetched and placed in the `ui/.env.local` file. Since Azure Key
 Vault is accessed through a SOCKS proxy, you need to open an SSH tunnel to Azure environment and set
-the `HTTPS_PROXY` environment variable as shown in the example below when you run the
+the `AZ_HTTPS_PROXY` environment variable as shown in the example below when you run the
 `./scripts/development.sh setup:env` command and the `ui/.env.local` file does not exist.
 
 ```sh
-HTTPS_PROXY=... ./scripts/development.sh setup:env
+AZ_HTTPS_PROXY=... ./scripts/development.sh setup:env
 ```
 
 For more information about opening an SSH tunnel, see the general JORE4 Azure guidance (in

--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -270,15 +270,15 @@ import_dump() {
 }
 
 download_digitransit_key() {
-  if [[ -z "$HTTPS_PROXY" ]]; then
-    echo "The HTTPS_PROXY environment variable must be set according to the general JORE4 Azure guidelines when fetching the Digitransit subscription key from Azure Key Vault."
+  if [[ -z "$AZ_HTTPS_PROXY" ]]; then
+    echo "The AZ_HTTPS_PROXY environment variable must be set according to the general JORE4 Azure guidelines when fetching the Digitransit subscription key from Azure Key Vault."
     exit 1
   fi
 
   login
 
   echo "Fetching Digitransit subscription key value to ui/.env.local"
-  { echo -n "NEXT_PUBLIC_DIGITRANSIT_API_KEY=" && az keyvault secret show --name "hsl-jore4-digitransit-api-key" --vault-name "kv-jore4-dev-001" --query "value"; } > ui/.env.local
+  { echo -n "NEXT_PUBLIC_DIGITRANSIT_API_KEY=" && HTTPS_PROXY="$AZ_HTTPS_PROXY" az keyvault secret show --name "hsl-jore4-digitransit-api-key" --vault-name "kv-jore4-dev-001" --query "value"; } > ui/.env.local
 }
 
 setup_environment() {
@@ -350,7 +350,7 @@ print_usage() {
     Start dependencies and seed databases with dump data.
 
     If the Digitransit subscription key has not yet been fetched (stored in
-    ui/.env.local), you will need to set the HTTPS_PROXY environment
+    ui/.env.local), you will need to set the AZ_HTTPS_PROXY environment
     variable. For more information, see the README.md file.
 
     You can change which version of the Docker Compose bundle is downloaded by
@@ -365,7 +365,7 @@ print_usage() {
     if you want to have terminal data in the database.
 
     If the Digitransit subscription key has not yet been fetched (stored in
-    ui/.env.local), you will need to set the HTTPS_PROXY environment
+    ui/.env.local), you will need to set the AZ_HTTPS_PROXY environment
     variable. For more information, see the README.md file.
 
     You can change which version of the Docker Compose bundle is downloaded by
@@ -388,7 +388,7 @@ print_usage() {
   digitransit:fetch
     Download Digitransit subscription key for JORE4 account.
 
-    You will need to set the HTTPS_PROXY environment variable. For more
+    You will need to set the AZ_HTTPS_PROXY environment variable. For more
     information, see the README.md file.
 
   check:images


### PR DESCRIPTION
Fix setting `HTTPS_PROXY` while fetching Digitransit key from Azure Key Vault.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1179)
<!-- Reviewable:end -->
