### PR TITLE
Assorted fixes

### DIFF
--- a/ui/src/components/map/queries/useResolveStopHoverTitle.ts
+++ b/ui/src/components/map/queries/useResolveStopHoverTitle.ts
@@ -24,7 +24,9 @@ type ResolveStopNameFn = (stopPlaceNetexId: string) => Promise<string | null>;
 function useResolveStopName(
   areas: ReadonlyArray<MapStopArea>,
 ): ResolveStopNameFn {
-  const [resolveStopNameFromDB] = useResolveStopNameLazyQuery();
+  const [resolveStopNameFromDB] = useResolveStopNameLazyQuery({
+    fetchPolicy: 'cache-first',
+  });
 
   return useCallback(
     async (stopPlaceNetexId: string) => {
@@ -38,7 +40,6 @@ function useResolveStopName(
 
       const dbName = await resolveStopNameFromDB({
         variables: { stopPlaceNetexId },
-        fetchPolicy: 'cache-first',
       }).then(
         (result) =>
           result.data?.stops_database?.stops_database_stop_place_newest_version.at(

--- a/ui/src/components/map/routes/hooks/useCreateRoute.ts
+++ b/ui/src/components/map/routes/hooks/useCreateRoute.ts
@@ -15,7 +15,6 @@ import { MIN_DATE } from '../../../../time';
 import {
   buildJourneyPatternStopSequence,
   mapToObject,
-  removeFromApolloCache,
   showDangerToastWithError,
 } from '../../../../utils';
 import { useCheckValidityAndPriorityConflicts } from '../../../common/hooks';
@@ -47,15 +46,7 @@ export const useCreateRoute = () => {
   const insertRouteMutation = async (
     variables: InsertRouteOneMutationVariables,
   ) => {
-    return mutateFunction({
-      variables,
-      update(cache) {
-        removeFromApolloCache(cache, {
-          line_id: variables.object.on_line_id,
-          __typename: 'route_line',
-        });
-      },
-    });
+    return mutateFunction({ variables });
   };
 
   const mapRouteDetailsToInsertMutationVariables = (

--- a/ui/src/components/map/routes/hooks/useDeleteRoute.ts
+++ b/ui/src/components/map/routes/hooks/useDeleteRoute.ts
@@ -1,10 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useDeleteRouteMutation } from '../../../../generated/graphql';
-import {
-  mapToVariables,
-  removeFromApolloCache,
-  showDangerToastWithError,
-} from '../../../../utils';
+import { mapToVariables, showDangerToastWithError } from '../../../../utils';
 
 export const useDeleteRoute = () => {
   const { t } = useTranslation();
@@ -17,12 +13,6 @@ export const useDeleteRoute = () => {
 
     const result = await mutateFunction({
       ...mapToVariables({ route_id: routeId }),
-      update(cache) {
-        removeFromApolloCache(cache, {
-          route_id: routeId,
-          __typename: 'route_route',
-        });
-      },
     });
     return result;
   };

--- a/ui/src/components/map/routes/hooks/useEditRouteGeometry.ts
+++ b/ui/src/components/map/routes/hooks/useEditRouteGeometry.ts
@@ -16,7 +16,6 @@ import {
 } from '../../../../graphql';
 import {
   buildJourneyPatternStopSequence,
-  removeFromApolloCache,
   showDangerToastWithError,
 } from '../../../../utils';
 import { useValidateRoute } from './useValidateRoute';
@@ -153,12 +152,6 @@ export const useEditRouteGeometry = () => {
   ) => {
     await mutateFunction({
       variables,
-      update(cache) {
-        removeFromApolloCache(cache, {
-          route_id: variables.route_id,
-          __typename: 'route_route',
-        });
-      },
       refetchQueries: [
         {
           query: GetRouteDetailsByIdDocument,

--- a/ui/src/components/map/routes/hooks/useEditRouteMetadata.ts
+++ b/ui/src/components/map/routes/hooks/useEditRouteMetadata.ts
@@ -15,7 +15,6 @@ import {
   defaultLocalizedString,
   mapDateInputToValidityEnd,
   mapDateInputToValidityStart,
-  removeFromApolloCache,
   showDangerToastWithError,
 } from '../../../../utils';
 import { useCheckValidityAndPriorityConflicts } from '../../../common/hooks';
@@ -161,15 +160,7 @@ export const useEditRouteMetadata = () => {
   });
 
   const editRouteMetadata = (variables: PatchRouteMutationVariables) => {
-    return mutateFunction({
-      variables,
-      update(cache) {
-        removeFromApolloCache(cache, {
-          route_id: variables.route_id,
-          __typename: 'route_route',
-        });
-      },
-    });
+    return mutateFunction({ variables });
   };
 
   // default handler that can be used to show error messages as toast

--- a/ui/src/components/map/stops/hooks/useCreateStop.ts
+++ b/ui/src/components/map/stops/hooks/useCreateStop.ts
@@ -17,7 +17,6 @@ import {
   LinkNotResolvedError,
   findKeyValue,
   getRouteLabelVariantText,
-  removeFromApolloCache,
 } from '../../../../utils';
 import { useCheckValidityAndPriorityConflicts } from '../../../common/hooks';
 import {
@@ -207,12 +206,6 @@ export function useCreateStop() {
           ...stopPoint,
           stop_place_ref: quayId,
         },
-      },
-      update(cache) {
-        removeFromApolloCache(cache, {
-          infrastructure_link_id: stopPoint.located_on_infrastructure_link_id,
-          __typename: 'infrastructure_network_infrastructure_link',
-        });
       },
     });
 

--- a/ui/src/components/map/stops/hooks/useDeleteStop.ts
+++ b/ui/src/components/map/stops/hooks/useDeleteStop.ts
@@ -9,7 +9,6 @@ import { mapStopResultToStop } from '../../../../graphql';
 import {
   EditRouteTerminalStopsError,
   InternalError,
-  removeFromApolloCache,
   showDangerToast,
   showDangerToastWithError,
 } from '../../../../utils';
@@ -93,13 +92,6 @@ export const useDeleteStop = () => {
   }: DeleteChanges) => {
     const removedStopPointResult = await removeStopMutation({
       variables: { stop_id: stopPointId },
-      // remove stop from cache after mutation
-      update(cache) {
-        removeFromApolloCache(cache, {
-          scheduled_stop_point_id: stopPointId,
-          __typename: 'service_pattern_scheduled_stop_point',
-        });
-      },
     });
 
     const removedQuayResult = await deleteQuay(stopPlaceId, quayId);

--- a/ui/src/components/map/stops/hooks/useEditStop.ts
+++ b/ui/src/components/map/stops/hooks/useEditStop.ts
@@ -36,7 +36,6 @@ import {
   TiamatUpdateFailedError,
   TimingPlaceRequiredError,
   defaultTo,
-  removeFromApolloCache,
   showDangerToast,
 } from '../../../../utils';
 import { useCheckValidityAndPriorityConflicts } from '../../../common/hooks';
@@ -578,13 +577,6 @@ export const useEditStop = () => {
       updateStopPointResult = await wrapErrors(
         editStopMutation({
           variables,
-          update(cache) {
-            removeFromApolloCache(cache, {
-              infrastructure_link_id:
-                variables.stop_patch.located_on_infrastructure_link_id,
-              __typename: 'infrastructure_network_infrastructure_link',
-            });
-          },
 
           // Always refetch map queries after StopPoint update.
           ...refetchQueries,

--- a/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -109,7 +109,7 @@ export const EditRoutePage: FC = () => {
           stopPointLabels: draftStops?.map((stop) => stop.label),
         });
         const variables = mapEditJourneyPatternChangesToVariables(changes);
-        await updateRouteGeometryMutation(variables);
+        await updateRouteGeometryMutation(variables, route.route_id);
       }
       onSubmit(form);
     } catch (err) {

--- a/ui/src/components/routes-and-lines/edit-route/useEditRouteJourneyPattern.ts
+++ b/ui/src/components/routes-and-lines/edit-route/useEditRouteJourneyPattern.ts
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client';
 import {
+  GetRouteDetailsByIdDocument,
   JourneyPatternStopFragment,
   RouteStopFieldsFragment,
   RouteWithInfrastructureLinksWithStopsAndJpsFragment,
@@ -16,7 +17,6 @@ import {
   buildJourneyPatternStopSequence,
   filterDistinctConsecutiveStops,
   mapRouteStopsToJourneyPatternStops,
-  removeFromApolloCache,
 } from '../../../utils';
 import { extractJourneyPatternCandidateStops } from '../../map/routes/hooks/useExtractRouteFromFeature';
 import { useValidateRoute } from '../../map/routes/hooks/useValidateRoute';
@@ -141,16 +141,14 @@ export const useEditRouteJourneyPattern = () => {
 
   const updateRouteGeometryMutation = async (
     variables: UpdateRouteJourneyPatternMutationVariables,
+    routeId: UUID,
   ) => {
     await updateRouteJourneyPatternMutation({
       variables,
-      // remove scheduled stop point from cache after mutation
-      update(cache) {
-        removeFromApolloCache(cache, {
-          journey_pattern_id: variables.journey_pattern_id,
-          __typename: 'journey_pattern_journey_pattern',
-        });
-      },
+      awaitRefetchQueries: true,
+      refetchQueries: [
+        { query: GetRouteDetailsByIdDocument, variables: { routeId } },
+      ],
     });
   };
 

--- a/ui/src/components/routes-and-lines/line-details/StopActionsDropdown.tsx
+++ b/ui/src/components/routes-and-lines/line-details/StopActionsDropdown.tsx
@@ -89,7 +89,7 @@ export const StopActionsDropdown: FC<StopActionsDropdownProps> = ({
 
       const variables = mapEditJourneyPatternChangesToVariables(changes);
 
-      await updateRouteGeometryMutation(variables);
+      await updateRouteGeometryMutation(variables, route.route_id);
       showSuccessToast(t(($) => $.routes.saveSuccess));
     } catch (err) {
       showDangerToast(`${t(($) => $.errors.saveFailed)}, '${err}'`);
@@ -107,7 +107,7 @@ export const StopActionsDropdown: FC<StopActionsDropdownProps> = ({
 
       const variables = mapEditJourneyPatternChangesToVariables(changes);
 
-      await updateRouteGeometryMutation(variables);
+      await updateRouteGeometryMutation(variables, route.route_id);
       showSuccessToast(t(($) => $.routes.saveSuccess));
     } catch (err) {
       showDangerToast(`${t(($) => $.errors.saveFailed)}, '${err}'`);

--- a/ui/src/components/stop-registry/components/ExternalLinks/ExternalLinksForm.tsx
+++ b/ui/src/components/stop-registry/components/ExternalLinks/ExternalLinksForm.tsx
@@ -104,7 +104,7 @@ export const ExternalLinksForm: FC<ExternalLinksFormProps> = ({
         onSubmit={handleSubmit(handleFormSubmit)}
       >
         {externalLinksFields.map((externalLink, idx) => (
-          <div key={externalLink.orderNum} data-testid={testIds.externalLink}>
+          <div key={externalLink.id} data-testid={testIds.externalLink}>
             <ExternalLinksFormFields
               index={idx}
               onRemove={onRemoveExternalLink}

--- a/ui/src/components/stop-registry/search/by-line/StopsByLineSearchGroupedStopsResults.tsx
+++ b/ui/src/components/stop-registry/search/by-line/StopsByLineSearchGroupedStopsResults.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, Fragment } from 'react';
 import { useGroupedResultSelection, useStopSearchRouterState } from '../utils';
 import { ActiveLineHeader } from './ActiveLineHeader';
 import { LineRoutesListing } from './LineRoutesListing';
@@ -52,7 +52,7 @@ export const StopsByLineSearchGroupedStopsResults: FC<
       {lines
         .filter((line) => selectedGroups.includes(line.line_id))
         .map((line, i) => (
-          <>
+          <Fragment key={line.line_id}>
             <ActiveLineHeader
               line={line}
               className={i > 0 ? 'mt-6' : ''}
@@ -65,7 +65,7 @@ export const StopsByLineSearchGroupedStopsResults: FC<
               sortingInfo={sortingInfo}
               selection={resultSelection}
             />
-          </>
+          </Fragment>
         ))}
     </>
   );

--- a/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useGetOverlappingStopVersions.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/stop-version/utils/useGetOverlappingStopVersions.ts
@@ -64,7 +64,9 @@ const GQL_GET_OVERLAPPING_STOP_VERSIONS_QUERY = gql`
 `;
 
 export function useGetOverlappingStopVersions() {
-  const [getOverlappingStopVersions] = useGetOverlappingStopVersionsLazyQuery();
+  const [getOverlappingStopVersions] = useGetOverlappingStopVersionsLazyQuery({
+    fetchPolicy: 'network-only',
+  });
   const [getOverlappingStopVersionsIndefinite] =
     useGetOverlappingStopVersionsIndefiniteLazyQuery();
 
@@ -94,7 +96,6 @@ export function useGetOverlappingStopVersions() {
             fromDate: fromDateTime,
             toDate: toDateTime,
           },
-          fetchPolicy: 'network-only',
         });
 
         if (data && data?.service_pattern_scheduled_stop_point.length > 0) {

--- a/ui/src/utils/graphql.ts
+++ b/ui/src/utils/graphql.ts
@@ -1,6 +1,3 @@
-import { ApolloCache, Reference, StoreObject } from '@apollo/client';
-import { log } from './logger';
-
 export const mapToObject = (object: ExplicitAny) => {
   return { object };
 };
@@ -16,31 +13,6 @@ export const mapToData = (data: ExplicitAny) => {
 export const defaultTo = <V, D>(value: V, defaultValue: D) =>
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   value === undefined ? defaultValue : value;
-
-// Removes item from apollo's cache.
-// TODO: do we really have to do this manually?
-export const removeFromApolloCache = (
-  cache: ApolloCache<ExplicitAny>,
-  identity: StoreObject | Reference,
-) => {
-  try {
-    // Based on https://stackoverflow.com/a/66713628
-    const cached = cache.identify(identity);
-    // @ts-expect-error something seems to be wrong here. The solution mentioned
-    // above stackoverflow response won't give ts errors, but it doesn't work either...
-    cache.evict(cached);
-    cache.gc();
-  } catch (e) {
-    log.warn(
-      `Failed to evict entity '\`${JSON.stringify(
-        identity,
-        null,
-        0,
-      )}\`' from Apollo cache! Reason:`,
-      e,
-    );
-  }
-};
 
 /**
  * It seems that hasura requires function parameter arrays to be


### PR DESCRIPTION
### Reacy: Fix improper/missing key props

- ExternalLinks: Fix key prop to use proper id in edit form.
- StopsByLineSearchGroupedStopsResults: Add missing key prop.


### Apollo: On lazy hooks `ferchPolicy` goes on hook, not on trigger


### Apollo: Drop manual cache item eviction code

There were several problems with the code sections removed:
* Some trying to remove wrong type of an cache object: Made changes to DB entity type A, but dropped item of type B from cache.
* Some were giving in undefined ids, thus causing errors to be printed into the dev console.
* Some were just outright illogical, patching an object, returning and caching the updated data, and then removing the freshly updated item.
* There were couple of proper use cases (DeleteStop, DeleteRoute) where the eviction call was valid, but those have also been removed to let automatic garbage collection then handle that at a later point.

BUT!: Then there was a bug in the eviction code it self. `cache.evict` takes in an options parameter in the form of `{ id: thing to remove }`, but the `removeFromApolloCache` function incorrectly passed in the id string straight to the evict call. Type script did warn the original developer about this, but said developer (T. K.) ignored the warning and thought he knew better and suppressed said error with a handy dandy `@ts-expect-error` comment.

What that did do, was that it instead removing a single item from the cache, it reset the whole Apollo cache to an empty state, which in turn resulted in active queries being refetched from the database. Line details page was relying on this unconventional data refresh strategy to function correctly, so a proper data refetch has been added for that as a fix.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1418)
<!-- Reviewable:end -->
