### PR TITLE
fix map stops to not gray out with unset stop_state

### DIFF
--- a/ui/src/components/map/stops/hooks/useMapStops.ts
+++ b/ui/src/components/map/stops/hooks/useMapStops.ts
@@ -112,7 +112,8 @@ export const useMapStops = (displayedRouteIds: ReadonlyArray<string>) => {
   const getStopShouldBeGray = useCallback(
     (stop: MapStop): boolean =>
       (!!selectedRouteId && !usedStopLabels.includes(stop.label)) ||
-      stop.stop_state !== StopPlaceState.InOperation ||
+      (stop.stop_state !== null &&
+        stop.stop_state !== StopPlaceState.InOperation) ||
       !isCurrentEntity(observationDate, stop),
     [selectedRouteId, observationDate, usedStopLabels],
   );


### PR DESCRIPTION
I'm not 100% sure that is this the wanted result. But this surely fixes the reported "grey tram stops" -bug.

Maybe we should dig deeper why the stop_state is null at the first place?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1400)
<!-- Reviewable:end -->
