### PR TITLE
Fix Common Substitute Day test flakyness

### DIFF
--- a/cypress/e2e/commonSubstituteDays.cy.ts
+++ b/cypress/e2e/commonSubstituteDays.cy.ts
@@ -75,18 +75,14 @@ describe('Common substitute operating periods', () => {
 
       // Make sure the page is clear
       substituteDaySettingsPage.observationPeriodForm.setObservationPeriod(
-        '2023-02-02',
-        '2023-02-02',
-      );
-
-      cy.getByTestId('ObservationPeriodForm::filterButton').click();
-
-      substituteDaySettingsPage.observationPeriodForm.setObservationPeriod(
         '2023-01-01',
         '2023-12-31',
       );
 
       cy.getByTestId('ObservationPeriodForm::filterButton').click();
+      substituteDaySettingsPage
+        .getLoadingCommonSubstitutePeriods()
+        .should('not.exist');
 
       // Add a common substitute day
       substituteDaySettingsPage.commonSubstitutePeriodForm.editCommonSubstitutePeriod(
@@ -98,6 +94,7 @@ describe('Common substitute operating periods', () => {
       );
       substituteDaySettingsPage.commonSubstitutePeriodForm
         .getSaveButton()
+        .should('be.enabled')
         .click();
       toast.expectSuccessToast('Tallennus onnistui');
 
@@ -198,18 +195,13 @@ describe('Common substitute operating periods', () => {
 
       // Make sure the page is clear
       substituteDaySettingsPage.observationPeriodForm.setObservationPeriod(
-        '2023-02-02',
-        '2023-02-02',
-      );
-
-      cy.getByTestId('ObservationPeriodForm::filterButton').click();
-
-      substituteDaySettingsPage.observationPeriodForm.setObservationPeriod(
         '2023-01-01',
         '2023-12-31',
       );
-
       cy.getByTestId('ObservationPeriodForm::filterButton').click();
+      substituteDaySettingsPage
+        .getLoadingCommonSubstitutePeriods()
+        .should('not.exist');
 
       substituteDaySettingsPage.commonSubstitutePeriodForm.removeCommonSubstitutePeriod(
         'Tapaninpäivä 2023',

--- a/cypress/pageObjects/CommonSubstitutePeriodForm.ts
+++ b/cypress/pageObjects/CommonSubstitutePeriodForm.ts
@@ -12,7 +12,7 @@ export class CommonSubstitutePeriodForm {
     substituteDay: string;
     lineTypes?: string[];
   }) {
-    this.commonSubstitutePeriodItem.clickCommonSubstitutePeriodEditCloseButton(
+    this.commonSubstitutePeriodItem.clickCommonSubstitutePeriodEditButton(
       values.periodName,
     );
     this.commonSubstitutePeriodItem
@@ -39,7 +39,7 @@ export class CommonSubstitutePeriodForm {
   }
 
   removeCommonSubstitutePeriod(periodName: string) {
-    this.commonSubstitutePeriodItem.clickCommonSubstitutePeriodEditCloseButton(
+    this.commonSubstitutePeriodItem.clickCommonSubstitutePeriodCloseButton(
       periodName,
     );
     this.getSaveButton().click();

--- a/cypress/pageObjects/CommonSubstitutePeriodItem.ts
+++ b/cypress/pageObjects/CommonSubstitutePeriodItem.ts
@@ -5,13 +5,23 @@ export class CommonSubstitutePeriodItem {
     );
   }
 
-  getEditCloseButton() {
-    return cy.getByTestId('CommonSubstitutePeriodItem::editCloseButton');
+  getEditButton() {
+    return cy.getByTestId('CommonSubstitutePeriodItem::editButton');
   }
 
-  clickCommonSubstitutePeriodEditCloseButton(periodName: string) {
+  getCloseButton() {
+    return cy.getByTestId('CommonSubstitutePeriodItem::closeButton');
+  }
+
+  clickCommonSubstitutePeriodEditButton(periodName: string) {
     this.getContainer(periodName).within(() => {
-      this.getEditCloseButton().click();
+      this.getEditButton().click();
+    });
+  }
+
+  clickCommonSubstitutePeriodCloseButton(periodName: string) {
+    this.getContainer(periodName).within(() => {
+      this.getCloseButton().click();
     });
   }
 

--- a/cypress/pageObjects/SubstituteDaySettingsPage.ts
+++ b/cypress/pageObjects/SubstituteDaySettingsPage.ts
@@ -12,6 +12,12 @@ export class SubstituteDaySettingsPage {
 
   toast = new Toast();
 
+  getLoadingCommonSubstitutePeriods() {
+    return cy.getByTestId(
+      'CommonSubstitutePeriodSection::loadingCommonSubstitutePeriods',
+    );
+  }
+
   close = () => {
     cy.getByTestId('SubstituteDaySettingsPage::closeButton').click();
   };

--- a/ui/src/components/forms/timetables/ObservationPeriodForm.tsx
+++ b/ui/src/components/forms/timetables/ObservationPeriodForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import noop from 'lodash/noop';
 import { DateTime, Duration } from 'luxon';
-import { Dispatch, FC, SetStateAction, useCallback } from 'react';
+import { Dispatch, FC, SetStateAction } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { MdWarning } from 'react-icons/md';
@@ -112,11 +112,21 @@ export const ObservationPeriodForm: FC<ObservationPeriodFormProps> = ({
   });
 
   const onSubmit = form.handleSubmit((formValues) => {
-    setDateRange({
-      startDate: DateTime.fromISO(formValues.startDate),
-      endDate: DateTime.fromISO(formValues.endDate),
+    setDateRange((prevRange) => {
+      const newRange = {
+        startDate: parseDate(formValues.startDate),
+        endDate: parseDate(formValues.endDate),
+      };
+
+      // Preserve object identity
+      if (areEqual(prevRange, newRange)) {
+        return prevRange;
+      }
+
+      return newRange;
     });
   });
+
   const formDisabled =
     isOccasionalSubstitutePeriodFormDirty || isCommonSubstitutePeriodFormDirty;
 

--- a/ui/src/components/forms/timetables/ObservationPeriodForm.tsx
+++ b/ui/src/components/forms/timetables/ObservationPeriodForm.tsx
@@ -10,8 +10,10 @@ import { useAppSelector } from '../../../hooks';
 import { Visible } from '../../../layoutComponents';
 import { Row } from '../../../layoutComponents/Row';
 import { selectTimetable } from '../../../redux';
+import { parseDate } from '../../../time';
 import { DateRange } from '../../../types';
 import { SimpleButton } from '../../../uiComponents';
+import { areEqual } from '../../../utils';
 import { InputField, requiredDate } from '../common';
 
 const testIds = {
@@ -118,17 +120,6 @@ export const ObservationPeriodForm: FC<ObservationPeriodFormProps> = ({
   const formDisabled =
     isOccasionalSubstitutePeriodFormDirty || isCommonSubstitutePeriodFormDirty;
 
-  const handleKeyDown = useCallback(
-    (event: { key: string }) => {
-      if (event.key === 'Enter') {
-        if (!formDisabled) {
-          onSubmit();
-        }
-      }
-    },
-    [formDisabled, onSubmit],
-  );
-
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <FormProvider {...form}>
@@ -142,7 +133,6 @@ export const ObservationPeriodForm: FC<ObservationPeriodFormProps> = ({
                 fieldPath="startDate"
                 testId={testIds.startDate}
                 disabled={formDisabled}
-                onKeyDown={handleKeyDown}
               />
               <InputField<ObservationPeriodSchema>
                 type="date"
@@ -150,7 +140,6 @@ export const ObservationPeriodForm: FC<ObservationPeriodFormProps> = ({
                 fieldPath="endDate"
                 testId={testIds.endDate}
                 disabled={formDisabled}
-                onKeyDown={handleKeyDown}
               />
               <div className="flex self-end pb-2">
                 <SimpleButton

--- a/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodForm.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodForm.tsx
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { TimetablesServiceCalendarSubstituteOperatingPeriod } from '../../../../generated/graphql';
+import { SubstituteOperatingPeriodSettingsInfoFragment } from '../../../../generated/graphql';
 import { useAppDispatch } from '../../../../hooks';
 import { Row } from '../../../../layoutComponents';
 import { setIsCommonSubstitutePeriodFormDirtyAction } from '../../../../redux/slices/timetable';
@@ -62,7 +62,7 @@ const generatePresetDatesForDateRange = (
 };
 
 export const mapCommonSubstituteOperatingPeriodsToCommonDays = (
-  commonSubstituteOperatingPeriods: ReadonlyArray<TimetablesServiceCalendarSubstituteOperatingPeriod>,
+  commonSubstituteOperatingPeriods: ReadonlyArray<SubstituteOperatingPeriodSettingsInfoFragment>,
 ): CommonDayType[] => {
   return commonSubstituteOperatingPeriods?.map((period) => {
     const lineTypes: Set<string> = new Set();

--- a/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodItem.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodItem.tsx
@@ -20,7 +20,8 @@ const testIds = {
   substituteDayOfWeek:
     'CommonSubstitutePeriodItem::substituteDayOfWeekDropdown',
   lineTypes: 'CommonSubstitutePeriodItem::lineTypesDropdown',
-  editCloseButton: 'CommonSubstitutePeriodItem::editCloseButton',
+  editButton: 'CommonSubstitutePeriodItem::editButton',
+  closeButton: 'CommonSubstitutePeriodItem::closeButton',
 };
 
 type CommonSubstitutePeriodItemProps = {
@@ -86,7 +87,7 @@ export const CommonSubstitutePeriodItem: FC<
             showEdit={toBeDeleted}
             onEdit={() => update(index, toBeDeleted, 'toBeDeleted')}
             onClose={() => update(index, toBeDeleted, 'toBeDeleted')}
-            testId={testIds.editCloseButton}
+            testId={toBeDeleted ? testIds.editButton : testIds.closeButton}
           />
         ) : (
           <EditCloseButton
@@ -95,7 +96,7 @@ export const CommonSubstitutePeriodItem: FC<
             showEdit={!edited}
             onEdit={() => update(index, edited, 'created')}
             onClose={() => update(index, edited, 'created')}
-            testId={testIds.editCloseButton}
+            testId={!edited ? testIds.editButton : testIds.closeButton}
           />
         )}
       </div>

--- a/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodSection.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodSection.tsx
@@ -28,8 +28,11 @@ export const CommonSubstitutePeriodSection: FC<
 > = ({ className = '', dateRange }) => {
   const { t } = useTranslation();
 
-  const { commonSubstituteOperatingPeriods, refetch, loading } =
-    useGetCommonSubstituteOperatingPeriods(dateRange);
+  const {
+    substitutePeriods: commonSubstituteOperatingPeriods,
+    refetch,
+    loading,
+  } = useGetCommonSubstituteOperatingPeriods(dateRange);
   const commonDays = useMemo(
     () =>
       mapCommonSubstituteOperatingPeriodsToCommonDays(

--- a/ui/src/components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { AiOutlinePlus } from 'react-icons/ai';
 import {
   Maybe,
-  TimetablesServiceCalendarSubstituteOperatingPeriod,
+  SubstituteOperatingPeriodSettingsInfoFragment,
 } from '../../../../generated/graphql';
 import { useAppDispatch } from '../../../../hooks';
 import { Row, Visible } from '../../../../layoutComponents';
@@ -63,7 +63,7 @@ const mapDurationToString = (duration: Maybe<Duration> | undefined) => {
 };
 
 const convertToPeriodSchema = (
-  input: ReadonlyArray<TimetablesServiceCalendarSubstituteOperatingPeriod>,
+  input: ReadonlyArray<SubstituteOperatingPeriodSettingsInfoFragment>,
 ): FormState => {
   const periods = input?.map((item) => {
     const periodBeginDate = minBy(
@@ -105,7 +105,7 @@ const convertToPeriodSchema = (
 };
 
 export const mapOccasionalSubstituteOperatingPeriodsToFormState = (
-  occasionalSubstituteOperatingPeriods: ReadonlyArray<TimetablesServiceCalendarSubstituteOperatingPeriod>,
+  occasionalSubstituteOperatingPeriods: ReadonlyArray<SubstituteOperatingPeriodSettingsInfoFragment>,
 ) => {
   return convertToPeriodSchema(occasionalSubstituteOperatingPeriods);
 };

--- a/ui/src/components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodSection.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodSection.tsx
@@ -1,6 +1,7 @@
 import { Dispatch, FC, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DateRange } from '../../../../types';
+import { areEqual } from '../../../../utils';
 import {
   showDangerToastWithError,
   showSuccessToast,
@@ -26,8 +27,11 @@ export const OccasionalSubstitutePeriodSection: FC<
   OccasionalSubstitutePeriodSectionProps
 > = ({ dateRange, setDateRange }) => {
   const { t } = useTranslation();
-  const { occasionalSubstituteOperatingPeriods, refetch, loading } =
-    useGetOccasionalSubstituteOperatingPeriods(dateRange);
+  const {
+    substitutePeriods: occasionalSubstituteOperatingPeriods,
+    refetch,
+    loading,
+  } = useGetOccasionalSubstituteOperatingPeriods(dateRange);
   const { prepareAndExecute: prepareAndExecuteCreate } =
     useCreateSubstituteOperatingPeriod();
 
@@ -43,9 +47,18 @@ export const OccasionalSubstitutePeriodSection: FC<
       await prepareAndExecuteEdit({ form });
       await prepareAndExecuteCreate({ form });
 
-      setDateRange({
-        startDate: findEarliestDate(form),
-        endDate: findLatestDate(form),
+      setDateRange((prevRange) => {
+        const newRange = {
+          startDate: findEarliestDate(form),
+          endDate: findLatestDate(form),
+        };
+
+        // Preserve object identity
+        if (areEqual(prevRange, newRange)) {
+          return prevRange;
+        }
+
+        return newRange;
       });
 
       await refetch();

--- a/ui/src/components/timetables/substitute-day-settings/hooks/useGetSubstituteOperatingPeriod.ts
+++ b/ui/src/components/timetables/substitute-day-settings/hooks/useGetSubstituteOperatingPeriod.ts
@@ -1,100 +1,80 @@
 import { gql } from '@apollo/client';
+import compact from 'lodash/compact';
 import { DateTime } from 'luxon';
+import { useMemo } from 'react';
 import {
-  GetSubstituteOperatingPeriodsQuery,
-  TimetablesServiceCalendarSubstituteOperatingPeriod,
+  GetSubstituteOperatingPeriodsQueryVariables,
   useGetSubstituteOperatingPeriodsQuery,
 } from '../../../../generated/graphql';
-import {
-  buildActiveDateRangeGqlFilterForSubstituteOperatingPeriods,
-  buildIsPresetSubstituteOperatingPeriodFilter,
-} from '../../../../utils';
 
 const GQL_GET_SUBSTITUTE_OPERATING_PERIODS = gql`
   query GetSubstituteOperatingPeriods(
-    $periodFilters: timetables_service_calendar_substitute_operating_period_bool_exp
+    $startDate: date!
+    $endDate: date!
+    $isPreset: Boolean!
   ) {
     timetables {
       timetables_service_calendar_substitute_operating_period(
-        where: $periodFilters
-      ) {
-        period_name
-        is_preset
-        substitute_operating_period_id
-        substitute_operating_day_by_line_types {
-          begin_time
-          end_time
-          substitute_day_of_week
-          substitute_operating_day_by_line_type_id
-          superseded_date
-          type_of_line
+        where: {
+          substitute_operating_day_by_line_types: {
+            _and: [
+              { superseded_date: { _gte: $startDate } }
+              { superseded_date: { _lte: $endDate } }
+            ]
+          }
+          is_preset: { _eq: $isPreset }
         }
+      ) {
+        ...SubstituteOperatingPeriodSettingsInfo
       }
+    }
+  }
+
+  fragment SubstituteOperatingPeriodSettingsInfo on timetables_service_calendar_substitute_operating_period {
+    period_name
+    is_preset
+    substitute_operating_period_id
+    substitute_operating_day_by_line_types {
+      begin_time
+      end_time
+      substitute_day_of_week
+      substitute_operating_day_by_line_type_id
+      superseded_date
+      type_of_line
     }
   }
 `;
 
-const mapSubstituteOperatingPeriodsResult = (
-  result?: GetSubstituteOperatingPeriodsQuery,
-) => {
-  return result?.timetables
-    ?.timetables_service_calendar_substitute_operating_period as ReadonlyArray<TimetablesServiceCalendarSubstituteOperatingPeriod>;
+type DateRange = {
+  readonly startDate: DateTime;
+  readonly endDate: DateTime;
 };
 
-export const useGetCommonSubstituteOperatingPeriods = ({
-  startDate,
-  endDate,
-}: {
-  startDate: DateTime;
-  endDate: DateTime;
-}) => {
-  const periodDateRangeFilter = {
-    ...buildActiveDateRangeGqlFilterForSubstituteOperatingPeriods(
-      startDate,
-      endDate,
-    ),
-  };
-
-  const commonPeriodFilter = {
-    ...periodDateRangeFilter,
-    ...buildIsPresetSubstituteOperatingPeriodFilter(true),
-  };
-
+function useGetSubstituteOperatingPeriods(
+  variables: GetSubstituteOperatingPeriodsQueryVariables,
+) {
   const { data, ...rest } = useGetSubstituteOperatingPeriodsQuery({
-    variables: { periodFilters: commonPeriodFilter },
+    variables,
   });
 
-  const commonSubstituteOperatingPeriods =
-    mapSubstituteOperatingPeriodsResult(data);
+  const substitutePeriods = useMemo(
+    () =>
+      compact(
+        data?.timetables
+          ?.timetables_service_calendar_substitute_operating_period,
+      ),
+    [data],
+  );
 
-  return { ...rest, commonSubstituteOperatingPeriods };
-};
+  return { ...rest, substitutePeriods };
+}
 
-export const useGetOccasionalSubstituteOperatingPeriods = ({
-  startDate,
-  endDate,
-}: {
-  startDate: DateTime;
-  endDate: DateTime;
-}) => {
-  const periodDateRangeFilter = {
-    ...buildActiveDateRangeGqlFilterForSubstituteOperatingPeriods(
-      startDate,
-      endDate,
-    ),
-  };
+export function useGetCommonSubstituteOperatingPeriods(dateRange: DateRange) {
+  return useGetSubstituteOperatingPeriods({ ...dateRange, isPreset: true });
+}
 
-  const occasionalPeriodFilter = {
-    ...periodDateRangeFilter,
-    ...buildIsPresetSubstituteOperatingPeriodFilter(false),
-  };
-
-  const { data, ...rest } = useGetSubstituteOperatingPeriodsQuery({
-    variables: { periodFilters: occasionalPeriodFilter },
-  });
-
-  const occasionalSubstituteOperatingPeriods =
-    mapSubstituteOperatingPeriodsResult(data);
-
-  return { ...rest, occasionalSubstituteOperatingPeriods };
-};
+export function useGetOccasionalSubstituteOperatingPeriods(
+  dateRange: DateRange,
+) {
+  return useGetSubstituteOperatingPeriods({ ...dateRange, isPreset: false });
+}

--- a/ui/src/utils/gql.ts
+++ b/ui/src/utils/gql.ts
@@ -72,28 +72,6 @@ export const buildActiveDateRangeGqlFilter = (
     },
   ],
 });
-/**
- * Builds an object for gql to filter out all
- * substitute operating periods which
- * don't have substitute operating days on the given date range
- */
-export const buildActiveDateRangeGqlFilterForSubstituteOperatingPeriods = (
-  startDate: DateTime,
-  endDate: DateTime,
-) => ({
-  _and: [
-    {
-      substitute_operating_day_by_line_types: {
-        superseded_date: { _gte: startDate },
-      },
-    },
-    {
-      substitute_operating_day_by_line_types: {
-        superseded_date: { _lte: endDate },
-      },
-    },
-  ],
-});
 
 /** Builds an object for gql to filter out all drafts if
  * the given priority is not draft itself
@@ -204,14 +182,6 @@ export const buildPrimaryVehicleModeGqlFilter = (
 export const buildTypeOfLineGqlFilter = (typeOfLine: RouteTypeOfLineEnum) => ({
   type_of_line: {
     _eq: typeOfLine,
-  },
-});
-
-export const buildIsPresetSubstituteOperatingPeriodFilter = (
-  isPreset: boolean,
-) => ({
-  is_preset: {
-    _eq: isPreset,
   },
 });
 


### PR DESCRIPTION
### Apollo client, serialize date DateTime explicitly as ISO Date


### Cleanup and improve comon SubstituteDay tests


### ObservationPeriodForm: Prevent duplicate form submission
A HTML form that has a `<button type="submit" />` in it will by dfault trigger and submit event when enter is pressed within a regular `<input>` element contained in the same form.


### SubstituteDaySettingsPage: make date range more stable


### SubstituteDaySettingsPage: Improve query typings
* Use actual generated types, instead of force casting the result into the full potential type. Not all fields were present in reality → Potential for NPEs.
* Reduce code duplication → Single base hook implementation, with just proper query params given.
* Inline query params into the query itself, instead of generation raw-where conditions → Makes the query more readable in Network tab, and Apollo's cache.


### Hack/Fix E2E Common substitute day test flakyness


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1201)
<!-- Reviewable:end -->
