### PR TITLE
Fix terminal update to not update the private code

### DIFF
--- a/ui/src/components/stop-registry/terminals/components/basic-details/basic-details-form/useUpdateTerminalDetails.tsx
+++ b/ui/src/components/stop-registry/terminals/components/basic-details/basic-details-form/useUpdateTerminalDetails.tsx
@@ -56,10 +56,6 @@ const mapFormStateToInput = ({
         nameType: StopRegistryNameType.Alias,
       },
     ]),
-    privateCode: {
-      value: state.privateCode,
-      type: 'HSL/JORE-4',
-    },
     name: {
       value: state.name,
       lang: 'fin',


### PR DESCRIPTION
Private code is immutable and should never be included in mutations. This broke the E2E tests as the HSL/Test type private codes were being converted into HSL/Jore-4 type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1181)
<!-- Reviewable:end -->
