### PR TITLE
Fix terminal search

### DIFF
--- a/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
+++ b/ui/src/components/stop-registry/main/StopRegistryMainPage.tsx
@@ -11,6 +11,7 @@ import {
   StopSearchBar,
   StopSearchFilters,
   StopSearchNavigationState,
+  defaultFilters,
   defaultSortingInfo,
 } from '../search';
 import {
@@ -43,7 +44,10 @@ export const StopRegistryMainPage: FC = () => {
       {
         pathname: Path.stopSearch,
         search: stopSearchUrlStateToSearch({
-          filters: nextFilters,
+          filters: {
+            ...defaultFilters,
+            ...nextFilters,
+          },
           pagingInfo: {
             ...defaultPagingInfo,
             pageSize: pagingInfo.pageSize,

--- a/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
+++ b/ui/src/components/stop-registry/search/StopSearchResultsPage.tsx
@@ -19,6 +19,7 @@ import {
   StopSearchFilters,
   StopSearchNavigationState,
   StopSearchResultsProps,
+  defaultFilters,
   defaultSortingInfo,
 } from './types';
 import { trSearchFor, useStopSearchUrlState } from './utils';
@@ -112,7 +113,9 @@ export const StopSearchResultPage: FC = () => {
 
   const onSubmitFilters = (nextFilters: StopSearchFilters) => {
     dispatch(resetSelectedRowsAction());
+
     setFlatState({
+      ...defaultFilters,
       ...nextFilters,
       ...defaultSortingInfo,
       ...defaultPagingInfo,


### PR DESCRIPTION
### TypedUrlState: Provide usefull (de)serialization errors


### StopSearch: Fix Area/Terminal search when Extra filters are open
When a field is marked as `disabled` in the react-hook-form it is ommitted completely from the onSubmit values. When accepting new Filters from the Filter bar to the URL also spread the default filters in just in case some field is missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1213)
<!-- Reviewable:end -->
