### PR TITLE
Fix issues of terminal info spots found in testing

### DIFF
--- a/ui/src/components/common/info-container/InfoContainer.tsx
+++ b/ui/src/components/common/info-container/InfoContainer.tsx
@@ -62,6 +62,7 @@ type InfoContainerProps = {
    */
   readonly title: ReactNode;
   readonly addNewButton?: ReactNode;
+  readonly disableSaveButton?: boolean;
 };
 
 const testIds = {
@@ -83,6 +84,7 @@ export const InfoContainer: FC<InfoContainerProps> = ({
   testIdPrefix = '',
   title,
   bodyClassName,
+  disableSaveButton,
 }) => {
   const { t } = useTranslation();
 
@@ -149,6 +151,7 @@ export const InfoContainer: FC<InfoContainerProps> = ({
             <SimpleButton
               onClick={controls.onSave}
               testId={testIds.saveButton(testIdPrefix)}
+              disabled={disableSaveButton}
             >
               {t('save')}
             </SimpleButton>

--- a/ui/src/components/stop-registry/terminals/components/info-spots/TerminalInfoSpotsSection.tsx
+++ b/ui/src/components/stop-registry/terminals/components/info-spots/TerminalInfoSpotsSection.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useRef, useState } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EnrichedParentStopPlace } from '../../../../../types';
 import { showSuccessToast, submitFormByRef } from '../../../../../utils';
@@ -51,6 +51,7 @@ export const TerminalInfoSpotsSection: FC<TerminalInfoSpotsSectionProps> = ({
   const { isInEditMode } = infoContainerControls;
 
   const [latestAdded, setLatestAdded] = useState<string | undefined>();
+  const [formIsDirty, setFormIsDirty] = useState(false);
 
   const onSubmit = async (state: TerminalInfoSpotFormState) => {
     try {
@@ -63,6 +64,12 @@ export const TerminalInfoSpotsSection: FC<TerminalInfoSpotsSectionProps> = ({
       defaultErrorHandler(err as Error);
     }
   };
+
+  useEffect(() => {
+    if (!infoContainerControls.isExpanded) {
+      setLatestAdded(undefined);
+    }
+  }, [infoContainerControls.isExpanded]);
 
   return (
     <InfoContainer
@@ -81,6 +88,7 @@ export const TerminalInfoSpotsSection: FC<TerminalInfoSpotsSectionProps> = ({
           : t('terminalDetails.infoSpots.title')
       }
       testIdPrefix="TerminalInfoSpotsSection"
+      disableSaveButton={!formIsDirty}
     >
       {isInEditMode ? (
         <TerminalInfoSpotsForm
@@ -89,6 +97,7 @@ export const TerminalInfoSpotsSection: FC<TerminalInfoSpotsSectionProps> = ({
           ref={formRef}
           terminal={terminal}
           onSubmit={onSubmit}
+          setFormIsDirty={setFormIsDirty}
         />
       ) : (
         <TerminalInfoSpotsViewList

--- a/ui/src/components/stop-registry/terminals/components/info-spots/TerminalInfoSpotsViewCard.tsx
+++ b/ui/src/components/stop-registry/terminals/components/info-spots/TerminalInfoSpotsViewCard.tsx
@@ -32,7 +32,7 @@ export const TerminalInfoSpotsViewCard: FC<TerminalInfoSpotsViewCardProps> = ({
   return (
     <div data-testid={testIds.container}>
       <div className="bg-background-hsl-commuter-train-purple bg-opacity-25 p-5 pt-0">
-        <DetailRow>
+        <DetailRow className="flex-wrap">
           <LabeledDetail
             title={t('stopDetails.infoSpots.label')}
             detail={infoSpot.label}

--- a/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spot-row/TerminalInfoSpotRow.tsx
+++ b/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spot-row/TerminalInfoSpotRow.tsx
@@ -37,6 +37,8 @@ export const TerminalInfoSpotRow: FC<TerminalInfoSpotRowProps> = ({
 }) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(openByDefault ?? false);
+  const [formIsDirty, setFormIsDirty] = useState(false);
+
   const { saveTerminalInfoSpots, defaultErrorHandler } =
     useEditTerminalInfoSpots();
 
@@ -100,6 +102,7 @@ export const TerminalInfoSpotRow: FC<TerminalInfoSpotRowProps> = ({
                 ref={formRef}
                 terminal={terminal}
                 onSubmit={onSubmit}
+                setFormIsDirty={setFormIsDirty}
               />
             </div>
 
@@ -115,6 +118,7 @@ export const TerminalInfoSpotRow: FC<TerminalInfoSpotRowProps> = ({
               <SimpleButton
                 onClick={infoContainerControls.onSave}
                 testId={testIds.saveButton}
+                disabled={!formIsDirty}
               >
                 {t('save')}
               </SimpleButton>

--- a/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spot-row/TerminalInfoSpotRowHeader.tsx
+++ b/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spot-row/TerminalInfoSpotRowHeader.tsx
@@ -71,7 +71,7 @@ export const TerminalInfoSpotRowHeader: FC<TerminalInfoSpotRowHeaderProps> = ({
     >
       {isOpen ? (
         <td colSpan={7} className="p-0">
-          <div className="border-t border-border-hsl-commuter-train-purple py-5 pl-5 pr-3">
+          <div className="border-t border-border-hsl-commuter-train-purple py-3 pl-5 pr-3 xl:py-5">
             <span className="text-xl" data-testid={testIds.idAndQuayCell}>
               {infoSpotQuay
                 ? t('terminalDetails.infoSpots.infoSpotWithQuay', {

--- a/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spots-form/TerminalInfoSpotsForm.tsx
+++ b/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spots-form/TerminalInfoSpotsForm.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ForwardRefRenderFunction, forwardRef } from 'react';
+import { ForwardRefRenderFunction, forwardRef, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { InfoSpotDetailsFragment } from '../../../../../../generated/graphql';
 import { EnrichedParentStopPlace } from '../../../../../../types';
@@ -16,6 +16,7 @@ type TerminalInfoSpotsFormProps = {
   readonly className?: string;
   readonly defaultValues: TerminalInfoSpotFormState;
   readonly infoSpot?: InfoSpotDetailsFragment;
+  readonly setFormIsDirty?: (val: boolean) => void;
   readonly onSubmit: (state: TerminalInfoSpotFormState) => void;
   readonly terminal: EnrichedParentStopPlace;
 };
@@ -23,13 +24,17 @@ type TerminalInfoSpotsFormProps = {
 const TerminalInfoSpotsFormComponent: ForwardRefRenderFunction<
   HTMLFormElement,
   TerminalInfoSpotsFormProps
-> = ({ className, defaultValues, onSubmit, terminal, infoSpot }, ref) => {
+> = (
+  { className, defaultValues, setFormIsDirty, onSubmit, terminal, infoSpot },
+  ref,
+) => {
   const methods = useForm<TerminalInfoSpotFormState>({
     defaultValues,
     resolver: zodResolver(terminalInfoSpotSchema),
   });
-  useDirtyFormBlockNavigation(methods.formState, 'TerminalInfoSpotsForm');
-  const { setValue, getValues, handleSubmit } = methods;
+  const { setValue, getValues, handleSubmit, formState } = methods;
+  useDirtyFormBlockNavigation(formState, 'TerminalInfoSpotsForm');
+  const { isDirty } = formState;
 
   const addNewPoster = () => {
     const newPoster: PosterState = {
@@ -57,6 +62,12 @@ const TerminalInfoSpotsFormComponent: ForwardRefRenderFunction<
       shouldTouch: true,
     });
   };
+
+  useEffect(() => {
+    if (setFormIsDirty) {
+      setFormIsDirty(isDirty);
+    }
+  }, [isDirty, setFormIsDirty]);
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spots-form/TerminalInfoSpotsFormFields.tsx
+++ b/ui/src/components/stop-registry/terminals/components/info-spots/terminal-info-spots-form/TerminalInfoSpotsFormFields.tsx
@@ -62,7 +62,7 @@ export const TerminalInfoSpotFormFields: FC<
 
   return (
     <Column>
-      <div className="bg-background p-5">
+      <div className="bg-background-hsl-commuter-train-purple bg-opacity-25 p-5">
         <Row className="flex-wrap items-end gap-4 py-2.5">
           <InputField<TerminalInfoSpotFormState>
             type="text"
@@ -151,7 +151,7 @@ export const TerminalInfoSpotFormFields: FC<
 
         <FormRow
           mdColumns={1}
-          className="flex-wrap items-end gap-4 bg-background py-2.5 lg:flex-nowrap"
+          className="flex-wrap items-end gap-4 py-2.5 lg:flex-nowrap"
         >
           <InputField<TerminalInfoSpotFormState>
             type="text"

--- a/ui/src/components/stop-registry/terminals/components/info-spots/utils.ts
+++ b/ui/src/components/stop-registry/terminals/components/info-spots/utils.ts
@@ -14,9 +14,9 @@ export const CSS_CLASSES = {
   evenRow: 'bg-background',
   oddRow: '',
   openRow: '!bg-background-hsl-commuter-train-purple bg-opacity-25',
-  tableCell: 'w-0 text-nowrap px-5 py-3 text-sm',
-  descriptionCell: 'w-full px-5 py-3 text-sm',
-  actionCell: 'w-0 py-2 pr-3 text-sm',
+  tableCell: 'w-0 text-nowrap px-3 xl:px-5 py-3 text-sm',
+  descriptionCell: 'w-full px-3 xl:px-5 py-3 text-sm',
+  actionCell: 'w-0 py-3 pr-3 text-sm',
 };
 
 export function resolveQuayPublicCode(


### PR DESCRIPTION
Fix the following:
- Change info spot box background to light purple, like in the design
- Deactivate the save button until changes are made
- Make the table work also on smaller screens
- Fix the logic of opening the latest added info spot

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1194)
<!-- Reviewable:end -->
