### PR TITLE
Improve time parsing handling

### DIFF
--- a/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopAreaDetails.cy.ts
@@ -209,8 +209,7 @@ describe('Stop area details', { tags: Tag.StopRegistry }, () => {
     StopAreaDetailsPage.versioningRow
       .getChangeHistoryLink()
       .shouldBeVisible()
-      .invoke('text')
-      .should('match', /\d{2}\.\d{2}\.\d{4}\s+\d{2}:\d{2}/); // Matches format: DD.MM.YYYY HH:mm
+      .shouldContainDateTime();
 
     const { details } = StopAreaDetailsPage;
     details.getName().shouldHaveText(expected.name);

--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -524,8 +524,7 @@ describe('Stop details', { tags: [Tag.StopRegistry] }, () => {
 
       StopDetailsPage.changeHistoryLink()
         .shouldBeVisible()
-        .invoke('text')
-        .should('match', /\d{2}\.\d{2}\.\d{4}\s+\d{2}:\d{2}/); // Matches format: DD.MM.YYYY HH:mm
+        .shouldContainDateTime();
 
       StopDetailsPage.headerSummaryRow.lineCount().should('have.text', 0);
 

--- a/cypress/e2e/stop-registry/terminals.cy.ts
+++ b/cypress/e2e/stop-registry/terminals.cy.ts
@@ -238,8 +238,7 @@ describe('Terminal details', { tags: [Tag.StopRegistry, Tag.Map] }, () => {
       TerminalDetailsPage.versioningRow
         .getChangeHistoryLink()
         .shouldBeVisible()
-        .invoke('text')
-        .should('match', /\d{2}\.\d{2}\.\d{4}\s+\d{2}:\d{2}/); // Matches format: DD.MM.YYYY HH:mm
+        .shouldContainDateTime();
 
       verifyInitialBasicDetails();
     });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -114,6 +114,18 @@ Cypress.Commands.add(
   },
 );
 
+Cypress.Commands.add(
+  'shouldContainDateTime',
+  { prevSubject: 'element' },
+  (subject) => {
+    cy.wrap(subject)
+      .invoke('text')
+      // Matches formats with or without zero padded date and month values.
+      // Time values with either a '.' or ':' as the separator.
+      .should('match', /\d{1,2}\.\d{1,2}\.\d{4}\s+\d{1,2}[.:]\d{2}/); // Matches format: D(D).M(M).YYYY HH:mm
+  },
+);
+
 Cypress.Commands.add('closeDropdown', () => {
   cy.press('Escape');
 });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -66,6 +66,11 @@ declare namespace Cypress {
     shouldBeDisabled(): Chainable<JQuery<HtmlElement>>;
 
     /**
+     * Custom command to check that the text content of an element contains a datetime value.
+     */
+    shouldContainDateTime(): Chainable<void>;
+
+    /**
      * Closes active dropdown. (Presses escape)
      */
     closeDropdown(): Chainable<void>;

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaVersioningRow.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/components/StopAreaVersioningRow.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { Path, routeDetails } from '../../../../../router/routeDetails';
-import { mapToShortDate, mapUTCToDateTime } from '../../../../../time';
+import { mapToShortDate, mapToShortDateTime } from '../../../../../time';
 import { StopAreaComponentProps } from '../types';
 
 const testIds = {
@@ -35,7 +35,7 @@ export const StopAreaVersioningRow: FC<StopAreaComponentProps> = ({
         className="ml-auto flex items-center text-base text-tweaked-brand hover:underline"
         data-testid={testIds.changeHistoryLink}
       >
-        {mapUTCToDateTime(area.changed)} | {area.changedByUserName ?? 'HSL'}{' '}
+        {mapToShortDateTime(area.changed)} | {area.changedByUserName ?? 'HSL'}{' '}
         <i className="icon-history text-xl" aria-hidden />
       </Link>
     </div>

--- a/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../../hooks';
 import { Container, Visible } from '../../../../layoutComponents';
 import { Path, routeDetails } from '../../../../router/routeDetails';
-import { mapToShortDate, mapUTCToDateTime } from '../../../../time';
+import { mapToShortDate, mapToShortDateTime } from '../../../../time';
 import { Priority } from '../../../../types/enums';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
 import { navigationBlockerContext } from '../../../forms/common/NavigationBlocker';
@@ -94,7 +94,7 @@ export const StopDetailsPage: FC = () => {
           className="ml-auto flex items-center text-base text-tweaked-brand hover:underline"
           data-testid={testIds.changeHistoryLink}
         >
-          {mapUTCToDateTime(stopDetails?.quay?.changed)} |{' '}
+          {mapToShortDateTime(stopDetails?.quay?.changed)} |{' '}
           {stopDetails?.quay?.changedByUserName ?? 'HSL'}{' '}
           <i className="icon-history text-xl" aria-hidden />
         </Link>

--- a/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
+++ b/ui/src/components/stop-registry/stops/versions/components/StopVersionRow.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twJoin, twMerge } from 'tailwind-merge';
-import { mapToShortDate, mapUTCToDateTime } from '../../../../../time';
+import { mapToShortDate, mapToShortDateTime } from '../../../../../time';
 import { LocatorActionButton } from '../../../components';
 import { StopVersion, StopVersionStatus } from '../types';
 import { ActionMenuStop } from '../types/ActionMenuStop';
@@ -96,7 +96,7 @@ export const StopVersionRow: FC<StopVersionRowProps> = ({
       </td>
 
       <td className="px-4 py-2 text-center" data-testid={testIds.changed}>
-        {mapUTCToDateTime(stopVersion.changed)}
+        {mapToShortDateTime(stopVersion.changed)}
       </td>
 
       <td className="px-4 py-2 text-center" data-testid={testIds.changedBy}>

--- a/ui/src/components/stop-registry/terminals/components/terminal-versions/TerminalVersioningRow.tsx
+++ b/ui/src/components/stop-registry/terminals/components/terminal-versions/TerminalVersioningRow.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import { Path, routeDetails } from '../../../../../router/routeDetails';
-import { mapToShortDate, mapUTCToDateTime } from '../../../../../time';
+import { mapToShortDate, mapToShortDateTime } from '../../../../../time';
 import { TerminalComponentProps } from '../../types';
 import { EditTerminalValidityButton } from './EditTerminalValidityButton';
 
@@ -37,7 +37,7 @@ export const TerminalVersioningRow: FC<TerminalComponentProps> = ({
         className="ml-auto flex items-center text-base text-tweaked-brand hover:underline"
         data-testid={testIds.changeHistoryLink}
       >
-        {mapUTCToDateTime(terminal.changed)} |{' '}
+        {mapToShortDateTime(terminal.changed)} |{' '}
         {terminal.changedByUserName ?? 'HSL'}{' '}
         <i className="icon-history text-xl" aria-hidden />
       </Link>

--- a/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodSection.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/CommonSubstitutePeriodSection.tsx
@@ -1,12 +1,14 @@
 import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DateRange } from '../../../../types';
+import { SubstituteDayOfWeek } from '../../../../types/enums';
 import { LoadingWrapper } from '../../../../uiComponents/LoadingWrapper';
 import { showDangerToastWithError, showSuccessToast } from '../../../../utils';
 import { useCreateSubstituteOperatingPeriod } from '../hooks/useCreateSubstituteOperatingPeriod';
 import { useDeleteSubstituteOperatingPeriod } from '../hooks/useDeleteSubstituteOperatingPeriod';
 import { useEditSubstituteOperatingPeriod } from '../hooks/useEditSubstituteOperatingPeriod';
 import { useGetCommonSubstituteOperatingPeriods } from '../hooks/useGetSubstituteOperatingPeriod';
+import { CommonSubstitutePeriodType } from '../OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types';
 import {
   CommonSubstitutePeriodForm,
   mapCommonSubstituteOperatingPeriodsToCommonDays,
@@ -56,12 +58,15 @@ export const CommonSubstitutePeriodSection: FC<
     // occasional substitute operating periods form type
     const periods = form.commonDays
       .filter((day) => day.created || day.fromDatabase)
-      .map((d) => ({
-        ...d,
-        beginDate: d.supersededDate,
-        endDate: d.supersededDate,
-        toBeDeleted: d.toBeDeleted ?? false,
-      }));
+      .map(
+        (d): CommonSubstitutePeriodType => ({
+          ...d,
+          substituteDayOfWeek: d.substituteDayOfWeek as SubstituteDayOfWeek,
+          beginDate: d.supersededDate,
+          endDate: d.supersededDate,
+          toBeDeleted: d.toBeDeleted ?? false,
+        }),
+      );
 
     try {
       await deleteSubstituteOperatingPeriod({ periods });

--- a/ui/src/components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types.ts
+++ b/ui/src/components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types.ts
@@ -24,5 +24,12 @@ export const schema = z.object({
 });
 
 export type PeriodType = z.infer<typeof periodSchema>;
+export type CommonSubstitutePeriodType = Omit<
+  PeriodType,
+  'beginTime' | 'endTime'
+> & {
+  beginTime?: never;
+  endTime?: never;
+};
 
 export type FormState = z.infer<typeof schema>;

--- a/ui/src/components/timetables/substitute-day-settings/hooks/useCreateSubstituteOperatingPeriod.ts
+++ b/ui/src/components/timetables/substitute-day-settings/hooks/useCreateSubstituteOperatingPeriod.ts
@@ -5,7 +5,10 @@ import {
 } from '../../../../generated/graphql';
 import { MutationHook, extendHook } from '../../../../hooks';
 import { mapPeriodsToDayByLineTypes, mapToData } from '../../../../utils';
-import { FormState } from '../OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types';
+import {
+  CommonSubstitutePeriodType,
+  PeriodType,
+} from '../OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types';
 
 const GQL_CREATE_SUBSTITUTE_OPERATING_PERIOD = gql`
   mutation CreateSubstituteOperatingPeriod(
@@ -34,7 +37,9 @@ const GQL_CREATE_SUBSTITUTE_OPERATING_PERIOD = gql`
 `;
 
 type CreateParams = {
-  readonly form: FormState;
+  readonly form: {
+    readonly periods: ReadonlyArray<PeriodType | CommonSubstitutePeriodType>;
+  };
 };
 
 type CreateChanges = {

--- a/ui/src/components/timetables/substitute-day-settings/hooks/useEditSubstituteOperatingPeriod.ts
+++ b/ui/src/components/timetables/substitute-day-settings/hooks/useEditSubstituteOperatingPeriod.ts
@@ -7,7 +7,10 @@ import {
 } from '../../../../generated/graphql';
 import { MutationHook, extendHook } from '../../../../hooks';
 import { mapPeriodsToDayByLineTypes } from '../../../../utils';
-import { FormState } from '../OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types';
+import {
+  CommonSubstitutePeriodType,
+  PeriodType,
+} from '../OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types';
 
 // Hasura doesn't support updating nested objects in one mutation
 // https://hasura.io/docs/latest/mutations/postgres/update/
@@ -47,7 +50,9 @@ const GQL_UPDATE_SUBSTITUTE_PERIOD = gql`
 `;
 
 type EditParams = {
-  readonly form: FormState;
+  readonly form: {
+    readonly periods: ReadonlyArray<PeriodType | CommonSubstitutePeriodType>;
+  };
 };
 
 type EditChanges = {

--- a/ui/src/hooks/mutationHook.ts
+++ b/ui/src/hooks/mutationHook.ts
@@ -43,7 +43,7 @@ export const extendHook = <
       prepare,
       mapChangesToVariables,
       executeMutation,
-    );
+    ) as (params: TParams) => Promise<FetchResult>;
 
     return {
       ...hookFunctions,

--- a/ui/src/time.ts
+++ b/ui/src/time.ts
@@ -1,16 +1,28 @@
 import isString from 'lodash/isString';
 import padStart from 'lodash/padStart';
-import { DateTime, Duration, Interval, Settings } from 'luxon';
+import {
+  DateTime,
+  Duration,
+  FixedOffsetZone,
+  IANAZone,
+  Interval,
+  Settings,
+} from 'luxon';
 import { Maybe, ValidityPeriod } from './generated/graphql';
 
-Settings.defaultZone = 'Europe/Helsinki';
+// Use Helsinki as the time default time zone.
+const helsinkiTimeZone = IANAZone.create('Europe/Helsinki');
+Settings.defaultZone = helsinkiTimeZone;
 
+// This is in fact false at the moment.
+// Previous versions of the luxon typings did not care about validity.
+// Currently, our code base can produce NPEs when working with Luxon classes.
+// Settings.throwOnInvalid = true; should be set next to defaultZone.
+// Setting this to true, breaks half of the code base as they rely on
+// parsing and creating invalid dates.
+// TODO: Set the throwOnInvalid setting or fix the codebase to deal with nulls produced by Luxon.
+Settings.throwOnInvalid = false;
 declare module 'luxon' {
-  // This is in fact false at the moment.
-  // Previous versions of the luxon typings did not care about validity.
-  // Currently, our code base can produce NPEs when working with Luxon classes.
-  // Settings.throwOnInvalid = true; should be set next to defaultZone.
-  // TODO: Set the throwOnInvalid setting or fix the codebase to deal with nulls produced by Luxon.
   interface TSSettings {
     throwOnInvalid: true;
   }
@@ -20,6 +32,19 @@ export type DateLike = DateTime | string;
 
 export function isDateLike(input?: unknown): input is DateLike {
   return DateTime.isDateTime(input) || isString(input);
+}
+
+function parseActualStringToDateTime(date: string): DateTime {
+  if (date.length <= 10) {
+    // Set directly to Europe/Helsinki timezone to keep the time at midnight.
+    return DateTime.fromISO(date, { zone: helsinkiTimeZone });
+  }
+
+  // It is a date & time string.
+  return DateTime.fromISO(date, {
+    // If no timezone / offset info is specified, assume UTC
+    zone: FixedOffsetZone.utcInstance,
+  }).setZone(helsinkiTimeZone); // Convert to Helsinki time.
 }
 
 export function parseDate(date: DateLike): DateTime;
@@ -38,9 +63,8 @@ export function parseDate(date?: DateLike | null) {
     return date;
   }
 
-  // if valid DateTime from date string, return it
-  // can handle yyyy-mm-dd date strings as well
-  const dt = DateTime.fromISO(date);
+  // It is a date string
+  const dt = parseActualStringToDateTime(date);
   if (dt.isValid) {
     return dt;
   }
@@ -72,16 +96,6 @@ export const mapToShortTime = (date?: DateLike | null) =>
 // "shortDateTime" means format "D.M.YYYY H.mm"
 export const mapToShortDateTime = (date?: DateLike | null) =>
   formatDateWithoutLocale('d.L.yyyy H.mm', date);
-
-// Convert UTC timestamp to Helsinki timezone and format as date time
-export const mapUTCToDateTime = (date?: string | null) => {
-  if (!date) {
-    return undefined;
-  }
-  return DateTime.fromISO(date, { zone: 'utc' })
-    .setZone('Europe/Helsinki')
-    .toFormat('dd.MM.yyyy HH:mm');
-};
 
 export function mapToISODate(date: DateLike): string;
 export function mapToISODate(date: null | undefined): undefined;
@@ -136,7 +150,3 @@ export const findEarliestTime = (times: ReadonlyArray<DateTime>) => {
 export const findLatestTime = (times: ReadonlyArray<DateTime>) => {
   return DateTime.fromMillis(Math.max(...times.map((item) => item.toMillis())));
 };
-
-export function toUtcDate(dateTime: DateTime): DateTime {
-  return DateTime.utc(dateTime.year, dateTime.month, dateTime.day);
-}

--- a/ui/src/utils/substituteOperatingPeriod.ts
+++ b/ui/src/utils/substituteOperatingPeriod.ts
@@ -1,5 +1,8 @@
 import { DateTime, Duration } from 'luxon';
-import { PeriodType } from '../components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types';
+import {
+  CommonSubstitutePeriodType,
+  PeriodType,
+} from '../components/timetables/substitute-day-settings/OccasionalSubstitutePeriod/OccasionalSubstitutePeriodForm.types';
 import {
   Maybe,
   RouteTypeOfLineEnum,
@@ -25,8 +28,18 @@ export const parseSubstituteDayOfWeek = (
   return SubstituteDayOfWeek.NoTraffic;
 };
 
+function parseOptionalInterval(
+  str: string | undefined | null,
+): Duration | null {
+  if (!str) {
+    return null;
+  }
+
+  return Duration.fromISOTime(str);
+}
+
 export const mapPeriodsToDayByLineTypes = (
-  input: PeriodType,
+  input: PeriodType | CommonSubstitutePeriodType,
 ): TimetablesServiceCalendarSubstituteOperatingDayByLineTypeInsertInput[] => {
   const {
     beginDate,
@@ -58,8 +71,8 @@ export const mapPeriodsToDayByLineTypes = (
           superseded_date: date,
           substitute_day_of_week:
             mapSubstituteDayOfWeekToNumber(substituteDayOfWeek),
-          begin_time: Duration.fromISOTime(beginTime),
-          end_time: Duration.fromISOTime(endTime),
+          begin_time: parseOptionalInterval(beginTime),
+          end_time: parseOptionalInterval(endTime),
           substitute_operating_period_id: periodId,
         });
       }


### PR DESCRIPTION
### SubstitutePeriod: Fix types and interval parsing

Due to an oversight in the implementation of `extendHook` function, it was returning an function that took in `any` as it's parameters, thus loosing type info in between.

Then later in the code there ware expectations made about the input Substitution periods' shape, namely they were all expected to be occasional ones with custom begin and end times defined. But in reality they could have also been common periods as well, which default to the full time period (beginTime = null, endTime = null) in the db. As all periods were expected by the code to contain a valid time periods, those fields were directly fed into the Luxon.Duration parsing functions.

That can work, when the Luxon settings are set to not throw on invalid input and instead just invalid return garbage data, that eventually mapped to null when serializing the data on the transport layer.


### Improve time parsing handling
* Improve timezone handling when parsing date(time) strings:
  - Correctly set Date only values to Helsinki midnight DateTime objects.
  - Assume date time strings without an explicit timezone or offset info are in UTC time, and convert them to Helsinki time.



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1419)
<!-- Reviewable:end -->
