### PR TITLE
Fix route selection after delete

### DIFF
--- a/ui/src/components/map/routes/RouteEditor.tsx
+++ b/ui/src/components/map/routes/RouteEditor.tsx
@@ -298,6 +298,10 @@ const RouteEditorComponent: ForwardRefRenderFunction<ExplicitAny> = (
       await deleteRoute(editedRouteId);
       showSuccessToast(t(($) => $.routes.deleteSuccess));
 
+      // clear the route from the map and reset redux state
+      dispatch(stopRouteEditingAction());
+      dispatch(setSelectedRouteIdAction(undefined));
+
       setIsDeleting(false);
       resetUrlState();
     } catch (err) {


### PR DESCRIPTION
When deleting an existing route, also clear route editor UI state:
- Remove drawn route from map
- Stop route editing mode
- Clear selected route id

This prevents deleted routes from staying highlighted/selected on the map.

User story: 31281
Task: 78763

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1425)
<!-- Reviewable:end -->
