### PR TITLE
Test Quay generation utilities

### DIFF
--- a/cypress/datasets/base.ts
+++ b/cypress/datasets/base.ts
@@ -7,6 +7,7 @@ import {
   RouteInsertInput,
   RouteTypeOfLineEnum,
   StopInJourneyPatternInsertInput,
+  StopInsertInput,
   buildLine,
   buildRoute,
   buildStop,
@@ -48,7 +49,9 @@ export const stopCoordinatesByLabel = {
   E2E010: [24.706945, 60.157696, 0],
 };
 
-export const buildStopsOnInfraLinks = (testInfraLinkIds: UUID[]) => [
+export const buildStopsOnInfraLinks = (
+  testInfraLinkIds: UUID[],
+): StopInsertInput[] => [
   // Stops along test route 901 Outbound
   {
     ...buildStop({

--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -160,8 +160,8 @@ describe('Stop area details', () => {
     validTo: testStopArea.StopArea.validBetween?.toDate as DateTime,
     areaSize: '-',
     parentTerminal: '-',
-    longitude: testStopArea.StopArea.geometry?.coordinates[0],
-    latitude: testStopArea.StopArea.geometry?.coordinates[1],
+    longitude: testStopArea.StopArea.geometry?.coordinates?.at(0) ?? 0,
+    latitude: testStopArea.StopArea.geometry?.coordinates?.at(1) ?? 0,
   };
 
   before(() => {

--- a/cypress/e2e/stop-registry/stopSearch.cy.ts
+++ b/cypress/e2e/stop-registry/stopSearch.cy.ts
@@ -3,6 +3,7 @@ import {
   Priority,
   RouteTypeOfLineEnum,
   StopAreaInput,
+  StopInsertInput,
   StopRegistryGeoJsonType,
   buildLine,
   buildStop,
@@ -993,7 +994,7 @@ describe('Stop search', () => {
     const startDate = today.minus({ years: 1 });
 
     beforeEach(() => {
-      const extraPrioStops = [
+      const extraPrioStops: StopInsertInput[] = [
         {
           // All good
           ...buildStop({
@@ -1157,7 +1158,7 @@ describe('Stop search', () => {
                 { key: 'priority', values: [stopPoint.priority.toString()] },
                 {
                   key: 'validityStart',
-                  values: [stopPoint.validity_start.toISODate()],
+                  values: [stopPoint.validity_start?.toISODate() ?? null],
                 },
                 {
                   key: 'validityEnd',

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -6,6 +6,7 @@
 
 declare namespace Cypress {
   import type { DateTime } from 'luxon';
+  import type { InsertQuayInputs, InsertQuaysResult } from './types';
 
   interface Chainable {
     /**
@@ -60,6 +61,18 @@ declare namespace Cypress {
      * @example cy.setupTests()
      */
     setupTests(): Chainable<void>;
+
+    /**
+     * Inserts the specified quays into the DB with real proper generated
+     * public and private codes.
+     *
+     * @param event task id 'insertQuaysWithRealIds'
+     * @param inputs quays to insert
+     */
+    task<Tags extends string>(
+      event: 'insertQuaysWithRealIds',
+      inputs: InsertQuayInputs<Tags>,
+    ): Chainable<InsertQuaysResult<Tags>>;
   }
 }
 

--- a/cypress/support/insertQuaysWithRealIds.ts
+++ b/cypress/support/insertQuaysWithRealIds.ts
@@ -1,0 +1,101 @@
+import {
+  StopRegistryQuayInput,
+  getPrivateCodeGenerator,
+  getQuayPublicCodeGenerator,
+  insertStopPlaces,
+} from '@hsl/jore4-test-db-manager';
+import {
+  InsertQuayInput,
+  InsertQuayInputs,
+  InsertQuaysResult,
+  QuayTagToNetextId,
+  QuayTagToPublicCode,
+  QuayTagToShelters,
+} from './types';
+
+async function fillInIds<Tags extends string>(
+  inputs: InsertQuayInputs<Tags>,
+): Promise<InsertQuayInputs<Tags>> {
+  const genPublicCode = getQuayPublicCodeGenerator();
+  const genPrivateCode = getPrivateCodeGenerator('quay');
+
+  const promisedEntriesWithIds = Object.entries<InsertQuayInput>(inputs).map<
+    Promise<[Tags, InsertQuayInput]>
+  >(async ([tag, { stopPlaceId, input }]) => {
+    const [publicCode, privateCode] = await Promise.all([
+      input.publicCode ?? genPublicCode(input.geometry),
+      input.privateCode ??
+        genPrivateCode().then((value) => ({
+          type: 'HSL/JORE-4',
+          value,
+        })),
+    ]);
+
+    const quayWithIds: StopRegistryQuayInput = {
+      ...input,
+      publicCode,
+      privateCode,
+    };
+
+    return [tag as Tags, { stopPlaceId, input: quayWithIds }];
+  });
+
+  return Object.fromEntries(
+    await Promise.all(promisedEntriesWithIds),
+  ) as InsertQuayInputs<Tags>;
+}
+
+async function updateQuayStopPlaces<Tags extends string>(
+  inputsWithIds: InsertQuayInputs<Tags>,
+) {
+  const byStopPlace = Object.values<InsertQuayInput>(inputsWithIds).reduce<
+    Record<string, Array<StopRegistryQuayInput>>
+  >((r, { stopPlaceId, input }) => {
+    return {
+      ...r,
+      [stopPlaceId]: (r[stopPlaceId] ?? []).concat(input),
+    };
+  }, {});
+
+  const stopPlaceUpdates = Object.entries(
+    byStopPlace,
+  ).map<StopRegistryQuayInput>(([id, quays]) => ({ id, quays }));
+
+  return insertStopPlaces(stopPlaceUpdates, false);
+}
+
+export async function insertQuaysWithRealIds<Tags extends string>(
+  inputs: InsertQuayInputs<Tags>,
+): Promise<InsertQuaysResult<Tags>> {
+  const inputsWithIds = await fillInIds(inputs);
+  const { collectedQuayDetails } = await updateQuayStopPlaces(inputsWithIds);
+
+  const tagToPublicCode = Object.fromEntries(
+    Object.entries<InsertQuayInput>(inputsWithIds).map(([tag, input]) => [
+      tag,
+      input.input.publicCode ?? '',
+    ]),
+  ) as QuayTagToPublicCode<Tags>;
+
+  const tagToNetextId = Object.fromEntries(
+    Object.entries<InsertQuayInput>(inputsWithIds).map(([tag, input]) => [
+      tag,
+      collectedQuayDetails[input.input.publicCode ?? ''].netexId ?? '',
+    ]),
+  ) as QuayTagToNetextId<Tags>;
+
+  const tagToShelters = Object.fromEntries(
+    Object.entries<InsertQuayInput>(inputsWithIds).map(([tag, input]) => [
+      tag,
+      (collectedQuayDetails[input.input.publicCode ?? ''].shelters ??
+        []) as ReadonlyArray<string>,
+    ]),
+  ) as QuayTagToShelters<Tags>;
+
+  return {
+    inputs: inputsWithIds,
+    tagToPublicCode,
+    tagToNetextId,
+    tagToShelters,
+  };
+}

--- a/cypress/support/tasks.ts
+++ b/cypress/support/tasks.ts
@@ -38,6 +38,8 @@ import {
 } from '@hsl/timetables-data-inserter';
 import * as fs from 'fs';
 
+export { insertQuaysWithRealIds } from './insertQuaysWithRealIds';
+
 const jore4db = getDbConnection(e2eDatabaseConfig);
 const timetablesDb = getDbConnection(timetablesDatabaseConfig);
 const stopsDb = getDbConnection(stopsDatabaseConfig);

--- a/cypress/support/types.ts
+++ b/cypress/support/types.ts
@@ -1,0 +1,29 @@
+import { StopRegistryQuayInput } from '@hsl/jore4-test-db-manager/dist/CypressSpecExports';
+
+export type InsertQuayInput = {
+  readonly stopPlaceId: string;
+  readonly input: StopRegistryQuayInput;
+};
+
+export type InsertQuayInputs<Tags extends string> = Readonly<
+  Record<Tags, InsertQuayInput>
+>;
+
+export type QuayTagToPublicCode<Tags extends string> = Readonly<
+  Record<Tags, string>
+>;
+
+export type QuayTagToNetextId<Tags extends string> = Readonly<
+  Record<Tags, string>
+>;
+
+export type QuayTagToShelters<Tags extends string> = Readonly<
+  Record<Tags, ReadonlyArray<string>>
+>;
+
+export type InsertQuaysResult<Tags extends string> = {
+  readonly inputs: InsertQuayInputs<Tags>;
+  readonly tagToPublicCode: QuayTagToPublicCode<Tags>;
+  readonly tagToNetextId: QuayTagToNetextId<Tags>;
+  readonly tagToShelters: QuayTagToShelters<Tags>;
+};

--- a/test-db-manager/src/builders/mutations/utils.ts
+++ b/test-db-manager/src/builders/mutations/utils.ts
@@ -1,5 +1,13 @@
 import { DocumentNode } from 'graphql';
 
-export const getGqlString = (doc: DocumentNode) => {
-  return doc.loc && doc.loc.source.body;
-};
+export function getGqlString(doc: DocumentNode): string {
+  const body = doc.loc?.source.body;
+
+  if (!body) {
+    throw new Error(
+      `Unable to locate GraphGL query! Document:\n${JSON.stringify(doc, null, 2)}`,
+    );
+  }
+
+  return body;
+}

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -68533,3 +68533,93 @@ export type GetAllStopPlaceLabelsAndIdsQuery = {
     } | null> | null
   } | null
 };
+
+export type GetQuayMaxPrivateCodeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetQuayMaxPrivateCodeQuery = {
+  __typename?: 'query_root',
+  sdb?: {
+    __typename?: 'stops_database_stops_database_query',
+    table: {
+      __typename?: 'stops_database_quay_aggregate',
+      aggregate?: {
+        __typename?: 'stops_database_quay_aggregate_fields',
+        max?: {
+          __typename?: 'stops_database_quay_max_fields',
+          code?: string | null
+        } | null
+      } | null
+    }
+  } | null
+};
+
+export type GetStopAreaMaxPrivateCodeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetStopAreaMaxPrivateCodeQuery = {
+  __typename?: 'query_root',
+  sdb?: {
+    __typename?: 'stops_database_stops_database_query',
+    table: {
+      __typename?: 'stops_database_stop_place_aggregate',
+      aggregate?: {
+        __typename?: 'stops_database_stop_place_aggregate_fields',
+        max?: {
+          __typename?: 'stops_database_stop_place_max_fields',
+          code?: string | null
+        } | null
+      } | null
+    }
+  } | null
+};
+
+export type GetTerminalMaxPrivateCodeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetTerminalMaxPrivateCodeQuery = {
+  __typename?: 'query_root',
+  sdb?: {
+    __typename?: 'stops_database_stops_database_query',
+    table: {
+      __typename?: 'stops_database_stop_place_aggregate',
+      aggregate?: {
+        __typename?: 'stops_database_stop_place_aggregate_fields',
+        max?: {
+          __typename?: 'stops_database_stop_place_max_fields',
+          code?: string | null
+        } | null
+      } | null
+    }
+  } | null
+};
+
+export type GetLocationMunicipalityQueryVariables = Exact<{
+  location: Scalars['geometry']['input'];
+}>;
+
+
+export type GetLocationMunicipalityQuery = {
+  __typename?: 'query_root',
+  stopsDatabase?: {
+    __typename?: 'stops_database_stops_database_query',
+    municipality: Array<{
+      __typename?: 'stops_database_topographic_place',
+      name?: string | null
+    }>
+  } | null
+};
+
+export type GetExistingQuayPublicCodesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetExistingQuayPublicCodesQuery = {
+  __typename?: 'query_root',
+  stopsDatabase?: {
+    __typename?: 'stops_database_stops_database_query',
+    usedPublicCodes: Array<{
+      __typename?: 'stops_database_quay',
+      publicCode?: string | null
+    }>
+  } | null
+};

--- a/test-db-manager/src/hasuraApi.ts
+++ b/test-db-manager/src/hasuraApi.ts
@@ -1,4 +1,6 @@
 import fetch from 'cross-fetch';
+import { DocumentNode } from 'graphql';
+import { getGqlString } from './builders/mutations/utils';
 
 enum HasuraURL {
   Dev = 'http://127.0.0.1:3201/v1/graphql',
@@ -32,14 +34,113 @@ const getHasuraAuthenticationHeaders = (): { [key: string]: string } => {
   };
 };
 
-export const hasuraApi = async (jsonPayload: unknown): Promise<unknown> => {
+export type HasuraStringQueryBody<
+  Variables extends Readonly<Record<string, unknown>>,
+> = {
+  readonly operationName?: string;
+  readonly query: string;
+  readonly variables?: Variables;
+};
+
+export type HasuraDocumentNodeQueryBody<
+  Variables extends Readonly<Record<string, unknown>>,
+> = {
+  readonly query: DocumentNode;
+  readonly variables?: Variables;
+};
+
+export type HasuraQueryBody<
+  Variables extends Readonly<Record<string, unknown>>,
+> = HasuraStringQueryBody<Variables> | HasuraDocumentNodeQueryBody<Variables>;
+
+export type HasuraErrorLocation = {
+  readonly line: number;
+  readonly column: number;
+};
+
+export type HasuraError = {
+  readonly message: string;
+  readonly locations?: ReadonlyArray<HasuraErrorLocation>;
+  readonly path?: ReadonlyArray<string | number>;
+};
+
+export type HasuraResponseBody<Data> = {
+  readonly errors?: ReadonlyArray<HasuraError>;
+  readonly data?: Data;
+};
+
+const contentTypeHeader = 'content-type';
+const contentTypeJson = 'application/json; charset=utf-8';
+
+class HasuraException extends Error {
+  readonly response: HasuraResponseBody<unknown>;
+
+  constructor(response: HasuraResponseBody<unknown>) {
+    super(
+      `Hasura response contains errors! Response: ${JSON.stringify(response, null, 2)}`,
+    );
+    this.response = response;
+  }
+}
+
+function processHasuraRequestBody<
+  Variables extends Readonly<Record<string, unknown>>,
+>(body: HasuraQueryBody<Variables>): HasuraStringQueryBody<Variables> {
+  if (typeof body.query === 'string') {
+    return body as HasuraStringQueryBody<Variables>;
+  }
+
+  return {
+    operationName: body.query.definitions.find(
+      (def) => def.kind === 'OperationDefinition',
+    )?.name?.value,
+    query: getGqlString(body.query),
+    variables: body.variables,
+  };
+}
+
+export async function hasuraApi<
+  Data = unknown,
+  Variables extends Readonly<Record<string, unknown>> = Readonly<
+    Record<string, unknown>
+  >,
+>(
+  requestBody: HasuraQueryBody<Variables>,
+  expectNoErrors = false,
+): Promise<HasuraResponseBody<Data>> {
   const req = {
     method: 'POST',
-    body: JSON.stringify(jsonPayload),
+    body: JSON.stringify(processHasuraRequestBody(requestBody)),
     headers: {
-      'Content-type': 'application/json; charset=UTF-8',
+      [contentTypeHeader]: contentTypeJson,
       ...getHasuraAuthenticationHeaders(),
     },
   };
-  return fetch(getHasuraURL(), req).then((response) => response.json());
-};
+
+  const response = await fetch(getHasuraURL(), req);
+
+  if (
+    !response.ok ||
+    response.headers.get(contentTypeHeader) !== contentTypeJson
+  ) {
+    const responseJson = JSON.stringify(
+      {
+        status: response.status,
+        headers: Object.fromEntries(response.headers.entries()),
+        body: await response.text(),
+      },
+      null,
+      2,
+    );
+
+    throw new Error(`Hasura request failed! Response:  ${responseJson}`);
+  }
+
+  const body: HasuraResponseBody<Data> = await response.json();
+
+  if (expectNoErrors && body.errors?.length) {
+    throw new HasuraException(body);
+  }
+
+  return body;
+}

--- a/test-db-manager/src/queries/index.ts
+++ b/test-db-manager/src/queries/index.ts
@@ -1,4 +1,5 @@
 export * from './infrastructure';
 export * from './routesAndLines';
 export * from './stopRegistry';
+export * from './stopRegistryCodeResolvers';
 export * from './timetables';

--- a/test-db-manager/src/queries/stopRegistryCodeResolvers/getPrivateCodeGenerator.ts
+++ b/test-db-manager/src/queries/stopRegistryCodeResolvers/getPrivateCodeGenerator.ts
@@ -1,0 +1,124 @@
+import { DocumentNode } from 'graphql';
+import { gql } from 'graphql-tag';
+import { getGqlString } from '../../builders/mutations/utils';
+import { GetQuayMaxPrivateCodeQuery } from '../../generated/graphql';
+import { hasuraApi } from '../../hasuraApi';
+
+const GQL_GET_QUAY_MAX_PRIVATE_CODE = gql`
+  query GetQuayMaxPrivateCode {
+    sdb: stops_database {
+      table: stops_database_quay_aggregate(
+        where: { private_code_value: { _like: "7______" } }
+      ) {
+        aggregate {
+          max {
+            code: private_code_value
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GQL_GET_STOP_AREA_MAX_PRIVATE_CODE = gql`
+  query GetStopAreaMaxPrivateCode {
+    sdb: stops_database {
+      table: stops_database_stop_place_aggregate(
+        where: {
+          private_code_value: { _like: "7_____" }
+          parent_stop_place: { _eq: false }
+        }
+      ) {
+        aggregate {
+          max {
+            code: private_code_value
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GQL_GET_TERMINAL_MAX_PRIVATE_CODE = gql`
+  query GetTerminalMaxPrivateCode {
+    sdb: stops_database {
+      table: stops_database_stop_place_aggregate(
+        where: {
+          private_code_value: { _like: "7______" }
+          parent_stop_place: { _eq: true }
+        }
+      ) {
+        aggregate {
+          max {
+            code: private_code_value
+          }
+        }
+      }
+    }
+  }
+`;
+
+type PrivateCodeEntityType = 'quay' | 'area' | 'terminal';
+
+type MinMax = {
+  readonly min: number;
+  readonly max: number;
+};
+
+const codeRanges: Readonly<Record<PrivateCodeEntityType, MinMax>> = {
+  quay: { min: 7000000, max: 7999999 },
+  area: { min: 700000, max: 799999 },
+  terminal: { min: 7000000, max: 7999999 },
+} as const;
+
+const queries: Readonly<Record<PrivateCodeEntityType, DocumentNode>> = {
+  quay: GQL_GET_QUAY_MAX_PRIVATE_CODE,
+  area: GQL_GET_STOP_AREA_MAX_PRIVATE_CODE,
+  terminal: GQL_GET_TERMINAL_MAX_PRIVATE_CODE,
+};
+
+class Incrementable {
+  #value: number;
+
+  constructor(value: number) {
+    this.#value = value;
+  }
+
+  increment() {
+    this.#value += 1;
+    return this.#value;
+  }
+}
+
+type PrivateCodeGeneratorFn = () => Promise<string>;
+
+export function getPrivateCodeGenerator(
+  entity: PrivateCodeEntityType,
+): PrivateCodeGeneratorFn {
+  const minMax = codeRanges[entity];
+
+  // Initialize DB query, and perform it on the background.
+  // Keep this top level function synchronous, by only capturing the Promise
+  // without awaiting it here yet.
+  const promisedMaxCode = hasuraApi<GetQuayMaxPrivateCodeQuery>(
+    { query: getGqlString(queries[entity]) },
+    true,
+  )
+    .then((result) => result.data?.sdb?.table.aggregate?.max?.code)
+    .then((rawMaxCode) => Math.max(minMax.min, Number(rawMaxCode ?? 0)))
+    .then((maxCode) => new Incrementable(maxCode));
+
+  // Had we awaited the DB's max code in the parent function, we could return
+  // a synchronous code generator. But at the cost of slightly more obscure code,
+  // doing it this way nicely aligns the private code generator with the
+  return async () => {
+    const maxCode = await promisedMaxCode;
+    const nextCode = maxCode.increment();
+
+    if (nextCode > minMax.max) {
+      throw new Error('No more private codes available!');
+    }
+
+    return nextCode.toString(10);
+  };
+}

--- a/test-db-manager/src/queries/stopRegistryCodeResolvers/getQuayPublicCodeGenerator.ts
+++ b/test-db-manager/src/queries/stopRegistryCodeResolvers/getQuayPublicCodeGenerator.ts
@@ -1,0 +1,207 @@
+// eslint-disable-next-line n/no-extraneous-import
+import type { Point } from 'geojson';
+import { gql } from 'graphql-tag';
+import compact from 'lodash/compact';
+import { getGqlString } from '../../builders/mutations/utils';
+import {
+  GetExistingQuayPublicCodesQuery,
+  GetLocationMunicipalityQuery,
+  GetLocationMunicipalityQueryVariables,
+  StopRegistryGeoJsonInput,
+} from '../../generated/graphql';
+import { hasuraApi } from '../../hasuraApi';
+
+const GQL_GET_LOCATION_MUNICIPALITY = gql`
+  query GetLocationMunicipality($location: geometry!) {
+    stopsDatabase: stops_database {
+      municipality: stops_database_topographic_place(
+        where: {
+          topographic_place_type: { _eq: "MUNICIPALITY" }
+          persistable_polygon: { polygon: { _st_contains: $location } }
+        }
+        limit: 1 # There should be no overlapping municipalities
+      ) {
+        name: name_value
+      }
+    }
+  }
+`;
+
+const GQL_GET_EXISTING_PUBLIC_CODES = gql`
+  query GetExistingQuayPublicCodes {
+    stopsDatabase: stops_database {
+      usedPublicCodes: stops_database_quay(distinct_on: [public_code]) {
+        publicCode: public_code
+      }
+    }
+  }
+`;
+
+const knownMunicipalityPrefixes = {
+  Helsinki: 'H',
+  Vantaa: 'V',
+  Espoo: 'E',
+  Kauniainen: 'Ka',
+  Siuntio: 'So',
+  Kirkkonummi: 'Ki',
+  Sipoo: 'Si',
+  Kerava: 'Ke',
+  Tuusula: 'Tu',
+} as const;
+
+function assertIsPoint(
+  location: StopRegistryGeoJsonInput | Point | null | undefined,
+): asserts location is Point {
+  if (!location) {
+    throw new Error(
+      `Given location is not of type Point! Location: ${location}`,
+    );
+  }
+
+  const json = JSON.stringify(location, null, 0);
+
+  if (location.type !== 'Point') {
+    throw new Error(`Given location is not of type Point! Location: ${json}`);
+  }
+
+  const coordinates = location.coordinates as unknown as readonly unknown[];
+  if (!Array.isArray(location.coordinates)) {
+    throw new Error(
+      `Given location does not have a list of coordinates! Location: ${json}`,
+    );
+  }
+
+  const [long, lat, ...unexpected] = coordinates;
+  if (
+    typeof long !== 'number' ||
+    typeof lat !== 'number' ||
+    unexpected.length
+  ) {
+    throw new Error(
+      `Given location does not have a proper list of coordinates! Location: ${json}`,
+    );
+  }
+}
+
+type ExpectedPrefixResult = {
+  readonly expectedPrefix: string;
+  readonly municipality: string;
+};
+
+function getExpectedPrefix(
+  data: GetLocationMunicipalityQuery | undefined,
+): ExpectedPrefixResult | null {
+  const municipality = data?.stopsDatabase?.municipality.at(0)?.name ?? '';
+
+  if (municipality in knownMunicipalityPrefixes) {
+    const expectedPrefix =
+      knownMunicipalityPrefixes[
+        municipality as keyof typeof knownMunicipalityPrefixes
+      ];
+
+    return { expectedPrefix, municipality };
+  }
+
+  return null;
+}
+
+function getUsedPublicCodes(
+  data: GetExistingQuayPublicCodesQuery | undefined,
+): Set<string> {
+  const rawCodes = data?.stopsDatabase?.usedPublicCodes;
+  return new Set(compact(rawCodes?.map((it) => it.publicCode)));
+}
+
+function genNextPublicCode(
+  usedPublicCodes: ReadonlySet<string>,
+  nextFrom: string,
+): string | null {
+  const regExpMatches = /(\p{Letter}+)(\d*)/u.exec(nextFrom);
+  if (!regExpMatches) {
+    return null;
+  }
+
+  const [, prefix, currentIndexStr] = regExpMatches;
+
+  // Make sure we have a numeric code of at least 4 numbers.
+  // Needed when generating code based on user input.
+  const paddedIndexStr = currentIndexStr.padEnd(4, '0');
+  const currentIndex = Number(paddedIndexStr);
+  if (!Number.isSafeInteger(currentIndex)) {
+    return null;
+  }
+
+  let nextIndex = currentIndex + 1;
+  while (nextIndex <= 9999) {
+    const candidate = `${prefix}${nextIndex.toString(10).padStart(4, '0')}`;
+    if (!usedPublicCodes.has(candidate)) {
+      return candidate;
+    }
+    nextIndex += 1;
+  }
+
+  return null;
+}
+
+type QuayPublicCodeGeneratorFn = (
+  location: StopRegistryGeoJsonInput | Point | null | undefined,
+) => Promise<string>;
+
+async function resolveCodePrefixForLocation(
+  location: StopRegistryGeoJsonInput | Point | null | undefined,
+): Promise<ExpectedPrefixResult> {
+  assertIsPoint(location);
+
+  const { data } = await hasuraApi<
+    GetLocationMunicipalityQuery,
+    GetLocationMunicipalityQueryVariables
+  >(
+    {
+      query: getGqlString(GQL_GET_LOCATION_MUNICIPALITY),
+      variables: { location },
+    },
+    true,
+  );
+
+  const prefixInfo = getExpectedPrefix(data);
+  if (!prefixInfo) {
+    throw new Error(
+      `Failed to resolve Municipality prefix for location(${location.coordinates})! Hasura response: ${JSON.stringify(data, null, 2)}`,
+    );
+  }
+
+  return prefixInfo;
+}
+
+export function getQuayPublicCodeGenerator(): QuayPublicCodeGeneratorFn {
+  // Initialize DB query, and perform it on the background.
+  // Keep this top level function synchronous, by only capturing the Promise
+  // without awaiting it here yet.
+  const promisedUsedPublicCodes = hasuraApi<GetExistingQuayPublicCodesQuery>(
+    { query: getGqlString(GQL_GET_EXISTING_PUBLIC_CODES) },
+    true,
+  )
+    .then((result) => result.data)
+    .then(getUsedPublicCodes);
+
+  return async (
+    location: StopRegistryGeoJsonInput | Point | null | undefined,
+  ) => {
+    const [{ expectedPrefix, municipality }, usedCodes] = await Promise.all([
+      resolveCodePrefixForLocation(location),
+      // Await the promised DB codes. Returns the same object (Set) each time
+      // the Promise is awaited.
+      promisedUsedPublicCodes,
+    ]);
+    const nextCode = genNextPublicCode(usedCodes, expectedPrefix);
+
+    if (!nextCode) {
+      throw new Error(
+        `Unabled to generate new Quay PublicCode for location(${location?.coordinates}) on Municipality(${municipality})!`,
+      );
+    }
+
+    usedCodes.add(nextCode);
+    return nextCode;
+  };
+}

--- a/test-db-manager/src/queries/stopRegistryCodeResolvers/index.ts
+++ b/test-db-manager/src/queries/stopRegistryCodeResolvers/index.ts
@@ -1,0 +1,2 @@
+export * from './getQuayPublicCodeGenerator';
+export * from './getPrivateCodeGenerator';


### PR DESCRIPTION

### TDBM: Add support for typed Hasura Queries
* Add types to `hasuraApi` function calls.
* No actual types for `response.data` or input variables added to old code.
* Add support for throwing on results containing errors.
* Throw on invalid query string.


### TDBM: Add Public/Private code generation helpers


### E2E: Add utility for generating real quays
