### PR TITLE
ChangeHistory: Fix broken history on priority change

### DIFF
--- a/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistory.ts
+++ b/ui/src/components/routes-and-lines/line-change-history/queries/useGetLineChangeHistory.ts
@@ -23,14 +23,9 @@ import {
 import { LineChangeHistoryItem, TgOperation } from '../types';
 
 const GQL_GET_LINE_CHANGE_HISTORY = gql`
-  query GetLineChangeHistory($label: String!, $priority: Int!) {
+  query GetLineChangeHistory($label: String!) {
     historyItems: route_line_change_history(
-      where: {
-        _and: [
-          { line_label: { _eq: $label } }
-          { line_priority: { _eq: $priority } }
-        ]
-      }
+      where: { line_label: { _eq: $label } }
     ) {
       ...LineChangeHistoryItemDetails
     }
@@ -241,8 +236,12 @@ function filterHistoryItems(
 ): (item: LineChangeHistoryItem) => boolean {
   const from = filters.from.startOf('day');
   const to = filters.to.endOf('day');
+  const { priority } = filters;
 
-  return (item) => from <= item.changed && item.changed <= to;
+  return (item) =>
+    item.linePriority === priority &&
+    from <= item.changed &&
+    item.changed <= to;
 }
 
 const noopGetUserNameById: GetUserNameById = () => null;
@@ -285,7 +284,7 @@ export function useGetLineChangeHistoryItems({
   sortingInfo,
 }: GetLineChangeHistoryOptions) {
   const { data, ...rest } = useGetLineChangeHistoryQuery({
-    variables: { label, priority: filters.priority },
+    variables: { label },
   });
 
   const historyItems: ReadonlyArray<LineChangeHistoryItem> = useMemo(

--- a/ui/src/components/stop-registry/stops/change-history/queries/useGetStopChangeHistoryItems.ts
+++ b/ui/src/components/stop-registry/stops/change-history/queries/useGetStopChangeHistoryItems.ts
@@ -12,19 +12,18 @@ import {
   ChangeHistoryFilters,
   ChangeHistorySortingInfo,
 } from '../../../../common/ChangeHistory';
-import { sortByVersion, useSortTiamatHistoryItems } from '../../../utils';
+import {
+  historyItemIsDateRange,
+  sortByVersion,
+  useSortTiamatHistoryItems,
+} from '../../../utils';
 import { sortByChangedTime } from '../../../utils/sortTiamatChangeHistoryItems';
 
 const GQL_GET_STOP_CHANGE_HISTORY = gql`
-  query GetStopChangeHistory($publicCode: String!, $priority: String!) {
+  query GetStopChangeHistory($publicCode: String!) {
     stopsDb: stops_database {
       historyItems: getQuayChangeHistory(
-        where: {
-          _and: [
-            { publicCode: { _eq: $publicCode } }
-            { priority: { _eq: $priority } }
-          ]
-        }
+        where: { publicCode: { _eq: $publicCode } }
       ) {
         ...QuayChangeHistoryItemDetails
       }
@@ -61,12 +60,9 @@ type GetStopChangeHistoryOptions = {
   readonly publicCode: string;
 };
 
-function useGetStopChangeHistorySortedByVersion(
-  publicCode: string,
-  priority: Priority,
-) {
+function useGetStopChangeHistorySortedByVersion(publicCode: string) {
   const { data, ...rest } = useGetStopChangeHistoryQuery({
-    variables: { publicCode, priority: String(priority) },
+    variables: { publicCode },
   });
 
   const rawHistoryItems = data?.stopsDb?.historyItems;
@@ -84,16 +80,22 @@ function useGetStopChangeHistorySortedByVersion(
   return { ...rest, historyItems };
 }
 
+function filterQuayHistoryItems(
+  filters: ChangeHistoryFilters,
+): (item: QuayChangeHistoryItem) => boolean {
+  const priorityStr = String(filters.priority);
+  const isInDateRange = historyItemIsDateRange(filters);
+
+  return (item) => item.priority === priorityStr && isInDateRange(item);
+}
+
 export function useGetStopChangeHistoryItems({
   filters,
   getUserNameById,
   publicCode,
   sortingInfo,
 }: GetStopChangeHistoryOptions) {
-  const base = useGetStopChangeHistorySortedByVersion(
-    publicCode,
-    filters.priority,
-  );
+  const base = useGetStopChangeHistorySortedByVersion(publicCode);
 
   const sortedHistoryItems: ReadonlyArray<QuayChangeHistoryItem> =
     useSortTiamatHistoryItems(
@@ -101,6 +103,7 @@ export function useGetStopChangeHistoryItems({
       filters,
       sortingInfo,
       getUserNameById,
+      filterQuayHistoryItems,
     );
 
   return { ...base, sortedHistoryItems };
@@ -112,15 +115,18 @@ export function useGetLatestStopChangeHistory(
   publicCode: string,
   priority: Priority,
 ) {
-  const base = useGetStopChangeHistorySortedByVersion(publicCode, priority);
+  const priorityStr = String(priority);
+  const base = useGetStopChangeHistorySortedByVersion(publicCode);
+
   return {
     ...base,
     latestHistoryItems: useMemo(
       () =>
         base.historyItems
+          .filter((it) => it.priority === priorityStr)
           .toSorted(sortByChangedTime(SortOrder.DESCENDING))
           .slice(0, latestChangesLimit),
-      [base.historyItems],
+      [base.historyItems, priorityStr],
     ),
   };
 }

--- a/ui/src/components/stop-registry/utils/useSortTiamatHistoryItems.ts
+++ b/ui/src/components/stop-registry/utils/useSortTiamatHistoryItems.ts
@@ -11,7 +11,7 @@ import { sortBySortingInfo } from './sortTiamatChangeHistoryItems';
 
 export const noopGetUserNameById: GetUserNameById = () => null;
 
-function historyItemIsDateRange({
+export function historyItemIsDateRange({
   from,
   to,
 }: ChangeHistoryFilters): (item: BaseTiamatChangeHistoryItem) => boolean {
@@ -30,6 +30,9 @@ export function useSortTiamatHistoryItems<
   filters: ChangeHistoryFilters,
   sortingInfo: ChangeHistorySortingInfo,
   getUserNameByIdRealImpl: GetUserNameById,
+  getFilterFn: (
+    filters: ChangeHistoryFilters,
+  ) => (item: T) => boolean = historyItemIsDateRange,
 ): ReadonlyArray<T> {
   const collator = useCollator({ numeric: true });
 
@@ -43,8 +46,15 @@ export function useSortTiamatHistoryItems<
   return useMemo(
     () =>
       historyItems
-        .filter(historyItemIsDateRange(filters))
+        .filter(getFilterFn(filters))
         .sort(sortBySortingInfo(sortingInfo, collator, getUserNameById)),
-    [historyItems, filters, sortingInfo, collator, getUserNameById],
+    [
+      historyItems,
+      filters,
+      sortingInfo,
+      collator,
+      getUserNameById,
+      getFilterFn,
+    ],
   );
 }


### PR DESCRIPTION
Always fetch all history items, and perform the priority filtering on UI side post fact, for the final list of items to display. This ensures we don't end up in a situation where we have a "missing" version, due to it having a wrong priority.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1422)
<!-- Reviewable:end -->
