### PR TITLE
Add translated errors for moving quay to stop area

### DIFF
--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/MoveQuayToStopAreaModal.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/MoveQuayToStopAreaModal.tsx
@@ -8,6 +8,7 @@ import {
   NewModalFooter,
 } from '../../../../../uiComponents';
 import { Modal } from '../../../../../uiComponents/modal/Modal';
+import { showSuccessToast } from '../../../../../utils';
 import { SelectStopDropdown } from '../../../components/SelectMemberStops';
 import { SelectedStop } from '../../../components/SelectMemberStops/common/schema';
 import { SlimSimpleButton } from '../../../stops/stop-details/layout';
@@ -159,6 +160,8 @@ export const MoveQuayToStopAreaModal: FC<MoveQuayToStopAreaModalProps> = ({
     try {
       await moveQuayToStopPlace(saveParams);
       await refetch();
+
+      showSuccessToast(t('stopAreaDetails.memberStops.moveSuccess'));
 
       onSave();
       handleClose();

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -189,7 +189,15 @@
         "removed": "Removed"
       },
       "futureVersionsAlert": "There are future versions of the stop area. After the transfer, the stop will only belong to the currently viewed version of the stop area. Create a copy of the stop for future versions of the area if necessary.",
-      "moveError": "Error moving stop to stop area. Reason:\n{{ reason }}"
+      "moveError": "Error moving stop to stop area. Reason:\n{{ reason }}",
+      "moveSuccess": "Stop moved to stop area.",
+      "errors": {
+        "noOriginalQuaysFound": "Original quay information not found.",
+        "noNewQuaysFound": "No information found for the moved quay.",
+        "originalQuayIdRequired": "Original quay ID is required.",
+        "noMappingForQuayId": "No mapping found for quay ID: {{ quayId }}.",
+        "stopPointIdRequired": "Stop point ID is required."
+      }
     },
     "errors": {
       "stopPlacesUniqueName": "Stop area should have unique name but {{name}} is already in use!",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -189,7 +189,15 @@
         "removed": "poistettu"
       },
       "futureVersionsAlert": "Pysäkkialueesta on tulevia versioita. Pysäkki kuuluu siirron jälkeen ainoastaan nyt tarkasteltavaan pysäkkialueen versioon. Luo pysäkistä kopio tuleviin alueen versioihin tarpeen vaatiessa.",
-      "moveError": "Virhe pysäkin siirtämisessä alueelle. Syy:\n{{ reason }}"
+      "moveError": "Virhe pysäkin siirtämisessä alueelle. Syy:\n{{ reason }}",
+      "moveSuccess": "Pysäkki siirretty pysäkkialueelle.",
+      "errors": {
+        "noOriginalQuaysFound": "Alkuperäisen pysäkin tietoja ei löydetty.",
+        "noNewQuaysFound": "Siirretyn pysäkin tietoja ei löydetty.",
+        "originalQuayIdRequired": "Alkuperäisen pysäkin ID on pakollinen.",
+        "noMappingForQuayId": "Vastaavuutta ei löytynyt pysäkin ID:llä {{ quayId }}.",
+        "stopPointIdRequired": "Pysähdyspisteen ID on pakollinen."
+      }
     },
     "errors": {
       "stopPlacesUniqueName": "Pysäkkialueella tulee olla uniikki nimi, mutta nimi {{name}} on jo jonkin toisen alueen käytössä!",


### PR DESCRIPTION
- Add translated errors for moving quay to stop area
- Add a success toast when moving the quay to the stop area

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1189)
<!-- Reviewable:end -->
