### PR TITLE
Timing place required bug

### DIFF
--- a/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsSection.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/basic-details/BasicDetailsSection.tsx
@@ -23,8 +23,7 @@ const mapStopBasicDetailsDataToFormState = (stop: StopWithDetails) => {
     abbreviationSwe: stop.stop_place?.abbreviationSwe,
     transportMode: stop.stop_place?.transportMode,
     elyNumber: stop.quay?.elyNumber ?? undefined,
-    timingPlaceId:
-      stop.quay?.timingPlaceId ?? stop.timing_place_id ?? undefined,
+    timingPlaceId: stop.quay?.timingPlaceId ?? stop.timing_place_id ?? null,
     stopState: stop.quay?.stopState ?? undefined,
     stopTypes: stop.quay?.stopType,
   };


### PR DESCRIPTION
This commit fixes a bug where leaving timing place empty would cause an error. It was because timing place defaulted to undefined while the schema expected string or null.

Story: 79228
Task: 80008

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1412)
<!-- Reviewable:end -->
