### PR TITLE
Add version comment field to routes and lines

### DIFF
--- a/cypress/e2e/editRoute.cy.ts
+++ b/cypress/e2e/editRoute.cy.ts
@@ -13,6 +13,7 @@ import { Tag } from '../enums';
 import {
   ConfirmationDialog,
   EditRoutePage,
+  LineChangeHistory,
   LineDetailsPage,
   RouteRow,
   TerminusNameInputs,
@@ -52,6 +53,8 @@ describe('Route editing', { tags: [Tag.Routes] }, () => {
     });
 
     it("Should edit a routes's information", { tags: [Tag.Smoke] }, () => {
+      const versionComment = 'E2E route edit reason';
+
       LineDetailsPage.visit(baseDbResources.lines[0].line_id);
       RouteRow.getEditRouteButton('901', RouteDirectionEnum.Inbound).click();
 
@@ -60,6 +63,7 @@ describe('Route editing', { tags: [Tag.Routes] }, () => {
         finnishName: 'Edited route name',
         label: '901E',
         variant: '8',
+        versionComment,
         direction: RouteDirectionEnum.Outbound,
         origin: {
           finnishName: 'Edited origin FIN',
@@ -94,6 +98,13 @@ describe('Route editing', { tags: [Tag.Routes] }, () => {
         '901E',
         RouteDirectionEnum.Outbound,
       ).should('contain', '1.1.2022 - 31.12.2030');
+
+      LineDetailsPage.getChangeHistoryLink().click();
+      LineChangeHistory.changeHistoryTable.sectionHeader
+        .getVersionComment()
+        .should('be.visible')
+        .and('contain', versionComment);
+      cy.go('back');
 
       // Verify rest of the information from the edit route page
       RouteRow.getEditRouteButton('901E', RouteDirectionEnum.Outbound).click();
@@ -176,6 +187,7 @@ describe('Route editing', { tags: [Tag.Routes] }, () => {
         finnishName: 'Edited route name',
         label: '901E',
         variant: '8',
+        versionComment: 'E2E route validation reason',
         direction: RouteDirectionEnum.Outbound,
         origin: {
           finnishName: 'Edited origin FIN',

--- a/cypress/e2e/lines.cy.ts
+++ b/cypress/e2e/lines.cy.ts
@@ -6,6 +6,7 @@ import {
 } from '@hsl/jore4-test-db-manager/dist/CypressSpecExports';
 import { Tag } from '../enums';
 import {
+  LineChangeHistory,
   LineDetailsPage,
   LineForm,
   LineValidityPeriod,
@@ -46,6 +47,8 @@ describe('Lines', { tags: [Tag.Lines] }, () => {
     });
 
     it('Creates new line as expected', { tags: [Tag.Smoke] }, () => {
+      const versionComment = 'E2E line create reason';
+
       LineForm.getLabelInput().type('7327');
       LineForm.getFinnishNameInput().type('Testilinja FI');
       LineForm.getSwedishNameInput().type('Testilinja SV');
@@ -59,6 +62,7 @@ describe('Lines', { tags: [Tag.Lines] }, () => {
       LineForm.priorityForm.setPriority(Priority.Standard);
       ValidityPeriodForm.setStartDate('2022-01-01');
       ValidityPeriodForm.setEndDate('2050-01-01');
+      LineForm.getVersionCommentInput().type(versionComment);
 
       LineForm.save();
       LineForm.checkLineSubmitSuccess();
@@ -75,6 +79,13 @@ describe('Lines', { tags: [Tag.Lines] }, () => {
       );
       LineDetailsPage.getPrimaryVehicleMode().should('contain', 'Bussi');
       LineDetailsPage.getTypeOfLine().should('contain', 'Peruslinja');
+
+      LineDetailsPage.getChangeHistoryLink().click();
+      LineChangeHistory.changeHistoryTable.sectionHeader
+        .getVersionComment()
+        .should('be.visible')
+        .and('contain', versionComment);
+      cy.go('back');
 
       // Check line text from edit page
       LineDetailsPage.getEditLineButton().click();
@@ -100,6 +111,7 @@ describe('Lines', { tags: [Tag.Lines] }, () => {
 
       PriorityForm.setAsDraft();
       ValidityPeriodForm.setStartDate('2022-01-01');
+      LineForm.getVersionCommentInput().type('E2E line edit reason');
 
       LineForm.save();
       LineForm.checkLineSubmitSuccess();
@@ -143,6 +155,25 @@ describe('Lines', { tags: [Tag.Lines] }, () => {
       cy.getByTestId('ValidationError::message::typeOfLine').shouldHaveText(
         'Linjan tyyppi ei vastaa sen kulkumuotoa',
       );
+    });
+
+    it('should show version comment in line change history after edit', () => {
+      const versionComment = 'E2E line change history reason';
+
+      LineDetailsPage.getEditLineButton().click();
+      LineForm.getFinnishNameInput().clearAndType('Muutettu historia-nimi');
+      ValidityPeriodForm.setStartDate('2022-01-01');
+      ValidityPeriodForm.setEndDate('2050-01-01');
+      LineForm.getVersionCommentInput().type(versionComment);
+
+      LineForm.save();
+      LineForm.checkLineSubmitSuccess();
+
+      LineDetailsPage.getChangeHistoryLink().click();
+      LineChangeHistory.changeHistoryTable.sectionHeader
+        .getVersionComment()
+        .should('be.visible')
+        .and('contain', versionComment);
     });
   });
 });

--- a/cypress/e2e/map/createRoute.cy.ts
+++ b/cypress/e2e/map/createRoute.cy.ts
@@ -13,6 +13,8 @@ import {
 import { Tag } from '../../enums';
 import {
   FilterPanel,
+  LineChangeHistory,
+  LineDetailsPage,
   MapFooter,
   MapPage,
   RouteStopsOverlay,
@@ -62,12 +64,14 @@ describe('Route creation', rootOpts, () => {
     cy.mockLogin();
   });
 
-  it(
+  it.only(
     'Should create a new route',
     {
       tags: [Tag.Smoke, Tag.Network],
     },
     () => {
+      const versionComment = 'E2E create route reason';
+
       MapPage.map.visit(mapLocation);
 
       FilterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
@@ -93,6 +97,7 @@ describe('Route creation', rootOpts, () => {
           swedishShortName: 'Test destination SWE shortName',
         },
         priority: Priority.Standard,
+        versionComment,
         validityStartISODate: '2025-01-01',
         validityEndISODate: '2030-12-01',
       });
@@ -151,6 +156,13 @@ describe('Route creation', rootOpts, () => {
       RouteStopsOverlay.getNthRouteStopsOverlayRow(3).shouldHaveText(
         'E2E005 -',
       );
+
+      LineDetailsPage.visit(baseDbResources.lines[0].line_id);
+      LineDetailsPage.getChangeHistoryLink().click();
+      LineChangeHistory.changeHistoryTable.sectionHeader
+        .getVersionComment()
+        .should('be.visible')
+        .and('contain', versionComment);
     },
   );
 
@@ -163,6 +175,7 @@ describe('Route creation', rootOpts, () => {
       finnishName: 'Test route',
       label: '901Y',
       variant: '56',
+      versionComment: 'E2E cancel create route reason',
       line: '901',
       direction: RouteDirectionEnum.Outbound,
       origin: {
@@ -201,6 +214,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Test route',
         label: '901X',
+        versionComment: 'E2E create route with removed stop reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {
@@ -295,6 +309,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Erronous route',
         label: '901F',
+        versionComment: 'E2E invalid single-stop route reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {
@@ -367,6 +382,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Indefinite end time route',
         label: '901I',
+        versionComment: 'E2E indefinite route reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {
@@ -425,6 +441,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Based on template test route',
         label: '901T',
+        versionComment: 'E2E template route reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {

--- a/cypress/e2e/map/createRoute.cy.ts
+++ b/cypress/e2e/map/createRoute.cy.ts
@@ -13,6 +13,8 @@ import {
 import { Tag } from '../../enums';
 import {
   FilterPanel,
+  LineChangeHistory,
+  LineDetailsPage,
   MapFooter,
   MapPage,
   RouteStopsOverlay,
@@ -68,6 +70,8 @@ describe('Route creation', rootOpts, () => {
       tags: [Tag.Smoke, Tag.Network],
     },
     () => {
+      const versionComment = 'E2E create route reason';
+
       MapPage.map.visit(mapLocation);
 
       FilterPanel.toggleShowStops(ReusableComponentsVehicleModeEnum.Bus);
@@ -93,6 +97,7 @@ describe('Route creation', rootOpts, () => {
           swedishShortName: 'Test destination SWE shortName',
         },
         priority: Priority.Standard,
+        versionComment,
         validityStartISODate: '2025-01-01',
         validityEndISODate: '2030-12-01',
       });
@@ -151,6 +156,13 @@ describe('Route creation', rootOpts, () => {
       RouteStopsOverlay.getNthRouteStopsOverlayRow(3).shouldHaveText(
         'E2E005 -',
       );
+
+      LineDetailsPage.visit(baseDbResources.lines[0].line_id);
+      LineDetailsPage.getChangeHistoryLink().click();
+      LineChangeHistory.changeHistoryTable.sectionHeader
+        .getVersionComment()
+        .should('be.visible')
+        .and('contain', versionComment);
     },
   );
 
@@ -163,6 +175,7 @@ describe('Route creation', rootOpts, () => {
       finnishName: 'Test route',
       label: '901Y',
       variant: '56',
+      versionComment: 'E2E cancel create route reason',
       line: '901',
       direction: RouteDirectionEnum.Outbound,
       origin: {
@@ -201,6 +214,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Test route',
         label: '901X',
+        versionComment: 'E2E create route with removed stop reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {
@@ -295,6 +309,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Erronous route',
         label: '901F',
+        versionComment: 'E2E invalid single-stop route reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {
@@ -367,6 +382,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Indefinite end time route',
         label: '901I',
+        versionComment: 'E2E indefinite route reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {
@@ -425,6 +441,7 @@ describe('Route creation', rootOpts, () => {
       MapPage.routePropertiesForm.fillRouteProperties({
         finnishName: 'Based on template test route',
         label: '901T',
+        versionComment: 'E2E template route reason',
         line: '901',
         direction: RouteDirectionEnum.Outbound,
         origin: {

--- a/cypress/pageObjects/forms/LineForm.ts
+++ b/cypress/pageObjects/forms/LineForm.ts
@@ -58,6 +58,10 @@ export class LineForm {
     return cy.getByTestId('LinePropertiesForm::descriptionInput');
   }
 
+  static getVersionCommentInput() {
+    return cy.getByTestId('LineForm::versionComment');
+  }
+
   static save() {
     cy.getByTestId('LineForm::saveButton').scrollIntoView();
     return cy.getByTestId('LineForm::saveButton').click();

--- a/cypress/pageObjects/forms/RoutePropertiesForm.ts
+++ b/cypress/pageObjects/forms/RoutePropertiesForm.ts
@@ -17,6 +17,7 @@ export interface RouteFormInfo
   finnishName?: string;
   label?: string;
   variant?: string;
+  versionComment?: string;
   direction?: RouteDirectionEnum;
   line?: string;
   origin?: TerminusValues;
@@ -54,6 +55,10 @@ export class RoutePropertiesForm {
     return cy.getByTestId(
       'RoutePropertiesFormComponent::useTemplateRouteButton',
     );
+  }
+
+  static getVersionCommentInput() {
+    return cy.getByTestId('RoutePropertiesFormComponent::versionComment');
   }
 
   static selectDirection(direction: RouteDirectionEnum) {
@@ -124,6 +129,12 @@ export class RoutePropertiesForm {
       RoutePropertiesForm.getUseTemplateRouteButton().scrollIntoViewAndClick();
       TemplateRouteSelector.fillForm(
         values.templateRoute.templateRouteSelectorInfo,
+      );
+    }
+
+    if (values.versionComment) {
+      RoutePropertiesForm.getVersionCommentInput().clearAndType(
+        values.versionComment,
       );
     }
 

--- a/cypress/pageObjects/routes-and-lines/LineChangeHistory.ts
+++ b/cypress/pageObjects/routes-and-lines/LineChangeHistory.ts
@@ -24,6 +24,7 @@ const LineChangeHistoryTable = createSimplePageObject(
 
     // DataDiffSectionLoading
     'ChangeHistory::SectionHeader::LoadingLineData',
+    'ChangeHistory::SectionHeader::VersionComment',
 
     // LineDetailsChangedSectionRow
     'ChangeHistory::SectionHeader::LineDetails',

--- a/ui/src/components/forms/common/ChangeValidityForm.tsx
+++ b/ui/src/components/forms/common/ChangeValidityForm.tsx
@@ -1,7 +1,10 @@
-import { FC } from 'react';
+import { FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { TranslationKey } from '../../../i18n';
 import { Row } from '../../../layoutComponents';
 import { Priority } from '../../../types/enums';
+import { FormRow } from './FormRow';
+import { InputField } from './InputField';
 import {
   PriorityForm,
   PriorityFormState,
@@ -17,6 +20,12 @@ export const schema = validityPeriodFormSchema.merge(priorityFormSchema);
 
 export type FormState = ValidityPeriodFormState & PriorityFormState;
 
+type VersionCommentFieldProps = {
+  readonly translationPrefix: TranslationKey;
+  readonly testId: string;
+  readonly customTitlePath?: TranslationKey;
+};
+
 const testIds = {
   container: 'ChangeValidityForm::container',
   priorityButton: (priorityLabel: string) =>
@@ -27,26 +36,60 @@ type ChangeValidityFormProps = {
   readonly className?: string;
   readonly hiddenPriorities?: ReadonlyArray<Priority>;
   readonly dateInputRowClassName?: string;
+  readonly modalLayout?: boolean;
+  readonly title?: string;
+  readonly versionCommentField?: VersionCommentFieldProps;
 };
 
 /**
  * Component for selecting priority and validity period for an entity (e.g. line, route, stop).
  * Can be merged with other forms.
  */
-export const ChangeValidityForm: FC<ChangeValidityFormProps> = ({
+export const ChangeValidityForm = <TFormState extends FieldValues = FormState>({
   className,
   hiddenPriorities,
   dateInputRowClassName,
-}) => {
+  modalLayout = false,
+  title,
+  versionCommentField,
+}: ChangeValidityFormProps) => {
   const { t } = useTranslation();
 
   return (
     <div className={className} data-testid={testIds.container}>
-      <h3>{t(($) => $.saveChangesModal.validityPeriod)}</h3>
-      <Row className="mb-4 pt-6">
-        <PriorityForm hiddenPriorities={hiddenPriorities} />
-      </Row>
-      <ValidityPeriodForm dateInputRowClassName={dateInputRowClassName} />
+      <h3>{title ?? t(($) => $.saveChangesModal.validityPeriod)}</h3>
+      <div className={modalLayout ? undefined : 'w-full lg:w-fit'}>
+        {versionCommentField && (
+          <FormRow className="mb-4 pt-6 md:gap-x-4" mdColumns={1} smColumns={1}>
+            <InputField<TFormState>
+              type="text"
+              translationPrefix={versionCommentField.translationPrefix}
+              customTitlePath={versionCommentField.customTitlePath}
+              fieldPath={'versionComment' as Path<TFormState>}
+              testId={versionCommentField.testId}
+            />
+          </FormRow>
+        )}
+        {modalLayout ? (
+          <>
+            <Row className="mb-4 pt-6">
+              <PriorityForm hiddenPriorities={hiddenPriorities} />
+            </Row>
+            <ValidityPeriodForm dateInputRowClassName={dateInputRowClassName} />
+          </>
+        ) : (
+          <Row className="mb-4 items-start gap-6 pt-2">
+            <PriorityForm
+              hiddenPriorities={hiddenPriorities}
+              priorityButtonClassName="w-auto min-w-[128px] shrink-0 grow-0"
+            />
+            <ValidityPeriodForm
+              dateInputRowClassName={dateInputRowClassName}
+              compactDateInputs
+            />
+          </Row>
+        )}
+      </div>
     </div>
   );
 };

--- a/ui/src/components/forms/common/ChangeValidityForm.tsx
+++ b/ui/src/components/forms/common/ChangeValidityForm.tsx
@@ -1,7 +1,10 @@
-import { FC } from 'react';
+import { FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { TranslationKey } from '../../../i18n';
 import { Row } from '../../../layoutComponents';
 import { Priority } from '../../../types/enums';
+import { FormRow } from './FormRow';
+import { InputField } from './InputField';
 import {
   PriorityForm,
   PriorityFormState,
@@ -17,6 +20,12 @@ export const schema = validityPeriodFormSchema.merge(priorityFormSchema);
 
 export type FormState = ValidityPeriodFormState & PriorityFormState;
 
+type VersionCommentFieldProps = {
+  readonly translationPrefix: TranslationKey;
+  readonly testId: string;
+  readonly customTitlePath?: TranslationKey;
+};
+
 const testIds = {
   container: 'ChangeValidityForm::container',
   priorityButton: (priorityLabel: string) =>
@@ -27,26 +36,57 @@ type ChangeValidityFormProps = {
   readonly className?: string;
   readonly hiddenPriorities?: ReadonlyArray<Priority>;
   readonly dateInputRowClassName?: string;
+  readonly modalLayout?: boolean;
+  readonly title?: string;
+  readonly versionCommentField?: VersionCommentFieldProps;
 };
 
 /**
  * Component for selecting priority and validity period for an entity (e.g. line, route, stop).
  * Can be merged with other forms.
  */
-export const ChangeValidityForm: FC<ChangeValidityFormProps> = ({
+export const ChangeValidityForm = <TFormState extends FieldValues = FormState>({
   className,
   hiddenPriorities,
   dateInputRowClassName,
-}) => {
+  modalLayout = false,
+  title,
+  versionCommentField,
+}: ChangeValidityFormProps) => {
   const { t } = useTranslation();
 
   return (
     <div className={className} data-testid={testIds.container}>
-      <h3>{t(($) => $.saveChangesModal.validityPeriod)}</h3>
-      <Row className="mb-4 pt-6">
-        <PriorityForm hiddenPriorities={hiddenPriorities} />
-      </Row>
-      <ValidityPeriodForm dateInputRowClassName={dateInputRowClassName} />
+      <h3>{title ?? t(($) => $.saveChangesModal.validityPeriod)}</h3>
+      <div className={modalLayout ? undefined : 'w-full lg:w-fit'}>
+        {versionCommentField && (
+          <FormRow className="mb-4 pt-6 md:gap-x-4" mdColumns={1} smColumns={1}>
+            <InputField<TFormState>
+              type="text"
+              translationPrefix={versionCommentField.translationPrefix}
+              customTitlePath={versionCommentField.customTitlePath}
+              fieldPath={'versionComment' as Path<TFormState>}
+              testId={versionCommentField.testId}
+            />
+          </FormRow>
+        )}
+        {modalLayout ? (
+          <>
+            <Row className="mb-4 pt-6">
+              <PriorityForm hiddenPriorities={hiddenPriorities} />
+            </Row>
+            <ValidityPeriodForm dateInputRowClassName={dateInputRowClassName} />
+          </>
+        ) : (
+          <Row className="mb-4 items-start gap-6 pt-2">
+            <PriorityForm
+              hiddenPriorities={hiddenPriorities}
+              priorityButtonClassName="w-auto min-w-[128px] shrink-0 grow-0"
+            />
+            <ValidityPeriodForm dateInputRowClassName={dateInputRowClassName} />
+          </Row>
+        )}
+      </div>
     </div>
   );
 };

--- a/ui/src/components/forms/common/PriorityForm.tsx
+++ b/ui/src/components/forms/common/PriorityForm.tsx
@@ -2,6 +2,7 @@ import { SelectorParam } from 'i18next';
 import { FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { twJoin } from 'tailwind-merge';
 import { z } from 'zod';
 import { Column, Row } from '../../../layoutComponents';
 import { Priority } from '../../../types/enums';
@@ -45,13 +46,17 @@ const defaultPriorities: ReadonlyArray<PriorityButtonProps> = [
 
 type PriorityFormProps = {
   readonly hiddenPriorities?: ReadonlyArray<Priority>;
+  readonly priorityButtonClassName?: string;
 };
 
 /**
  * Component for selecting priority.
  * Can be merged with other forms.
  */
-export const PriorityForm: FC<PriorityFormProps> = ({ hiddenPriorities }) => {
+export const PriorityForm: FC<PriorityFormProps> = ({
+  hiddenPriorities,
+  priorityButtonClassName,
+}) => {
   const { t } = useTranslation();
   const {
     setValue,
@@ -80,7 +85,7 @@ export const PriorityForm: FC<PriorityFormProps> = ({ hiddenPriorities }) => {
           {displayedPriorities.map(
             ({ priority, testIdPrefix, translationKey }) => (
               <LabeledRadioButton
-                className="grow"
+                className={twJoin('grow', priorityButtonClassName)}
                 id={`priority.${testIdPrefix}`}
                 fieldPath="priority"
                 value={priority}

--- a/ui/src/components/forms/common/ValidityPeriodForm.tsx
+++ b/ui/src/components/forms/common/ValidityPeriodForm.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { twJoin } from 'tailwind-merge';
 import { z } from 'zod';
 import { Row } from '../../../layoutComponents';
 import { requiredString } from './customZodSchemas';
@@ -66,6 +67,7 @@ const testIds = {
 type ValidityPeriodFormProps = {
   readonly className?: string;
   readonly dateInputRowClassName?: string;
+  readonly compactDateInputs?: boolean;
 };
 
 /**
@@ -75,6 +77,7 @@ type ValidityPeriodFormProps = {
 export const ValidityPeriodForm: FC<ValidityPeriodFormProps> = ({
   className,
   dateInputRowClassName,
+  compactDateInputs,
 }) => {
   const { t } = useTranslation();
   const { register, watch } = useFormContext<ValidityPeriodFormState>();
@@ -84,8 +87,13 @@ export const ValidityPeriodForm: FC<ValidityPeriodFormProps> = ({
   return (
     <div className={className}>
       <FormColumn>
-        <FormRow className={dateInputRowClassName} mdColumns={2}>
+        <FormRow
+          className={dateInputRowClassName}
+          mdColumns={2}
+          lgColumns={compactDateInputs ? 4 : undefined}
+        >
           <InputField<ValidityPeriodFormState>
+            className={compactDateInputs ? 'lg:col-span-2' : undefined}
             type="date"
             max="9999-12-31"
             translationPrefix="validityPeriod"
@@ -93,7 +101,10 @@ export const ValidityPeriodForm: FC<ValidityPeriodFormProps> = ({
             testId={testIds.startDateInput}
           />
           <InputField<ValidityPeriodFormState>
-            className={indefinite ? 'hidden' : ''}
+            className={twJoin(
+              indefinite ? 'hidden' : '',
+              compactDateInputs ? 'lg:col-span-2' : '',
+            )}
             type="date"
             max="9999-12-31"
             translationPrefix="validityPeriod"
@@ -103,12 +114,15 @@ export const ValidityPeriodForm: FC<ValidityPeriodFormProps> = ({
         </FormRow>
       </FormColumn>
       <Row>
-        <label htmlFor="indefinite" className="mt-3.5 inline-flex font-normal">
+        <label
+          htmlFor="indefinite"
+          className="mt-3.5 inline-flex items-center gap-3.5 font-normal"
+        >
           <input
             type="checkbox"
             id="indefinite"
             {...register('indefinite', {})}
-            className="mr-3.5 h-6 w-6"
+            className="h-6 w-6 shrink-0"
             data-testid={testIds.indefiniteCheckbox}
           />
           {t(($) => $.saveChangesModal.indefinite)}

--- a/ui/src/components/forms/common/ValidityPeriodForm.tsx
+++ b/ui/src/components/forms/common/ValidityPeriodForm.tsx
@@ -103,12 +103,15 @@ export const ValidityPeriodForm: FC<ValidityPeriodFormProps> = ({
         </FormRow>
       </FormColumn>
       <Row>
-        <label htmlFor="indefinite" className="mt-3.5 inline-flex font-normal">
+        <label
+          htmlFor="indefinite"
+          className="mt-3.5 inline-flex items-center gap-3.5 font-normal"
+        >
           <input
             type="checkbox"
             id="indefinite"
             {...register('indefinite', {})}
-            className="mr-3.5 h-6 w-6"
+            className="h-6 w-6 shrink-0"
             data-testid={testIds.indefiniteCheckbox}
           />
           {t(($) => $.saveChangesModal.indefinite)}

--- a/ui/src/components/forms/common/dirtyFields.ts
+++ b/ui/src/components/forms/common/dirtyFields.ts
@@ -1,0 +1,28 @@
+type HasSavableDirtyFieldsOptions = {
+  readonly dirtyFields: unknown;
+  readonly ignoredFields?: ReadonlyArray<string>;
+};
+
+export function hasSavableDirtyFields({
+  dirtyFields,
+  ignoredFields = [],
+}: HasSavableDirtyFieldsOptions): boolean {
+  if (!dirtyFields || typeof dirtyFields !== 'object') {
+    return false;
+  }
+
+  return Object.entries(dirtyFields).some(([key, value]) => {
+    if (ignoredFields.includes(key)) {
+      return false;
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    return hasSavableDirtyFields({
+      dirtyFields: value,
+      ignoredFields,
+    });
+  });
+}

--- a/ui/src/components/forms/common/dirtyFields.ts
+++ b/ui/src/components/forms/common/dirtyFields.ts
@@ -1,0 +1,32 @@
+type HasSavableDirtyFieldsOptions = {
+  readonly dirtyFields: unknown;
+  readonly ignoredFields?: ReadonlyArray<string>;
+};
+
+export function hasSavableDirtyFields({
+  dirtyFields,
+  ignoredFields = [],
+}: HasSavableDirtyFieldsOptions): boolean {
+  if (!dirtyFields || typeof dirtyFields !== 'object') {
+    return false;
+  }
+
+  return Object.entries(dirtyFields).some(([key, value]) => {
+    if (ignoredFields.includes(key)) {
+      return false;
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    return hasSavableDirtyFields({
+      dirtyFields: value,
+      ignoredFields,
+    });
+  });
+}

--- a/ui/src/components/forms/common/index.ts
+++ b/ui/src/components/forms/common/index.ts
@@ -1,6 +1,7 @@
 export * from './AutomaticallyResizingTextArea';
 export * from './ChangeValidityForm';
 export * from './customZodSchemas';
+export * from './dirtyFields';
 export * from './DateInputField';
 export * from './FormActionButtons';
 export * from './DateRange';

--- a/ui/src/components/forms/line/LineForm.tsx
+++ b/ui/src/components/forms/line/LineForm.tsx
@@ -3,6 +3,7 @@ import { FC, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
+import { z } from 'zod';
 import { Row } from '../../../layoutComponents';
 import { Priority } from '../../../types/enums';
 import { FormContainer, SimpleButton } from '../../../uiComponents';
@@ -11,6 +12,7 @@ import {
   ChangeValidityForm,
   FormState as ChangeValidityFormState,
   schema as changeValidityFormSaveFormSchema,
+  hasSavableDirtyFields,
   refineValidityPeriodSchema,
 } from '../common';
 import { useDirtyFormBlockNavigation } from '../common/NavigationBlocker';
@@ -21,17 +23,26 @@ import {
 } from './LinePropertiesForm';
 import { lineTypesByVehicleMode } from './LineTypeDropdown';
 
-export type FormState = LinePropertiesFormState & ChangeValidityFormState;
+export type FormState = LinePropertiesFormState &
+  ChangeValidityFormState & {
+    readonly versionComment?: string;
+  };
 
 const testIds = {
   saveButton: 'LineForm::saveButton',
   cancelButton: 'LineForm::cancelButton',
+  versionComment: 'LineForm::versionComment',
 };
 
 const INVALID_LINE_TYPE = 'invalidLineType';
 
 const formSchema = linePropertiesFormSchema
   .merge(changeValidityFormSaveFormSchema)
+  .merge(
+    z.object({
+      versionComment: z.string().optional(),
+    }),
+  )
   .superRefine(refineValidityPeriodSchema)
   .superRefine((line, ctx) => {
     const validLineTypes = lineTypesByVehicleMode[line.primaryVehicleMode];
@@ -48,12 +59,14 @@ type LineFormProps = {
   readonly defaultValues: Partial<FormState>;
   readonly editing?: boolean;
   readonly onSubmit: (state: FormState) => void;
+  readonly validityPeriodTitle?: string;
 };
 
 export const LineForm: FC<LineFormProps> = ({
   defaultValues,
   editing = false,
   onSubmit,
+  validityPeriodTitle,
 }) => {
   const navigate = useNavigate();
   const formRef = useRef<ExplicitAny>(null);
@@ -65,6 +78,10 @@ export const LineForm: FC<LineFormProps> = ({
   });
   useDirtyFormBlockNavigation(methods.formState, 'LineForm');
   const { handleSubmit } = methods;
+  const hasSavableChanges = hasSavableDirtyFields({
+    dirtyFields: methods.formState.dirtyFields,
+    ignoredFields: ['versionComment'],
+  });
 
   const onSave = () => {
     submitFormByRef(formRef);
@@ -88,6 +105,12 @@ export const LineForm: FC<LineFormProps> = ({
             <ChangeValidityForm
               className="mb-2 ml-2"
               hiddenPriorities={[Priority.Temporary]} // Line does not have temporary priority, so hide it
+              title={validityPeriodTitle}
+              versionCommentField={{
+                translationPrefix: 'lines',
+                customTitlePath: 'reasonForChangeForm.reasonForChange',
+                testId: testIds.versionComment,
+              }}
             />
           </FormContainer>
         </Row>
@@ -104,9 +127,7 @@ export const LineForm: FC<LineFormProps> = ({
             onClick={onSave}
             id="save-button"
             testId={testIds.saveButton}
-            disabled={
-              !methods.formState.isDirty || methods.formState.isSubmitting
-            }
+            disabled={!hasSavableChanges || methods.formState.isSubmitting}
           >
             {t(($) => $.save)}
           </SimpleButton>

--- a/ui/src/components/forms/route/RoutePropertiesForm.tsx
+++ b/ui/src/components/forms/route/RoutePropertiesForm.tsx
@@ -18,6 +18,7 @@ import {
   FormColumn,
   FormRow,
   InputField,
+  hasSavableDirtyFields,
 } from '../common';
 import { useDirtyFormBlockNavigation } from '../common/NavigationBlocker';
 import { ChooseLineDropdown } from './ChooseLineDropdown';
@@ -41,6 +42,7 @@ export type RoutePropertiesFormProps = {
   readonly deleteButtonText?: string;
   readonly actionButtonsClassName?: string;
   readonly variant?: 'infoContainer' | 'modal';
+  readonly modalLayout?: boolean;
 };
 
 const testIds = {
@@ -49,6 +51,7 @@ const testIds = {
   label: 'RoutePropertiesFormComponent::label',
   finnishName: 'RoutePropertiesFormComponent::finnishName',
   variant: 'RoutePropertiesFormComponent::variant',
+  versionComment: 'RoutePropertiesFormComponent::versionComment',
   useTemplateRouteButton:
     'RoutePropertiesFormComponent::useTemplateRouteButton',
 };
@@ -69,6 +72,7 @@ export const RoutePropertiesFormComponent: ForwardRefRenderFunction<
     deleteButtonText,
     actionButtonsClassName,
     variant,
+    modalLayout,
   },
   ref,
 ) => {
@@ -91,6 +95,10 @@ export const RoutePropertiesFormComponent: ForwardRefRenderFunction<
     useState(false);
 
   const { handleSubmit } = methods;
+  const hasSavableChanges = hasSavableDirtyFields({
+    dirtyFields: methods.formState.dirtyFields,
+    ignoredFields: ['versionComment'],
+  });
 
   const setTemplateRoute = (uuid?: UUID) => {
     dispatch(setTemplateRouteIdAction(uuid));
@@ -197,15 +205,22 @@ export const RoutePropertiesFormComponent: ForwardRefRenderFunction<
             </>
           )}
           <FormRow className="border-t border-light-grey p-4">
-            <ChangeValidityForm dateInputRowClassName="sm:gap-x-4 md:gap-x-4 lg:gap-x-4" />
+            <ChangeValidityForm<FormState>
+              dateInputRowClassName="sm:gap-x-4 md:gap-x-4 lg:gap-x-4"
+              modalLayout={modalLayout}
+              title={t(($) => $.routes.routeValidityPeriod)}
+              versionCommentField={{
+                translationPrefix: 'routes',
+                customTitlePath: 'reasonForChangeForm.reasonForChange',
+                testId: testIds.versionComment,
+              }}
+            />
           </FormRow>
         </div>
         <FormActionButtons
           onCancel={onCancel}
           testIdPrefix={testIdPrefix}
-          isDisabled={
-            !methods.formState.isDirty || methods.formState.isSubmitting
-          }
+          isDisabled={!hasSavableChanges || methods.formState.isSubmitting}
           isSubmitting={methods.formState.isSubmitting}
           className={actionButtonsClassName}
           onDelete={onDelete}

--- a/ui/src/components/forms/route/RoutePropertiesForm.types.ts
+++ b/ui/src/components/forms/route/RoutePropertiesForm.types.ts
@@ -26,6 +26,7 @@ export const routeFormSchema = z
     origin: namesSchema.required(),
     destination: namesSchema.required(),
     variant: nullablePositiveNumber,
+    versionComment: z.string().optional(),
   })
   .merge(changeValidityFormSchema)
   .superRefine(refineValidityPeriodSchema);

--- a/ui/src/components/map/routes/EditRouteModal.tsx
+++ b/ui/src/components/map/routes/EditRouteModal.tsx
@@ -47,6 +47,7 @@ export const EditRouteModal: FC<EditRouteModalProps> = ({
           testIdPrefix={testIds.modal}
           className="min-h-0"
           variant="modal"
+          modalLayout
         />
       </Modal>
     </CustomOverlay>

--- a/ui/src/components/map/routes/hooks/useEditRouteMetadata.ts
+++ b/ui/src/components/map/routes/hooks/useEditRouteMetadata.ts
@@ -43,6 +43,7 @@ export const mapRouteFormToInput = (state: RouteFormState) => {
     variant: Number.isInteger(variant) ? variant : null,
     direction: state.direction,
     priority,
+    version_comment: state.versionComment?.trim() ?? null,
     validity_start: mapDateInputToValidityStart(validityStart),
     validity_end: mapDateInputToValidityEnd(validityEnd, indefinite),
     origin_name_i18n: defaultLocalizedString(state.origin?.name),
@@ -59,6 +60,7 @@ export const mapRouteToFormState = (
   route: RouteAllFieldsFragment,
 ): RouteFormState => ({
   finnishName: route.name_i18n?.fi_FI ?? '',
+  versionComment: '',
   label: route.label,
   onLineId: route.on_line_id,
   variant: route.variant ?? null,

--- a/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
+++ b/ui/src/components/routes-and-lines/create-line/CreateNewLinePage.tsx
@@ -72,7 +72,11 @@ export const CreateNewLinePage: FC = () => {
         <i className="icon-bus-alt text-6xl text-tweaked-brand" />
         <PageTitle.H1>{t(($) => $.lines.createNew)}</PageTitle.H1>
       </Row>
-      <LineForm onSubmit={onSubmit} defaultValues={defaultValues} />
+      <LineForm
+        onSubmit={onSubmit}
+        defaultValues={defaultValues}
+        validityPeriodTitle={t(($) => $.lines.lineValidityPeriod)}
+      />
     </Container>
   );
 };

--- a/ui/src/components/routes-and-lines/create-line/useCreateLine.ts
+++ b/ui/src/components/routes-and-lines/create-line/useCreateLine.ts
@@ -39,6 +39,7 @@ export const mapFormToInput = (state: FormState) => {
       state.validityEnd,
       state.indefinite,
     ),
+    version_comment: state.versionComment?.trim() ?? null,
   };
   return input;
 };

--- a/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
@@ -27,6 +27,7 @@ import { useEditLine } from './useEditLine';
 const mapLineToFormState = (line: LineAllFieldsFragment): FormState => ({
   label: line.label,
   description: line.description ?? undefined,
+  versionComment: '',
   name: defaultLocalizedString(line.name_i18n),
   shortName: defaultLocalizedString(line.short_name_i18n),
   primaryVehicleMode: line.primary_vehicle_mode,
@@ -102,6 +103,7 @@ export const EditLinePage: FC = () => {
             onSubmit={onSubmit}
             defaultValues={mapLineToFormState(line)}
             editing
+            validityPeriodTitle={t(($) => $.lines.lineValidityPeriod)}
           />
         )}
       </Container>

--- a/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -75,6 +75,7 @@ export const EditRoutePage: FC = () => {
       }
       const variables = mapEditRouteMetadataChangesToVariables(changes);
       await editRouteMetadata(variables);
+      showSuccessToast(t(($) => $.routes.updateSuccess));
       setHasFinishedEditing(true);
       setRouteFormData(null);
     } catch (err) {

--- a/ui/src/graphql/route.ts
+++ b/ui/src/graphql/route.ts
@@ -17,6 +17,7 @@ const LINE_DEFAULT_FIELDS = gql`
     line_id
     label
     description
+    version_comment
     name_i18n
     short_name_i18n
     validity_start
@@ -64,6 +65,7 @@ const ROUTE_DEFAULT_FIELDS = gql`
     ...route_unique_fields
     name_i18n
     description_i18n
+    version_comment
     origin_name_i18n
     origin_short_name_i18n
     destination_name_i18n

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -13,6 +13,7 @@
     "routes": "Routes and lines",
     "save": "Save route",
     "saveSuccess": "Route saved",
+    "updateSuccess": "Changes saved",
     "deleteSuccess": "Route deleted",
     "enterRouteData": "Enter route data",
     "finnishName": "Name of the route",
@@ -52,6 +53,8 @@
     "chooseRoute": "Choose route",
     "direction": "Direction",
     "variant": "Hidden variant",
+    "versionComment": "Reason for change",
+    "routeValidityPeriod": "Route validity period",
     "chooseDirection": "Choose direction",
     "tooFewStops": "There must be at least two stops on route.",
     "startNotInsideLineValidity": "Route's validity period cannot start before line's validity period.",
@@ -95,7 +98,8 @@
     "showDraftDetails": "Show draft details",
     "routesOutsideValidity": "The following routes' validity period exceed the line's new validity period",
     "lineNotValidForDay": "The line is not valid on the selected day.",
-    "lineMissingDefault": "Unknown error in line information."
+    "lineMissingDefault": "Unknown error in line information.",
+    "lineValidityPeriod": "Line validity period"
   },
   "stops": {
     "stops": "Stops",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -13,6 +13,7 @@
     "routes": "Reitit ja linjat",
     "save": "Tallenna reitti",
     "saveSuccess": "Reitti tallennettu",
+    "updateSuccess": "Muutokset tallennettu",
     "deleteSuccess": "Reitti poistettu",
     "enterRouteData": "Anna reitin tiedot",
     "finnishName": "Reitin nimi",
@@ -52,6 +53,8 @@
     "chooseRoute": "Valitse reitti",
     "direction": "Suunta",
     "variant": "Piilovariantti",
+    "versionComment": "Muutoksen syy",
+    "routeValidityPeriod": "Reitin voimassaolo",
     "chooseDirection": "Valitse suunta",
     "tooFewStops": "Reitillä on oltava ainakin kaksi pysäkkiä.",
     "startNotInsideLineValidity": "Reitin voimassaoloaika ei voi alkaa ennen linjan voimassaoloajan alkamista.",
@@ -95,7 +98,8 @@
     "showDraftDetails": "Näytä luonnoksen tiedot",
     "routesOutsideValidity": "Seuraavien reittien voimassaolo ylittää linjan uuden voimassaoloajan",
     "lineNotValidForDay": "Linja ei ole voimassa valittuna päivänä.",
-    "lineMissingDefault": "Tuntematon virhe linjan tiedoissa."
+    "lineMissingDefault": "Tuntematon virhe linjan tiedoissa.",
+    "lineValidityPeriod": "Linjan voimassaolo"
   },
   "stops": {
     "stops": "Pysäkit",


### PR DESCRIPTION
Adds version comment field to:
- Line creation
- Line edit
- Route creation
- Route edit

Also makes the ChangeValidityForm more compact.
Previously the date components were too wide for the view.

Story: 31593
Task: 77217

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1409)
<!-- Reviewable:end -->
