### PR TITLE
Small fixes and pre commits for stop search on map

### DIFF
--- a/ui/src/components/map/FilterPanel.tsx
+++ b/ui/src/components/map/FilterPanel.tsx
@@ -2,6 +2,7 @@ import { TFunction } from 'i18next';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdLayers } from 'react-icons/md';
+import { twMerge } from 'tailwind-merge';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { Row } from '../../layoutComponents';
 import {
@@ -107,7 +108,12 @@ export const FilterPanel: FC<FilterPanelProps> = ({
   const { showMapEntityTypeFilterOverlay } = useAppSelector(selectMapFilter);
 
   return (
-    <div className={`flex items-end gap-2 bg-white p-2 ${className}`}>
+    <div
+      className={twMerge(
+        'flex items-end gap-2 bg-white p-2 shadow-md',
+        className,
+      )}
+    >
       <i
         className="icon-favicon text-5xl text-tweaked-brand"
         role="presentation"

--- a/ui/src/components/map/Maplibre.tsx
+++ b/ui/src/components/map/Maplibre.tsx
@@ -1,4 +1,3 @@
-import { Units, distance, point } from '@turf/turf';
 import { generateStyle } from 'hsl-map-style';
 import debounce from 'lodash/debounce';
 import {
@@ -90,14 +89,12 @@ export const Maplibre: FC<PropsWithChildren<MaplibreProps>> = ({
           latitude: number,
           longitude: number,
           zoom: number,
-          radius: number,
           bounds: [number, number][],
         ) => {
           dispatch(
             setViewPortAction({
               latitude,
               longitude,
-              radius,
               bounds,
             }),
           );
@@ -123,20 +120,12 @@ export const Maplibre: FC<PropsWithChildren<MaplibreProps>> = ({
 
       const bounds = mapGL.getBounds();
 
-      const from = point([newViewport.longitude, newViewport.latitude]);
-      // eslint-disable-next-line no-underscore-dangle
-      const to = point([bounds._sw.lng, bounds._sw.lat]);
-      const options = { units: 'meters' as Units };
-
-      const radius = distance(from, to, options);
-
       // Update map details with a debounce to avoid hundreds of updates while
       // user is changing map position
       updateMapDetailsDebounced(
         newViewport.latitude,
         newViewport.longitude,
         newViewport.zoom,
-        radius,
         bounds.toArray(),
       );
     }

--- a/ui/src/components/stop-registry/search/components/StopSearchBar/ExtraFilters/MunicipalityFilter.tsx
+++ b/ui/src/components/stop-registry/search/components/StopSearchBar/ExtraFilters/MunicipalityFilter.tsx
@@ -17,7 +17,7 @@ type Option = StringMunicipality | AllOptionEnum.All;
 
 const options: ReadonlyArray<Option> = [
   AllOptionEnum.All,
-  ...knownMunicipalities,
+  ...knownMunicipalities.toSorted((a, b) => a.localeCompare(b)),
 ];
 
 function uiNameMapper(t: TFunction, value: Option): string {

--- a/ui/src/components/stop-registry/search/components/StopSearchBar/ExtraFilters/PriorityFilter.tsx
+++ b/ui/src/components/stop-registry/search/components/StopSearchBar/ExtraFilters/PriorityFilter.tsx
@@ -40,6 +40,7 @@ export const PriorityFilter: FC<DisableableFilterProps> = ({
         {knownPriorityValues.map((priority) => (
           <LabeledCheckbox
             key={priority}
+            className="h-[--input-height]"
             label={mapPriorityToUiName(t, priority)}
             onBlur={onBlur}
             onClick={togglePriority(priority)}

--- a/ui/src/redux/slices/mapModal.ts
+++ b/ui/src/redux/slices/mapModal.ts
@@ -18,7 +18,6 @@ const initialState: IState = {
   isOpen: false,
   viewport: {
     ...HELSINKI_CITY_CENTER_COORDINATES,
-    radius: 0,
     bounds: [
       [0, 0],
       [0, 0],

--- a/ui/src/redux/types/mapModal.ts
+++ b/ui/src/redux/types/mapModal.ts
@@ -1,6 +1,5 @@
 export type Viewport = {
   readonly latitude: number;
   readonly longitude: number;
-  readonly radius: number;
   readonly bounds: ReadonlyArray<readonly [number, number]>;
 };

--- a/ui/src/utils/gql.ts
+++ b/ui/src/utils/gql.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import {
-  GeographyComparisonExp,
   GeometryComparisonExp,
   ReusableComponentsVehicleModeEnum,
   RouteTypeOfLineEnum,
@@ -134,18 +133,6 @@ export const buildLabelLikeGqlFilter = (label?: string) => ({
 /** Builds an object for gql to filter route by line label */
 export const buildRouteLineLabelGqlFilter = (label: string) => ({
   route_line: buildLabelGqlFilter(label),
-});
-
-export const buildWithinViewportGqlFilter = (
-  viewport: Viewport,
-): GeographyComparisonExp => ({
-  _st_d_within: {
-    from: {
-      type: 'Point',
-      coordinates: [viewport.longitude, viewport.latitude],
-    },
-    distance: viewport.radius,
-  },
 });
 
 export const buildWithinViewportGqlGeometryFilter = (


### PR DESCRIPTION

### Map: Add missing shadow to filter panel


### Map|Redux: Remove deprecated `viewport.radius`
Radius has been replaced by the nw⋄se coordinate bounding box in earlier changes and there we no longer any active code consuming/using the old radius value, thus it is safe to now drop it off completely.


### StopSearch: Filters - Sort municipalities


### StopSearch: Apply standard input height to Priority filters

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1218)
<!-- Reviewable:end -->
