### PR TITLE
Stop area change history

### DIFF
--- a/cypress/e2e/stop-registry/stopAreaChangeHistory.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaChangeHistory.cy.ts
@@ -1,0 +1,500 @@
+import {
+  GetInfrastructureLinksByExternalIdsResult,
+  KnownValueKey,
+  Priority,
+  ReusableComponentsVehicleModeEnum,
+  StopAreaInput,
+  StopInsertInput,
+  StopRegistryNameType,
+  StopRegistryTransportModeType,
+  buildStop,
+  buildTimingPlace,
+  extractInfrastructureLinkIdsFromResponse,
+  mapToGetInfrastructureLinksByExternalIdsQuery,
+  quayH2003,
+  seedOrganisations,
+} from '@hsl/jore4-test-db-manager/dist/CypressSpecExports';
+import { DateTime } from 'luxon';
+import { Tag } from '../../enums';
+import {
+  MapPage,
+  Pagination,
+  StopAreaChangeHistory,
+  StopAreaDetailsPage,
+} from '../../pageObjects';
+import { UUID } from '../../types';
+import { SupportedResources, insertToDbHelper } from '../../utils';
+import { InsertedStopRegistryIds } from '../utils';
+import {
+  changedBasicDetails,
+  inputBasicDetails,
+  setValidity,
+  waitForSaveToBeFinished,
+} from './stopAreaUtils';
+
+const testInfraLinks = [
+  {
+    externalId: '7d29bd61-6cf7-4d2c-8bd8-b8e835fe90b7:1',
+    coordinates: [24.92669962, 60.16418108, 10.09699999],
+  },
+];
+
+const timingPlaces = [
+  buildTimingPlace('352f8fd6-0eaa-4b01-a2db-734431092d62', '1AACKT'),
+  buildTimingPlace('0388c3fb-a08b-461c-8655-581f06e9c2f5', '1AURLA'),
+];
+
+const buildScheduledStopPoints = (
+  infrastructureLinkIds: UUID[],
+): StopInsertInput[] => [
+  {
+    ...buildStop({
+      label: 'H2003',
+      located_on_infrastructure_link_id: infrastructureLinkIds[0],
+    }),
+    validity_start: DateTime.fromISO('2020-03-20'),
+    validity_end: DateTime.fromISO('2050-05-31'),
+    scheduled_stop_point_id: '29dfb688-7ecc-4cb5-876d-c2c7f1a1f00a',
+    timing_place_id: timingPlaces[0].timing_place_id,
+    measured_location: {
+      type: 'Point',
+      coordinates: testInfraLinks[0].coordinates,
+    },
+  },
+];
+
+const initialValidityStart = DateTime.fromISO('2000-01-01');
+const initialValidityEnd = DateTime.fromISO('2052-01-01');
+
+const stopAreaInput: StopAreaInput = {
+  StopArea: {
+    privateCode: { type: 'HSL/TEST', value: 'AreaA' },
+    name: { lang: 'fin', value: 'Pohjoisesplanadi' },
+    transportMode: StopRegistryTransportModeType.Tram,
+    alternativeNames: [
+      {
+        name: { lang: 'swe', value: 'Norraesplanaden' },
+        nameType: StopRegistryNameType.Translation,
+      },
+      {
+        name: { lang: 'eng', value: 'North esplanade' },
+        nameType: StopRegistryNameType.Translation,
+      },
+      {
+        name: { lang: 'fin', value: 'Pohjoisesplanadi (pitkä)' },
+        nameType: StopRegistryNameType.Alias,
+      },
+      {
+        name: { lang: 'swe', value: 'Norraesplanaden (lång)' },
+        nameType: StopRegistryNameType.Alias,
+      },
+      {
+        name: { lang: 'eng', value: 'North esplanade (long)' },
+        nameType: StopRegistryNameType.Alias,
+      },
+      {
+        name: { lang: 'fin', value: 'Pohj.esplanadi' },
+        nameType: StopRegistryNameType.Other,
+      },
+      {
+        name: { lang: 'swe', value: 'N.esplanaden' },
+        nameType: StopRegistryNameType.Other,
+      },
+
+      {
+        name: { lang: 'eng', value: 'N.esplanade' },
+        nameType: StopRegistryNameType.Other,
+      },
+    ],
+    keyValues: [
+      {
+        key: KnownValueKey.ValidityStart,
+        values: [initialValidityStart.toISODate()],
+      },
+      {
+        key: KnownValueKey.ValidityEnd,
+        values: [initialValidityEnd.toISODate()],
+      },
+    ],
+    geometry: quayH2003.quay.geometry,
+    quays: [quayH2003.quay],
+  },
+  organisations: null,
+};
+
+function assertValueChanged([oldValue, newValue]: readonly [string, string]) {
+  return () => {
+    StopAreaChangeHistory.changeHistoryTable.changedValues
+      .getOldValue()
+      .shouldHaveText(oldValue);
+    StopAreaChangeHistory.changeHistoryTable.changedValues
+      .getNewValue()
+      .shouldHaveText(newValue);
+  };
+}
+
+function assertGroupValidityPeriod(
+  index: number,
+  start: DateTime,
+  end: DateTime | null,
+) {
+  StopAreaChangeHistory.changeHistoryTable.group
+    .getAllGroupElements()
+    .eq(index)
+    .within(() => {
+      StopAreaChangeHistory.changeHistoryTable.sectionHeader
+        .getValidityStart()
+        .shouldHaveText(start.toFormat('d.L.yyyy'));
+
+      if (end) {
+        StopAreaChangeHistory.changeHistoryTable.sectionHeader
+          .getValidityEnd()
+          .shouldHaveText(end.toFormat('d.L.yyyy'));
+      } else {
+        StopAreaChangeHistory.changeHistoryTable.sectionHeader
+          .getValidityEnd()
+          .shouldHaveText('-');
+      }
+    });
+}
+
+const tags = [Tag.StopRegistry, Tag.ChangeHistory];
+describe('Stop Change History', { tags }, () => {
+  let dbResources: SupportedResources &
+    Required<Pick<SupportedResources, 'stops'>>;
+
+  before(() => {
+    cy.task<GetInfrastructureLinksByExternalIdsResult>(
+      'hasuraAPI',
+      mapToGetInfrastructureLinksByExternalIdsQuery(
+        testInfraLinks.map((infralink) => infralink.externalId),
+      ),
+    ).then((res) => {
+      const infraLinkIds = extractInfrastructureLinkIdsFromResponse(res);
+
+      const stops = buildScheduledStopPoints(infraLinkIds);
+      dbResources = {
+        timingPlaces,
+        stops,
+      };
+    });
+  });
+
+  beforeEach(() => {
+    cy.task('resetDbs');
+
+    insertToDbHelper(dbResources);
+
+    cy.task<InsertedStopRegistryIds>('insertStopRegistryData', {
+      stopPlaces: [stopAreaInput],
+      organisations: seedOrganisations,
+    });
+
+    cy.setupTests();
+    cy.mockLogin();
+  });
+
+  it('Should diff basic Stop Area details', () => {
+    StopAreaDetailsPage.visit('AreaA');
+
+    cy.section('Make changes', () => {
+      StopAreaDetailsPage.details.getEditButton().click();
+      inputBasicDetails(changedBasicDetails);
+      StopAreaDetailsPage.details.edit.getSaveButton().click();
+      waitForSaveToBeFinished();
+    });
+
+    StopAreaDetailsPage.versioningRow.getChangeHistoryLink().click();
+
+    cy.section('Check changed details', () => {
+      const { stopAreaDetails } =
+        StopAreaChangeHistory.changeHistoryTable.changedValues;
+
+      StopAreaChangeHistory.changeHistoryTable.group
+        .getAllGroupElements()
+        .eq(0)
+        .within(() => {
+          stopAreaDetails
+            .getNameFin()
+            .within(
+              assertValueChanged([
+                'Pohjoisesplanadi',
+                changedBasicDetails.name,
+              ]),
+            );
+          stopAreaDetails
+            .getNameSwe()
+            .within(
+              assertValueChanged([
+                'Norraesplanaden',
+                changedBasicDetails.nameSwe,
+              ]),
+            );
+          stopAreaDetails
+            .getNameEng()
+            .within(
+              assertValueChanged([
+                'North esplanade',
+                changedBasicDetails.nameEng,
+              ]),
+            );
+
+          stopAreaDetails
+            .getLongNameFin()
+            .within(
+              assertValueChanged([
+                'Pohjoisesplanadi (pitkä)',
+                changedBasicDetails.nameLongFin,
+              ]),
+            );
+          stopAreaDetails
+            .getLongNameSwe()
+            .within(
+              assertValueChanged([
+                'Norraesplanaden (lång)',
+                changedBasicDetails.nameLongSwe,
+              ]),
+            );
+          stopAreaDetails
+            .getLongNameEng()
+            .within(
+              assertValueChanged([
+                'North esplanade (long)',
+                changedBasicDetails.nameLongEng,
+              ]),
+            );
+
+          stopAreaDetails
+            .getAbbreviationFin()
+            .within(
+              assertValueChanged([
+                'Pohj.esplanadi',
+                changedBasicDetails.abbreviationFin,
+              ]),
+            );
+          stopAreaDetails
+            .getAbbreviationSwe()
+            .within(
+              assertValueChanged([
+                'N.esplanaden',
+                changedBasicDetails.abbreviationSwe,
+              ]),
+            );
+          stopAreaDetails
+            .getAbbreviationEng()
+            .within(
+              assertValueChanged([
+                'N.esplanade',
+                changedBasicDetails.abbreviationEng,
+              ]),
+            );
+
+          stopAreaDetails
+            .getValidityStart()
+            .within(
+              assertValueChanged([
+                '1.1.2000',
+                changedBasicDetails.validFrom.toFormat('d.L.yyyy'),
+              ]),
+            );
+          stopAreaDetails
+            .getValidityEnd()
+            .within(assertValueChanged(['1.1.2052', '-']));
+        });
+    });
+  });
+
+  it('Should diff list of stops', () => {
+    MapPage.map.visit({
+      zoom: 16,
+      lat: 60.164074274478054,
+      lng: 24.93021804533524,
+    });
+
+    cy.section('Add a new stop onto the area', () => {
+      MapPage.createStopAtLocation({
+        stopFormInfo: {
+          publicCode: 'T1234',
+          stopPlace: 'AreaA',
+          validityStartISODate: '2022-01-01',
+          priority: Priority.Standard,
+          reasonForChange: 'Initial creation',
+        },
+        clickRelativePoint: {
+          xPercentage: 40,
+          yPercentage: 55,
+        },
+        vehicleMode: ReusableComponentsVehicleModeEnum.Tram,
+      });
+
+      MapPage.gqlStopShouldBeCreatedSuccessfully();
+      MapPage.checkStopSubmitSuccessToast();
+    });
+
+    StopAreaDetailsPage.visit('AreaA');
+    StopAreaDetailsPage.versioningRow.getChangeHistoryLink().click();
+
+    cy.section('Check changed details', () => {
+      StopAreaChangeHistory.changeHistoryTable.group
+        .getAllGroupElements()
+        .eq(0)
+        .within(() => {
+          StopAreaChangeHistory.changeHistoryTable.changedValues.stopAreaDetails
+            .getStops()
+            .within(assertValueChanged(['H2003', ['H2003', 'T1234'].join('')]));
+        });
+    });
+  });
+
+  it('Should filter and page items', () => {
+    StopAreaDetailsPage.visit('AreaA');
+
+    cy.section('Make changes to Finnish name', () => {
+      StopAreaDetailsPage.details.getEditButton().click();
+      StopAreaDetailsPage.details.edit
+        .getName()
+        .clearAndType(changedBasicDetails.name);
+      StopAreaDetailsPage.details.edit.getSaveButton().click();
+      waitForSaveToBeFinished();
+    });
+
+    cy.section('Check paging', () => {
+      cy.visit('/stop-registry/stop-areas/AreaA/history?pageSize=1');
+
+      StopAreaChangeHistory.changeHistoryTable.group
+        .getAllGroupElements()
+        .should('have.length', 1);
+      StopAreaChangeHistory.changeHistoryTable.group
+        .getAllGroupElements()
+        .eq(0)
+        .within(() => {
+          StopAreaChangeHistory.changeHistoryTable.changedValues.stopAreaDetails
+            .getNameFin()
+            .within(() => {
+              StopAreaChangeHistory.changeHistoryTable.changedValues
+                .getNewValue()
+                .shouldHaveText(changedBasicDetails.name);
+            });
+        });
+
+      Pagination.getPageButton(3).should('not.exist');
+      Pagination.getPageButton(2).shouldBeVisible().click();
+
+      StopAreaChangeHistory.changeHistoryTable.group
+        .getAllGroupElements()
+        .should('have.length', 1);
+      StopAreaChangeHistory.changeHistoryTable.group
+        .getAllGroupElements()
+        .eq(0)
+        .within(() =>
+          StopAreaChangeHistory.changeHistoryTable.sectionHeader
+            .getCreatedAreaVersion()
+            .shouldBeVisible(),
+        );
+    });
+
+    cy.section('Check filtering', () => {
+      cy.visit('/stop-registry/stop-areas/AreaA/history?pageSize=10');
+
+      StopAreaChangeHistory.dateFilter
+        .getToDate()
+        .focus()
+        .inputDateValue(DateTime.now().minus({ months: 1 }));
+
+      StopAreaChangeHistory.changeHistoryTable.group
+        .getAllGroupElements()
+        .should('have.length', 0);
+    });
+  });
+
+  it('Should sort items', () => {
+    StopAreaDetailsPage.visit('AreaA');
+
+    const start = DateTime.local(2026, 1, 1);
+    const mid = DateTime.local(2026, 6, 15);
+    const end = DateTime.local(2026, 10, 31);
+
+    cy.section('Make changes to validity period', () => {
+      StopAreaDetailsPage.details.getEditButton().click();
+      setValidity(start, mid);
+      StopAreaDetailsPage.details.edit.getSaveButton().click();
+      waitForSaveToBeFinished();
+
+      StopAreaDetailsPage.details.getEditButton().click();
+      setValidity(mid, end);
+      StopAreaDetailsPage.details.edit.getSaveButton().click();
+      waitForSaveToBeFinished();
+    });
+
+    StopAreaDetailsPage.versioningRow.getChangeHistoryLink().click();
+    StopAreaChangeHistory.changeHistoryTable.group
+      .getAllGroupElements()
+      .should('have.length', 3);
+
+    cy.section('Check sorting by change time - Descending (default)', () => {
+      StopAreaChangeHistory.changeHistoryTable.sortByButton
+        .getChanged()
+        .should('have.attr', 'data-is-active', 'true')
+        .and('have.attr', 'data-sort-direction', 'desc');
+
+      assertGroupValidityPeriod(0, mid, end);
+      assertGroupValidityPeriod(1, start, mid);
+      assertGroupValidityPeriod(2, initialValidityStart, initialValidityEnd);
+    });
+
+    cy.section('Check sorting by change time - Ascending', () => {
+      StopAreaChangeHistory.changeHistoryTable.sortByButton.sortBy(
+        'Changed',
+        'asc',
+      );
+
+      assertGroupValidityPeriod(0, initialValidityStart, initialValidityEnd);
+      assertGroupValidityPeriod(1, start, mid);
+      assertGroupValidityPeriod(2, mid, end);
+    });
+
+    cy.section('Check sorting by validity start - Ascending', () => {
+      StopAreaChangeHistory.changeHistoryTable.sortByButton.sortBy(
+        'ValidityStart',
+        'asc',
+      );
+
+      assertGroupValidityPeriod(0, initialValidityStart, initialValidityEnd);
+      assertGroupValidityPeriod(1, start, mid);
+      assertGroupValidityPeriod(2, mid, end);
+    });
+
+    cy.section('Check sorting by validity start - Descending', () => {
+      StopAreaChangeHistory.changeHistoryTable.sortByButton.sortBy(
+        'ValidityStart',
+        'desc',
+      );
+
+      assertGroupValidityPeriod(0, mid, end);
+      assertGroupValidityPeriod(1, start, mid);
+      assertGroupValidityPeriod(2, initialValidityStart, initialValidityEnd);
+    });
+
+    cy.section('Check sorting by validity End - Ascending', () => {
+      StopAreaChangeHistory.changeHistoryTable.sortByButton.sortBy(
+        'ValidityEnd',
+        'asc',
+      );
+
+      assertGroupValidityPeriod(0, start, mid);
+      assertGroupValidityPeriod(1, mid, end);
+      assertGroupValidityPeriod(2, initialValidityStart, initialValidityEnd);
+    });
+
+    cy.section('Check sorting by validity End - Descending', () => {
+      StopAreaChangeHistory.changeHistoryTable.sortByButton.sortBy(
+        'ValidityEnd',
+        'desc',
+      );
+
+      assertGroupValidityPeriod(0, initialValidityStart, initialValidityEnd);
+      assertGroupValidityPeriod(1, mid, end);
+      assertGroupValidityPeriod(2, start, mid);
+    });
+  });
+});

--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -30,6 +30,13 @@ import { UUID } from '../../types';
 import { SupportedResources, insertToDbHelper } from '../../utils';
 import { expectGraphQLCallToSucceed } from '../../utils/assertions';
 import { InsertedStopRegistryIds } from '../utils';
+import {
+  ExpectedBasicDetails,
+  changedBasicDetails,
+  inputBasicDetails,
+  setValidity,
+  waitForSaveToBeFinished,
+} from './stopAreaUtils';
 
 function mapToShortDate(date: DateTime | null) {
   if (!date) {
@@ -38,25 +45,6 @@ function mapToShortDate(date: DateTime | null) {
 
   return date.setLocale('fi').toFormat('d.L.yyyy');
 }
-
-type ExpectedBasicDetails = {
-  readonly name: string;
-  readonly nameSwe: string;
-  readonly nameEng: string;
-  readonly nameLongFin: string;
-  readonly nameLongSwe: string;
-  readonly nameLongEng: string;
-  readonly abbreviationFin: string;
-  readonly abbreviationSwe: string;
-  readonly abbreviationEng: string;
-  readonly privateCode: string;
-  readonly areaSize: string;
-  readonly parentTerminal: string;
-  readonly validFrom: DateTime;
-  readonly validTo: DateTime | null;
-  readonly longitude: number;
-  readonly latitude: number;
-};
 
 describe('Stop area details', { tags: Tag.StopRegistry }, () => {
   let dbResources: SupportedResources;
@@ -287,63 +275,12 @@ describe('Stop area details', { tags: Tag.StopRegistry }, () => {
   });
 
   describe('Editing', () => {
-    function setValidity(from: DateTime, to: DateTime | null) {
-      StopAreaDetailsPage.details.edit.validity.setStartDate(
-        from.toISODate() ?? '',
-      );
-      if (to) {
-        StopAreaDetailsPage.details.edit.validity.setAsIndefinite(false);
-        StopAreaDetailsPage.details.edit.validity.setEndDate(
-          to.toISODate() ?? '',
-        );
-      } else {
-        StopAreaDetailsPage.details.edit.validity.setAsIndefinite(true);
-      }
-    }
-
-    function waitForSaveToBeFinished() {
-      expectGraphQLCallToSucceed('@gqlUpsertStopArea');
-      Toast.expectSuccessToast('Pysäkkialue muokattu');
-    }
-
-    function inputBasicDetails(inputs: ExpectedBasicDetails) {
-      const { edit } = StopAreaDetailsPage.details;
-
-      edit.getName().clearAndType(inputs.name);
-      edit.getNameSwe().clearAndType(inputs.nameSwe);
-      AlternativeNamesEdit.getNameEng().clearAndType(inputs.nameEng);
-      AlternativeNamesEdit.getNameLongFin().clearAndType(inputs.nameLongFin);
-      AlternativeNamesEdit.getNameLongSwe().clearAndType(inputs.nameLongSwe);
-      AlternativeNamesEdit.getNameLongEng().clearAndType(inputs.nameLongEng);
-      AlternativeNamesEdit.getAbbreviationFin().clearAndType(
-        inputs.abbreviationFin,
-      );
-      AlternativeNamesEdit.getAbbreviationSwe().clearAndType(
-        inputs.abbreviationSwe,
-      );
-      AlternativeNamesEdit.getAbbreviationEng().clearAndType(
-        inputs.abbreviationEng,
-      );
-
-      setValidity(inputs.validFrom, inputs.validTo);
-    }
-
     it('should allow editing details', () => {
       assertBasicDetails(testAreaExpectedBasicDetails);
 
       const newBasicDetails: ExpectedBasicDetails = {
         ...testAreaExpectedBasicDetails,
-        name: 'New name',
-        nameSwe: 'New name swe',
-        nameEng: 'New name eng',
-        nameLongFin: 'New name long fin',
-        nameLongSwe: 'New name long swe',
-        nameLongEng: 'New name long eng',
-        abbreviationFin: 'New abbreviation swe',
-        abbreviationSwe: 'New abbreviation swe',
-        abbreviationEng: 'New abbreviation eng',
-        validFrom: DateTime.now(),
-        validTo: null,
+        ...changedBasicDetails,
       };
 
       // Edit basic details

--- a/cypress/e2e/stop-registry/stopAreaUtils.ts
+++ b/cypress/e2e/stop-registry/stopAreaUtils.ts
@@ -1,0 +1,82 @@
+import { DateTime } from 'luxon';
+import {
+  AlternativeNamesEdit,
+  StopAreaDetailsPage,
+  Toast,
+} from '../../pageObjects';
+import { expectGraphQLCallToSucceed } from '../../utils/assertions';
+
+export type EditableBasicDetails = {
+  readonly name: string;
+  readonly nameSwe: string;
+  readonly nameEng: string;
+  readonly nameLongFin: string;
+  readonly nameLongSwe: string;
+  readonly nameLongEng: string;
+  readonly abbreviationFin: string;
+  readonly abbreviationSwe: string;
+  readonly abbreviationEng: string;
+  readonly validFrom: DateTime;
+  readonly validTo: DateTime | null;
+};
+
+export type ExpectedBasicDetails = EditableBasicDetails & {
+  readonly privateCode: string;
+  readonly areaSize: string;
+  readonly parentTerminal: string;
+  readonly longitude: number;
+  readonly latitude: number;
+};
+
+export function setValidity(from: DateTime, to: DateTime | null) {
+  StopAreaDetailsPage.details.edit.validity.setStartDate(
+    from.toISODate() ?? '',
+  );
+  if (to) {
+    StopAreaDetailsPage.details.edit.validity.setAsIndefinite(false);
+    StopAreaDetailsPage.details.edit.validity.setEndDate(to.toISODate() ?? '');
+  } else {
+    StopAreaDetailsPage.details.edit.validity.setAsIndefinite(true);
+  }
+}
+
+export function inputBasicDetails(inputs: EditableBasicDetails) {
+  const { edit } = StopAreaDetailsPage.details;
+
+  edit.getName().clearAndType(inputs.name);
+  edit.getNameSwe().clearAndType(inputs.nameSwe);
+  AlternativeNamesEdit.getNameEng().clearAndType(inputs.nameEng);
+  AlternativeNamesEdit.getNameLongFin().clearAndType(inputs.nameLongFin);
+  AlternativeNamesEdit.getNameLongSwe().clearAndType(inputs.nameLongSwe);
+  AlternativeNamesEdit.getNameLongEng().clearAndType(inputs.nameLongEng);
+  AlternativeNamesEdit.getAbbreviationFin().clearAndType(
+    inputs.abbreviationFin,
+  );
+  AlternativeNamesEdit.getAbbreviationSwe().clearAndType(
+    inputs.abbreviationSwe,
+  );
+  AlternativeNamesEdit.getAbbreviationEng().clearAndType(
+    inputs.abbreviationEng,
+  );
+
+  setValidity(inputs.validFrom, inputs.validTo);
+}
+
+export function waitForSaveToBeFinished() {
+  expectGraphQLCallToSucceed('@gqlUpsertStopArea');
+  Toast.expectSuccessToast('Pysäkkialue muokattu');
+}
+
+export const changedBasicDetails: EditableBasicDetails = {
+  name: 'New name',
+  nameSwe: 'New name swe',
+  nameEng: 'New name eng',
+  nameLongFin: 'New name long fin',
+  nameLongSwe: 'New name long swe',
+  nameLongEng: 'New name long eng',
+  abbreviationFin: 'New abbreviation swe',
+  abbreviationSwe: 'New abbreviation swe',
+  abbreviationEng: 'New abbreviation eng',
+  validFrom: DateTime.now(),
+  validTo: null,
+};

--- a/cypress/pageObjects/base-change-history/BaseChangeHistoryTable.ts
+++ b/cypress/pageObjects/base-change-history/BaseChangeHistoryTable.ts
@@ -47,5 +47,45 @@ export const BaseChangeHistoryTable = createSimplePageObject(
         cy.get('[data-testid^="ChangeHistory::Group::"]'),
       getGroup: (id: string) => cy.getByTestId(`ChangeHistory::Group::${id}`),
     },
+    sortByButton: {
+      ...base.sortByButton,
+      sortBy(
+        by: 'ValidityStart' | 'ValidityEnd' | 'Changed' | 'ChangedBy',
+        order: 'asc' | 'desc',
+      ) {
+        const toggleSort = (getButton: () => Cypress.Chainable<JQuery>) => {
+          getButton().then((button) => {
+            if (button.attr('data-is-active') !== 'true') {
+              button.get(0).click();
+            }
+          });
+          getButton().should('have.attr', 'data-is-active', 'true');
+
+          getButton().then((button) => {
+            if (button.attr('data-sort-direction') !== order) {
+              button.get(0).click();
+            }
+          });
+          getButton().should('have.attr', 'data-sort-direction', order);
+        };
+
+        switch (by) {
+          case 'ValidityStart':
+            return toggleSort(base.sortByButton.getValidityStart);
+
+          case 'ValidityEnd':
+            return toggleSort(base.sortByButton.getValidityEnd);
+
+          case 'Changed':
+            return toggleSort(base.sortByButton.getChanged);
+
+          case 'ChangedBy':
+            return toggleSort(base.sortByButton.getChangedBy);
+
+          default:
+            throw new Error(`Not implemented: by - ${by}`);
+        }
+      },
+    },
   }),
 );

--- a/cypress/pageObjects/stop-registry/StopAreaChangeHistory.ts
+++ b/cypress/pageObjects/stop-registry/StopAreaChangeHistory.ts
@@ -1,0 +1,71 @@
+import {
+  BaseChangeHistoryPage,
+  BaseChangeHistoryTable,
+} from '../base-change-history';
+import { createSimplePageObject } from '../createSimplePageObject';
+
+const StopAreaChangeHistoryTable = createSimplePageObject(
+  'ChangeHistory',
+  [
+    // StopAreaChangeHistoryFirstVersionHeaderRow
+    'ChangeHistory::SectionHeader::CreatedAreaVersion',
+    'ChangeHistory::SectionHeader::ImportedAreaVersion',
+
+    // DataDiffFailedToLoadSection
+    'ChangeHistory::SectionHeader::FailedToLoadStopAreaData',
+    'ChangeHistory::FailedToLoadStopAreaData::RetryButton',
+
+    // DataDiffSectionLoading
+    'ChangeHistory::SectionHeader::LoadingStopAreaData',
+
+    // LineDetailsChangedSectionRow
+    'ChangeHistory::SectionHeader::StopAreaDetails',
+    'ChangeHistory::ChangedValues::StopAreaDetails::NameFin',
+    'ChangeHistory::ChangedValues::StopAreaDetails::NameSwe',
+    'ChangeHistory::ChangedValues::StopAreaDetails::NameEng',
+    'ChangeHistory::ChangedValues::StopAreaDetails::LongNameFin',
+    'ChangeHistory::ChangedValues::StopAreaDetails::LongNameSwe',
+    'ChangeHistory::ChangedValues::StopAreaDetails::LongNameEng',
+    'ChangeHistory::ChangedValues::StopAreaDetails::AbbreviationFin',
+    'ChangeHistory::ChangedValues::StopAreaDetails::AbbreviationSwe',
+    'ChangeHistory::ChangedValues::StopAreaDetails::AbbreviationEng',
+    'ChangeHistory::ChangedValues::StopAreaDetails::ValidityStart',
+    'ChangeHistory::ChangedValues::StopAreaDetails::ValidityEnd',
+    'ChangeHistory::ChangedValues::StopAreaDetails::TransportMode',
+    'ChangeHistory::ChangedValues::StopAreaDetails::Stops',
+    'ChangeHistory::ChangedValues::StopAreaDetails::Latitude',
+    'ChangeHistory::ChangedValues::StopAreaDetails::Longitude',
+  ],
+  (base) => ({
+    ...BaseChangeHistoryTable,
+    ...base,
+    sectionHeader: {
+      ...BaseChangeHistoryTable.sectionHeader,
+      ...base.sectionHeader,
+    },
+    changedValues: {
+      ...BaseChangeHistoryTable.changedValues,
+      ...base.changedValues,
+    },
+  }),
+);
+
+export const StopAreaChangeHistory = createSimplePageObject(
+  'StopAreaChangeHistoryPage',
+  [
+    // StopChangeHistoryPage
+    'StopAreaChangeHistoryPage::Container',
+
+    // StopChangeHistoryPageTitleRow
+    'StopAreaChangeHistoryPage::ReturnButton',
+    'StopAreaChangeHistoryPage::Title',
+
+    // StopChangeHistoryNames
+    'StopAreaChangeHistoryPage::Names',
+  ],
+  (base) => ({
+    ...BaseChangeHistoryPage,
+    ...base,
+    changeHistoryTable: StopAreaChangeHistoryTable,
+  }),
+);

--- a/cypress/pageObjects/stop-registry/index.ts
+++ b/cypress/pageObjects/stop-registry/index.ts
@@ -4,6 +4,7 @@ export * from './ExternalLinksForm';
 export * from './ExternalLinksSection';
 export * from './search';
 export * from './SortByButton';
+export * from './StopAreaChangeHistory';
 export * from './StopAreaDetailsPage';
 export * from './StopAreaPopup';
 export * from './StopChangeHistoryPage';

--- a/ui/src/components/common/ChangeHistory/StopsList.tsx
+++ b/ui/src/components/common/ChangeHistory/StopsList.tsx
@@ -1,0 +1,36 @@
+import { TFunction } from 'i18next';
+import { FC } from 'react';
+import { Link } from 'react-router';
+import { Path, routeDetails } from '../../../router/routeDetails';
+
+type StopsListProps = {
+  readonly t: TFunction;
+  readonly stopLabels: ReadonlyArray<string>;
+  readonly getLinkTestId: (stopLabel: string) => string;
+};
+
+export const StopsList: FC<StopsListProps> = ({
+  t,
+  stopLabels,
+  getLinkTestId,
+}) => {
+  return (
+    <ol className="flex list-none flex-wrap gap-x-3 gap-y-1">
+      {stopLabels.map((stopLabel) => (
+        <li key={stopLabel}>
+          <Link
+            className="flex"
+            data-testid={getLinkTestId(stopLabel)}
+            title={t(($) => $.accessibility.stops.showStopDetails, {
+              stopLabel,
+            })}
+            to={routeDetails[Path.stopDetails].getLink(stopLabel)}
+          >
+            {stopLabel}
+            <i className="icon-open-in-new" aria-hidden />
+          </Link>
+        </li>
+      ))}
+    </ol>
+  );
+};

--- a/ui/src/components/common/ChangeHistory/index.ts
+++ b/ui/src/components/common/ChangeHistory/index.ts
@@ -7,3 +7,4 @@ export * from './DateRangeFilter';
 export * from './EmptyCell';
 export * from './FailedToLoadChangeHistory';
 export * from './LoadingChangeHistory';
+export * from './StopsList';

--- a/ui/src/components/common/ChangeHistory/types/PreviousVersion.ts
+++ b/ui/src/components/common/ChangeHistory/types/PreviousVersion.ts
@@ -1,0 +1,2 @@
+export const NoEarlierVersionExists = Symbol('NoEarlierVersionExists');
+export const PreviousVersionUnknown = Symbol('PreviousVersionUnknown');

--- a/ui/src/components/common/ChangeHistory/types/index.ts
+++ b/ui/src/components/common/ChangeHistory/types/index.ts
@@ -3,4 +3,5 @@ export * from './ChangedValue';
 export * from './ChangeHistoryFilters';
 export * from './ChangeHistoryRouterState';
 export * from './ChangeHistorySortingInfo';
+export * from './PreviousVersion';
 export * from './SortChangeHistoryBy';

--- a/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryDataRows.tsx
+++ b/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryDataRows.tsx
@@ -2,11 +2,10 @@ import { FC } from 'react';
 import { GetUserNameById } from '../../../../hooks';
 import { PagingInfo } from '../../../../types';
 import {
-  LineChangeHistoryItem,
   NoEarlierVersionExists,
-  PreviousLineChangeHistoryItem,
   PreviousVersionUnknown,
-} from '../types';
+} from '../../../common/ChangeHistory';
+import { LineChangeHistoryItem, PreviousLineChangeHistoryItem } from '../types';
 import { LineChangeHistoryItemSections } from './LineChangeHistoryItem';
 
 const testIds = {
@@ -60,7 +59,6 @@ export const LineChangeHistoryDataRows: FC<LineChangeHistoryDataRowsProps> = ({
       className="group"
     >
       <LineChangeHistoryItemSections
-        key={historyItem.id}
         getUserNameById={getUserNameById}
         historyItem={historyItem}
         previousHistoryItem={findPreviousVersion(historyItems, historyItem)}

--- a/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryItem.tsx
+++ b/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryItem.tsx
@@ -1,10 +1,7 @@
 import { FC } from 'react';
 import { GetUserNameById } from '../../../../hooks';
-import {
-  LineChangeHistoryItem,
-  NoEarlierVersionExists,
-  PreviousLineChangeHistoryItem,
-} from '../types';
+import { NoEarlierVersionExists } from '../../../common/ChangeHistory';
+import { LineChangeHistoryItem, PreviousLineChangeHistoryItem } from '../types';
 import { DataDiffSections } from './DataDiffSections';
 import { LineChangeDeletedVersionHeaderRow } from './LineChangeDeletedVersionHeaderRow';
 import { LineChangeFirstVersionHeaderRow } from './LineChangeFirstVersionHeaderRow';

--- a/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistory.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistory.ts
@@ -1,14 +1,20 @@
 import { gql } from '@apollo/client';
-import identity from 'lodash/identity';
 import { DateTime } from 'luxon';
 import { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import {
   LineChangeHistoryItemDetailsFragment,
   useGetLineChangeHistoryQuery,
 } from '../../../../generated/graphql';
 import { GetUserNameById } from '../../../../hooks';
 import { SortOrder } from '../../../../types';
+import {
+  Comparator,
+  NullOrder,
+  chainedComparator,
+  compareValues,
+  getOrder,
+  useCollator,
+} from '../../../../utils';
 import {
   ChangeHistoryFilters,
   ChangeHistorySortingInfo,
@@ -73,94 +79,31 @@ function parseRawLineChangeHistoryItem(
   };
 }
 
-type NullOrder = 'NullsFirst' | 'NullsLast';
-type Comparator = (
-  a: LineChangeHistoryItem,
-  b: LineChangeHistoryItem,
-) => number;
-type Order = (comparator: Comparator) => Comparator;
-
-function getOrder(sortOrder: SortOrder): Order {
-  if (sortOrder === SortOrder.ASCENDING) {
-    return identity;
-  }
-
-  return (comparator) => (a, b) => -1 * comparator(a, b);
-}
-
-function compareValues<ValueT>(
-  rawA: ValueT,
-  rawB: ValueT,
-  compareNonNullable: (
-    a: NonNullable<ValueT>,
-    b: NonNullable<ValueT>,
-  ) => number,
-  nullOrder: NullOrder = 'NullsLast',
-): number {
-  const a = rawA ?? null;
-  const b = rawB ?? null;
-
-  if (a !== null && b !== null) {
-    return compareNonNullable(a, b);
-  }
-
-  if (a === null && b !== null) {
-    return nullOrder === 'NullsLast'
-      ? Number.NEGATIVE_INFINITY
-      : Number.POSITIVE_INFINITY;
-  }
-
-  if (b === null && a !== null) {
-    return nullOrder === 'NullsLast'
-      ? Number.POSITIVE_INFINITY
-      : Number.NEGATIVE_INFINITY;
-  }
-
-  return 0;
-}
-
-function chainedComparator(
-  ...comparators: ReadonlyArray<Comparator>
-): Comparator {
-  return (a, b) => {
-    let result = 0;
-
-    for (const comparator of comparators) {
-      result = comparator(a, b);
-      if (result !== 0) {
-        return result;
-      }
-    }
-
-    return result;
-  };
-}
-
 function diffDateTime(a: DateTime, b: DateTime) {
   return a.valueOf() - b.valueOf();
 }
 
-function byChanged(): Comparator {
+function byChanged(): Comparator<LineChangeHistoryItem> {
   return (a, b) => compareValues(a.changed, b.changed, diffDateTime);
 }
 
-function byValidityStart(): Comparator {
+function byValidityStart(): Comparator<LineChangeHistoryItem> {
   return (a, b) =>
     compareValues(a.validityStart, b.validityStart, diffDateTime);
 }
 
-function byValidityEnd(): Comparator {
+function byValidityEnd(): Comparator<LineChangeHistoryItem> {
   return (a, b) => compareValues(a.validityEnd, b.validityEnd, diffDateTime);
 }
 
-function byDbId(): Comparator {
+function byDbId(): Comparator<LineChangeHistoryItem> {
   return (a, b) => Number(a.id) - Number(b.id);
 }
 
 function byChanger(
   collator: Intl.Collator,
   getUserNameById: GetUserNameById,
-): Comparator {
+): Comparator<LineChangeHistoryItem> {
   return (a, b) =>
     compareValues(
       getUserNameById(a.changedBy) ?? a.changedBy ?? 'HSL',
@@ -172,7 +115,7 @@ function byChanger(
 function byLineLabel(
   collator: Intl.Collator,
   nullOrder?: NullOrder,
-): Comparator {
+): Comparator<LineChangeHistoryItem> {
   return (a, b) =>
     compareValues(
       a.lineLabel,
@@ -185,7 +128,7 @@ function byLineLabel(
 function byRouteLabel(
   collator: Intl.Collator,
   nullOrder?: NullOrder,
-): Comparator {
+): Comparator<LineChangeHistoryItem> {
   return (a, b) =>
     compareValues(
       a.routeLabel,
@@ -195,8 +138,10 @@ function byRouteLabel(
     );
 }
 
-function sortByChangedTime(sortOrder: SortOrder): Comparator {
-  const order = getOrder(sortOrder);
+function sortByChangedTime(
+  sortOrder: SortOrder,
+): Comparator<LineChangeHistoryItem> {
+  const order = getOrder<LineChangeHistoryItem>(sortOrder);
   return chainedComparator(order(byChanged()), order(byDbId()));
 }
 
@@ -204,8 +149,8 @@ function sortByChanger(
   sortOrder: SortOrder,
   collator: Intl.Collator,
   getUserNameById: GetUserNameById,
-): Comparator {
-  const order = getOrder(sortOrder);
+): Comparator<LineChangeHistoryItem> {
+  const order = getOrder<LineChangeHistoryItem>(sortOrder);
   return chainedComparator(
     order(byChanger(collator, getUserNameById)),
     order(byChanged()),
@@ -216,8 +161,8 @@ function sortByChanger(
 function sortByValidityStart(
   sortOrder: SortOrder,
   collator: Intl.Collator,
-): Comparator {
-  const order = getOrder(sortOrder);
+): Comparator<LineChangeHistoryItem> {
+  const order = getOrder<LineChangeHistoryItem>(sortOrder);
   return chainedComparator(
     order(byValidityStart()),
     order(byLineLabel(collator)),
@@ -230,8 +175,8 @@ function sortByValidityStart(
 function sortByValidityEnd(
   sortOrder: SortOrder,
   collator: Intl.Collator,
-): Comparator {
-  const order = getOrder(sortOrder);
+): Comparator<LineChangeHistoryItem> {
+  const order = getOrder<LineChangeHistoryItem>(sortOrder);
   return chainedComparator(
     order(byValidityEnd()),
     order(byLineLabel(collator)),
@@ -245,7 +190,7 @@ function sortBySortingInfo(
   { sortBy, sortOrder }: ChangeHistorySortingInfo,
   collator: Intl.Collator,
   getUserNameById: GetUserNameById,
-): Comparator {
+): Comparator<LineChangeHistoryItem> {
   switch (sortBy) {
     case SortChangeHistoryBy.Changed:
       return sortByChangedTime(sortOrder);
@@ -276,17 +221,19 @@ function compareUUIDs(a: UUID, b: UUID) {
   return 1;
 }
 
-function byLineId(): Comparator {
+function byLineId(): Comparator<LineChangeHistoryItem> {
   return (a, b) => compareValues(a.lineId, b.lineId, compareUUIDs);
 }
 
-function byRouteId(): Comparator {
+function byRouteId(): Comparator<LineChangeHistoryItem> {
   return (a, b) =>
     compareValues(a.routeId, b.routeId, compareUUIDs, 'NullsFirst');
 }
 
-function sortByVersion(): Comparator {
-  const inDescendingOrder = getOrder(SortOrder.DESCENDING);
+function sortByVersion(): Comparator<LineChangeHistoryItem> {
+  const inDescendingOrder = getOrder<LineChangeHistoryItem>(
+    SortOrder.DESCENDING,
+  );
   return chainedComparator(
     byLineId(),
     byRouteId(),
@@ -302,12 +249,7 @@ function useSortHistoryItems(
   sortingInfo: ChangeHistorySortingInfo,
   getUserNameByIdRealImpl: GetUserNameById,
 ): ReadonlyArray<LineChangeHistoryItem> {
-  const { t } = useTranslation();
-  const langCode = t(($) => $.languages.intlLangCode);
-  const collator = useMemo(
-    () => new Intl.Collator(langCode, { numeric: true }),
-    [langCode],
-  );
+  const collator = useCollator({ numeric: true });
 
   // Most sorting setups do not need to access the mapped username.
   // Thus, we do not need to react to changes in them.

--- a/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistoryItemData.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistoryItemData.ts
@@ -3,11 +3,11 @@ import {
   OrderBy,
   useGetLineChangeHistoryItemDataQuery,
 } from '../../../../generated/graphql';
+import { PreviousVersionUnknown } from '../../../common/ChangeHistory';
 import { DataNotFoundError } from '../errors';
 import {
   LineChangeHistoryItem,
   LineData,
-  PreviousVersionUnknown,
   TruePreviousLineChangeHistoryItem,
 } from '../types';
 

--- a/ui/src/components/routes-and-lines/line-change-history/types/PreviousLineChangeHistoryItem.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/types/PreviousLineChangeHistoryItem.ts
@@ -1,7 +1,8 @@
+import {
+  NoEarlierVersionExists,
+  PreviousVersionUnknown,
+} from '../../../common/ChangeHistory';
 import { LineChangeHistoryItem } from './LineChangeHistoryItem';
-
-export const NoEarlierVersionExists = Symbol('NoEarlierVersionExists');
-export const PreviousVersionUnknown = Symbol('PreviousVersionUnknown');
 
 export type TruePreviousLineChangeHistoryItem =
   | LineChangeHistoryItem

--- a/ui/src/components/routes-and-lines/line-change-history/utils/diffStopDrivingOrder.tsx
+++ b/ui/src/components/routes-and-lines/line-change-history/utils/diffStopDrivingOrder.tsx
@@ -1,44 +1,11 @@
 import { TFunction } from 'i18next';
-import { FC } from 'react';
-import { Link } from 'react-router';
-import { Path, routeDetails } from '../../../../router/routeDetails';
 import {
   KeyedChangedValue,
+  StopsList,
   diffKeyedValues,
 } from '../../../common/ChangeHistory';
 import { RouteData } from '../types';
-
-const testIds = {
-  stopLink: (label: string) =>
-    `ChangeHistory::ChangedValues::RouteDetails::RouteLink::${label}`,
-};
-
-type RouteStopsListProps = {
-  readonly t: TFunction;
-  readonly stopLabels: ReadonlyArray<string>;
-};
-
-export const RouteStopsList: FC<RouteStopsListProps> = ({ t, stopLabels }) => {
-  return (
-    <ol className="flex list-none flex-wrap gap-y-1">
-      {stopLabels.map((stopLabel) => (
-        <li key={stopLabel} className="basis-1/3 px-1.5">
-          <Link
-            className="flex"
-            data-testid={testIds.stopLink(stopLabel)}
-            title={t(($) => $.accessibility.stops.showStopDetails, {
-              stopLabel,
-            })}
-            to={routeDetails[Path.stopDetails].getLink(stopLabel)}
-          >
-            {stopLabel}
-            <i className="icon-open-in-new" aria-hidden />
-          </Link>
-        </li>
-      ))}
-    </ol>
-  );
-};
+import { getRouteStopLinkTestId } from './getRouteStopLinkTestId';
 
 export function diffStopDrivingOrder(
   t: TFunction,
@@ -51,7 +18,13 @@ export function diffStopDrivingOrder(
       field: t(($) => $.lineChangeHistory.extraFields.drivingOrder),
       oldValue: previous.stops.map((it) => it.scheduled_stop_point_label),
       newValue: current.stops.map((it) => it.scheduled_stop_point_label),
-      mapper: (stopLabels) => <RouteStopsList t={t} stopLabels={stopLabels} />,
+      mapper: (stopLabels) => (
+        <StopsList
+          t={t}
+          stopLabels={stopLabels}
+          getLinkTestId={getRouteStopLinkTestId}
+        />
+      ),
     }),
   ];
 }

--- a/ui/src/components/routes-and-lines/line-change-history/utils/diffTimingPoints.tsx
+++ b/ui/src/components/routes-and-lines/line-change-history/utils/diffTimingPoints.tsx
@@ -8,10 +8,11 @@ import { useResolveTimingPointNamesQuery } from '../../../../generated/graphql';
 import { theme } from '../../../../generated/theme';
 import {
   KeyedChangedValue,
+  StopsList,
   diffKeyedValues,
 } from '../../../common/ChangeHistory';
 import { RouteData, RouteStopData } from '../types';
-import { RouteStopsList } from './diffStopDrivingOrder';
+import { getRouteStopLinkTestId } from './getRouteStopLinkTestId';
 
 const testIds = {
   timingPoint: (label: string) =>
@@ -113,7 +114,13 @@ export function diffTimingPoints(
       newValue: currentRegulationPoints.map(
         (it) => it.scheduled_stop_point_label,
       ),
-      mapper: (stopLabels) => <RouteStopsList t={t} stopLabels={stopLabels} />,
+      mapper: (stopLabels) => (
+        <StopsList
+          t={t}
+          stopLabels={stopLabels}
+          getLinkTestId={getRouteStopLinkTestId}
+        />
+      ),
     }),
     diffKeyedValues({
       key: 'LoadingTimeAllowedOn',
@@ -122,7 +129,13 @@ export function diffTimingPoints(
         (it) => it.scheduled_stop_point_label,
       ),
       newValue: currentLoadingPoints.map((it) => it.scheduled_stop_point_label),
-      mapper: (stopLabels) => <RouteStopsList t={t} stopLabels={stopLabels} />,
+      mapper: (stopLabels) => (
+        <StopsList
+          t={t}
+          stopLabels={stopLabels}
+          getLinkTestId={getRouteStopLinkTestId}
+        />
+      ),
     }),
   ];
 }

--- a/ui/src/components/routes-and-lines/line-change-history/utils/getRouteStopLinkTestId.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/utils/getRouteStopLinkTestId.ts
@@ -1,0 +1,3 @@
+export function getRouteStopLinkTestId(label: string) {
+  return `ChangeHistory::ChangedValues::RouteDetails::RouteLink::${label}`;
+}

--- a/ui/src/components/stop-registry/stop-areas/change-history/StopAreaChangeHistoryPage.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/StopAreaChangeHistoryPage.tsx
@@ -1,0 +1,82 @@
+import { FC } from 'react';
+import { useGetUserNames, useRequiredParams } from '../../../../hooks';
+import { Container } from '../../../../layoutComponents';
+import { Pagination } from '../../../../uiComponents';
+import {
+  DateRangeFilter,
+  useChangeHistoryPageRouterState,
+} from '../../../common/ChangeHistory';
+import {
+  StopAreaChangeHistoryPageTitleRow,
+  StopAreaChangeHistoryTable,
+} from './components';
+import {
+  useGetStopPlaceChangeHistory,
+  useGetTodaysNameForStopPlace,
+} from './queries';
+
+const testIds = {
+  container: 'StopAreaChangeHistoryPage::Container',
+};
+
+export const StopAreaChangeHistoryPage: FC = () => {
+  const {
+    filters,
+    setFilters,
+    pagingInfo,
+    setPagingInfo,
+    sortingInfo,
+    setSortingInfo,
+  } = useChangeHistoryPageRouterState();
+
+  const { privateCode } = useRequiredParams<{ privateCode: string }>();
+  const { todaysNameForStopPlace } = useGetTodaysNameForStopPlace(privateCode);
+
+  const { getUserNameById } = useGetUserNames();
+  const { historyItems, sortedHistoryItems, loading, error, refetch } =
+    useGetStopPlaceChangeHistory({
+      filters,
+      getUserNameById,
+      privateCode,
+      sortingInfo,
+    });
+
+  return (
+    <Container
+      className="flex flex-col items-stretch"
+      testId={testIds.container}
+      type="fluid"
+    >
+      <StopAreaChangeHistoryPageTitleRow
+        names={todaysNameForStopPlace}
+        privateCode={privateCode}
+      />
+
+      <DateRangeFilter
+        className="mt-5"
+        filters={filters}
+        setFilters={setFilters}
+      />
+
+      <StopAreaChangeHistoryTable
+        className="mt-5"
+        error={error ?? null}
+        getUserNameById={getUserNameById}
+        historyItems={historyItems}
+        sortedHistoryItems={sortedHistoryItems}
+        loading={loading}
+        pagingInfo={pagingInfo}
+        refetch={refetch}
+        setSortingInfo={setSortingInfo}
+        sortingInfo={sortingInfo}
+      />
+
+      <Pagination
+        className="mt-5 self-center"
+        pagingInfo={pagingInfo}
+        setPagingInfo={setPagingInfo}
+        totalItemsCount={historyItems.length}
+      />
+    </Container>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/DataDiffFailedToLoadSection.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/DataDiffFailedToLoadSection.tsx
@@ -1,0 +1,63 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
+import { SimpleButton } from '../../../../../uiComponents';
+import { ChangeHistoryItemSectionHeaderRow } from '../../../../common/ChangeHistory';
+import { SectionTitle } from './SectionTitle';
+
+const testIds = {
+  // Expands to ChangeHistory::SectionHeader::FailedToLoadStopAreaData
+  failedToLoad: 'FailedToLoadStopAreaData',
+  retryButton: 'ChangeHistory::FailedToLoadStopAreaData::RetryButton',
+};
+
+type DataDiffFailedToLoadSectionProps = {
+  readonly getUserNameById: GetUserNameById;
+  readonly historyItem: StopPlaceChangeHistoryItem;
+  readonly refetch: () => void;
+};
+
+export const DataDiffFailedToLoadSection: FC<
+  DataDiffFailedToLoadSectionProps
+> = ({ getUserNameById, historyItem, refetch }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ChangeHistoryItemSectionHeaderRow
+        getUserNameById={getUserNameById}
+        historyItem={historyItem}
+        sectionTitle={
+          <SectionTitle
+            historyItem={historyItem}
+            section={t(
+              ($) => $.stopAreaChangeHistory.sectionTitle,
+              historyItem,
+            )}
+          />
+        }
+        testId={testIds.failedToLoad}
+      />
+
+      <tr>
+        <td className="p-5" colSpan={7}>
+          {t(($) => $.stopAreaChangeHistory.failedToLoad)}
+        </td>
+      </tr>
+
+      <tr>
+        <td className="p-5" colSpan={7}>
+          <SimpleButton
+            shape="slim"
+            inverted
+            onClick={refetch}
+            testId={testIds.retryButton}
+          >
+            {t(($) => $.changeHistory.tryAgainButton)}
+          </SimpleButton>
+        </td>
+      </tr>
+    </>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/DataDiffSectionLoading.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/DataDiffSectionLoading.tsx
@@ -1,0 +1,56 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PulseLoader } from 'react-spinners';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { theme } from '../../../../../generated/theme';
+import { GetUserNameById } from '../../../../../hooks';
+import { ChangeHistoryItemSectionHeaderRow } from '../../../../common/ChangeHistory';
+import { SectionTitle } from './SectionTitle';
+
+const testIds = {
+  // Expands to ChangeHistory::SectionHeader::LoadingStopAreaData
+  sectionTitle: 'LoadingStopAreaData',
+  contentCell: "ChangeHistory::LoadingStopAreaData::Content'",
+};
+
+type DataDiffSectionLoadingProps = {
+  readonly getUserNameById: GetUserNameById;
+  readonly historyItem: StopPlaceChangeHistoryItem;
+};
+
+export const DataDiffSectionLoading: FC<DataDiffSectionLoadingProps> = ({
+  getUserNameById,
+  historyItem,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ChangeHistoryItemSectionHeaderRow
+        getUserNameById={getUserNameById}
+        historyItem={historyItem}
+        sectionTitle={
+          <SectionTitle
+            historyItem={historyItem}
+            section={t(
+              ($) => $.stopAreaChangeHistory.sectionTitle,
+              historyItem,
+            )}
+          />
+        }
+        testId={testIds.sectionTitle}
+      />
+
+      <tr>
+        <td
+          className="p-5"
+          colSpan={7}
+          data-testid={testIds.contentCell}
+          title={t(($) => $.stopAreaChangeHistory.versionLoading)}
+        >
+          <PulseLoader color={theme.colors.brand} size={14} />
+        </td>
+      </tr>
+    </>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/DataDiffSections.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/DataDiffSections.tsx
@@ -1,0 +1,80 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
+import { ChangedValuesWithHeaderRow } from '../../../../common/ChangeHistory';
+import { useGetHistoricalStopAreaDetails } from '../queries';
+import { diffStopArea } from '../utils';
+import { DataDiffFailedToLoadSection } from './DataDiffFailedToLoadSection';
+import { DataDiffSectionLoading } from './DataDiffSectionLoading';
+import { SectionTitle } from './SectionTitle';
+
+type DataDiffSectionsProps = {
+  readonly getUserNameById: GetUserNameById;
+  readonly historyItem: StopPlaceChangeHistoryItem;
+  readonly previousHistoryItem: StopPlaceChangeHistoryItem;
+};
+
+export const DataDiffSections: FC<DataDiffSectionsProps> = ({
+  getUserNameById,
+  historyItem,
+  previousHistoryItem,
+}) => {
+  const { t } = useTranslation();
+
+  const {
+    data: current,
+    error: currentError,
+    refetch: currentRefetch,
+    loading: currentLoading,
+  } = useGetHistoricalStopAreaDetails(historyItem);
+  const {
+    data: previous,
+    error: previousError,
+    refetch: previousRefetch,
+    loading: previousLoading,
+  } = useGetHistoricalStopAreaDetails(previousHistoryItem);
+
+  if (currentLoading || previousLoading) {
+    return (
+      <DataDiffSectionLoading
+        getUserNameById={getUserNameById}
+        historyItem={historyItem}
+      />
+    );
+  }
+
+  if (!!currentError || !!previousError || !current || !previous) {
+    return (
+      <DataDiffFailedToLoadSection
+        getUserNameById={getUserNameById}
+        historyItem={historyItem}
+        refetch={() => {
+          if (currentError) {
+            currentRefetch();
+          }
+          if (previousError) {
+            previousRefetch();
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <ChangedValuesWithHeaderRow
+      getUserNameById={getUserNameById}
+      historyItem={historyItem}
+      diffVersions={diffStopArea}
+      current={current}
+      previous={previous}
+      testId="StopAreaDetails"
+      sectionTitle={
+        <SectionTitle
+          historyItem={historyItem}
+          section={t(($) => $.stopAreaChangeHistory.sectionTitle, historyItem)}
+        />
+      }
+    />
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/SectionTitle.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/SectionTitle.tsx
@@ -1,0 +1,26 @@
+import { FC, ReactNode } from 'react';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+
+const testIds = { comment: 'ChangeHistory::SectionHeader::VersionComment' };
+
+type SectionTitleProps = {
+  readonly historyItem: StopPlaceChangeHistoryItem;
+  readonly section: ReactNode;
+};
+
+export const SectionTitle: FC<SectionTitleProps> = ({
+  historyItem: { versionComment },
+  section,
+}) => {
+  if (versionComment) {
+    return (
+      <div className="flex gap-x-2">
+        <h5>{section}</h5>
+        <span>|</span>
+        <span data-testid={testIds.comment}>{versionComment}</span>
+      </div>
+    );
+  }
+
+  return <h5>{section}</h5>;
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryDataRows.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryDataRows.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
+import { PagingInfo } from '../../../../../types';
+import { NoEarlierVersionExists } from '../../../../common/ChangeHistory';
+import { PreviousStopPlaceChangeHistoryItem } from '../types';
+import { StopAreaChangeHistoryItemSections } from './StopAreaChangeHistoryItemSections';
+
+const testIds = {
+  group: (id: string) => `ChangeHistory::Group::${id}`,
+};
+
+function findPreviousVersion(
+  historyItemsSortedByVersion: ReadonlyArray<StopPlaceChangeHistoryItem>,
+  item: StopPlaceChangeHistoryItem,
+): PreviousStopPlaceChangeHistoryItem {
+  const previous = historyItemsSortedByVersion.find(
+    (other) =>
+      other.netexId === item.netexId &&
+      Number(other.version) < Number(item.version),
+  );
+
+  return previous ?? NoEarlierVersionExists;
+}
+
+type StopPlaceChangeHistoryDataRowsProps = {
+  readonly getUserNameById: GetUserNameById;
+  readonly historyItems: ReadonlyArray<StopPlaceChangeHistoryItem>;
+  readonly sortedHistoryItems: ReadonlyArray<StopPlaceChangeHistoryItem>;
+  readonly pagingInfo: PagingInfo;
+};
+
+export const StopPlaceChangeHistoryDataRows: FC<
+  StopPlaceChangeHistoryDataRowsProps
+> = ({
+  getUserNameById,
+  historyItems,
+  sortedHistoryItems,
+  pagingInfo: { page, pageSize },
+}) => {
+  const pagedItems = sortedHistoryItems.slice(
+    (page - 1) * pageSize,
+    page * pageSize,
+  );
+
+  return pagedItems.map((historyItem) => {
+    const key = `${historyItem.netexId}-${historyItem.version}`;
+
+    return (
+      <tbody
+        key={key}
+        data-testid={testIds.group(key)}
+        data-netexid={historyItem.netexId}
+        data-version={historyItem.version}
+        className="group"
+      >
+        <StopAreaChangeHistoryItemSections
+          getUserNameById={getUserNameById}
+          historyItem={historyItem}
+          previousHistoryItem={findPreviousVersion(historyItems, historyItem)}
+        />
+      </tbody>
+    );
+  });
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryFirstVersionHeaderRow.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryFirstVersionHeaderRow.tsx
@@ -1,0 +1,53 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
+import { ChangeHistoryItemSectionHeaderRow } from '../../../../common/ChangeHistory';
+import { SectionTitle } from './SectionTitle';
+
+const testIds = {
+  // These will expand to: ChangeHistory::SectionHeader::${testId}
+  createdAreaVersion: 'CreatedAreaVersion',
+  importedAreaVersion: 'ImportedAreaVersion',
+};
+
+type StopAreaChangeHistoryFirstVersionHeaderRowProps = {
+  readonly getUserNameById: GetUserNameById;
+  readonly historyItem: StopPlaceChangeHistoryItem;
+};
+
+export const StopAreaChangeHistoryFirstVersionHeaderRow: FC<
+  StopAreaChangeHistoryFirstVersionHeaderRowProps
+> = ({ getUserNameById, historyItem }) => {
+  const { t } = useTranslation();
+
+  if (historyItem.privateCodeType === 'HSL/JORE-3') {
+    return (
+      <ChangeHistoryItemSectionHeaderRow
+        getUserNameById={getUserNameById}
+        historyItem={historyItem}
+        sectionTitle={
+          <SectionTitle
+            historyItem={historyItem}
+            section={t(($) => $.stopAreaChangeHistory.importedStopAreaVersion)}
+          />
+        }
+        testId={testIds.importedAreaVersion}
+      />
+    );
+  }
+
+  return (
+    <ChangeHistoryItemSectionHeaderRow
+      getUserNameById={getUserNameById}
+      historyItem={historyItem}
+      sectionTitle={
+        <SectionTitle
+          historyItem={historyItem}
+          section={t(($) => $.stopAreaChangeHistory.newStopAreaVersion)}
+        />
+      }
+      testId={testIds.createdAreaVersion}
+    />
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryItemSections.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryItemSections.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
+import { NoEarlierVersionExists } from '../../../../common/ChangeHistory';
+import { PreviousStopPlaceChangeHistoryItem } from '../types';
+import { DataDiffSections } from './DataDiffSections';
+import { StopAreaChangeHistoryFirstVersionHeaderRow } from './StopAreaChangeHistoryFirstVersionHeaderRow';
+
+type StopAreaChangeHistoryItemSectionsProps = {
+  readonly getUserNameById: GetUserNameById;
+  readonly historyItem: StopPlaceChangeHistoryItem;
+  readonly previousHistoryItem: PreviousStopPlaceChangeHistoryItem;
+};
+
+export const StopAreaChangeHistoryItemSections: FC<
+  StopAreaChangeHistoryItemSectionsProps
+> = ({ getUserNameById, historyItem, previousHistoryItem }) => {
+  if (previousHistoryItem === NoEarlierVersionExists) {
+    return (
+      <StopAreaChangeHistoryFirstVersionHeaderRow
+        getUserNameById={getUserNameById}
+        historyItem={historyItem}
+      />
+    );
+  }
+
+  return (
+    <DataDiffSections
+      getUserNameById={getUserNameById}
+      historyItem={historyItem}
+      previousHistoryItem={previousHistoryItem}
+    />
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryPageTitleRow.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryPageTitleRow.tsx
@@ -1,0 +1,61 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigateBackSafely } from '../../../../../hooks';
+import { Row } from '../../../../../layoutComponents';
+import { Path, routeDetails } from '../../../../../router/routeDetails';
+import { CloseIconButton } from '../../../../../uiComponents';
+import { PageTitle } from '../../../../common';
+import { TodaysName } from '../../../stops/change-history/types';
+
+const testIds = {
+  returnButton: 'StopAreaChangeHistoryPage::ReturnButton',
+  title: 'StopAreaChangeHistoryPage::Title',
+  names: 'StopAreaChangeHistoryPage::Names',
+};
+
+type StopAreaChangeHistoryPageTitleRowProps = {
+  readonly names: TodaysName | null;
+  readonly privateCode: string;
+};
+
+export const StopAreaChangeHistoryPageTitleRow: FC<
+  StopAreaChangeHistoryPageTitleRowProps
+> = ({ names, privateCode }) => {
+  const { t } = useTranslation();
+
+  const goBack = useNavigateBackSafely();
+
+  const name = names?.name ?? names?.nameSwe;
+  const titleText = name
+    ? t(($) => $.stopAreaChangeHistory.titleWithName, { privateCode, name })
+    : t(($) => $.stopAreaChangeHistory.title, { privateCode });
+
+  return (
+    <>
+      <Row className="items-end justify-between">
+        <PageTitle.H1 titleText={titleText} testId={testIds.title}>
+          {t(($) => $.stopAreaChangeHistory.title, { privateCode })}
+        </PageTitle.H1>
+
+        <CloseIconButton
+          className="font-bold text-brand [&>i]:text-xl"
+          onClick={() =>
+            goBack(routeDetails[Path.stopAreaDetails].getLink(privateCode), {
+              replace: true,
+            })
+          }
+          testId={testIds.returnButton}
+          label={t(($) => $.stopAreaChangeHistory.goBack)}
+        />
+      </Row>
+
+      {names && (
+        <h2 data-testid={testIds.names}>
+          <span>{names.name ?? ''}</span>
+          {' - '}
+          <span>{names.nameSwe ?? ''}</span>
+        </h2>
+      )}
+    </>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryTable.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/StopAreaChangeHistoryTable.tsx
@@ -1,0 +1,63 @@
+import { Dispatch, FC, SetStateAction } from 'react';
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
+import { PagingInfo } from '../../../../../types';
+import {
+  ChangeHistorySortingInfo,
+  ChangeHistoryTable,
+  FailedToLoadChangeHistory,
+  LoadingChangeHistory,
+} from '../../../../common/ChangeHistory';
+import { StopPlaceChangeHistoryDataRows } from './StopAreaChangeHistoryDataRows';
+
+type StopAreaChangeHistoryTableProps = {
+  readonly className?: string;
+  readonly error: Error | null;
+  readonly getUserNameById: GetUserNameById;
+  readonly historyItems: ReadonlyArray<StopPlaceChangeHistoryItem>;
+  readonly sortedHistoryItems: ReadonlyArray<StopPlaceChangeHistoryItem>;
+  readonly loading: boolean;
+  readonly pagingInfo: PagingInfo;
+  readonly refetch: () => void;
+  readonly setSortingInfo: Dispatch<SetStateAction<ChangeHistorySortingInfo>>;
+  readonly sortingInfo: ChangeHistorySortingInfo;
+};
+
+export const StopAreaChangeHistoryTable: FC<
+  StopAreaChangeHistoryTableProps
+> = ({
+  className,
+  getUserNameById,
+  error,
+  historyItems,
+  sortedHistoryItems,
+  loading,
+  pagingInfo,
+  refetch,
+  setSortingInfo,
+  sortingInfo,
+}) => {
+  const showLoader = historyItems.length === 0 && loading;
+
+  return (
+    <ChangeHistoryTable
+      className={className}
+      loading={loading}
+      setSortingInfo={setSortingInfo}
+      sortingInfo={sortingInfo}
+    >
+      {error !== null && <FailedToLoadChangeHistory refetch={refetch} />}
+
+      {error === null && showLoader && <LoadingChangeHistory />}
+
+      {error === null && !showLoader && (
+        <StopPlaceChangeHistoryDataRows
+          getUserNameById={getUserNameById}
+          historyItems={historyItems}
+          sortedHistoryItems={sortedHistoryItems}
+          pagingInfo={pagingInfo}
+        />
+      )}
+    </ChangeHistoryTable>
+  );
+};

--- a/ui/src/components/stop-registry/stop-areas/change-history/components/index.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/components/index.ts
@@ -1,0 +1,2 @@
+export * from './StopAreaChangeHistoryPageTitleRow';
+export * from './StopAreaChangeHistoryTable';

--- a/ui/src/components/stop-registry/stop-areas/change-history/queries/index.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/queries/index.ts
@@ -1,0 +1,3 @@
+export * from './useGetHistoricalStopAreaDetails';
+export * from './useGetStopPlaceChangeHistory';
+export * from './useGetTodaysNameForStopPlace';

--- a/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetHistoricalStopAreaDetails.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetHistoricalStopAreaDetails.ts
@@ -1,0 +1,109 @@
+import { gql, useFragment } from '@apollo/client';
+import {
+  HistoricalStopAreaDetailsFragment,
+  HistoricalStopAreaDetailsFragmentDoc,
+  StopPlaceChangeHistoryItem,
+  useGetHistoricalStopAreaDetailsQuery,
+} from '../../../../../generated/graphql';
+
+const GQL_GET_HISTORICAL_STOP_AREA_DETAILS = gql`
+  query GetHistoricalStopAreaDetails($id: String!, $version: Int!) {
+    stopsRegistry: stop_registry {
+      stopPlace(id: $id, version: $version) {
+        ...HistoricalStopAreaDetails
+      }
+    }
+  }
+
+  fragment HistoricalStopAreaDetails on stop_registry_StopPlace {
+    id
+    version
+
+    name {
+      lang
+      value
+    }
+    alternativeNames {
+      name {
+        lang
+        value
+      }
+      nameType
+    }
+
+    privateCode {
+      value
+      type
+    }
+
+    geometry {
+      type
+      coordinates
+    }
+
+    transportMode
+
+    keyValues {
+      key
+      values
+    }
+
+    quays {
+      ...HistoricalStopAreaQuayDetails
+    }
+
+    parentStopPlace {
+      ...HistoricalStopAreaTerminalDetails
+    }
+  }
+
+  fragment HistoricalStopAreaQuayDetails on stop_registry_Quay {
+    id
+    version
+    publicCode
+  }
+
+  fragment HistoricalStopAreaTerminalDetails on stop_registry_ParentStopPlace {
+    id
+    version
+
+    name {
+      lang
+      value
+    }
+
+    privateCode {
+      value
+      type
+    }
+  }
+`;
+
+export function useGetHistoricalStopAreaDetails({
+  netexId: id,
+  version,
+}: StopPlaceChangeHistoryItem) {
+  // Grab data from cache, if it is there
+  const { data, complete } = useFragment<HistoricalStopAreaDetailsFragment>({
+    fragment: HistoricalStopAreaDetailsFragmentDoc,
+    fragmentName: 'HistoricalStopAreaDetails',
+    from: { __typename: 'stop_registry_StopPlace', id, version },
+  });
+
+  // If not in cache, run a query that will then populate it into the cache.
+  const { loading, error, refetch } = useGetHistoricalStopAreaDetailsQuery({
+    variables: { id, version: Number(version) },
+    skip: complete,
+  });
+
+  if (complete) {
+    return {
+      data: data as HistoricalStopAreaDetailsFragment,
+      error: null,
+      loading: false,
+      refetch,
+    };
+  }
+
+  return { data: null, error, refetch, loading };
+}

--- a/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetStopPlaceChangeHistory.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetStopPlaceChangeHistory.ts
@@ -1,0 +1,239 @@
+import { gql } from '@apollo/client';
+import compact from 'lodash/compact';
+import { useMemo } from 'react';
+import {
+  StopPlaceChangeHistoryItem,
+  useGetStopPlaceChangeHistoryQuery,
+} from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
+import { SortOrder } from '../../../../../types';
+import {
+  Comparator,
+  chainedComparator,
+  comparePrimitive,
+  compareValues,
+  getOrder,
+  useCollator,
+} from '../../../../../utils';
+import {
+  ChangeHistoryFilters,
+  ChangeHistorySortingInfo,
+  SortChangeHistoryBy,
+} from '../../../../common/ChangeHistory';
+
+const GQL_GET_STOP_PLACE_CHANGE_HISTORY_QUERY = gql`
+  query getStopPlaceChangeHistory($privateCode: String!) {
+    stopsDb: stops_database {
+      historyItems: getStopPlaceChangeHistory(
+        where: { privateCodeValue: { _eq: $privateCode } }
+      ) {
+        ...StopPlaceChangeHistoryItemDetails
+      }
+    }
+  }
+
+  fragment StopPlaceChangeHistoryItemDetails on StopPlaceChangeHistoryItem {
+    netexId
+    version
+
+    changed
+    changedBy
+    versionComment
+
+    # Used to determine whether the StopPlace was imported from JORE3 or created in JORE4.
+    privateCodeType
+    privateCodeValue
+
+    validityStart
+    validityEnd
+    priority
+
+    parentStopPlace
+  }
+`;
+
+function byNetexId(): Comparator<StopPlaceChangeHistoryItem> {
+  return (a, b) => compareValues(a.netexId, b.netexId, comparePrimitive);
+}
+
+function byVersion(): Comparator<StopPlaceChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(Number(a.version), Number(b.version), comparePrimitive);
+}
+
+function byChanged(): Comparator<StopPlaceChangeHistoryItem> {
+  return (a, b) => compareValues(a.changed, b.changed, comparePrimitive);
+}
+
+function byChanger(
+  collator: Intl.Collator,
+  getUserNameById: GetUserNameById,
+): Comparator<StopPlaceChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(
+      getUserNameById(a.changedBy) ?? a.changedBy ?? 'HSL',
+      getUserNameById(b.changedBy) ?? b.changedBy ?? 'HSL',
+      collator.compare.bind(collator),
+    );
+}
+
+function byValidityStart(): Comparator<StopPlaceChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(a.validityStart, b.validityStart, comparePrimitive);
+}
+
+function byValidityEnd(): Comparator<StopPlaceChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(a.validityEnd, b.validityEnd, comparePrimitive);
+}
+
+function sortByVersion(): Comparator<StopPlaceChangeHistoryItem> {
+  const inDescendingOrder = getOrder<StopPlaceChangeHistoryItem>(
+    SortOrder.DESCENDING,
+  );
+  return chainedComparator(byNetexId(), inDescendingOrder(byVersion()));
+}
+
+function sortByChangedTime(
+  sortOrder: SortOrder,
+): Comparator<StopPlaceChangeHistoryItem> {
+  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+function sortByChanger(
+  sortOrder: SortOrder,
+  collator: Intl.Collator,
+  getUserNameById: GetUserNameById,
+): Comparator<StopPlaceChangeHistoryItem> {
+  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byChanger(collator, getUserNameById)),
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+function sortByValidityStart(
+  sortOrder: SortOrder,
+): Comparator<StopPlaceChangeHistoryItem> {
+  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byValidityStart()),
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+function sortByValidityEnd(
+  sortOrder: SortOrder,
+): Comparator<StopPlaceChangeHistoryItem> {
+  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byValidityEnd()),
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+function sortBySortingInfo(
+  { sortBy, sortOrder }: ChangeHistorySortingInfo,
+  collator: Intl.Collator,
+  getUserNameById: GetUserNameById,
+): Comparator<StopPlaceChangeHistoryItem> {
+  switch (sortBy) {
+    case SortChangeHistoryBy.Changed:
+      return sortByChangedTime(sortOrder);
+
+    case SortChangeHistoryBy.ChangedBy:
+      return sortByChanger(sortOrder, collator, getUserNameById);
+
+    case SortChangeHistoryBy.ValidityStart:
+      return sortByValidityStart(sortOrder);
+
+    case SortChangeHistoryBy.ValidityEnd:
+      return sortByValidityEnd(sortOrder);
+
+    default:
+      return () => 0;
+  }
+}
+
+function filterHistoryItems({
+  from,
+  to,
+}: ChangeHistoryFilters): (item: StopPlaceChangeHistoryItem) => boolean {
+  const fromStr = from.startOf('day').toUTC().toISO({ includeOffset: false });
+  const toStr = to.endOf('day').toUTC().toISO({ includeOffset: false });
+
+  // Changed is a ISO 8601 date-time string and be compared as string.
+  return (item) => fromStr <= item.changed && item.changed <= toStr;
+}
+
+const noopGetUserNameById: GetUserNameById = () => null;
+
+function useSortHistoryItems(
+  historyItems: ReadonlyArray<StopPlaceChangeHistoryItem>,
+  filters: ChangeHistoryFilters,
+  sortingInfo: ChangeHistorySortingInfo,
+  getUserNameByIdRealImpl: GetUserNameById,
+): ReadonlyArray<StopPlaceChangeHistoryItem> {
+  const collator = useCollator({ numeric: true });
+
+  // Most sorting setups do not need to access the mapped username.
+  // Thus, we do not need to react to changes in them.
+  const getUserNameById: GetUserNameById =
+    sortingInfo.sortBy === SortChangeHistoryBy.ChangedBy
+      ? getUserNameByIdRealImpl
+      : noopGetUserNameById;
+
+  return useMemo(
+    () =>
+      historyItems
+        .filter(filterHistoryItems(filters))
+        .sort(sortBySortingInfo(sortingInfo, collator, getUserNameById)),
+    [historyItems, filters, sortingInfo, collator, getUserNameById],
+  );
+}
+
+type GetStopPlaceChangeHistoryOptions = {
+  readonly filters: ChangeHistoryFilters;
+  readonly getUserNameById: GetUserNameById;
+  readonly privateCode: string;
+  readonly sortingInfo: ChangeHistorySortingInfo;
+};
+
+export function useGetStopPlaceChangeHistory({
+  filters,
+  getUserNameById,
+  privateCode,
+  sortingInfo,
+}: GetStopPlaceChangeHistoryOptions) {
+  const { data, ...rest } = useGetStopPlaceChangeHistoryQuery({
+    variables: { privateCode },
+  });
+
+  const rawHistoryItems = data?.stopsDb?.historyItems;
+  const historyItems: ReadonlyArray<StopPlaceChangeHistoryItem> = useMemo(
+    () =>
+      compact(rawHistoryItems)
+        .map((item) => ({
+          ...item,
+          versionComment: item.versionComment?.trim(),
+        }))
+        .sort(sortByVersion()),
+    [rawHistoryItems],
+  );
+
+  const sortedHistoryItems: ReadonlyArray<StopPlaceChangeHistoryItem> =
+    useSortHistoryItems(historyItems, filters, sortingInfo, getUserNameById);
+
+  return { ...rest, historyItems, sortedHistoryItems };
+}

--- a/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetTodaysNameForStopPlace.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetTodaysNameForStopPlace.ts
@@ -1,0 +1,46 @@
+import { gql } from '@apollo/client';
+import { DateTime } from 'luxon';
+import { useMemo } from 'react';
+import { useGetTodaysNameForStopPlaceQuery } from '../../../../../generated/graphql';
+import { getNamesFromStopPlace } from '../../../stops/change-history/queries';
+import { TodaysName } from '../../../stops/change-history/types';
+
+const GQL_GET_TODAYS_NAME_FOR_STOP_PLACE = gql`
+  query GetTodaysNameForStopPlace($privateCode: String!, $today: String!) {
+    stopsDb: stops_database {
+      stopPlaces: stops_database_stop_place_newest_version(
+        where: {
+          private_code_value: { _eq: $privateCode }
+          validity_start: { _lte: $today }
+          _or: [
+            { validity_end: { _gte: $today } }
+            { validity_end: { _is_null: true } }
+          ]
+        }
+        limit: 1
+      ) {
+        id
+        name: name_value
+
+        alternativeNames: stop_place_alternative_names {
+          ...StopPlaceAlternativeNames
+        }
+      }
+    }
+  }
+`;
+
+export function useGetTodaysNameForStopPlace(privateCode: string) {
+  const today = DateTime.now().toISODate();
+  const { data, ...rest } = useGetTodaysNameForStopPlaceQuery({
+    variables: { privateCode, today },
+  });
+
+  const rawStopPlace = data?.stopsDb?.stopPlaces?.at(0);
+  const todaysNameForStopPlace: TodaysName = useMemo(
+    () => getNamesFromStopPlace(rawStopPlace),
+    [rawStopPlace],
+  );
+
+  return { ...rest, todaysNameForStopPlace };
+}

--- a/ui/src/components/stop-registry/stop-areas/change-history/types/PreviousStopPlaceChangeHistoryItem.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/types/PreviousStopPlaceChangeHistoryItem.ts
@@ -1,0 +1,6 @@
+import { StopPlaceChangeHistoryItem } from '../../../../../generated/graphql';
+import { NoEarlierVersionExists } from '../../../../common/ChangeHistory';
+
+export type PreviousStopPlaceChangeHistoryItem =
+  | StopPlaceChangeHistoryItem
+  | typeof NoEarlierVersionExists;

--- a/ui/src/components/stop-registry/stop-areas/change-history/types/index.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/types/index.ts
@@ -1,0 +1,1 @@
+export * from './PreviousStopPlaceChangeHistoryItem';

--- a/ui/src/components/stop-registry/stop-areas/change-history/utils/diffStopArea.tsx
+++ b/ui/src/components/stop-registry/stop-areas/change-history/utils/diffStopArea.tsx
@@ -1,0 +1,189 @@
+import { TFunction } from 'i18next';
+import compact from 'lodash/compact';
+import {
+  HistoricalStopAreaDetailsFragment,
+  StopRegistryNameType,
+} from '../../../../../generated/graphql';
+import { mapStopRegistryTransportModeTypeToUiName } from '../../../../../i18n/uiNameMappings';
+import { mapToShortDate } from '../../../../../time';
+import {
+  KnownValueKey,
+  findAlternativeName,
+  findKeyValue,
+  getEmbeddedName,
+  getGeometryPoint,
+} from '../../../../../utils';
+import {
+  ChangedValue,
+  StopsList,
+  diffKeyedValues,
+  mapNullable,
+} from '../../../../common/ChangeHistory';
+
+export function diffStopArea(
+  t: TFunction,
+  previous: HistoricalStopAreaDetailsFragment,
+  current: HistoricalStopAreaDetailsFragment,
+): Array<ChangedValue> {
+  const previousPoint = getGeometryPoint(previous.geometry);
+  const currentPoint = getGeometryPoint(current.geometry);
+
+  return compact([
+    diffKeyedValues({
+      key: 'ValidityStart',
+      field: t(($) => $.changeHistory.tableHeaders.validityStart),
+      oldValue: findKeyValue(previous, KnownValueKey.ValidityStart),
+      newValue: findKeyValue(current, KnownValueKey.ValidityStart),
+      mapper: mapToShortDate,
+    }),
+    diffKeyedValues({
+      key: 'ValidityEnd',
+      field: t(($) => $.changeHistory.tableHeaders.validityEnd),
+      oldValue: findKeyValue(previous, KnownValueKey.ValidityEnd),
+      newValue: findKeyValue(current, KnownValueKey.ValidityEnd),
+      mapper: mapToShortDate,
+    }),
+
+    diffKeyedValues({
+      key: 'NameFin',
+      field: t(($) => $.stopAreaDetails.basicDetails.name),
+      oldValue: previous.name?.value,
+      newValue: current.name?.value,
+    }),
+    diffKeyedValues({
+      key: 'NameSwe',
+      field: t(($) => $.stopAreaDetails.basicDetails.nameSwe),
+      oldValue: findAlternativeName(
+        previous,
+        'swe',
+        StopRegistryNameType.Translation,
+      ),
+      newValue: findAlternativeName(
+        current,
+        'swe',
+        StopRegistryNameType.Translation,
+      ),
+      mapper: getEmbeddedName,
+    }),
+    diffKeyedValues({
+      key: 'NameEng',
+      field: t(($) => $.stopAreaDetails.basicDetails.nameEng),
+      oldValue: findAlternativeName(
+        previous,
+        'eng',
+        StopRegistryNameType.Translation,
+      ),
+      newValue: findAlternativeName(
+        current,
+        'eng',
+        StopRegistryNameType.Translation,
+      ),
+      mapper: getEmbeddedName,
+    }),
+
+    diffKeyedValues({
+      key: 'LongNameFin',
+      field: t(($) => $.stopAreaDetails.basicDetails.nameLongFin),
+      oldValue: findAlternativeName(
+        previous,
+        'fin',
+        StopRegistryNameType.Alias,
+      ),
+      newValue: findAlternativeName(current, 'fin', StopRegistryNameType.Alias),
+      mapper: getEmbeddedName,
+    }),
+    diffKeyedValues({
+      key: 'LongNameSwe',
+      field: t(($) => $.stopAreaDetails.basicDetails.nameLongSwe),
+      oldValue: findAlternativeName(
+        previous,
+        'swe',
+        StopRegistryNameType.Alias,
+      ),
+      newValue: findAlternativeName(current, 'swe', StopRegistryNameType.Alias),
+      mapper: getEmbeddedName,
+    }),
+    diffKeyedValues({
+      key: 'LongNameEng',
+      field: t(($) => $.stopAreaDetails.basicDetails.nameLongEng),
+      oldValue: findAlternativeName(
+        previous,
+        'eng',
+        StopRegistryNameType.Alias,
+      ),
+      newValue: findAlternativeName(current, 'eng', StopRegistryNameType.Alias),
+      mapper: getEmbeddedName,
+    }),
+
+    diffKeyedValues({
+      key: 'AbbreviationFin',
+      field: t(($) => $.stopAreaDetails.basicDetails.abbreviationFin),
+      oldValue: findAlternativeName(
+        previous,
+        'fin',
+        StopRegistryNameType.Other,
+      ),
+      newValue: findAlternativeName(current, 'fin', StopRegistryNameType.Other),
+      mapper: getEmbeddedName,
+    }),
+    diffKeyedValues({
+      key: 'AbbreviationSwe',
+      field: t(($) => $.stopAreaDetails.basicDetails.abbreviationSwe),
+      oldValue: findAlternativeName(
+        previous,
+        'swe',
+        StopRegistryNameType.Other,
+      ),
+      newValue: findAlternativeName(current, 'swe', StopRegistryNameType.Other),
+      mapper: getEmbeddedName,
+    }),
+    diffKeyedValues({
+      key: 'AbbreviationEng',
+      field: t(($) => $.stopAreaDetails.basicDetails.abbreviationEng),
+      oldValue: findAlternativeName(
+        previous,
+        'eng',
+        StopRegistryNameType.Other,
+      ),
+      newValue: findAlternativeName(current, 'eng', StopRegistryNameType.Other),
+      mapper: getEmbeddedName,
+    }),
+
+    diffKeyedValues({
+      key: 'TransportMode',
+      field: t(($) => $.stopDetails.basicDetails.transportMode),
+      oldValue: previous.transportMode,
+      newValue: current.transportMode,
+      mapper: mapNullable((v) =>
+        mapStopRegistryTransportModeTypeToUiName(t, v),
+      ),
+    }),
+
+    diffKeyedValues({
+      key: 'Stops',
+      field: t(($) => $.stopArea.quays),
+      oldValue: compact(previous.quays?.map((it) => it?.publicCode)).sort(),
+      newValue: compact(current.quays?.map((it) => it?.publicCode)).sort(),
+      mapper: (stopLabels) => (
+        <StopsList
+          t={t}
+          stopLabels={stopLabels}
+          getLinkTestId={(l) => `ChangeHistory::ChangedValues::StopLink::${l}`}
+        />
+      ),
+    }),
+
+    diffKeyedValues({
+      key: 'Latitude',
+      field: t(($) => $.stopDetails.location.latitude),
+      oldValue: previousPoint?.latitude,
+      newValue: currentPoint?.latitude,
+    }),
+    diffKeyedValues({
+      key: 'Longitude',
+      field: t(($) => $.stopDetails.location.longitude),
+      oldValue: previousPoint?.longitude,
+      newValue: currentPoint?.longitude,
+    }),
+  ]);
+}

--- a/ui/src/components/stop-registry/stop-areas/change-history/utils/index.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './diffStopArea';

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaVersioningRow.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaVersioningRow.tsx
@@ -29,7 +29,9 @@ export const StopAreaVersioningRow: FC<StopAreaComponentProps> = ({
         {mapToShortDate(area.validityEnd)}
       </div>
       <Link
-        to={routeDetails[Path.stopAreaDetails].getLink(area.privateCode?.value)}
+        to={routeDetails[Path.stopAreaChangeHistory].getLink(
+          area.privateCode?.value,
+        )}
         className="ml-auto flex items-center text-base text-tweaked-brand hover:underline"
         data-testid={testIds.changeHistoryLink}
       >

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/hooks/useGetStopPlaceChangeHistory.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/hooks/useGetStopPlaceChangeHistory.ts
@@ -2,26 +2,7 @@ import { gql } from '@apollo/client';
 import {
   StopsDatabaseStopPlaceBoolExp,
   useGetLatestStopPlaceChangeQuery,
-  useGetStopPlaceChangeHistoryQuery,
 } from '../../../../../generated/graphql';
-
-const GQL_GET_STOP_PLACE_CHANGE_HISTORY = gql`
-  query GetStopPlaceChangeHistory($where: stops_database_stop_place_bool_exp!) {
-    stopsDb: stops_database {
-      stopPlace: stops_database_stop_place(
-        where: $where
-        order_by: { version: desc }
-      ) {
-        changed
-        changed_by
-        private_code_value
-        netex_id
-        version
-        version_comment
-      }
-    }
-  }
-`;
 
 const GQL_GET_LATEST_STOP_PLACE_CHANGE = gql`
   query GetLatestStopPlaceChange($where: stops_database_stop_place_bool_exp!) {
@@ -39,21 +20,6 @@ const GQL_GET_LATEST_STOP_PLACE_CHANGE = gql`
     }
   }
 `;
-
-export function useGetStopPlaceChangeHistory(
-  where: StopsDatabaseStopPlaceBoolExp,
-) {
-  const { data, ...rest } = useGetStopPlaceChangeHistoryQuery({
-    variables: { where },
-  });
-
-  const stopPlaceVersions = data?.stopsDb?.stopPlace ?? [];
-
-  return {
-    ...rest,
-    stopPlaceVersions,
-  };
-}
 
 export function useGetLatestStopPlaceChange(
   where: StopsDatabaseStopPlaceBoolExp,

--- a/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryNames.tsx
+++ b/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryNames.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react';
-import { TodaysNameForQuay } from '../types';
+import { TodaysName } from '../types';
 
 const testIds = {
   names: 'StopChangeHistoryPage::Names',
 };
 
 type StopChangeHistoryNamesProps = {
-  readonly names: TodaysNameForQuay;
+  readonly names: TodaysName;
 };
 
 export const StopChangeHistoryNames: FC<StopChangeHistoryNamesProps> = ({

--- a/ui/src/components/stop-registry/stops/change-history/queries/useGetTodaysNameForQuay.ts
+++ b/ui/src/components/stop-registry/stops/change-history/queries/useGetTodaysNameForQuay.ts
@@ -1,9 +1,12 @@
 import { gql } from '@apollo/client';
 import { DateTime } from 'luxon';
 import { useMemo } from 'react';
-import { useGetTodaysNameForQuayQuery } from '../../../../../generated/graphql';
+import {
+  StopPlaceAlternativeNamesFragment,
+  useGetTodaysNameForQuayQuery,
+} from '../../../../../generated/graphql';
 import { Priority } from '../../../../../types/enums';
-import { TodaysNameForQuay } from '../types';
+import { TodaysName } from '../types';
 
 const GQL_GET_TODAYS_NAME_FOR_QUAY = gql`
   query GetTodaysNameForQuay(
@@ -31,20 +34,42 @@ const GQL_GET_TODAYS_NAME_FOR_QUAY = gql`
           name: name_value
 
           alternativeNames: stop_place_alternative_names {
-            stop_place_id
-            alternative_names_id
-            alternativeName: alternative_name {
-              id
-              name_value
-              name_lang
-              name_type
-            }
+            ...StopPlaceAlternativeNames
           }
         }
       }
     }
   }
+
+  fragment StopPlaceAlternativeNames on stops_database_stop_place_alternative_names {
+    stop_place_id
+    alternative_names_id
+    alternativeName: alternative_name {
+      id
+      name_value
+      name_lang
+      name_type
+    }
+  }
 `;
+
+type StopPlaceWithNames = {
+  readonly name?: string | null;
+  readonly alternativeNames: ReadonlyArray<StopPlaceAlternativeNamesFragment>;
+};
+
+export function getNamesFromStopPlace(
+  stopPlace: StopPlaceWithNames | null | undefined,
+): TodaysName {
+  const name = stopPlace?.name ?? null;
+  const nameSwe =
+    stopPlace?.alternativeNames
+      .map((it) => it.alternativeName)
+      .find((it) => it.name_lang === 'swe' && it.name_type === 'TRANSLATION')
+      ?.name_value ?? null;
+
+  return { name, nameSwe };
+}
 
 export function useGetTodaysNameForQuay(
   publicCode: string,
@@ -56,16 +81,10 @@ export function useGetTodaysNameForQuay(
   });
 
   const rawStopPlace = data?.stopsDb?.stop?.at(0)?.stopPlace;
-  const todaysNameForQuay: TodaysNameForQuay = useMemo(() => {
-    const name = rawStopPlace?.name ?? null;
-    const nameSwe =
-      rawStopPlace?.alternativeNames
-        .map((it) => it.alternativeName)
-        .find((it) => it.name_lang === 'swe' && it.name_type === 'TRANSLATION')
-        ?.name_value ?? null;
-
-    return { name, nameSwe };
-  }, [rawStopPlace]);
+  const todaysNameForQuay: TodaysName = useMemo(
+    () => getNamesFromStopPlace(rawStopPlace),
+    [rawStopPlace],
+  );
 
   return { ...rest, todaysNameForQuay };
 }

--- a/ui/src/components/stop-registry/stops/change-history/types/TodaysName.ts
+++ b/ui/src/components/stop-registry/stops/change-history/types/TodaysName.ts
@@ -1,4 +1,4 @@
-export type TodaysNameForQuay = {
+export type TodaysName = {
   readonly name: string | null;
   readonly nameSwe: string | null;
 };

--- a/ui/src/components/stop-registry/stops/change-history/types/index.ts
+++ b/ui/src/components/stop-registry/stops/change-history/types/index.ts
@@ -1,3 +1,3 @@
 export * from './HistoricalStopData';
 export * from './HistoricalStopVersionSpecifier';
-export * from './TodaysNameForQuay';
+export * from './TodaysName';

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -1561,6 +1561,16 @@
       "loadingTimeAllowedOn": "Loading time allowed on stops"
     }
   },
+  "stopAreaChangeHistory": {
+    "title": "Change history | Stop Area {{privateCode}}",
+    "titleWithName": "Change history | Stop Area {{privateCode}} {{name}}",
+    "goBack": "Back",
+    "newStopAreaVersion": "New Stop Area version created",
+    "importedStopAreaVersion": "Stop Area imported from Jore 3",
+    "sectionTitle": "Stop Area {{privateCodeValue}}",
+    "failedToLoad": "Failed to load change details",
+    "versionLoading": "Resolving changed fields"
+  },
   "dataModelRefactor": {
     "disabled": "This feature has been disabled due to the revent Data model refactorings, and in general due to the ongoing development of the Stop Registry features. This feature is being worked on and should be re-enabled soon."
   },

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -1561,6 +1561,16 @@
       "loadingTimeAllowedOn": "Lastausaika sallittu pysäkeillä"
     }
   },
+  "stopAreaChangeHistory": {
+    "title": "Muutoshistoria | Pysäkkialue {{privateCode}}",
+    "titleWithName": "Muutoshistoria | Pysäkkialue {{privateCode}} {{name}}",
+    "goBack": "Palaa",
+    "newStopAreaVersion": "Uusi versio pysäkkialueesta luotu",
+    "importedStopAreaVersion": "Pysäkkialue tuotu Jore 3:sta",
+    "sectionTitle": "Pysäkkialue {{privateCodeValue}}",
+    "failedToLoad": "Muuttuneiden kenttien selvitys epäonnistui",
+    "versionLoading": "Selvitetään muuttuneita kenttiä"
+  },
   "dataModelRefactor": {
     "disabled": "Tämä toiminto on väliaikaisesti poistettu käytöstä vastikäisten tietomallimuutosten, sekä yleisemminkin pysäkkirekisterin kehityksen, johdosta. Toiminnon uusi toteutus on työn alla ja palautunee käyttöön pikapuolin."
   },

--- a/ui/src/router/Router.tsx
+++ b/ui/src/router/Router.tsx
@@ -35,6 +35,7 @@ import {
   StopDetailsPage,
   StopSearchResultPage,
 } from '../components/stop-registry';
+import { StopAreaChangeHistoryPage } from '../components/stop-registry/stop-areas/change-history/StopAreaChangeHistoryPage';
 import { StopAreaDetailsPage } from '../components/stop-registry/stop-areas/stop-area-details/StopAreaDetailsPage';
 import { StopChangeHistoryPage } from '../components/stop-registry/stops/change-history';
 import { StopVersionsPage } from '../components/stop-registry/stops/versions';
@@ -268,6 +269,11 @@ const joreRoutes: ReadonlyArray<SimpleJoreRoute> = [
     path: Path.stopAreaDetails,
     protected: true,
     element: <StopAreaDetailsPage />,
+  },
+  {
+    path: Path.stopAreaChangeHistory,
+    protected: true,
+    element: <StopAreaChangeHistoryPage />,
   },
   {
     path: Path.terminalDetails,

--- a/ui/src/router/routeDetails.ts
+++ b/ui/src/router/routeDetails.ts
@@ -28,6 +28,7 @@ export const Path = {
   stopChangeHistory: '/stop-registry/stops/:label/history',
   terminalDetails: '/stop-registry/terminals/:privateCode',
   stopAreaDetails: '/stop-registry/stop-areas/:id',
+  stopAreaChangeHistory: '/stop-registry/stop-areas/:privateCode/history',
 
   // Timetables
   timetablesSearch: '/timetables/search',
@@ -178,6 +179,13 @@ export const routeDetails: Readonly<Record<PathValue, RouteDetails>> = {
   },
   [Path.stopAreaDetails]: {
     getLink: genVariableLinkGenerator(Path.stopAreaDetails),
+    includeInNav: false,
+  },
+  [Path.stopAreaChangeHistory]: {
+    getLink: genVariableLinkGenerator(
+      Path.stopAreaChangeHistory,
+      ':privateCode',
+    ),
     includeInNav: false,
   },
   [Path.terminalDetails]: {

--- a/ui/src/utils/sort.ts
+++ b/ui/src/utils/sort.ts
@@ -1,12 +1,104 @@
-export const sortAlphabetically = <T>(
+import identity from 'lodash/identity';
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SortOrder } from '../types';
+import { areEqual } from './areEqual';
+import { memoizeOne } from './memoizeOne';
+
+export function sortAlphabetically<T>(
   array: ReadonlyArray<T>,
   attribute: keyof T,
-): T[] =>
-  array.toSorted((a, b) =>
+): T[] {
+  return array.toSorted((a, b) =>
     String(a[attribute]).localeCompare(String(b[attribute])),
   );
+}
 
-export const sortReverseAlphabetically = <T>(
+export function sortReverseAlphabetically<T>(
   array: ReadonlyArray<T>,
   attribute: keyof T,
-): T[] => sortAlphabetically(array, attribute).reverse();
+): T[] {
+  return sortAlphabetically(array, attribute).reverse();
+}
+
+export type NullOrder = 'NullsFirst' | 'NullsLast';
+export type Comparator<T> = (a: T, b: T) => number;
+export type Order<T> = (comparator: Comparator<T>) => Comparator<T>;
+
+export function getOrder<T>(sortOrder: SortOrder): Order<T> {
+  if (sortOrder === SortOrder.ASCENDING) {
+    return identity;
+  }
+
+  return (comparator) => (a, b) => -comparator(a, b);
+}
+
+export function comparePrimitive(a: number, b: number): number;
+export function comparePrimitive(a: bigint, b: bigint): number;
+export function comparePrimitive(a: string, b: string): number;
+export function comparePrimitive(a: boolean, b: boolean): number;
+export function comparePrimitive<T extends number | bigint | string | boolean>(
+  a: T,
+  b: T,
+): number {
+  if (a < b) {
+    return -1;
+  }
+
+  if (a > b) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export function compareValues<ValueT>(
+  rawA: ValueT,
+  rawB: ValueT,
+  compareNonNullable: Comparator<NonNullable<ValueT>>,
+  nullOrder: NullOrder = 'NullsLast',
+): number {
+  const a = rawA ?? null;
+  const b = rawB ?? null;
+
+  if (a !== null && b !== null) {
+    return compareNonNullable(a, b);
+  }
+
+  if (a === null && b !== null) {
+    return nullOrder === 'NullsLast'
+      ? Number.NEGATIVE_INFINITY
+      : Number.POSITIVE_INFINITY;
+  }
+
+  if (b === null && a !== null) {
+    return nullOrder === 'NullsLast'
+      ? Number.POSITIVE_INFINITY
+      : Number.NEGATIVE_INFINITY;
+  }
+
+  return 0;
+}
+
+export function chainedComparator<T>(
+  ...comparators: ReadonlyArray<Comparator<T>>
+): Comparator<T> {
+  return (a, b) => {
+    let result = 0;
+
+    for (const comparator of comparators) {
+      result = comparator(a, b);
+      if (result !== 0) {
+        return result;
+      }
+    }
+
+    return result;
+  };
+}
+
+export function useCollator(options?: Intl.CollatorOptions) {
+  const { t } = useTranslation();
+  const langCode = t(($) => $.languages.intlLangCode);
+  return useRef(memoizeOne(Intl.Collator, areEqual)).current(langCode, options);
+}

--- a/ui/src/utils/stop-registry/alternativeNames.ts
+++ b/ui/src/utils/stop-registry/alternativeNames.ts
@@ -1,4 +1,9 @@
 import i18next from 'i18next';
+import {
+  StopRegistryAlternativeName,
+  StopRegistryEmbeddableMultilingualString,
+  StopRegistryNameType,
+} from '../../generated/graphql';
 
 type AlternativeName = {
   readonly name_lang?: string | null;
@@ -48,4 +53,25 @@ export function getNameFromAlternatives(
   }
 
   return defaultName ?? null;
+}
+
+export const findAlternativeName = (
+  entity: {
+    readonly alternativeNames?: ReadonlyArray<
+      StopRegistryAlternativeName | null | undefined
+    > | null;
+  },
+  lang: string,
+  nameType: StopRegistryNameType = StopRegistryNameType.Translation,
+): StopRegistryEmbeddableMultilingualString | null => {
+  const matchingName = entity.alternativeNames?.find(
+    (an) => an?.name.lang === lang && an.nameType === nameType,
+  );
+  return matchingName?.name ?? null;
+};
+
+export function getEmbeddedName(
+  name: StopRegistryEmbeddableMultilingualString | null | undefined,
+): string | null {
+  return name?.value ?? null;
 }

--- a/ui/src/utils/stop-registry/stopPlace.ts
+++ b/ui/src/utils/stop-registry/stopPlace.ts
@@ -27,6 +27,7 @@ import { StopOwner, StopPlaceState } from '../../types/stop-registry';
 import { findKeyValue, findKeyValueParsed } from '../findKeyValue';
 import { mapLngLatToPoint } from '../gis';
 import { KnownValueKey } from '../knownValueKey';
+import { findAlternativeName } from './alternativeNames';
 
 type StopPlaceType = Pick<StopRegistryStopPlace, '__typename'>;
 type ParentStopPlaceType = Pick<StopRegistryParentStopPlace, '__typename'>;
@@ -84,17 +85,6 @@ export const getParentStopPlacesFromQueryResult = <
 
 // Required in DB so can't be null.
 export const defaultAccessibilityLevel = StopRegistryAccessibilityLevel.Unknown;
-
-const findAlternativeName = (
-  stopPlace: Pick<StopRegistryStopPlace, 'alternativeNames'>,
-  lang: string,
-  nameType: StopRegistryNameType = StopRegistryNameType.Translation,
-): StopRegistryEmbeddableMultilingualString | null => {
-  const matchingName = stopPlace.alternativeNames?.find(
-    (an) => an?.name.lang === lang && an.nameType === nameType,
-  );
-  return matchingName?.name ?? null;
-};
 
 export const setAlternativeName = (
   initialAlternativeNames:


### PR DESCRIPTION
### ChangeHistory: Extract out more reusable code
* Generic StopsList component to list stops of Routes, Lines, and/or StopAreas or Terminals.
* Expose Previous version Symbols.
* Expose helper methods for finding Alternative names.
* Expose and generify UI side sorting utilities.


### Implement StopArea ChangeHistory


### E2E: Add tests for StopArea ChangeHistory

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1405)
<!-- Reviewable:end -->
