### PR TITLE
Simplify change history fetching

### DIFF
--- a/cypress/e2e/stop-registry/stopChangeHistory.cy.ts
+++ b/cypress/e2e/stop-registry/stopChangeHistory.cy.ts
@@ -1082,7 +1082,6 @@ describe('Stop Change History', { tags }, () => {
           .getChanged()
           .filter(':visible')
           .click();
-        expectGraphQLCallToSucceed('@gqlGetStopChangeHistory');
         cy.info('Sort buttons should have new correct state.');
         assertSortButtonState('Changed', 'asc');
         cy.info('Data rows should be ordered correctly Changed|Asc.');
@@ -1134,7 +1133,6 @@ describe('Stop Change History', { tags }, () => {
           .getValidityStart()
           .filter(':visible')
           .click();
-        expectGraphQLCallToSucceed('@gqlGetStopChangeHistory');
         assertSortButtonState('ValidityStart', 'desc');
 
         cy.info('Data rows should be ordered correctly ValidityStart|Desc.');
@@ -1155,7 +1153,6 @@ describe('Stop Change History', { tags }, () => {
           .getValidityStart()
           .filter(':visible')
           .click();
-        expectGraphQLCallToSucceed('@gqlGetStopChangeHistory');
         cy.info('Sort buttons should have new correct state.');
         assertSortButtonState('ValidityStart', 'asc');
         cy.info('Data rows should be ordered correctly ValidityStart|Asc.');
@@ -1177,7 +1174,6 @@ describe('Stop Change History', { tags }, () => {
           .getValidityEnd()
           .filter(':visible')
           .click();
-        expectGraphQLCallToSucceed('@gqlGetStopChangeHistory');
         assertSortButtonState('ValidityEnd', 'asc');
         cy.info('Data rows should be ordered correctly ValidityEnd|Asc.');
         assertSectionsAreInOrder((current, next) => {
@@ -1197,7 +1193,6 @@ describe('Stop Change History', { tags }, () => {
           .getValidityEnd()
           .filter(':visible')
           .click();
-        expectGraphQLCallToSucceed('@gqlGetStopChangeHistory');
         cy.info('Sort buttons should have new correct state.');
         assertSortButtonState('ValidityEnd', 'desc');
         cy.info('Data rows should be ordered correctly ValidityEnd|Desc.');
@@ -1265,7 +1260,6 @@ describe('Stop Change History', { tags }, () => {
           .getToDate()
           .focus()
           .inputDateValue(DateTime.now().minus({ months: 1 }));
-        expectGraphQLCallToSucceed('@gqlGetStopChangeHistory');
 
         StopChangeHistoryPage.changeHistoryTable.sectionHeader
           .getBasicDetails()

--- a/cypress/pageObjects/stop-registry/StopChangeHistoryPage.ts
+++ b/cypress/pageObjects/stop-registry/StopChangeHistoryPage.ts
@@ -54,7 +54,6 @@ const StopChangeHistoryTable = createSimplePageObject(
   [
     // Stop Change history table getters
     // StopChangeHistoryItem | NoPreviousChangeVersionSection
-    'ChangeHistory::SectionHeader::InvalidVersion',
     'ChangeHistory::SectionHeader::ImportedVersion',
     'ChangeHistory::SectionHeader::CreatedVersion',
     'ChangeHistory::SectionHeader::CopiedVersion',

--- a/ui/src/components/common/ChangeHistory/types/PreviousVersion.ts
+++ b/ui/src/components/common/ChangeHistory/types/PreviousVersion.ts
@@ -1,2 +1,1 @@
 export const NoEarlierVersionExists = Symbol('NoEarlierVersionExists');
-export const PreviousVersionUnknown = Symbol('PreviousVersionUnknown');

--- a/ui/src/components/routes-and-lines/line-change-history/components/DataDiffSections.tsx
+++ b/ui/src/components/routes-and-lines/line-change-history/components/DataDiffSections.tsx
@@ -1,10 +1,7 @@
 import { FC } from 'react';
 import { GetUserNameById } from '../../../../hooks';
 import { useGetLineChangeHistoryItemData } from '../queries';
-import {
-  LineChangeHistoryItem,
-  TruePreviousLineChangeHistoryItem,
-} from '../types';
+import { LineChangeHistoryItem } from '../types';
 import { DataDiffFailedToLoadSection } from './DataDiffFailedToLoadSection';
 import { DataDiffSectionLoading } from './DataDiffSectionLoading';
 import { LineDetailsChangedSectionRow } from './LineDetailsChangedSectionRow';
@@ -13,7 +10,7 @@ import { RouteDetailsChangedSectionRow } from './RouteDetailsChangedSectionRow';
 type DataDiffSectionsProps = {
   readonly getUserNameById: GetUserNameById;
   readonly historyItem: LineChangeHistoryItem;
-  readonly previousHistoryItem: TruePreviousLineChangeHistoryItem;
+  readonly previousHistoryItem: LineChangeHistoryItem;
 };
 
 export const DataDiffSections: FC<DataDiffSectionsProps> = ({

--- a/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryDataRows.tsx
+++ b/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryDataRows.tsx
@@ -1,10 +1,7 @@
 import { FC } from 'react';
 import { GetUserNameById } from '../../../../hooks';
 import { PagingInfo } from '../../../../types';
-import {
-  NoEarlierVersionExists,
-  PreviousVersionUnknown,
-} from '../../../common/ChangeHistory';
+import { NoEarlierVersionExists } from '../../../common/ChangeHistory';
 import { LineChangeHistoryItem, PreviousLineChangeHistoryItem } from '../types';
 import { LineChangeHistoryItemSections } from './LineChangeHistoryItem';
 
@@ -27,7 +24,11 @@ function findPreviousVersion(
       other.routeId === item.routeId,
   );
 
-  return previous ?? PreviousVersionUnknown;
+  if (previous) {
+    return previous;
+  }
+
+  throw new Error('Unable to find previous version!');
 }
 
 type LineChangeHistoryDataRowsProps = {

--- a/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryTable.tsx
+++ b/ui/src/components/routes-and-lines/line-change-history/components/LineChangeHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, FC, SetStateAction } from 'react';
 import { GetUserNameById } from '../../../../hooks';
 import { PagingInfo } from '../../../../types';
 import {
@@ -9,41 +9,6 @@ import {
 } from '../../../common/ChangeHistory';
 import { LineChangeHistoryItem } from '../types';
 import { LineChangeHistoryDataRows } from './LineChangeHistoryDataRows';
-
-/**
- * Prevent flashing of various loading states on a fast connection.
- *
- * Don't show the loader at all, if we already know the previous result.
- * If we don't know the previous result, show the old results and wait for
- * 0.15s before switching to the loader state.
- *
- * @param loading
- * @param historyItems
- */
-function usePrettyLoaderState(
-  loading: boolean,
-  historyItems: ReadonlyArray<LineChangeHistoryItem>,
-) {
-  const [showLoader, setShowLoader] = useState(loading);
-  const [previousHistoryItems, setPreviousHistoryItems] =
-    useState(historyItems);
-
-  useEffect(() => {
-    if (!loading || historyItems.length > 0) {
-      setPreviousHistoryItems(historyItems);
-    }
-  }, [loading, historyItems]);
-
-  useEffect(() => {
-    const id = setTimeout(
-      () => setShowLoader(loading && historyItems.length === 0),
-      150, // Matches with the transition time for the sorting buttons.
-    );
-    return () => clearTimeout(id);
-  }, [loading, historyItems]);
-
-  return { showLoader, previousHistoryItems };
-}
 
 type LineChangeHistoryTableProps = {
   readonly className?: string;
@@ -70,10 +35,7 @@ export const LineChangeHistoryTable: FC<LineChangeHistoryTableProps> = ({
   setSortingInfo,
   sortingInfo,
 }) => {
-  const { showLoader, previousHistoryItems } = usePrettyLoaderState(
-    loading,
-    sortedHistoryItems,
-  );
+  const showLoader = historyItems.length === 0 && loading;
 
   return (
     <ChangeHistoryTable
@@ -90,9 +52,7 @@ export const LineChangeHistoryTable: FC<LineChangeHistoryTableProps> = ({
         <LineChangeHistoryDataRows
           getUserNameById={getUserNameById}
           historyItems={historyItems}
-          sortedHistoryItems={
-            loading ? previousHistoryItems : sortedHistoryItems
-          }
+          sortedHistoryItems={sortedHistoryItems}
           pagingInfo={pagingInfo}
         />
       )}

--- a/ui/src/components/routes-and-lines/line-change-history/errors/DataNotFoundError.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/errors/DataNotFoundError.ts
@@ -1,21 +1,17 @@
 /* eslint-disable @stylistic/lines-between-class-members */
-import {
-  LineChangeHistoryItem,
-  LineData,
-  PreviousLineChangeHistoryItem,
-} from '../types';
+import { LineChangeHistoryItem, LineData } from '../types';
 
 interface DataNotFoundErrorData {
   readonly currentHistoryItem: LineChangeHistoryItem;
   readonly currentItemData: LineData | null;
-  readonly previousHistoryItem: PreviousLineChangeHistoryItem;
+  readonly previousHistoryItem: LineChangeHistoryItem;
   readonly previousItemData: LineData | null;
 }
 
 export class DataNotFoundError extends Error implements DataNotFoundErrorData {
   readonly currentHistoryItem: LineChangeHistoryItem;
   readonly currentItemData: LineData | null;
-  readonly previousHistoryItem: PreviousLineChangeHistoryItem;
+  readonly previousHistoryItem: LineChangeHistoryItem;
   readonly previousItemData: LineData | null;
 
   constructor(props: DataNotFoundErrorData) {

--- a/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistory.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistory.ts
@@ -23,19 +23,12 @@ import {
 import { LineChangeHistoryItem, TgOperation } from '../types';
 
 const GQL_GET_LINE_CHANGE_HISTORY = gql`
-  query GetLineChangeHistory(
-    $label: String!
-    $from: timestamptz!
-    $to: timestamptz!
-    $priority: Int!
-  ) {
+  query GetLineChangeHistory($label: String!, $priority: Int!) {
     historyItems: route_line_change_history(
       where: {
         _and: [
           { line_label: { _eq: $label } }
           { line_priority: { _eq: $priority } }
-          { changed: { _gte: $from } }
-          { changed: { _lte: $to } }
         ]
       }
     ) {
@@ -73,6 +66,7 @@ function parseRawLineChangeHistoryItem(
 ): LineChangeHistoryItem {
   return {
     ...raw,
+    versionComment: raw.versionComment?.trim() ?? null,
     tgOperation: raw.tgOperation as TgOperation,
     validityStart: raw.routeId ? raw.routeValidityStart : raw.lineValidityStart,
     validityEnd: raw.routeId ? raw.routeValidityEnd : raw.lineValidityEnd,
@@ -242,10 +236,20 @@ function sortByVersion(): Comparator<LineChangeHistoryItem> {
   );
 }
 
+function filterHistoryItems(
+  filters: ChangeHistoryFilters,
+): (item: LineChangeHistoryItem) => boolean {
+  const from = filters.from.startOf('day');
+  const to = filters.to.endOf('day');
+
+  return (item) => from <= item.changed && item.changed <= to;
+}
+
 const noopGetUserNameById: GetUserNameById = () => null;
 
 function useSortHistoryItems(
   historyItems: ReadonlyArray<LineChangeHistoryItem>,
+  filters: ChangeHistoryFilters,
   sortingInfo: ChangeHistorySortingInfo,
   getUserNameByIdRealImpl: GetUserNameById,
 ): ReadonlyArray<LineChangeHistoryItem> {
@@ -260,10 +264,10 @@ function useSortHistoryItems(
 
   return useMemo(
     () =>
-      historyItems.toSorted(
-        sortBySortingInfo(sortingInfo, collator, getUserNameById),
-      ),
-    [historyItems, sortingInfo, collator, getUserNameById],
+      historyItems
+        .filter(filterHistoryItems(filters))
+        .sort(sortBySortingInfo(sortingInfo, collator, getUserNameById)),
+    [historyItems, filters, sortingInfo, collator, getUserNameById],
   );
 }
 
@@ -275,18 +279,13 @@ type GetLineChangeHistoryOptions = {
 };
 
 export function useGetLineChangeHistoryItems({
-  filters: { from, to, priority },
+  filters,
   getUserNameById,
   label,
   sortingInfo,
 }: GetLineChangeHistoryOptions) {
   const { data, ...rest } = useGetLineChangeHistoryQuery({
-    variables: {
-      label,
-      priority,
-      from: from.startOf('day'),
-      to: to.endOf('day'),
-    },
+    variables: { label, priority: filters.priority },
   });
 
   const historyItems: ReadonlyArray<LineChangeHistoryItem> = useMemo(
@@ -298,7 +297,7 @@ export function useGetLineChangeHistoryItems({
   );
 
   const sortedHistoryItems: ReadonlyArray<LineChangeHistoryItem> =
-    useSortHistoryItems(historyItems, sortingInfo, getUserNameById);
+    useSortHistoryItems(historyItems, filters, sortingInfo, getUserNameById);
 
   return {
     ...rest,

--- a/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistoryItemData.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistoryItemData.ts
@@ -1,15 +1,7 @@
 import { gql } from '@apollo/client';
-import {
-  OrderBy,
-  useGetLineChangeHistoryItemDataQuery,
-} from '../../../../generated/graphql';
-import { PreviousVersionUnknown } from '../../../common/ChangeHistory';
+import { useGetLineChangeHistoryItemDataQuery } from '../../../../generated/graphql';
 import { DataNotFoundError } from '../errors';
-import {
-  LineChangeHistoryItem,
-  LineData,
-  TruePreviousLineChangeHistoryItem,
-} from '../types';
+import { LineChangeHistoryItem, LineData } from '../types';
 
 const GQL_GET_LINE_CHANGE_HISTORY_ITEM_DATA = gql`
   query GetLineChangeHistoryItemData(
@@ -41,37 +33,9 @@ function getByIdQueryOptions(item: LineChangeHistoryItem): QueryParameters {
   };
 }
 
-function getQueryOptionsForPreviousHistoryItem(
-  currentHistoryItem: LineChangeHistoryItem,
-  previousHistoryItem: TruePreviousLineChangeHistoryItem,
-): QueryParameters {
-  // Previous version was not included in the date filter range.
-  // We need to resolve it now.
-  if (previousHistoryItem === PreviousVersionUnknown) {
-    return {
-      variables: {
-        where: {
-          // Include LineLabel in query, so we can use the associated index.
-          line_label: { _eq: currentHistoryItem.lineLabel },
-          id: { _neq: currentHistoryItem.id },
-          changed: { _lte: currentHistoryItem.changed },
-          line_id: { _eq: currentHistoryItem.lineId },
-          ...(currentHistoryItem.routeId
-            ? { route_id: { _eq: currentHistoryItem.routeId } }
-            : { route_id: { _is_null: true } }),
-        },
-        orderBy: [{ changed: OrderBy.Desc }],
-      },
-    };
-  }
-
-  // We know the ID of the previous version, fetch by ID.
-  return getByIdQueryOptions(previousHistoryItem);
-}
-
 function getError(
   currentHistoryItem: LineChangeHistoryItem,
-  previousHistoryItem: TruePreviousLineChangeHistoryItem,
+  previousHistoryItem: LineChangeHistoryItem,
   currentItemResult: QueryResult,
   previousItemResult: QueryResult,
   currentItemData: LineData | null,
@@ -135,7 +99,7 @@ type GetLineChangeHistoryItemDataResult =
 
 export function useGetLineChangeHistoryItemData(
   currentHistoryItem: LineChangeHistoryItem,
-  previousHistoryItem: TruePreviousLineChangeHistoryItem,
+  previousHistoryItem: LineChangeHistoryItem,
 ): GetLineChangeHistoryItemDataResult {
   const currentItemResult = useGetLineChangeHistoryItemDataQuery({
     ...getByIdQueryOptions(currentHistoryItem),
@@ -144,10 +108,7 @@ export function useGetLineChangeHistoryItemData(
   });
 
   const previousItemResult = useGetLineChangeHistoryItemDataQuery({
-    ...getQueryOptionsForPreviousHistoryItem(
-      currentHistoryItem,
-      previousHistoryItem,
-    ),
+    ...getByIdQueryOptions(previousHistoryItem),
     fetchPolicy: 'cache-first',
     nextFetchPolicy: 'cache-first',
   });

--- a/ui/src/components/routes-and-lines/line-change-history/types/PreviousLineChangeHistoryItem.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/types/PreviousLineChangeHistoryItem.ts
@@ -1,14 +1,6 @@
-import {
-  NoEarlierVersionExists,
-  PreviousVersionUnknown,
-} from '../../../common/ChangeHistory';
+import { NoEarlierVersionExists } from '../../../common/ChangeHistory';
 import { LineChangeHistoryItem } from './LineChangeHistoryItem';
-
-export type TruePreviousLineChangeHistoryItem =
-  | LineChangeHistoryItem
-  | typeof PreviousVersionUnknown;
 
 export type PreviousLineChangeHistoryItem =
   | LineChangeHistoryItem
-  | typeof NoEarlierVersionExists
-  | typeof PreviousVersionUnknown;
+  | typeof NoEarlierVersionExists;

--- a/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetStopPlaceChangeHistory.ts
+++ b/ui/src/components/stop-registry/stop-areas/change-history/queries/useGetStopPlaceChangeHistory.ts
@@ -6,20 +6,11 @@ import {
   useGetStopPlaceChangeHistoryQuery,
 } from '../../../../../generated/graphql';
 import { GetUserNameById } from '../../../../../hooks';
-import { SortOrder } from '../../../../../types';
-import {
-  Comparator,
-  chainedComparator,
-  comparePrimitive,
-  compareValues,
-  getOrder,
-  useCollator,
-} from '../../../../../utils';
 import {
   ChangeHistoryFilters,
   ChangeHistorySortingInfo,
-  SortChangeHistoryBy,
 } from '../../../../common/ChangeHistory';
+import { sortByVersion, useSortTiamatHistoryItems } from '../../../utils';
 
 const GQL_GET_STOP_PLACE_CHANGE_HISTORY_QUERY = gql`
   query getStopPlaceChangeHistory($privateCode: String!) {
@@ -52,157 +43,6 @@ const GQL_GET_STOP_PLACE_CHANGE_HISTORY_QUERY = gql`
   }
 `;
 
-function byNetexId(): Comparator<StopPlaceChangeHistoryItem> {
-  return (a, b) => compareValues(a.netexId, b.netexId, comparePrimitive);
-}
-
-function byVersion(): Comparator<StopPlaceChangeHistoryItem> {
-  return (a, b) =>
-    compareValues(Number(a.version), Number(b.version), comparePrimitive);
-}
-
-function byChanged(): Comparator<StopPlaceChangeHistoryItem> {
-  return (a, b) => compareValues(a.changed, b.changed, comparePrimitive);
-}
-
-function byChanger(
-  collator: Intl.Collator,
-  getUserNameById: GetUserNameById,
-): Comparator<StopPlaceChangeHistoryItem> {
-  return (a, b) =>
-    compareValues(
-      getUserNameById(a.changedBy) ?? a.changedBy ?? 'HSL',
-      getUserNameById(b.changedBy) ?? b.changedBy ?? 'HSL',
-      collator.compare.bind(collator),
-    );
-}
-
-function byValidityStart(): Comparator<StopPlaceChangeHistoryItem> {
-  return (a, b) =>
-    compareValues(a.validityStart, b.validityStart, comparePrimitive);
-}
-
-function byValidityEnd(): Comparator<StopPlaceChangeHistoryItem> {
-  return (a, b) =>
-    compareValues(a.validityEnd, b.validityEnd, comparePrimitive);
-}
-
-function sortByVersion(): Comparator<StopPlaceChangeHistoryItem> {
-  const inDescendingOrder = getOrder<StopPlaceChangeHistoryItem>(
-    SortOrder.DESCENDING,
-  );
-  return chainedComparator(byNetexId(), inDescendingOrder(byVersion()));
-}
-
-function sortByChangedTime(
-  sortOrder: SortOrder,
-): Comparator<StopPlaceChangeHistoryItem> {
-  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
-  return chainedComparator(
-    order(byChanged()),
-    order(byNetexId()),
-    order(byVersion()),
-  );
-}
-
-function sortByChanger(
-  sortOrder: SortOrder,
-  collator: Intl.Collator,
-  getUserNameById: GetUserNameById,
-): Comparator<StopPlaceChangeHistoryItem> {
-  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
-  return chainedComparator(
-    order(byChanger(collator, getUserNameById)),
-    order(byChanged()),
-    order(byNetexId()),
-    order(byVersion()),
-  );
-}
-
-function sortByValidityStart(
-  sortOrder: SortOrder,
-): Comparator<StopPlaceChangeHistoryItem> {
-  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
-  return chainedComparator(
-    order(byValidityStart()),
-    order(byChanged()),
-    order(byNetexId()),
-    order(byVersion()),
-  );
-}
-
-function sortByValidityEnd(
-  sortOrder: SortOrder,
-): Comparator<StopPlaceChangeHistoryItem> {
-  const order = getOrder<StopPlaceChangeHistoryItem>(sortOrder);
-  return chainedComparator(
-    order(byValidityEnd()),
-    order(byChanged()),
-    order(byNetexId()),
-    order(byVersion()),
-  );
-}
-
-function sortBySortingInfo(
-  { sortBy, sortOrder }: ChangeHistorySortingInfo,
-  collator: Intl.Collator,
-  getUserNameById: GetUserNameById,
-): Comparator<StopPlaceChangeHistoryItem> {
-  switch (sortBy) {
-    case SortChangeHistoryBy.Changed:
-      return sortByChangedTime(sortOrder);
-
-    case SortChangeHistoryBy.ChangedBy:
-      return sortByChanger(sortOrder, collator, getUserNameById);
-
-    case SortChangeHistoryBy.ValidityStart:
-      return sortByValidityStart(sortOrder);
-
-    case SortChangeHistoryBy.ValidityEnd:
-      return sortByValidityEnd(sortOrder);
-
-    default:
-      return () => 0;
-  }
-}
-
-function filterHistoryItems({
-  from,
-  to,
-}: ChangeHistoryFilters): (item: StopPlaceChangeHistoryItem) => boolean {
-  const fromStr = from.startOf('day').toUTC().toISO({ includeOffset: false });
-  const toStr = to.endOf('day').toUTC().toISO({ includeOffset: false });
-
-  // Changed is a ISO 8601 date-time string and be compared as string.
-  return (item) => fromStr <= item.changed && item.changed <= toStr;
-}
-
-const noopGetUserNameById: GetUserNameById = () => null;
-
-function useSortHistoryItems(
-  historyItems: ReadonlyArray<StopPlaceChangeHistoryItem>,
-  filters: ChangeHistoryFilters,
-  sortingInfo: ChangeHistorySortingInfo,
-  getUserNameByIdRealImpl: GetUserNameById,
-): ReadonlyArray<StopPlaceChangeHistoryItem> {
-  const collator = useCollator({ numeric: true });
-
-  // Most sorting setups do not need to access the mapped username.
-  // Thus, we do not need to react to changes in them.
-  const getUserNameById: GetUserNameById =
-    sortingInfo.sortBy === SortChangeHistoryBy.ChangedBy
-      ? getUserNameByIdRealImpl
-      : noopGetUserNameById;
-
-  return useMemo(
-    () =>
-      historyItems
-        .filter(filterHistoryItems(filters))
-        .sort(sortBySortingInfo(sortingInfo, collator, getUserNameById)),
-    [historyItems, filters, sortingInfo, collator, getUserNameById],
-  );
-}
-
 type GetStopPlaceChangeHistoryOptions = {
   readonly filters: ChangeHistoryFilters;
   readonly getUserNameById: GetUserNameById;
@@ -233,7 +73,12 @@ export function useGetStopPlaceChangeHistory({
   );
 
   const sortedHistoryItems: ReadonlyArray<StopPlaceChangeHistoryItem> =
-    useSortHistoryItems(historyItems, filters, sortingInfo, getUserNameById);
+    useSortTiamatHistoryItems(
+      historyItems,
+      filters,
+      sortingInfo,
+      getUserNameById,
+    );
 
   return { ...rest, historyItems, sortedHistoryItems };
 }

--- a/ui/src/components/stop-registry/stops/change-history/StopChangeHistoryPage.tsx
+++ b/ui/src/components/stop-registry/stops/change-history/StopChangeHistoryPage.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { useRequiredParams } from '../../../../hooks';
+import { useGetUserNames, useRequiredParams } from '../../../../hooks';
 import { Container } from '../../../../layoutComponents';
 import { Pagination } from '../../../../uiComponents';
 import {
@@ -36,9 +36,12 @@ export const StopChangeHistoryPage: FC = () => {
     publicCode,
     filters.priority,
   );
-  const { historyItems, loading, error, refetch } =
+
+  const { getUserNameById } = useGetUserNames();
+  const { historyItems, sortedHistoryItems, loading, error, refetch } =
     useGetStopChangeHistoryItems({
       filters,
+      getUserNameById,
       publicCode,
       sortingInfo,
     });
@@ -65,8 +68,9 @@ export const StopChangeHistoryPage: FC = () => {
         <StopChangeHistoryTable
           className="mt-5"
           error={error ?? null}
-          filters={filters}
+          getUserNameById={getUserNameById}
           historyItems={historyItems}
+          sortedHistoryItems={sortedHistoryItems}
           loading={loading}
           pagingInfo={pagingInfo}
           refetch={refetch}

--- a/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryDataRows.tsx
+++ b/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryDataRows.tsx
@@ -1,92 +1,95 @@
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import { QuayChangeHistoryItem } from '../../../../../generated/graphql';
-import { useGetUserNames } from '../../../../../hooks';
+import { GetUserNameById } from '../../../../../hooks';
+import { parseDate } from '../../../../../time';
 import { PagingInfo } from '../../../../../types';
-import { ChangeHistoryFilters } from '../../../../common/ChangeHistory';
+import { NoEarlierVersionExists } from '../../../../common/ChangeHistory';
+import { PreviousQuayChangeHistoryItem } from '../types';
 import { StopChangeHistoryItem } from './StopChangeHistoryItem';
 
 const testIds = {
   group: (id: string) => `ChangeHistory::Group::${id}`,
 };
 
-/**
- * Extract the numeric sequence number from a Netex ID.
- * @param netexId
- */
-function sequenceNumber(netexId: string): number {
-  return Number(netexId.split(':').at(2));
+function findPreviousInstance(
+  historyItemsSortedByVersion: ReadonlyArray<QuayChangeHistoryItem>,
+  item: QuayChangeHistoryItem,
+): PreviousQuayChangeHistoryItem {
+  // Special case: Moved from one StopPlace to another.
+  // Under hood Tiamat sometimes creates a new version.
+  const importedIdIfMoved = `${item.publicCode}-${item.validityStart}-${item.priority}`;
+
+  if (item.importedId === importedIdIfMoved) {
+    const previousInstanceEndData = parseDate(item.validityStart)
+      ?.minus({ day: 1 })
+      ?.toISODate();
+
+    if (previousInstanceEndData) {
+      const previousInstance = historyItemsSortedByVersion.find(
+        (other) => other.validityEnd === previousInstanceEndData,
+      );
+
+      if (previousInstance) {
+        return previousInstance;
+      }
+    }
+  }
+
+  return NoEarlierVersionExists;
 }
 
 function findPreviousVersion(
   historyItemsSortedByVersion: ReadonlyArray<QuayChangeHistoryItem>,
   item: QuayChangeHistoryItem,
-): QuayChangeHistoryItem | null {
-  const index = historyItemsSortedByVersion.indexOf(item);
+): PreviousQuayChangeHistoryItem {
+  const previousVersion = historyItemsSortedByVersion.find(
+    (other) =>
+      other.netexId === item.netexId &&
+      Number(other.version) < Number(item.version),
+  );
 
-  // IndexOf should always find a valid index.
-  // But index of 0 is the first item, thus there is no previous version.
-  if (index <= 0) {
-    return null;
+  if (previousVersion) {
+    return previousVersion;
   }
 
-  return historyItemsSortedByVersion[index - 1];
+  return findPreviousInstance(historyItemsSortedByVersion, item);
 }
 
 type StopChangeHistoryDataRowsProps = {
-  readonly filters: ChangeHistoryFilters;
+  readonly getUserNameById: GetUserNameById;
   readonly historyItems: ReadonlyArray<QuayChangeHistoryItem>;
+  readonly sortedHistoryItems: ReadonlyArray<QuayChangeHistoryItem>;
   readonly pagingInfo: PagingInfo;
 };
 
 export const StopChangeHistoryDataRows: FC<StopChangeHistoryDataRowsProps> = ({
-  filters: { from, to },
+  getUserNameById,
   historyItems,
+  sortedHistoryItems,
   pagingInfo: { page, pageSize },
 }) => {
-  const { getUserNameById } = useGetUserNames();
-
-  // Item data sorted on actual version info.
-  // Needed to determine previous version.
-  const historyItemsSortedByVersion = useMemo(
-    () =>
-      historyItems.toSorted((a, b) => {
-        if (a.netexId === b.netexId) {
-          return Number(a.version) - Number(b.version);
-        }
-
-        return sequenceNumber(a.netexId) - sequenceNumber(b.netexId);
-      }),
-    [historyItems],
+  const pagedItems = sortedHistoryItems.slice(
+    (page - 1) * pageSize,
+    page * pageSize,
   );
 
-  // historyItems can contain extra versions needed to ćonstruct the diffs,
-  // even tough the version itself, should not be shown based on the time
-  // filters.
-  const itemsToShow = useMemo(() => {
-    const fromStr = from.toISO();
-    const toStr = to.toISO();
+  return pagedItems.map((historyItem) => {
+    const key = `${historyItem.netexId}-${historyItem.version}`;
 
-    return historyItems
-      .filter(({ changed }) => fromStr <= changed && changed <= toStr)
-      .slice((page - 1) * pageSize, page * pageSize);
-  }, [historyItems, from, to, page, pageSize]);
-
-  return itemsToShow.map((historyItem) => (
-    <tbody
-      data-testid={testIds.group(
-        `${historyItem.netexId}-${historyItem.version}`,
-      )}
-      className="group"
-    >
-      <StopChangeHistoryItem
-        key={`${historyItem.netexId}-${historyItem.version}`}
-        getUserNameById={getUserNameById}
-        historyItem={historyItem}
-        previousHistoryItem={findPreviousVersion(
-          historyItemsSortedByVersion,
-          historyItem,
-        )}
-      />
-    </tbody>
-  ));
+    return (
+      <tbody
+        key={key}
+        data-testid={testIds.group(key)}
+        data-netexid={historyItem.netexId}
+        data-version={historyItem.version}
+        className="group"
+      >
+        <StopChangeHistoryItem
+          getUserNameById={getUserNameById}
+          historyItem={historyItem}
+          previousHistoryItem={findPreviousVersion(historyItems, historyItem)}
+        />
+      </tbody>
+    );
+  });
 };

--- a/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryItem.tsx
+++ b/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryItem.tsx
@@ -1,22 +1,15 @@
 import { FC } from 'react';
-import { useTranslation } from 'react-i18next';
 import { QuayChangeHistoryItem } from '../../../../../generated/graphql';
 import { GetUserNameById } from '../../../../../hooks';
-import { ChangeHistoryItemSectionHeaderRow } from '../../../../common/ChangeHistory';
+import { NoEarlierVersionExists } from '../../../../common/ChangeHistory';
+import { PreviousQuayChangeHistoryItem } from '../types';
 import { DataDiffSections } from './DataDiffSections';
 import { NoPreviousChangeVersionSection } from './NoPreviousChangeVersionSection';
-
-const testIds = {
-  // These will expand to: ChangeHistory::SectionHeader::${testId}
-  invalidVersion: 'InvalidVersion',
-  importedVersion: 'ImportedVersion',
-  createdVersion: 'CreatedVersion',
-};
 
 type StopChangeHistoryItemProps = {
   readonly getUserNameById: GetUserNameById;
   readonly historyItem: QuayChangeHistoryItem;
-  readonly previousHistoryItem: QuayChangeHistoryItem | null;
+  readonly previousHistoryItem: PreviousQuayChangeHistoryItem;
 };
 
 export const StopChangeHistoryItem: FC<StopChangeHistoryItemProps> = ({
@@ -24,28 +17,7 @@ export const StopChangeHistoryItem: FC<StopChangeHistoryItemProps> = ({
   historyItem,
   previousHistoryItem,
 }) => {
-  const { t } = useTranslation();
-
-  const versionInt = Number(historyItem.version);
-
-  if (!Number.isSafeInteger(versionInt) || versionInt < 0) {
-    return (
-      <ChangeHistoryItemSectionHeaderRow
-        getUserNameById={getUserNameById}
-        historyItem={historyItem}
-        sectionTitle={
-          <h5>
-            {t(($) => $.stopChangeHistory.invalidVersion, {
-              version: historyItem.version,
-            })}
-          </h5>
-        }
-        testId={testIds.invalidVersion}
-      />
-    );
-  }
-
-  if (!previousHistoryItem) {
+  if (previousHistoryItem === NoEarlierVersionExists) {
     return (
       <NoPreviousChangeVersionSection
         getUserNameById={getUserNameById}

--- a/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryTable.tsx
+++ b/ui/src/components/stop-registry/stops/change-history/components/StopChangeHistoryTable.tsx
@@ -1,8 +1,8 @@
-import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, FC, SetStateAction } from 'react';
 import { QuayChangeHistoryItem } from '../../../../../generated/graphql';
+import { GetUserNameById } from '../../../../../hooks';
 import { PagingInfo } from '../../../../../types';
 import {
-  ChangeHistoryFilters,
   ChangeHistorySortingInfo,
   ChangeHistoryTable,
   FailedToLoadChangeHistory,
@@ -10,46 +10,12 @@ import {
 } from '../../../../common/ChangeHistory';
 import { StopChangeHistoryDataRows } from './StopChangeHistoryDataRows';
 
-/**
- * Prevent flashing of various loading states on a fast connection.
- *
- * Don't show the loader at all, if we already know the previous result.
- * If we don't know the previous result, show the old results and wait for
- * 0.15s before switching to the loader state.
- *
- * @param loading
- * @param historyItems
- */
-function usePrettyLoaderState(
-  loading: boolean,
-  historyItems: ReadonlyArray<QuayChangeHistoryItem>,
-) {
-  const [showLoader, setShowLoader] = useState(loading);
-  const [previousHistoryItems, setPreviousHistoryItems] =
-    useState(historyItems);
-
-  useEffect(() => {
-    if (!loading || historyItems.length > 0) {
-      setPreviousHistoryItems(historyItems);
-    }
-  }, [loading, historyItems]);
-
-  useEffect(() => {
-    const id = setTimeout(
-      () => setShowLoader(loading && historyItems.length === 0),
-      150, // Matches with the transition time for the sorting buttons.
-    );
-    return () => clearTimeout(id);
-  }, [loading, historyItems]);
-
-  return { showLoader, previousHistoryItems };
-}
-
 type StopChangeHistoryTableProps = {
   readonly className?: string;
   readonly error: Error | null;
-  readonly filters: ChangeHistoryFilters;
+  readonly getUserNameById: GetUserNameById;
   readonly historyItems: ReadonlyArray<QuayChangeHistoryItem>;
+  readonly sortedHistoryItems: ReadonlyArray<QuayChangeHistoryItem>;
   readonly loading: boolean;
   readonly pagingInfo: PagingInfo;
   readonly refetch: () => void;
@@ -59,19 +25,17 @@ type StopChangeHistoryTableProps = {
 
 export const StopChangeHistoryTable: FC<StopChangeHistoryTableProps> = ({
   className,
-  filters,
   error,
+  getUserNameById,
   historyItems,
+  sortedHistoryItems,
   loading,
   pagingInfo,
   refetch,
   setSortingInfo,
   sortingInfo,
 }) => {
-  const { showLoader, previousHistoryItems } = usePrettyLoaderState(
-    loading,
-    historyItems,
-  );
+  const showLoader = historyItems.length === 0 && loading;
 
   return (
     <ChangeHistoryTable
@@ -86,8 +50,9 @@ export const StopChangeHistoryTable: FC<StopChangeHistoryTableProps> = ({
 
       {error === null && !showLoader && (
         <StopChangeHistoryDataRows
-          filters={filters}
-          historyItems={loading ? previousHistoryItems : historyItems}
+          getUserNameById={getUserNameById}
+          historyItems={historyItems}
+          sortedHistoryItems={sortedHistoryItems}
           pagingInfo={pagingInfo}
         />
       )}

--- a/ui/src/components/stop-registry/stops/change-history/queries/useGetStopChangeHistoryItems.ts
+++ b/ui/src/components/stop-registry/stops/change-history/queries/useGetStopChangeHistoryItems.ts
@@ -2,56 +2,26 @@ import { gql } from '@apollo/client';
 import compact from 'lodash/compact';
 import { useMemo } from 'react';
 import {
-  OrderBy,
   QuayChangeHistoryItem,
-  StopsDatabaseQuayChangeHistoryItemOrderBy,
   useGetStopChangeHistoryQuery,
 } from '../../../../../generated/graphql';
-import { SortOrder } from '../../../../../types';
+import { GetUserNameById } from '../../../../../hooks';
 import {
   ChangeHistoryFilters,
   ChangeHistorySortingInfo,
-  SortChangeHistoryBy,
 } from '../../../../common/ChangeHistory';
+import { sortByVersion, useSortTiamatHistoryItems } from '../../../utils';
 
-// Normally paging should be done on the DB side.
-// But we would need a second native query for that,
-// or a proper view. The amount of data fetched by this query,
-// should be relatively minimal, and thus paging can be done
-// safely on the client side. At least for the time being.
-// This might change, in 10 years if we ger a million changed
-// done to a single stop.
 const GQL_GET_STOP_CHANGE_HISTORY = gql`
-  query GetStopChangeHistory(
-    $publicCode: String!
-    $from: timestamp!
-    $to: timestamp!
-    $priority: String!
-    $orderBy: [stops_database_QuayChangeHistoryItem_order_by!]!
-  ) {
+  query GetStopChangeHistory($publicCode: String!, $priority: String!) {
     stopsDb: stops_database {
       historyItems: getQuayChangeHistory(
         where: {
           _and: [
             { publicCode: { _eq: $publicCode } }
             { priority: { _eq: $priority } }
-            { changed: { _gte: $from } }
-            { changed: { _lte: $to } }
           ]
         }
-        order_by: $orderBy
-      ) {
-        ...QuayChangeHistoryItemDetails
-      }
-
-      extraDiffItem: getQuayChangeHistory(
-        where: {
-          publicCode: { _eq: $publicCode }
-          priority: { _eq: $priority }
-          changed: { _lt: $from }
-        }
-        order_by: [{ changed: desc }]
-        limit: 1
       ) {
         ...QuayChangeHistoryItemDetails
       }
@@ -81,65 +51,42 @@ const GQL_GET_STOP_CHANGE_HISTORY = gql`
   }
 `;
 
-function sortingInfoToOrderBy({
-  sortBy,
-  sortOrder,
-}: ChangeHistorySortingInfo): Array<StopsDatabaseQuayChangeHistoryItemOrderBy> {
-  const orderBy =
-    sortOrder === SortOrder.ASCENDING ? OrderBy.Asc : OrderBy.Desc;
-  const byVersion: StopsDatabaseQuayChangeHistoryItemOrderBy = {
-    version: orderBy,
-  };
-
-  switch (sortBy) {
-    case SortChangeHistoryBy.ValidityStart:
-      return [{ validityStart: orderBy }, byVersion];
-
-    case SortChangeHistoryBy.ValidityEnd:
-      return [{ validityEnd: orderBy }, byVersion];
-
-    case SortChangeHistoryBy.ChangedBy:
-      return [{ changedBy: orderBy }, byVersion];
-
-    case SortChangeHistoryBy.Changed:
-    default:
-      return [{ changed: orderBy }, byVersion];
-  }
-}
-
 type GetStopChangeHistoryOptions = {
   readonly filters: ChangeHistoryFilters;
+  readonly getUserNameById: GetUserNameById;
   readonly sortingInfo: ChangeHistorySortingInfo;
   readonly publicCode: string;
 };
 
 export function useGetStopChangeHistoryItems({
-  filters: { from, to, priority },
+  filters,
+  getUserNameById,
   publicCode,
   sortingInfo,
 }: GetStopChangeHistoryOptions) {
   const { data, ...rest } = useGetStopChangeHistoryQuery({
-    variables: {
-      publicCode,
-      priority: String(priority),
-      from: from.startOf('day').toISO(),
-      to: to.endOf('day').toISO(),
-      orderBy: sortingInfoToOrderBy(sortingInfo),
-    },
+    variables: { publicCode, priority: String(filters.priority) },
   });
 
-  const { historyItems: rawHistoryItems, extraDiffItem: rawExtraItem } =
-    data?.stopsDb ?? {};
+  const rawHistoryItems = data?.stopsDb?.historyItems;
   const historyItems: ReadonlyArray<QuayChangeHistoryItem> = useMemo(
     () =>
       compact(rawHistoryItems)
-        .concat(rawExtraItem ?? [])
         .map((item) => ({
           ...item,
           versionComment: item.versionComment?.trim(),
-        })),
-    [rawHistoryItems, rawExtraItem],
+        }))
+        .sort(sortByVersion()),
+    [rawHistoryItems],
   );
 
-  return { ...rest, historyItems };
+  const sortedHistoryItems: ReadonlyArray<QuayChangeHistoryItem> =
+    useSortTiamatHistoryItems(
+      historyItems,
+      filters,
+      sortingInfo,
+      getUserNameById,
+    );
+
+  return { ...rest, historyItems, sortedHistoryItems };
 }

--- a/ui/src/components/stop-registry/stops/change-history/types/PreviousQuayChangeHistoryItem.ts
+++ b/ui/src/components/stop-registry/stops/change-history/types/PreviousQuayChangeHistoryItem.ts
@@ -1,0 +1,6 @@
+import { QuayChangeHistoryItem } from '../../../../../generated/graphql';
+import { NoEarlierVersionExists } from '../../../../common/ChangeHistory';
+
+export type PreviousQuayChangeHistoryItem =
+  | QuayChangeHistoryItem
+  | typeof NoEarlierVersionExists;

--- a/ui/src/components/stop-registry/stops/change-history/types/index.ts
+++ b/ui/src/components/stop-registry/stops/change-history/types/index.ts
@@ -1,3 +1,4 @@
 export * from './HistoricalStopData';
 export * from './HistoricalStopVersionSpecifier';
+export * from './PreviousQuayChangeHistoryItem';
 export * from './TodaysName';

--- a/ui/src/components/stop-registry/types/BaseTiamatChangeHistoryItem.ts
+++ b/ui/src/components/stop-registry/types/BaseTiamatChangeHistoryItem.ts
@@ -1,0 +1,10 @@
+export type BaseTiamatChangeHistoryItem = {
+  readonly netexId: string;
+  readonly version: string;
+
+  readonly changed?: string | null;
+  readonly changedBy?: string | null;
+
+  readonly validityEnd?: string | null;
+  readonly validityStart?: string | null;
+};

--- a/ui/src/components/stop-registry/types/index.ts
+++ b/ui/src/components/stop-registry/types/index.ts
@@ -1,3 +1,4 @@
+export * from './BaseTiamatChangeHistoryItem';
 export * from './LocatableStop';
 export * from './LocatableStopProps';
 export * from './utils';

--- a/ui/src/components/stop-registry/utils/filterTiamatHistoryItems.ts
+++ b/ui/src/components/stop-registry/utils/filterTiamatHistoryItems.ts
@@ -1,0 +1,14 @@
+import { ChangeHistoryFilters } from '../../common/ChangeHistory';
+import { BaseTiamatChangeHistoryItem } from '../types';
+
+export function filterTiamatHistoryItems({
+  from,
+  to,
+}: ChangeHistoryFilters): (item: BaseTiamatChangeHistoryItem) => boolean {
+  const fromStr = from.startOf('day').toUTC().toISO({ includeOffset: false });
+  const toStr = to.endOf('day').toUTC().toISO({ includeOffset: false });
+
+  // Changed is a ISO 8601 date-time string and be compared as string.
+  return (item) =>
+    !!item.changed && fromStr <= item.changed && item.changed <= toStr;
+}

--- a/ui/src/components/stop-registry/utils/index.ts
+++ b/ui/src/components/stop-registry/utils/index.ts
@@ -4,4 +4,6 @@ export * from './mapInfoSpotToInput';
 export * from './mapQuayToInput';
 export * from './mapToEnrichedQuay';
 export * from './parseTerminalType';
+export { sortByVersion } from './sortTiamatChangeHistoryItems';
 export * from './useShowStopAreaOnMap';
+export * from './useSortTiamatHistoryItems';

--- a/ui/src/components/stop-registry/utils/sortTiamatChangeHistoryItems.ts
+++ b/ui/src/components/stop-registry/utils/sortTiamatChangeHistoryItems.ts
@@ -1,0 +1,128 @@
+import { GetUserNameById } from '../../../hooks';
+import { SortOrder } from '../../../types';
+import {
+  Comparator,
+  chainedComparator,
+  comparePrimitive,
+  compareValues,
+  getOrder,
+} from '../../../utils';
+import {
+  ChangeHistorySortingInfo,
+  SortChangeHistoryBy,
+} from '../../common/ChangeHistory';
+import { BaseTiamatChangeHistoryItem } from '../types';
+
+function byNetexId(): Comparator<BaseTiamatChangeHistoryItem> {
+  return (a, b) => compareValues(a.netexId, b.netexId, comparePrimitive);
+}
+
+function byVersion(): Comparator<BaseTiamatChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(Number(a.version), Number(b.version), comparePrimitive);
+}
+
+function byChanged(): Comparator<BaseTiamatChangeHistoryItem> {
+  return (a, b) => compareValues(a.changed, b.changed, comparePrimitive);
+}
+
+function byChanger(
+  collator: Intl.Collator,
+  getUserNameById: GetUserNameById,
+): Comparator<BaseTiamatChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(
+      getUserNameById(a.changedBy) ?? a.changedBy ?? 'HSL',
+      getUserNameById(b.changedBy) ?? b.changedBy ?? 'HSL',
+      collator.compare.bind(collator),
+    );
+}
+
+function byValidityStart(): Comparator<BaseTiamatChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(a.validityStart, b.validityStart, comparePrimitive);
+}
+
+function byValidityEnd(): Comparator<BaseTiamatChangeHistoryItem> {
+  return (a, b) =>
+    compareValues(a.validityEnd, b.validityEnd, comparePrimitive);
+}
+
+export function sortByVersion(): Comparator<BaseTiamatChangeHistoryItem> {
+  const inDescendingOrder = getOrder<BaseTiamatChangeHistoryItem>(
+    SortOrder.DESCENDING,
+  );
+  return chainedComparator(byNetexId(), inDescendingOrder(byVersion()));
+}
+
+function sortByChangedTime(
+  sortOrder: SortOrder,
+): Comparator<BaseTiamatChangeHistoryItem> {
+  const order = getOrder<BaseTiamatChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+function sortByChanger(
+  sortOrder: SortOrder,
+  collator: Intl.Collator,
+  getUserNameById: GetUserNameById,
+): Comparator<BaseTiamatChangeHistoryItem> {
+  const order = getOrder<BaseTiamatChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byChanger(collator, getUserNameById)),
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+function sortByValidityStart(
+  sortOrder: SortOrder,
+): Comparator<BaseTiamatChangeHistoryItem> {
+  const order = getOrder<BaseTiamatChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byValidityStart()),
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+function sortByValidityEnd(
+  sortOrder: SortOrder,
+): Comparator<BaseTiamatChangeHistoryItem> {
+  const order = getOrder<BaseTiamatChangeHistoryItem>(sortOrder);
+  return chainedComparator(
+    order(byValidityEnd()),
+    order(byChanged()),
+    order(byNetexId()),
+    order(byVersion()),
+  );
+}
+
+export function sortBySortingInfo(
+  { sortBy, sortOrder }: ChangeHistorySortingInfo,
+  collator: Intl.Collator,
+  getUserNameById: GetUserNameById,
+): Comparator<BaseTiamatChangeHistoryItem> {
+  switch (sortBy) {
+    case SortChangeHistoryBy.Changed:
+      return sortByChangedTime(sortOrder);
+
+    case SortChangeHistoryBy.ChangedBy:
+      return sortByChanger(sortOrder, collator, getUserNameById);
+
+    case SortChangeHistoryBy.ValidityStart:
+      return sortByValidityStart(sortOrder);
+
+    case SortChangeHistoryBy.ValidityEnd:
+      return sortByValidityEnd(sortOrder);
+
+    default:
+      return () => 0;
+  }
+}

--- a/ui/src/components/stop-registry/utils/useSortTiamatHistoryItems.ts
+++ b/ui/src/components/stop-registry/utils/useSortTiamatHistoryItems.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { GetUserNameById } from '../../../hooks';
+import { useCollator } from '../../../utils';
+import {
+  ChangeHistoryFilters,
+  ChangeHistorySortingInfo,
+  SortChangeHistoryBy,
+} from '../../common/ChangeHistory';
+import { BaseTiamatChangeHistoryItem } from '../types';
+import { filterTiamatHistoryItems } from './filterTiamatHistoryItems';
+import { sortBySortingInfo } from './sortTiamatChangeHistoryItems';
+
+const noopGetUserNameById: GetUserNameById = () => null;
+
+export function useSortTiamatHistoryItems<
+  T extends BaseTiamatChangeHistoryItem,
+>(
+  historyItems: ReadonlyArray<T>,
+  filters: ChangeHistoryFilters,
+  sortingInfo: ChangeHistorySortingInfo,
+  getUserNameByIdRealImpl: GetUserNameById,
+): ReadonlyArray<T> {
+  const collator = useCollator({ numeric: true });
+
+  // Most sorting setups do not need to access the mapped username.
+  // Thus, we do not need to react to changes in them.
+  const getUserNameById: GetUserNameById =
+    sortingInfo.sortBy === SortChangeHistoryBy.ChangedBy
+      ? getUserNameByIdRealImpl
+      : noopGetUserNameById;
+
+  return useMemo(
+    () =>
+      historyItems
+        .filter(filterTiamatHistoryItems(filters))
+        .sort(sortBySortingInfo(sortingInfo, collator, getUserNameById)),
+    [historyItems, filters, sortingInfo, collator, getUserNameById],
+  );
+}

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -1510,7 +1510,6 @@
     "firstVersion": "New stop created",
     "importedVersion": "Stop imported from Jore 3",
     "copiedVersion": "Stop copied from another version",
-    "invalidVersion": "Invalid version {{version}}",
     "failedToLoad": "Failed to load change details",
     "versionLoading": "Resolving changed fields",
     "ownerDetails": "Owner details",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -1510,7 +1510,6 @@
     "firstVersion": "Uusi pysäkki luotu",
     "importedVersion": "Pysäkki tuotu Jore 3:sta",
     "copiedVersion": "Pysäkki kopioitu toisesta versiosta",
-    "invalidVersion": "Tuntematon versionumero {{version}}",
     "failedToLoad": "Muuttuneiden kenttien selvitys epäonnistui",
     "versionLoading": "Selvitetään muuttuneita kenttiä",
     "ownerDetails": "Omistajan tiedot",


### PR DESCRIPTION
### LineChangeHistory: Simplify data fetching

Drop the backend date range filtering, and do it in UI instead. This way we always know the full history, and can easily pick the previous version UI side, without later having to do extra requests.

Lets assume we get a sane amount of changes made to the lines over their lifetime (hundreds, not tens of thousands). If this becomes slow in the future, well come up with a better way to implement this.


### StopChangeHistory: Simplify data fetching

* Use the same client side filtering, sorting and paging as with other ChangeHistory implementations.
* Make previous version resolving more robust.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1406)
<!-- Reviewable:end -->
