### PR TITLE
Mark trunk line route stops as trunk line stops on Line Details page

### DIFF
--- a/cypress/datasets/base.ts
+++ b/cypress/datasets/base.ts
@@ -51,7 +51,7 @@ export const stopCoordinatesByLabel = {
 };
 
 export const buildStopsOnInfraLinks = (
-  testInfraLinkIds: UUID[],
+  testInfraLinkIds: ReadonlyArray<UUID>,
 ): StopInsertInput[] => [
   // Stops along test route 901 Outbound
   {
@@ -413,7 +413,7 @@ const stopsInJourneyPattern: StopInJourneyPatternInsertInput[] = [
 ];
 
 export const buildInfraLinksAlongRoute = (
-  infrastructureLinkIds: UUID[],
+  infrastructureLinkIds: ReadonlyArray<UUID>,
 ): InfraLinkAlongRouteInsertInput[] => [
   {
     route_id: routes[0].route_id,

--- a/cypress/e2e/editRoute.cy.ts
+++ b/cypress/e2e/editRoute.cy.ts
@@ -1,7 +1,10 @@
 import {
   Priority,
   RouteDirectionEnum,
+  RouteInsertInput,
 } from '@hsl/jore4-test-db-manager/dist/CypressSpecExports';
+import identity from 'lodash/identity';
+import range from 'lodash/range';
 import { DateTime } from 'luxon';
 import {
   buildInfraLinksAlongRoute,
@@ -9,20 +12,26 @@ import {
   getClonedBaseDbResources,
   testInfraLinkExternalIds,
 } from '../datasets/base';
+import { getClonedBaseStopRegistryData } from '../datasets/stopRegistry';
 import { Tag } from '../enums';
 import {
+  BasicDetailsViewCard,
   ConfirmationDialog,
   EditRoutePage,
   LineChangeHistory,
   LineDetailsPage,
+  LineForm,
+  LineRouteList,
   RouteRow,
+  StopsNeedingUpdateModal,
   TerminusNameInputs,
   Toast,
   ValidityPeriodForm,
 } from '../pageObjects';
 import { UUID } from '../types';
-import { SupportedResources, insertToDbHelper } from '../utils';
+import { SupportedResources, insertToDbHelper, mapAt } from '../utils';
 import { expectGraphQLCallToSucceed } from '../utils/assertions';
+import { InsertedStopRegistryIds } from './utils';
 
 describe('Route editing', { tags: [Tag.Routes] }, () => {
   let dbResources: SupportedResources;
@@ -336,6 +345,169 @@ describe('Route editing', { tags: [Tag.Routes] }, () => {
           'contain',
           'Jos haluat pysäkit mukaan reitille, säädä ensin niiden prioriteetti vastaamaan reittiä.',
         );
+    });
+  });
+
+  describe('Trunk Line bus Route', () => {
+    const { lineRouteListItem } = LineRouteList;
+    const { routeRow, routeStopListItem } = lineRouteListItem;
+
+    function buildTestData(infraLinkIds: ReadonlyArray<UUID>) {
+      const stops = buildStopsOnInfraLinks(infraLinkIds);
+      const infraLinksAlongRoute = buildInfraLinksAlongRoute(infraLinkIds);
+
+      return {
+        ...getClonedBaseDbResources(),
+        stops,
+        infraLinksAlongRoute,
+      };
+    }
+
+    function initTrunkLineTest(
+      editResources: (
+        resources: ReturnType<typeof buildTestData>,
+      ) => SupportedResources = identity,
+    ) {
+      cy.task<UUID[]>(
+        'getInfrastructureLinkIdsByExternalIds',
+        testInfraLinkExternalIds,
+      )
+        .then(buildTestData)
+        .then(editResources)
+        .then((testResources) => {
+          cy.task('resetDbs');
+          insertToDbHelper(testResources);
+
+          cy.task<InsertedStopRegistryIds>(
+            'insertStopRegistryData',
+            getClonedBaseStopRegistryData(),
+          );
+
+          cy.setupTests();
+          cy.mockLogin();
+        });
+    }
+
+    function setRouteToDraft(route: RouteInsertInput): RouteInsertInput {
+      return { ...route, priority: Priority.Draft };
+    }
+
+    function setLineTypeToTrunkLineType() {
+      LineDetailsPage.getEditLineButton().click();
+      LineForm.selectLineType('Runkolinja');
+      LineForm.save();
+    }
+
+    function addExcludedStopToRoute() {
+      LineRouteList.getShowUnusedStopsSwitch().click();
+
+      LineRouteList.getNthLineRouteListItem(1).within(() => {
+        routeRow.getToggleAccordionButton().click();
+
+        lineRouteListItem
+          .getNthRouteStopListItem(4)
+          .should('contain', 'E2E010')
+          .and('contain', 'Ei reitin käytössä');
+
+        // Add E2E010 to the route
+        lineRouteListItem.getNthRouteStopListItem(4).within(() => {
+          routeStopListItem.getStopActionsDropdown().click();
+          cy.withinHeadlessPortal(() =>
+            routeStopListItem.stopActionsDropdown
+              .getAddStopToRouteButton()
+              .click(),
+          );
+        });
+      });
+    }
+
+    function assertStopsAreTrunkLine(areTrunkLine: boolean) {
+      const expectedContent = areTrunkLine ? 'Runkolinjapysäkki' : '-';
+
+      LineRouteList.getNthLineRouteListItem(1).within(() => {
+        lineRouteListItem
+          .getNthRouteStopListItem(0)
+          .within(() => lineRouteListItem.getLabel().click());
+      });
+
+      BasicDetailsViewCard.getStopType()
+        .shouldBeVisible()
+        .shouldHaveText(expectedContent);
+      cy.go(-1);
+
+      LineRouteList.getNthLineRouteListItem(1).within(() => {
+        routeRow.getToggleAccordionButton().click();
+
+        lineRouteListItem
+          .getNthRouteStopListItem(4)
+          .within(() => lineRouteListItem.getLabel().click());
+      });
+
+      BasicDetailsViewCard.getStopType()
+        .shouldBeVisible()
+        .shouldHaveText(expectedContent);
+    }
+
+    it('Should not update stop Trunk Line status for Draft route', () => {
+      cy.section('Init test data', () => {
+        initTrunkLineTest((resources) => ({
+          ...resources,
+          routes: mapAt(resources.routes, {
+            0: setRouteToDraft,
+            1: setRouteToDraft,
+          }),
+        }));
+      });
+
+      LineDetailsPage.visit(baseDbResources.lines[0].line_id);
+
+      cy.section('Change line type to Trunk Line', () => {
+        setLineTypeToTrunkLineType();
+        LineForm.checkLineSubmitSuccess();
+      });
+
+      LineDetailsPage.getShowDraftsButton().click();
+
+      cy.section('Toggle a stop onto a Trunk Line', () => {
+        addExcludedStopToRoute();
+        Toast.expectSuccessToast('Reitti tallennettu');
+      });
+
+      cy.section('Assert stop Trunk Line status', () =>
+        assertStopsAreTrunkLine(false),
+      );
+    });
+
+    it('Should update stop Trunk Line status for non Draft route', () => {
+      cy.section('Init test data', () => initTrunkLineTest());
+
+      LineDetailsPage.visit(baseDbResources.lines[0].line_id);
+
+      cy.section('Change line type to Trunk Line', () => {
+        setLineTypeToTrunkLineType();
+
+        StopsNeedingUpdateModal.getModal().shouldBeVisible();
+        range(1, 10).forEach((i) =>
+          StopsNeedingUpdateModal.getStopLink(`E2E00${i}`).shouldBeVisible(),
+        );
+        StopsNeedingUpdateModal.getConfirmButton().click();
+
+        LineForm.checkLineSubmitSuccess();
+      });
+
+      cy.section('Toggle a stop onto a Trunk Line', () => {
+        addExcludedStopToRoute();
+
+        StopsNeedingUpdateModal.getModal().shouldBeVisible();
+        StopsNeedingUpdateModal.getStopLink('E2E010').shouldBeVisible();
+        StopsNeedingUpdateModal.getConfirmButton().click();
+
+        Toast.expectSuccessToast('Reitti tallennettu');
+      });
+
+      cy.section('Assert stop Trunk Line status', () =>
+        assertStopsAreTrunkLine(true),
+      );
     });
   });
 });

--- a/cypress/pageObjects/routes-and-lines/StopsNeedingUpdateModal.ts
+++ b/cypress/pageObjects/routes-and-lines/StopsNeedingUpdateModal.ts
@@ -1,0 +1,17 @@
+import { createSimplePageObject } from '../createSimplePageObject';
+
+export const StopsNeedingUpdateModal = createSimplePageObject(
+  'StopsNeedingUpdateModal',
+  [
+    'StopsNeedingUpdateModal::modal',
+    'StopsNeedingUpdateModal::cancelButton',
+    'StopsNeedingUpdateModal::confirmButton',
+  ],
+  (base) => ({
+    ...base,
+    getStopLink: (publicCode: string) =>
+      cy.get(
+        `[data-testid^="StopsNeedingUpdateModal::stopLink::${publicCode}"]`,
+      ),
+  }),
+);

--- a/cypress/pageObjects/routes-and-lines/index.ts
+++ b/cypress/pageObjects/routes-and-lines/index.ts
@@ -11,4 +11,5 @@ export * from './RouteStopListItem';
 export * from './RoutesAndLinesPage';
 export * from './SearchContainer';
 export * from './SearchResultsPage';
+export * from './StopsNeedingUpdateModal';
 export * from './line-details-page';

--- a/cypress/pageObjects/routes-and-lines/line-details-page/LineRouteListItem.ts
+++ b/cypress/pageObjects/routes-and-lines/line-details-page/LineRouteListItem.ts
@@ -13,4 +13,8 @@ export class LineRouteListItem {
   static getNthRouteStopListItem(nth: number) {
     return LineRouteListItem.getRouteStopListItems().eq(nth);
   }
+
+  static getLabel() {
+    return cy.getByTestId('RouteStopListItem::label');
+  }
 }

--- a/cypress/utils/index.ts
+++ b/cypress/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './db';
 export * from './time';
+export * from './mapAt';

--- a/cypress/utils/mapAt.ts
+++ b/cypress/utils/mapAt.ts
@@ -1,0 +1,69 @@
+type Mapper<T, R> = (item: T) => R;
+type Mappers<T, R> = { readonly [key: number]: Mapper<T, R> };
+
+function mapSingleAt<T, R = T>(
+  array: ReadonlyArray<T>,
+  index: number,
+  mapper: Mapper<T, R>,
+): Array<T | R> {
+  if (index >= array.length) {
+    throw new RangeError(
+      `Trying to map index ${index} of an Array with length of ${array.length}!`,
+    );
+  }
+
+  const item = array[index];
+  return (array as Array<T | R>).with(index, mapper(item));
+}
+
+function mapMultipleAt<T, R = T>(
+  array: ReadonlyArray<T>,
+  mappers: Mappers<T, R>,
+): Array<T | R> {
+  const indexes = Object.keys(mappers).map(Number);
+
+  const invalidIndexes = indexes.filter((i) => i >= array.length);
+  if (invalidIndexes.length) {
+    throw new RangeError(
+      `Trying to map indexes ${invalidIndexes} of an Array with length of ${array.length}!`,
+    );
+  }
+
+  const copy: Array<T | R> = new Array(array.length);
+  for (let i = 0; i < array.length; i += 1) {
+    if (i in mappers) {
+      copy[i] = mappers[i](array[i]);
+    } else {
+      copy[i] = array[i];
+    }
+  }
+
+  return copy;
+}
+
+export function mapAt<T, R = T>(
+  array: ReadonlyArray<T>,
+  index: number,
+  mapper: (item: T) => R,
+): Array<T | R>;
+export function mapAt<T, R = T>(
+  array: ReadonlyArray<T>,
+  mappers: { readonly [key: number]: (item: T) => R },
+): Array<T | R>;
+export function mapAt<T, R = T>(
+  array: ReadonlyArray<T>,
+  indexOrMappers: number | Mappers<T, R>,
+  mapper?: Mapper<T, R>,
+): Array<T | R> {
+  if (mapper && typeof indexOrMappers === 'number') {
+    return mapSingleAt(array, indexOrMappers, mapper);
+  }
+
+  if (typeof indexOrMappers === 'object' && indexOrMappers !== null) {
+    return mapMultipleAt(array, indexOrMappers);
+  }
+
+  throw new TypeError(
+    'mapAt called with invalid parameters! Known Fn contract: (array,number,Mapper) | (array,Mappers)',
+  );
+}

--- a/graphql.config.yml
+++ b/graphql.config.yml
@@ -6,6 +6,12 @@ projects:
       - 'ui/src/**/*.ts'
       - 'ui/src/**/*.tsx'
     ignore: 'ui/src/generated/*'
+    extensions:
+      endpoints:
+        hasura:
+          url: http://localhost:3201/v1/graphql
+          headers:
+            x-hasura-admin-secret: 'hasura'
 
   tdb:
     schema: 'ui/graphql.schema.json'

--- a/ui/src/components/routes-and-lines/common/ConflictResolverModal.tsx
+++ b/ui/src/components/routes-and-lines/common/ConflictResolverModal.tsx
@@ -35,38 +35,44 @@ type CommonConflictItem = {
   readonly href?: string;
 };
 
-export const mapRouteToCommonConflictItem = (
+export function mapRouteToCommonConflictItem(
   route: RouteUniqueFieldsFragment,
-): CommonConflictItem => ({
-  validityStart: route.validity_start ?? undefined,
-  validityEnd: route.validity_end ?? undefined,
-  priority: route.priority,
-  label: route.label,
-  variant: route.variant,
-  id: route.route_id,
-  href: routeDetails[Path.editRoute].getLink(route.route_id),
-});
+): CommonConflictItem {
+  return {
+    validityStart: route.validity_start ?? undefined,
+    validityEnd: route.validity_end ?? undefined,
+    priority: route.priority,
+    label: route.label,
+    variant: route.variant,
+    id: route.route_id,
+    href: routeDetails[Path.editRoute].getLink(route.route_id),
+  };
+}
 
-export const mapLineToCommonConflictItem = (
+export function mapLineToCommonConflictItem(
   line: LineDefaultFieldsFragment,
-): CommonConflictItem => ({
-  validityStart: line.validity_start ?? undefined,
-  validityEnd: line.validity_end ?? undefined,
-  priority: line.priority,
-  label: line.label,
-  id: line.line_id,
-  href: routeDetails[Path.lineDetails].getLink(line.line_id),
-});
+): CommonConflictItem {
+  return {
+    validityStart: line.validity_start ?? undefined,
+    validityEnd: line.validity_end ?? undefined,
+    priority: line.priority,
+    label: line.label,
+    id: line.line_id,
+    href: routeDetails[Path.lineDetails].getLink(line.line_id),
+  };
+}
 
-export const mapStopToCommonConflictItem = (
+export function mapStopToCommonConflictItem(
   item: ScheduledStopPointDefaultFieldsFragment,
-): CommonConflictItem => ({
-  validityStart: item.validity_start ?? undefined,
-  validityEnd: item.validity_end ?? undefined,
-  priority: item.priority,
-  label: item.label,
-  id: item.scheduled_stop_point_id,
-});
+): CommonConflictItem {
+  return {
+    validityStart: item.validity_start ?? undefined,
+    validityEnd: item.validity_end ?? undefined,
+    priority: item.priority,
+    label: item.label,
+    id: item.scheduled_stop_point_id,
+  };
+}
 
 type ConflictItemRowProps = {
   readonly item: CommonConflictItem;
@@ -102,18 +108,19 @@ const ConflictItemRow: FC<ConflictItemRowProps> = ({ item }) => {
 };
 
 type ConflictResolverModalProps = {
-  readonly onClose: () => void;
   readonly className?: string;
-  readonly conflicts?: ReadonlyArray<CommonConflictItem>;
+  readonly conflicts: ReadonlyArray<CommonConflictItem>;
+  readonly isOpen?: boolean;
+  readonly onClose: () => void;
 };
 
 export const ConflictResolverModal: FC<ConflictResolverModalProps> = ({
   onClose,
   className,
-  conflicts = [],
+  conflicts,
+  isOpen = conflicts.length > 0,
 }) => {
   const { t } = useTranslation();
-  const isOpen = !!conflicts.length;
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} contentClassName={className}>

--- a/ui/src/components/routes-and-lines/common/SaveBlockers.ts
+++ b/ui/src/components/routes-and-lines/common/SaveBlockers.ts
@@ -1,0 +1,25 @@
+type PendingChanges = {
+  readonly conflicts: ReadonlyArray<unknown>;
+  readonly stopsNeedingUpdate: ReadonlyArray<unknown>;
+};
+
+export type SaveBlockers = {
+  readonly hasConflicts: boolean;
+  readonly hasStopsNeedingUpdate: boolean;
+};
+
+export function getBlockers(changes: PendingChanges | null): SaveBlockers {
+  if (changes === null) {
+    return { hasConflicts: false, hasStopsNeedingUpdate: false };
+  }
+
+  return {
+    hasConflicts: changes.conflicts.length > 0,
+    hasStopsNeedingUpdate: changes.stopsNeedingUpdate.length > 0,
+  };
+}
+
+export function hasBlockers(changes: PendingChanges | null): boolean {
+  const blockers = getBlockers(changes);
+  return blockers.hasConflicts || blockers.hasStopsNeedingUpdate;
+}

--- a/ui/src/components/routes-and-lines/common/StopsNeedingUpdateModal.tsx
+++ b/ui/src/components/routes-and-lines/common/StopsNeedingUpdateModal.tsx
@@ -1,0 +1,89 @@
+import { Description, DialogTitle } from '@headlessui/react';
+import uniq from 'lodash/uniq';
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { RouteTypeOfLineEnum } from '../../../generated/graphql';
+import { Row } from '../../../layoutComponents';
+import { Modal, ModalBody, SimpleButton } from '../../../uiComponents';
+import { StopsList } from '../../common/ChangeHistory';
+import { StopMetaTypeUpdateInfo } from './useUpdateStopRegistryStopMetatype';
+
+const testIds = {
+  modal: 'StopsNeedingUpdateModal::modal',
+  cancelButton: 'StopsNeedingUpdateModal::cancelButton',
+  confirmButton: 'StopsNeedingUpdateModal::confirmButton',
+  stopLink: (publicCode: string) =>
+    `StopsNeedingUpdateModal::stopLink::${publicCode}`,
+};
+
+type StopsNeedingUpdateModalProps = {
+  readonly className?: string;
+  readonly onCancel: () => void;
+  readonly onConfirm: () => void;
+  readonly isOpen: boolean;
+  readonly stops: ReadonlyArray<StopMetaTypeUpdateInfo>;
+  readonly typeOfLine: RouteTypeOfLineEnum | undefined | null;
+};
+
+export const StopsNeedingUpdateModal: FC<StopsNeedingUpdateModalProps> = ({
+  className,
+  onCancel,
+  onConfirm,
+  isOpen,
+  stops,
+  typeOfLine,
+}) => {
+  const { t } = useTranslation();
+
+  const getBodyContent = () => {
+    switch (typeOfLine) {
+      case RouteTypeOfLineEnum.ExpressBusService:
+        return t(($) => $.confirmAutoUpdateStops.bodyTrunkLine);
+
+      case RouteTypeOfLineEnum.RegionalTramService:
+        return t(($) => $.confirmAutoUpdateStops.bodySpeedTram);
+
+      default:
+        return null;
+    }
+  };
+
+  const affectedStopList = uniq(stops.map((it) => it.publicCode)).sort();
+
+  return (
+    <Modal
+      contentClassName={className}
+      isOpen={isOpen}
+      onClose={onCancel}
+      testId={testIds.modal}
+    >
+      <ModalBody className="max-w-[500px]">
+        <DialogTitle className="flex text-xl font-bold">
+          {t(($) => $.confirmAutoUpdateStops.title)}
+        </DialogTitle>
+
+        <Description as="div" className="my-4">
+          <p className="mb-4">{getBodyContent()}</p>
+          <StopsList
+            t={t}
+            stopLabels={affectedStopList}
+            getLinkTestId={testIds.stopLink}
+          />
+        </Description>
+
+        <Row className="justify-end gap-4">
+          <SimpleButton
+            onClick={onCancel}
+            inverted
+            testId={testIds.cancelButton}
+          >
+            {t(($) => $.cancel)}
+          </SimpleButton>
+          <SimpleButton onClick={onConfirm} testId={testIds.confirmButton}>
+            {t(($) => $.confirmAutoUpdateStops.confirm)}
+          </SimpleButton>
+        </Row>
+      </ModalBody>
+    </Modal>
+  );
+};

--- a/ui/src/components/routes-and-lines/common/useUpdateStopRegistryStopMetatype.ts
+++ b/ui/src/components/routes-and-lines/common/useUpdateStopRegistryStopMetatype.ts
@@ -1,0 +1,337 @@
+import { ApolloClient, gql, useApolloClient } from '@apollo/client';
+import { TFunction } from 'i18next';
+import compact from 'lodash/compact';
+import groupBy from 'lodash/groupBy';
+import uniq from 'lodash/uniq';
+import {
+  GetStopForMetaTypeUpdateDataFragment,
+  GetStopsForMetaTypeUpdateDocument,
+  GetStopsForMetaTypeUpdateQuery,
+  GetStopsForMetaTypeUpdateQueryVariables,
+  RawQuayKeyValueFragment,
+  ResolveLineStopPublicCodesDocument,
+  ResolveLineStopPublicCodesQuery,
+  ResolveLineStopPublicCodesQueryVariables,
+  RouteTypeOfLineEnum,
+  StopRegistryKeyValues,
+  StopRegistryTransportModeType,
+  UpdateQuayMetaTypeDocument,
+  UpdateQuayMetaTypeMutation,
+  UpdateQuayMetaTypeMutationVariables,
+} from '../../../generated/graphql';
+import { TError } from '../../../types/TError';
+import { KnownValueKey, findKeyValueParsed } from '../../../utils';
+
+const GQL_RESOLVE_LINE_STOP_PUBLIC_CODES = gql`
+  query ResolveLineStopPublicCodes($lineId: uuid!) {
+    stopPoints: journey_pattern_scheduled_stop_point_in_journey_pattern(
+      where: {
+        journey_pattern: {
+          journey_pattern_route: {
+            # Don't update stops on Draft routes
+            priority: { _lt: 30 }
+            on_line_id: { _eq: $lineId }
+          }
+        }
+      }
+    ) {
+      journey_pattern_id
+      scheduled_stop_point_sequence
+      publicCode: scheduled_stop_point_label
+    }
+  }
+`;
+
+const GQL_GET_STOPS_FOR_META_TYPE_UPDATE = gql`
+  query GetStopsForMetaTypeUpdate($publicCodes: [String!]!) {
+    stopsDb: stops_database {
+      quays: stops_database_quay_newest_version(
+        where: { public_code: { _in: $publicCodes } }
+      ) {
+        ...GetStopForMetaTypeUpdateData
+      }
+    }
+  }
+
+  fragment RawQuayKeyValue on stops_database_quay_key_values {
+    key_values_id
+    key_values_key
+    quay_id
+
+    value {
+      id
+      value_items {
+        value_id
+        items
+      }
+    }
+  }
+
+  fragment GetStopForMetaTypeUpdateData on stops_database_quay_newest_version {
+    netex_id
+    stop_place_netex_id
+    public_code
+
+    quay_key_values {
+      ...RawQuayKeyValue
+    }
+
+    stop_place {
+      id
+      transport_mode
+    }
+  }
+`;
+
+const GQL_UPDATE_QUAY_META_TYPE = gql`
+  mutation UpdateQuayMetaType(
+    $stopPlaceId: String!
+    $quays: [stop_registry_QuayInput!]!
+  ) {
+    stop_registry {
+      mutateStopPlace(StopPlace: { id: $stopPlaceId, quays: $quays }) {
+        id
+        version
+
+        quays {
+          id
+          version
+
+          keyValues {
+            key
+            values
+          }
+        }
+      }
+    }
+  }
+`;
+
+export type StopMetaTypeUpdateInfo = {
+  readonly publicCode: string;
+  readonly netexId: string;
+  readonly stopPlaceNetexId: string;
+  readonly transportMode: StopRegistryTransportModeType | null;
+  readonly isSpeedTramStop: boolean;
+  readonly isTrunkLineStop: boolean;
+  readonly keyValues: ReadonlyArray<StopRegistryKeyValues>;
+};
+
+async function resolveStopPublicCodesByLineId(
+  client: ApolloClient,
+  lineId: UUID,
+): Promise<ReadonlyArray<string>> {
+  const stopPointsResult = await client.query<
+    ResolveLineStopPublicCodesQuery,
+    ResolveLineStopPublicCodesQueryVariables
+  >({
+    query: ResolveLineStopPublicCodesDocument,
+    variables: { lineId },
+    fetchPolicy: 'network-only',
+  });
+
+  return uniq(stopPointsResult.data.stopPoints.map((it) => it.publicCode));
+}
+
+function mapRawKeyValues(
+  rawKeyValues: ReadonlyArray<RawQuayKeyValueFragment>,
+): Array<StopRegistryKeyValues> {
+  return compact(
+    rawKeyValues.map((rawKv) => {
+      const value = rawKv.value.value_items.at(0)?.items;
+
+      if (!value) {
+        return null;
+      }
+
+      return { key: rawKv.key_values_key, values: [value] };
+    }),
+  );
+}
+
+function mapRawQuay(
+  rawQuay: GetStopForMetaTypeUpdateDataFragment,
+): StopMetaTypeUpdateInfo | null {
+  const keyValues = mapRawKeyValues(rawQuay.quay_key_values);
+
+  if (
+    !rawQuay.netex_id ||
+    !rawQuay.stop_place_netex_id ||
+    !rawQuay.public_code
+  ) {
+    return null;
+  }
+
+  return {
+    netexId: rawQuay.netex_id,
+    stopPlaceNetexId: rawQuay.stop_place_netex_id,
+    publicCode: rawQuay.public_code,
+    transportMode: (rawQuay.stop_place?.transport_mode?.toLowerCase() ??
+      null) as StopRegistryTransportModeType | null,
+    isSpeedTramStop:
+      findKeyValueParsed({ keyValues }, KnownValueKey.SpeedTramStop, Boolean) ??
+      false,
+    isTrunkLineStop:
+      findKeyValueParsed({ keyValues }, KnownValueKey.TrunkLineStop, Boolean) ??
+      false,
+    keyValues,
+  };
+}
+
+export function lineTypeAffectsMetatypes(mode: RouteTypeOfLineEnum): boolean {
+  return (
+    mode === RouteTypeOfLineEnum.ExpressBusService ||
+    mode === RouteTypeOfLineEnum.RegionalTramService
+  );
+}
+
+export function filterNeedUpdateByLineType(
+  mode: RouteTypeOfLineEnum,
+): (item: StopMetaTypeUpdateInfo) => boolean {
+  if (mode === RouteTypeOfLineEnum.ExpressBusService) {
+    return (it) => !it.isTrunkLineStop;
+  }
+
+  if (mode === RouteTypeOfLineEnum.RegionalTramService) {
+    return (it) => !it.isSpeedTramStop;
+  }
+
+  return () => false;
+}
+
+export async function resolveStopInfoByPublicCodes(
+  client: ApolloClient,
+  publicCodes: ReadonlyArray<string>,
+): Promise<ReadonlyArray<StopMetaTypeUpdateInfo>> {
+  const quaysResult = await client.query<
+    GetStopsForMetaTypeUpdateQuery,
+    GetStopsForMetaTypeUpdateQueryVariables
+  >({
+    query: GetStopsForMetaTypeUpdateDocument,
+    variables: { publicCodes },
+    fetchPolicy: 'network-only',
+  });
+
+  const mapped = quaysResult.data.stopsDb?.quays.map(mapRawQuay);
+
+  return compact(mapped).sort((a, b) =>
+    a.publicCode.localeCompare(b.publicCode),
+  );
+}
+
+export async function resolveStopInfoByLine(
+  client: ApolloClient,
+  lineId: UUID,
+): Promise<ReadonlyArray<StopMetaTypeUpdateInfo>> {
+  const publicCodes = await resolveStopPublicCodesByLineId(client, lineId);
+  return resolveStopInfoByPublicCodes(client, publicCodes);
+}
+
+class FailedToUpdateStops extends AggregateError implements TError {
+  constructor(
+    public errors: Array<unknown>,
+    public stops: ReadonlyArray<string>,
+  ) {
+    super(errors, `Failed to update stops: ${stops.join(', ')}`);
+  }
+
+  translate(t: TFunction): string {
+    return t(($) => $.confirmAutoUpdateStops.failedToUpdate, {
+      stops: this.stops.join(', '),
+    });
+  }
+}
+
+const speedTramStopKeyValue: StopRegistryKeyValues = {
+  key: KnownValueKey.SpeedTramStop,
+  values: [String(true)],
+};
+
+const trunkLineStopKeyValue: StopRegistryKeyValues = {
+  key: KnownValueKey.TrunkLineStop,
+  values: [String(true)],
+};
+
+const metatypeKeyValues: ReadonlyArray<KnownValueKey> = [
+  KnownValueKey.SpeedTramStop,
+  KnownValueKey.TrunkLineStop,
+];
+
+function mapStopsToUpdates(
+  stops: ReadonlyArray<StopMetaTypeUpdateInfo>,
+): Array<UpdateQuayMetaTypeMutationVariables> {
+  const byStopPlace = groupBy(stops, (stop) => stop.stopPlaceNetexId);
+  const metatypeKeyValue =
+    stops.at(0)?.transportMode === StopRegistryTransportModeType.Tram
+      ? speedTramStopKeyValue
+      : trunkLineStopKeyValue;
+
+  return Object.entries(byStopPlace).map(
+    ([stopPlaceId, stopPlaceStops]): UpdateQuayMetaTypeMutationVariables => ({
+      stopPlaceId,
+      quays: stopPlaceStops.map((stop) => ({
+        id: stop.netexId,
+        keyValues: stop.keyValues
+          .filter((it) => !metatypeKeyValues.includes(it.key as KnownValueKey))
+          .concat(metatypeKeyValue),
+      })),
+    }),
+  );
+}
+
+async function performUpdates(
+  client: ApolloClient,
+  updates: ReadonlyArray<UpdateQuayMetaTypeMutationVariables>,
+) {
+  return Promise.allSettled(
+    updates.map((update) =>
+      client.mutate<
+        UpdateQuayMetaTypeMutation,
+        UpdateQuayMetaTypeMutationVariables
+      >({
+        mutation: UpdateQuayMetaTypeDocument,
+        variables: update,
+      }),
+    ),
+  );
+}
+
+function assertUpdateSucceeded(
+  stops: ReadonlyArray<StopMetaTypeUpdateInfo>,
+  results: Awaited<ReturnType<typeof performUpdates>>,
+) {
+  const failedUpdates = results.filter((r) => r.status === 'rejected');
+  if (failedUpdates.length > 0) {
+    const errors = failedUpdates.map((r) => r.reason);
+
+    const succeededQuayNetexIds = results
+      .filter((r) => r.status === 'fulfilled')
+      .flatMap((r) => r.value?.data?.stop_registry?.mutateStopPlace ?? [])
+      .flatMap((sp) => sp?.quays ?? [])
+      .map((q) => q?.id);
+
+    const failedStops = stops
+      .filter((s) => !succeededQuayNetexIds.includes(s.netexId))
+      .map((s) => s.publicCode);
+
+    throw new FailedToUpdateStops(errors, failedStops);
+  }
+}
+
+export async function updateStopRegistryStopMetatype(
+  client: ApolloClient,
+  stops: ReadonlyArray<StopMetaTypeUpdateInfo>,
+) {
+  const updates = mapStopsToUpdates(stops);
+  const results = await performUpdates(client, updates);
+
+  assertUpdateSucceeded(stops, results);
+
+  return true;
+}
+
+export function useUpdateStopRegistryStopMetatype() {
+  const client = useApolloClient();
+  return (stops: ReadonlyArray<StopMetaTypeUpdateInfo>) =>
+    updateStopRegistryStopMetatype(client, stops);
+}

--- a/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-line/EditLinePage.tsx
@@ -1,13 +1,13 @@
 import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Navigate } from 'react-router';
 import {
   LineAllFieldsFragment,
   useGetLineDetailsByIdQuery,
 } from '../../../generated/graphql';
 import { mapLineDetailsResult } from '../../../graphql';
-import { useRequiredParams } from '../../../hooks';
+import { useNavigateBackSafely, useRequiredParams } from '../../../hooks';
 import { Container } from '../../../layoutComponents';
+import { Operation } from '../../../redux';
 import { Path, routeDetails } from '../../../router/routeDetails';
 import { mapToISODate } from '../../../time';
 import {
@@ -16,81 +16,134 @@ import {
   showSuccessToast,
 } from '../../../utils';
 import { PageTitle } from '../../common';
+import { useLoader } from '../../common/hooks';
 import { FormState, LineForm } from '../../forms/line/LineForm';
 import {
   ConflictResolverModal,
   mapLineToCommonConflictItem,
 } from '../common/ConflictResolverModal';
 import { PageHeader } from '../common/PageHeader';
-import { useEditLine } from './useEditLine';
+import { getBlockers, hasBlockers } from '../common/SaveBlockers';
+import { StopsNeedingUpdateModal } from '../common/StopsNeedingUpdateModal';
+import { useUpdateStopRegistryStopMetatype } from '../common/useUpdateStopRegistryStopMetatype';
+import { EditLineChanges, useEditLine } from './useEditLine';
 
-const mapLineToFormState = (line: LineAllFieldsFragment): FormState => ({
-  label: line.label,
-  description: line.description ?? undefined,
-  versionComment: '',
-  name: defaultLocalizedString(line.name_i18n),
-  shortName: defaultLocalizedString(line.short_name_i18n),
-  primaryVehicleMode: line.primary_vehicle_mode,
-  priority: line.priority,
-  transportTarget: line.transport_target,
-  typeOfLine: line.type_of_line,
-  validityStart: mapToISODate(line.validity_start) ?? '',
-  validityEnd: mapToISODate(line.validity_end) ?? '',
-  indefinite: !line.validity_end,
-});
+function mapLineToFormState(line: LineAllFieldsFragment): FormState {
+  return {
+    label: line.label,
+    description: line.description ?? undefined,
+    versionComment: '',
+    name: defaultLocalizedString(line.name_i18n),
+    shortName: defaultLocalizedString(line.short_name_i18n),
+    primaryVehicleMode: line.primary_vehicle_mode,
+    priority: line.priority,
+    transportTarget: line.transport_target,
+    typeOfLine: line.type_of_line,
+    validityStart: mapToISODate(line.validity_start) ?? '',
+    validityEnd: mapToISODate(line.validity_end) ?? '',
+    indefinite: !line.validity_end,
+  };
+}
 
 export const EditLinePage: FC = () => {
-  const [hasFinishedEditing, setHasFinishedEditing] = useState(false);
-  const [conflicts, setConflicts] = useState<
-    ReadonlyArray<LineAllFieldsFragment>
-  >([]);
+  const { t } = useTranslation();
+
+  const { id } = useRequiredParams<{ id: string }>();
+  const navigateBack = useNavigateBackSafely();
+
+  const { setIsLoading } = useLoader(Operation.UpdateLine);
+
+  // Needed to disable the rendering of the actual form element,
+  // that blocks navigation after save.
+  const [saved, setSaved] = useState<boolean>(false);
+  const [pendingEditChanges, setPendingEditChanges] =
+    useState<EditLineChanges | null>(null);
+
   const {
     prepareEdit,
     mapEditChangesToVariables,
     editLineMutation,
     defaultErrorHandler,
   } = useEditLine();
+  const updateStopRegistryStopMetatype = useUpdateStopRegistryStopMetatype();
 
-  const { id } = useRequiredParams<{ id: string }>();
-  const lineDetailsResult = useGetLineDetailsByIdQuery(
-    mapToVariables({ line_id: id }),
+  const line = mapLineDetailsResult(
+    // Instead of subscribing to cache changes, we should only fetch the data once.
+    useGetLineDetailsByIdQuery(mapToVariables({ line_id: id })),
   );
-  const line = mapLineDetailsResult(lineDetailsResult);
-  const { t } = useTranslation();
 
-  const onSubmit = async (form: FormState) => {
+  const onCommitEditChanges = async (changes: EditLineChanges) => {
+    setIsLoading(true);
     try {
-      const changes = await prepareEdit({ lineId: id, form });
-      if (changes.conflicts?.length) {
-        setConflicts(changes.conflicts);
-        return;
-      }
-      const variables = mapEditChangesToVariables(changes);
-      await editLineMutation({ variables });
-      setHasFinishedEditing(true);
+      setPendingEditChanges(null);
+
+      await editLineMutation({ variables: mapEditChangesToVariables(changes) });
+      await updateStopRegistryStopMetatype(changes.stopsNeedingUpdate);
+
+      // Mark the line as saved
+      setSaved(true);
       showSuccessToast(t(($) => $.lines.saveSuccess));
+
+      // Navigate back to the previous page after this page has re-rendered.
+      setTimeout(
+        () =>
+          navigateBack(routeDetails[Path.lineDetails].getLink(id), {
+            replace: true,
+          }),
+        0,
+      );
     } catch (err) {
       defaultErrorHandler(err);
+    } finally {
+      setIsLoading(false);
     }
   };
 
-  if (hasFinishedEditing) {
-    // if line was successfully edited, redirect to its page
-    return (
-      <Navigate to={{ pathname: routeDetails[Path.lineDetails].getLink(id) }} />
-    );
-  }
+  const onSubmit = async (form: FormState) => {
+    setIsLoading(true);
+    try {
+      const changes = await prepareEdit({ lineId: id, form });
+
+      if (hasBlockers(changes)) {
+        setPendingEditChanges(changes);
+      } else {
+        await onCommitEditChanges(changes);
+      }
+    } catch (err) {
+      defaultErrorHandler(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   const pageTitleText = t(($) => $.lines.line, {
     label: line?.label,
   });
 
+  const blockers = getBlockers(pendingEditChanges);
+
   return (
     <div>
-      <ConflictResolverModal
-        onClose={() => setConflicts([])}
-        conflicts={conflicts.map(mapLineToCommonConflictItem)}
-      />
+      {pendingEditChanges ? (
+        <>
+          <ConflictResolverModal
+            isOpen={blockers.hasConflicts}
+            onClose={() => setPendingEditChanges(null)}
+            conflicts={pendingEditChanges.conflicts.map(
+              mapLineToCommonConflictItem,
+            )}
+          />
+
+          <StopsNeedingUpdateModal
+            isOpen={!blockers.hasConflicts && blockers.hasStopsNeedingUpdate}
+            onCancel={() => setPendingEditChanges(null)}
+            onConfirm={() => onCommitEditChanges(pendingEditChanges)}
+            stops={pendingEditChanges.stopsNeedingUpdate}
+            typeOfLine={pendingEditChanges.patch.type_of_line}
+          />
+        </>
+      ) : null}
+
       <PageHeader>
         <PageTitle.H1 titleText={pageTitleText}>
           <i className="icon-bus-alt text-tweaked-brand" />
@@ -98,7 +151,7 @@ export const EditLinePage: FC = () => {
         </PageTitle.H1>
       </PageHeader>
       <Container>
-        {line && (
+        {line && !saved && (
           <LineForm
             onSubmit={onSubmit}
             defaultValues={mapLineToFormState(line)}

--- a/ui/src/components/routes-and-lines/edit-line/useEditLine.ts
+++ b/ui/src/components/routes-and-lines/edit-line/useEditLine.ts
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
 import {
   LineAllFieldsFragment,
@@ -6,9 +7,16 @@ import {
   usePatchLineMutation,
 } from '../../../generated/graphql';
 import { MIN_DATE } from '../../../time';
+import { Priority } from '../../../types/enums';
 import { showDangerToastWithError } from '../../../utils';
 import { useCheckValidityAndPriorityConflicts } from '../../common/hooks/useCheckValidityAndPriorityConflicts';
 import { FormState } from '../../forms/line/LineForm';
+import {
+  StopMetaTypeUpdateInfo,
+  filterNeedUpdateByLineType,
+  lineTypeAffectsMetatypes,
+  resolveStopInfoByLine,
+} from '../common/useUpdateStopRegistryStopMetatype';
 import { mapFormToInput } from '../create-line/useCreateLine';
 import { useValidateLine } from './useValidateLine';
 
@@ -17,43 +25,62 @@ type EditParams = {
   readonly form: FormState;
 };
 
-type EditChanges = {
+export type EditLineChanges = {
   readonly lineId: UUID;
   readonly patch: RouteLineSetInput;
-  readonly conflicts?: ReadonlyArray<LineAllFieldsFragment>;
+  readonly conflicts: ReadonlyArray<LineAllFieldsFragment>;
+  readonly stopsNeedingUpdate: ReadonlyArray<StopMetaTypeUpdateInfo>;
 };
 
 export const useEditLine = () => {
   const { t } = useTranslation();
+  const client = useApolloClient();
   const [mutateFunction] = usePatchLineMutation();
   const { getConflictingLines } = useCheckValidityAndPriorityConflicts();
   const { validateLine } = useValidateLine();
 
-  const prepareEdit = async ({ lineId, form }: EditParams) => {
+  const prepareEdit = async ({
+    lineId,
+    form,
+  }: EditParams): Promise<EditLineChanges> => {
     const input = mapFormToInput(form);
 
-    await validateLine({ lineId, input });
-    const conflicts = await getConflictingLines(
-      {
-        label: form.label,
-        priority: form.priority,
-        validityStart: input.validity_start ?? MIN_DATE,
-        validityEnd: input.validity_end ?? undefined,
-      },
-      lineId,
-    );
+    const getConflicts = () =>
+      getConflictingLines(
+        {
+          label: form.label,
+          priority: form.priority,
+          validityStart: input.validity_start ?? MIN_DATE,
+          validityEnd: input.validity_end ?? undefined,
+        },
+        lineId,
+      );
 
-    const changes: EditChanges = {
-      lineId,
-      patch: input,
-      conflicts,
+    const getStopsNeedingUpdate = async () => {
+      if (
+        form.priority < Priority.Draft && // Draft should not change the stop type.
+        lineTypeAffectsMetatypes(form.typeOfLine)
+      ) {
+        const updatableStops = await resolveStopInfoByLine(client, lineId);
+        return updatableStops.filter(
+          filterNeedUpdateByLineType(form.typeOfLine),
+        );
+      }
+
+      return [];
     };
 
-    return changes;
+    const [conflicts, stopsNeedingUpdate] = await Promise.all([
+      getConflicts(),
+      getStopsNeedingUpdate(),
+      validateLine({ lineId, input }),
+    ]);
+
+    return { lineId, patch: input, conflicts, stopsNeedingUpdate };
   };
 
   const mapEditChangesToVariables = (
-    changes: EditChanges,
+    changes: EditLineChanges,
   ): PatchLineMutationVariables => ({
     line_id: changes.lineId,
     object: changes.patch,

--- a/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
+++ b/ui/src/components/routes-and-lines/edit-route/EditRoutePage.tsx
@@ -46,11 +46,8 @@ export const EditRoutePage: FC = () => {
   } = useEditRouteMetadata();
   const { deleteRoute, defaultErrorHandler: defaultDeleteErrorHandler } =
     useDeleteRoute();
-  const {
-    prepareDeleteStopFromRoute,
-    mapEditJourneyPatternChangesToVariables,
-    updateRouteGeometryMutation,
-  } = useEditRouteJourneyPattern();
+  const { prepareDeleteStopFromRoute, performUpdate } =
+    useEditRouteJourneyPattern();
   const [conflicts, setConflicts] = useState<
     ReadonlyArray<RouteDefaultFieldsFragment>
   >([]);
@@ -104,12 +101,11 @@ export const EditRoutePage: FC = () => {
   const onRemoveStopsFromRoute = async (form: RouteFormState) => {
     try {
       if (route) {
-        const changes = prepareDeleteStopFromRoute({
+        const changes = await prepareDeleteStopFromRoute({
           route,
           stopPointLabels: draftStops?.map((stop) => stop.label),
         });
-        const variables = mapEditJourneyPatternChangesToVariables(changes);
-        await updateRouteGeometryMutation(variables, route.route_id);
+        await performUpdate(changes);
       }
       onSubmit(form);
     } catch (err) {

--- a/ui/src/components/routes-and-lines/edit-route/useEditRouteJourneyPattern.ts
+++ b/ui/src/components/routes-and-lines/edit-route/useEditRouteJourneyPattern.ts
@@ -1,17 +1,17 @@
-import { gql } from '@apollo/client';
+import { gql, useApolloClient } from '@apollo/client';
 import {
   GetRouteDetailsByIdDocument,
   JourneyPatternStopFragment,
   RouteStopFieldsFragment,
   RouteWithInfrastructureLinksWithStopsAndJpsFragment,
   RouteWithInfrastructureLinksWithStopsFragment,
-  UpdateRouteJourneyPatternMutationVariables,
   useUpdateRouteJourneyPatternMutation,
 } from '../../../generated/graphql';
 import {
   mapInfrastructureLinksAlongRouteToRouteInfraLinks,
   stopBelongsToJourneyPattern,
 } from '../../../graphql';
+import { Priority } from '../../../types/enums';
 import {
   addOrRemoveStopLabelsFromIncludedStops,
   buildJourneyPatternStopSequence,
@@ -20,6 +20,13 @@ import {
 } from '../../../utils';
 import { extractJourneyPatternCandidateStops } from '../../map/routes/hooks/useExtractRouteFromFeature';
 import { useValidateRoute } from '../../map/routes/hooks/useValidateRoute';
+import {
+  StopMetaTypeUpdateInfo,
+  filterNeedUpdateByLineType,
+  lineTypeAffectsMetatypes,
+  resolveStopInfoByPublicCodes,
+  useUpdateStopRegistryStopMetatype,
+} from '../common/useUpdateStopRegistryStopMetatype';
 
 const GQL_UPDATE_ROUTE_JOURNEY_PATTERN = gql`
   mutation UpdateRouteJourneyPattern(
@@ -54,11 +61,13 @@ type DeleteStopParams = {
 
 type AddStopParams = DeleteStopParams;
 
-type UpdateJourneyPatternChanges = {
+export type UpdateJourneyPatternChanges = {
+  readonly routeId: UUID;
   readonly journeyPatternId: UUID;
   readonly stopsEligibleForJourneyPattern: ReadonlyArray<RouteStopFieldsFragment>;
   readonly includedStopLabels: ReadonlyArray<string>;
   readonly journeyPatternStops: ReadonlyArray<JourneyPatternStopFragment>;
+  readonly stopsNeedingUpdate: ReadonlyArray<StopMetaTypeUpdateInfo>;
 };
 
 export const getEligibleStopsAlongRoute = <
@@ -72,21 +81,37 @@ export const getEligibleStopsAlongRoute = <
   return extractJourneyPatternCandidateStops(links, route);
 };
 
-/**
- * Hook for adding and removing stops to route's journey pattern.
- */
-export const useEditRouteJourneyPattern = () => {
-  const [updateRouteJourneyPatternMutation] =
-    useUpdateRouteJourneyPatternMutation();
+function usePrepareUpdateJourneyPattern() {
+  const client = useApolloClient();
   const { validateStopCount } = useValidateRoute();
 
-  const prepareUpdateJourneyPattern = (
+  const getStopsNeedingUpdate = async ({
+    route,
+    stopPointLabels,
+  }: AddStopParams): Promise<ReadonlyArray<StopMetaTypeUpdateInfo>> => {
+    if (
+      route.priority < Priority.Draft && // Draft should not change the stop type.
+      lineTypeAffectsMetatypes(route.route_line.type_of_line)
+    ) {
+      const updatableStops = await resolveStopInfoByPublicCodes(
+        client,
+        stopPointLabels,
+      );
+      return updatableStops.filter(
+        filterNeedUpdateByLineType(route.route_line.type_of_line),
+      );
+    }
+
+    return [];
+  };
+
+  return async (
     params: AddStopParams | DeleteStopParams,
     stopBelongsToRoute: boolean,
-  ) => {
+  ): Promise<UpdateJourneyPatternChanges> => {
     const { route, stopPointLabels } = params;
 
-    // TODO: Get rid of stopsEligibleForJourneyPattern in this hook
+    // TODO: Get rid of stopsEligibleForJourneyPattern in this hook; Why?
     const stopsEligibleForJourneyPattern = filterDistinctConsecutiveStops(
       getEligibleStopsAlongRoute(route),
     );
@@ -109,53 +134,63 @@ export const useEditRouteJourneyPattern = () => {
       route.route_id,
     );
 
-    const changes: UpdateJourneyPatternChanges = {
+    const stopsNeedingUpdate = stopBelongsToRoute
+      ? await getStopsNeedingUpdate(params)
+      : [];
+
+    return {
+      routeId: route.route_id,
       // In our data model route has always exactly one journey pattern
       journeyPatternId: route.route_journey_patterns[0].journey_pattern_id,
       stopsEligibleForJourneyPattern,
       includedStopLabels,
       journeyPatternStops,
+      stopsNeedingUpdate,
     };
-
-    return changes;
   };
+}
 
-  const prepareDeleteStopFromRoute = (params: DeleteStopParams) => {
-    return prepareUpdateJourneyPattern(params, false);
-  };
+/**
+ * Hook for adding and removing stops to route's journey pattern.
+ */
+export function useEditRouteJourneyPattern() {
+  const [updateRouteJourneyPatternMutation] =
+    useUpdateRouteJourneyPatternMutation();
+  const updateStopRegistryStopMetatype = useUpdateStopRegistryStopMetatype();
 
-  const mapEditJourneyPatternChangesToVariables = (
-    changes: UpdateJourneyPatternChanges,
-  ) => {
-    const variables: UpdateRouteJourneyPatternMutationVariables = {
-      journey_pattern_id: changes.journeyPatternId,
-      new_stops_in_journey_pattern: buildJourneyPatternStopSequence(changes),
-    };
+  const prepareUpdateJourneyPattern = usePrepareUpdateJourneyPattern();
 
-    return variables;
-  };
+  const prepareAddStopToRoute = (params: AddStopParams) =>
+    prepareUpdateJourneyPattern(params, true);
 
-  const prepareAddStopToRoute = (params: AddStopParams) => {
-    return prepareUpdateJourneyPattern(params, true);
-  };
+  const prepareDeleteStopFromRoute = (params: DeleteStopParams) =>
+    prepareUpdateJourneyPattern(params, false);
 
-  const updateRouteGeometryMutation = async (
-    variables: UpdateRouteJourneyPatternMutationVariables,
-    routeId: UUID,
-  ) => {
-    await updateRouteJourneyPatternMutation({
-      variables,
+  const performUpdate = async (changes: UpdateJourneyPatternChanges) => {
+    const journeyPatternUpdate = updateRouteJourneyPatternMutation({
+      variables: {
+        journey_pattern_id: changes.journeyPatternId,
+        new_stops_in_journey_pattern: buildJourneyPatternStopSequence(changes),
+      },
       awaitRefetchQueries: true,
       refetchQueries: [
-        { query: GetRouteDetailsByIdDocument, variables: { routeId } },
+        {
+          query: GetRouteDetailsByIdDocument,
+          variables: { routeId: changes.routeId },
+        },
       ],
     });
+
+    const stopRegistryStopMetatypeUpdate = updateStopRegistryStopMetatype(
+      changes.stopsNeedingUpdate,
+    );
+
+    return Promise.all([journeyPatternUpdate, stopRegistryStopMetatypeUpdate]);
   };
 
   return {
     prepareDeleteStopFromRoute,
     prepareAddStopToRoute,
-    mapEditJourneyPatternChangesToVariables,
-    updateRouteGeometryMutation,
+    performUpdate,
   };
-};
+}

--- a/ui/src/components/routes-and-lines/line-details/RouteStopListItem.tsx
+++ b/ui/src/components/routes-and-lines/line-details/RouteStopListItem.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AiFillPlusCircle } from 'react-icons/ai';
 import { MdHistory } from 'react-icons/md';
+import { Link } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 import {
   RouteStopFieldsFragment,
@@ -111,8 +112,8 @@ export const RouteStopListItem: FC<RouteStopListItemProps> = ({
       data-testid={testIds.container}
     >
       <div className="col-span-3 items-center justify-center text-center text-2xl">
-        <a
-          href={routeDetails[Path.stopDetails].getLink(stop.label, {
+        <Link
+          to={routeDetails[Path.stopDetails].getLink(stop.label, {
             observationDate,
           })}
           data-testid={testIds.label}
@@ -121,7 +122,7 @@ export const RouteStopListItem: FC<RouteStopListItemProps> = ({
           })}
         >
           {stop.label}
-        </a>
+        </Link>
       </div>
       <div className="col-span-9 flex items-center" data-testid={testIds.name}>
         <span>{stop.stop_place?.at(0)?.name?.value ?? '-'}</span>

--- a/ui/src/components/routes-and-lines/line-details/StopActionsDropdown.tsx
+++ b/ui/src/components/routes-and-lines/line-details/StopActionsDropdown.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RouteWithInfrastructureLinksWithStopsAndJpsFragment } from '../../../generated/graphql';
 import { useAppDispatch, useAppSelector } from '../../../hooks';
@@ -14,7 +14,11 @@ import {
 } from '../../../uiComponents';
 import { showDangerToast, showSuccessToast } from '../../../utils';
 import { useLoader } from '../../common/hooks/useLoader';
-import { useEditRouteJourneyPattern } from '../edit-route/useEditRouteJourneyPattern';
+import { StopsNeedingUpdateModal } from '../common/StopsNeedingUpdateModal';
+import {
+  UpdateJourneyPatternChanges,
+  useEditRouteJourneyPattern,
+} from '../edit-route/useEditRouteJourneyPattern';
 
 const testIds = {
   menu: 'StopActionsDropdown::menu',
@@ -35,6 +39,7 @@ type StopActionsDropdownProps = {
   readonly tooltip: string;
 };
 
+// TODO: Fix this to be a simple presentation component, and externalize the actial update logic.
 export const StopActionsDropdown: FC<StopActionsDropdownProps> = ({
   journeyPatternId,
   scheduledStopPointSequence,
@@ -45,16 +50,16 @@ export const StopActionsDropdown: FC<StopActionsDropdownProps> = ({
   tooltip,
 }) => {
   const { t } = useTranslation();
+
+  const [pendingChanges, setPendingChanges] =
+    useState<UpdateJourneyPatternChanges | null>(null);
+
   const dispatch = useAppDispatch();
   const { setIsLoading } = useLoader(Operation.UpdateRouteJourneyPattern);
   const isLoading = useAppSelector(selectIsJoreOperationLoading);
 
-  const {
-    prepareAddStopToRoute,
-    prepareDeleteStopFromRoute,
-    mapEditJourneyPatternChangesToVariables,
-    updateRouteGeometryMutation,
-  } = useEditRouteJourneyPattern();
+  const { prepareAddStopToRoute, prepareDeleteStopFromRoute, performUpdate } =
+    useEditRouteJourneyPattern();
 
   const showViaModal = () => {
     if (journeyPatternId) {
@@ -79,18 +84,33 @@ export const StopActionsDropdown: FC<StopActionsDropdownProps> = ({
     }
   };
 
+  const onCommitUpdate = async (changes: UpdateJourneyPatternChanges) => {
+    setIsLoading(true);
+    setPendingChanges(null);
+
+    try {
+      await performUpdate(changes);
+      showSuccessToast(t(($) => $.routes.saveSuccess));
+    } catch (err) {
+      showDangerToast(`${t(($) => $.errors.saveFailed)}, '${err}'`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const onAddToRoute = async () => {
     setIsLoading(true);
     try {
-      const changes = prepareAddStopToRoute({
+      const changes = await prepareAddStopToRoute({
         stopPointLabels: [stopLabel],
         route,
       });
 
-      const variables = mapEditJourneyPatternChangesToVariables(changes);
-
-      await updateRouteGeometryMutation(variables, route.route_id);
-      showSuccessToast(t(($) => $.routes.saveSuccess));
+      if (changes.stopsNeedingUpdate.length) {
+        setPendingChanges(changes);
+      } else {
+        await onCommitUpdate(changes);
+      }
     } catch (err) {
       showDangerToast(`${t(($) => $.errors.saveFailed)}, '${err}'`);
     }
@@ -100,15 +120,16 @@ export const StopActionsDropdown: FC<StopActionsDropdownProps> = ({
   const onRemoveFromRoute = async () => {
     setIsLoading(true);
     try {
-      const changes = prepareDeleteStopFromRoute({
+      const changes = await prepareDeleteStopFromRoute({
         stopPointLabels: [stopLabel],
         route,
       });
 
-      const variables = mapEditJourneyPatternChangesToVariables(changes);
-
-      await updateRouteGeometryMutation(variables, route.route_id);
-      showSuccessToast(t(($) => $.routes.saveSuccess));
+      if (changes.stopsNeedingUpdate.length) {
+        setPendingChanges(changes);
+      } else {
+        await onCommitUpdate(changes);
+      }
     } catch (err) {
       showDangerToast(`${t(($) => $.errors.saveFailed)}, '${err}'`);
     }
@@ -116,44 +137,56 @@ export const StopActionsDropdown: FC<StopActionsDropdownProps> = ({
   };
 
   return (
-    <SimpleDropdownMenu
-      testId={testIds.menu}
-      disabled={isLoading}
-      tooltip={tooltip}
-    >
-      {stopBelongsToJourneyPattern ? (
-        <SimpleDropdownMenuItem
-          onClick={onRemoveFromRoute}
-          text={t(($) => $.stops.removeFromRoute)}
-          testId={testIds.removeStop}
-        />
-      ) : (
-        <SimpleDropdownMenuItem
-          onClick={onAddToRoute}
-          text={t(($) => $.stops.addToRoute)}
-          testId={testIds.addStop}
-        />
-      )}
-      {isViaPoint ? (
-        <SimpleDropdownMenuItem
-          onClick={showViaModal}
-          text={t(($) => $.viaModal.editViaPoint)}
-          testId={testIds.editViaPoint}
-        />
-      ) : (
+    <>
+      {' '}
+      <SimpleDropdownMenu
+        testId={testIds.menu}
+        disabled={isLoading}
+        tooltip={tooltip}
+      >
+        {stopBelongsToJourneyPattern ? (
+          <SimpleDropdownMenuItem
+            onClick={onRemoveFromRoute}
+            text={t(($) => $.stops.removeFromRoute)}
+            testId={testIds.removeStop}
+          />
+        ) : (
+          <SimpleDropdownMenuItem
+            onClick={onAddToRoute}
+            text={t(($) => $.stops.addToRoute)}
+            testId={testIds.addStop}
+          />
+        )}
+        {isViaPoint ? (
+          <SimpleDropdownMenuItem
+            onClick={showViaModal}
+            text={t(($) => $.viaModal.editViaPoint)}
+            testId={testIds.editViaPoint}
+          />
+        ) : (
+          <SimpleDropdownMenuItem
+            disabled={!stopBelongsToJourneyPattern}
+            onClick={showViaModal}
+            text={t(($) => $.viaModal.createViaPoint)}
+            testId={testIds.createViaPoint}
+          />
+        )}
         <SimpleDropdownMenuItem
           disabled={!stopBelongsToJourneyPattern}
-          onClick={showViaModal}
-          text={t(($) => $.viaModal.createViaPoint)}
-          testId={testIds.createViaPoint}
+          onClick={showTimingSettingsModal}
+          text={t(($) => $.timingSettingsModal.timingSettings)}
+          testId={testIds.openTimingSettings}
         />
-      )}
-      <SimpleDropdownMenuItem
-        disabled={!stopBelongsToJourneyPattern}
-        onClick={showTimingSettingsModal}
-        text={t(($) => $.timingSettingsModal.timingSettings)}
-        testId={testIds.openTimingSettings}
-      />
-    </SimpleDropdownMenu>
+      </SimpleDropdownMenu>
+      {pendingChanges ? (
+        <StopsNeedingUpdateModal
+          onCancel={() => setPendingChanges(null)}
+          onConfirm={() => onCommitUpdate(pendingChanges)}
+          isOpen
+          stops={pendingChanges.stopsNeedingUpdate}
+          typeOfLine={route.route_line.type_of_line}
+        />
+      ) : null}
+    </>
   );
 };

--- a/ui/src/components/routes-and-lines/line-details/__snapshots__/LineRouteList.spec.tsx.snap
+++ b/ui/src/components/routes-and-lines/line-details/__snapshots__/LineRouteList.spec.tsx.snap
@@ -408,6 +408,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 2`] =
               class="col-span-3 items-center justify-center text-center text-2xl"
             >
               <a
+                data-discover="true"
                 data-testid="RouteStopListItem::label"
                 href="/stop-registry/stops/H1234?observationDate=2017-02-14"
                 title="Näytä pysäkin H1234 tiedot"
@@ -469,6 +470,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 2`] =
                 </span>
               </div>
             </div>
+             
             <div
               class=""
               data-headlessui-state=""
@@ -515,6 +517,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 2`] =
               class="col-span-3 items-center justify-center text-center text-2xl"
             >
               <a
+                data-discover="true"
                 data-testid="RouteStopListItem::label"
                 href="/stop-registry/stops/H1236?observationDate=2017-02-14"
                 title="Näytä pysäkin H1236 tiedot"
@@ -576,6 +579,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 2`] =
                 </span>
               </div>
             </div>
+             
             <div
               class=""
               data-headlessui-state=""
@@ -829,6 +833,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 3`] =
               class="col-span-3 items-center justify-center text-center text-2xl"
             >
               <a
+                data-discover="true"
                 data-testid="RouteStopListItem::label"
                 href="/stop-registry/stops/H1234?observationDate=2017-02-14"
                 title="Näytä pysäkin H1234 tiedot"
@@ -890,6 +895,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 3`] =
                 </span>
               </div>
             </div>
+             
             <div
               class=""
               data-headlessui-state=""
@@ -936,6 +942,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 3`] =
               class="col-span-3 items-center justify-center text-center text-2xl"
             >
               <a
+                data-discover="true"
                 data-testid="RouteStopListItem::label"
                 href="/stop-registry/stops/H1235?observationDate=2017-02-14"
                 title="Näytä pysäkin H1235 tiedot"
@@ -997,6 +1004,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 3`] =
                 </span>
               </div>
             </div>
+             
             <div
               class=""
               data-headlessui-state=""
@@ -1043,6 +1051,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 3`] =
               class="col-span-3 items-center justify-center text-center text-2xl"
             >
               <a
+                data-discover="true"
                 data-testid="RouteStopListItem::label"
                 href="/stop-registry/stops/H1236?observationDate=2017-02-14"
                 title="Näytä pysäkin H1236 tiedot"
@@ -1104,6 +1113,7 @@ exports[`<LineRouteList /> Renders the route with stops along its geometry 3`] =
                 </span>
               </div>
             </div>
+             
             <div
               class=""
               data-headlessui-state=""

--- a/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/utils.spec.ts
@@ -11,6 +11,7 @@ describe('Stop registry utils', () => {
         stopType: {
           railReplacement: true,
           virtual: false,
+          trunkLineStop: false,
         },
       };
       const result = translateStopTypes(i18n.t, stopPlace);
@@ -22,10 +23,13 @@ describe('Stop registry utils', () => {
         stopType: {
           railReplacement: true,
           virtual: true,
+          trunkLineStop: true,
         },
       };
       const result = translateStopTypes(i18n.t, stopPlace);
-      expect(result).toBe('Raideliikennettä korvaava, virtuaalipysäkki');
+      expect(result).toBe(
+        'Raideliikennettä korvaava, virtuaalipysäkki, runkolinjapysäkki',
+      );
     });
 
     it('should return an empty string when stop has no types', () => {
@@ -33,6 +37,7 @@ describe('Stop registry utils', () => {
         stopType: {
           railReplacement: false,
           virtual: false,
+          trunkLineStop: false,
         },
       };
       const result = translateStopTypes(i18n.t, stopPlace);

--- a/ui/src/components/stop-registry/stops/stop-details/utils.ts
+++ b/ui/src/components/stop-registry/stops/stop-details/utils.ts
@@ -21,6 +21,7 @@ export const translateStopTypes = (
   const result = compact([
     quay.stopType.railReplacement && t(($) => $.stopPlaceTypes.railReplacement),
     quay.stopType.virtual && t(($) => $.stopPlaceTypes.virtual),
+    quay.stopType.trunkLineStop && t(($) => $.stopPlaceTypes.trunkLineStop),
   ])
     // Uncapitalize each translation.
     .map((stopType) => stopType.charAt(0).toLowerCase() + stopType.slice(1))

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -256,7 +256,8 @@
   },
   "stopPlaceTypes": {
     "railReplacement": "Rail replacement",
-    "virtual": "Virtual"
+    "virtual": "Virtual",
+    "trunkLineStop": "Trunk line stop"
   },
   "stopDetails": {
     "stopDetails": "Stop details",

--- a/ui/src/locales/en-US/common.json
+++ b/ui/src/locales/en-US/common.json
@@ -919,6 +919,13 @@
     "routeWithNVersions": "{{ routeLabel }} ({{ labelCount }} versions)",
     "confirmText": "OK"
   },
+  "confirmAutoUpdateStops": {
+    "title": "Changes to Stop details",
+    "bodySpeedTram": "Saving this route will mark the associated Stops as Speed Tram Stops. You can refine this on the Stops details page.",
+    "bodyTrunkLine": "Saving this route will mark the associated Stops as Trunk Line Stops. You can refine this on the Stops details page.",
+    "confirm": "Accept",
+    "failedToUpdate": "Failed to save stops: {{stops}}!"
+  },
   "confirmStopCopyDialog": {
     "title": "Copy stop",
     "description": "Next, place the new stop on the map. The equipment\ninformation for the copied stop will be preserved. You\ncan edit it in the stop equipment information view.",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -919,6 +919,13 @@
     "routeWithNVersions": "{{ routeLabel }} ({{ labelCount }} versiota)",
     "confirmText": "OK"
   },
+  "confirmAutoUpdateStops": {
+    "title": "Muutoksia pysäkkien tietoihin",
+    "bodySpeedTram": "Reitin tallennus merkitsee seuraavat pysäkit pikaratikkapysäkeiksi. Voit tarkentaa tätä valintaa pysäkin perustiedoissa.",
+    "bodyTrunkLine": "Reitin tallennus merkitsee seuraavat pysäkit runkolinjapysäkeiksi. Voit tarkentaa tätä valintaa pysäkin perustiedoissa.",
+    "confirm": "Hyväksy",
+    "failedToUpdate": "Pysäkkien ({{stops}}) päivitys epäonnistui!"
+  },
   "confirmStopCopyDialog": {
     "title": "Pysäkki kopioidaan",
     "description": "Sijoita seuraavaksi uusi pysäkki kartalle. Kopioidun\npysäkin varustelutiedot säilyvät. Voit muokata niitä\npysäkin varustelutietonäkymässä.",

--- a/ui/src/locales/fi-FI/common.json
+++ b/ui/src/locales/fi-FI/common.json
@@ -256,7 +256,8 @@
   },
   "stopPlaceTypes": {
     "railReplacement": "Raideliikennettä korvaava",
-    "virtual": "Virtuaalipysäkki"
+    "virtual": "Virtuaalipysäkki",
+    "trunkLineStop": "Runkolinjapysäkki"
   },
   "stopDetails": {
     "stopDetails": "Pysäkkitiedot",

--- a/ui/src/redux/slices/loader.ts
+++ b/ui/src/redux/slices/loader.ts
@@ -29,6 +29,7 @@ export enum Operation {
   DeleteTimetable = 'deleteTimetable',
   ResolveScheduledStopPoint = 'resolveScheduledStopPoint',
   UpdateRouteJourneyPattern = 'updateRouteJourneyPattern',
+  UpdateLine = 'updateLine',
 }
 
 /**
@@ -104,6 +105,7 @@ export const joreOperations = [
   Operation.ExportRoute,
   Operation.DeleteTimetable,
   Operation.UpdateRouteJourneyPattern,
+  Operation.UpdateLine,
 ];
 
 type IState = {

--- a/ui/src/types/EnrichedStopRegistryTypes.ts
+++ b/ui/src/types/EnrichedStopRegistryTypes.ts
@@ -64,6 +64,7 @@ export type QuayEnrichmentProperties = {
   readonly stopType: {
     readonly virtual: boolean;
     readonly railReplacement: boolean;
+    readonly trunkLineStop: boolean;
   };
   readonly validityStart: string | null;
   readonly validityEnd: string | null;

--- a/ui/src/types/TError.ts
+++ b/ui/src/types/TError.ts
@@ -1,0 +1,5 @@
+import { TFunction } from 'i18next';
+
+export interface TError extends Error {
+  translate(t: TFunction): string;
+}

--- a/ui/src/utils/knownValueKey.ts
+++ b/ui/src/utils/knownValueKey.ts
@@ -23,4 +23,6 @@ export enum KnownValueKey {
   OwnerContractId = 'owner-contractId',
   OwnerNote = 'owner-note',
   TimingPlaceId = 'timingPlaceId',
+  SpeedTramStop = 'speedTramStop',
+  TrunkLineStop = 'trunkLineStop',
 }

--- a/ui/src/utils/stop-registry/stopPlace.ts
+++ b/ui/src/utils/stop-registry/stopPlace.ts
@@ -260,6 +260,7 @@ export const getQuayDetailsForEnrichment = <
       virtual: findKeyValue(quay, KnownValueKey.Virtual) === 'true',
       railReplacement:
         findKeyValue(quay, KnownValueKey.RailReplacement) === 'true',
+      trunkLineStop: findKeyValue(quay, KnownValueKey.TrunkLineStop) === 'true',
     },
     validityStart: findKeyValue(quay, KnownValueKey.ValidityStart),
     validityEnd: findKeyValue(quay, KnownValueKey.ValidityEnd),


### PR DESCRIPTION
### Add local Hasura endpoint to Graphql.config.yml


### Line page: Mark route stops as TrunkLine stops on save

Implements the basic helpers needed to mark Stops in StopRegistry as Trunk Line stops, when changing a line type to Trunk Line type, or when adding a new stop onto a route on the Line Details page.

Due to reasons, this commit also adds basic bits needed to mark a stop as a Speed Tram stop.

Overall this is not a pretty clean commit.


### StopDetails: List Trunk Stop status on Basic Details


### Route stop: Use `<Link>` instead of raw `<a>` tag


### E2E: Should mark stops as TrunkLine on Line details page

-----------------------------------------------

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1427)
<!-- Reviewable:end -->
