### PR TITLE
Show draft indicator in stop details

### DIFF
--- a/cypress/e2e/stop-registry/stopDetails.cy.ts
+++ b/cypress/e2e/stop-registry/stopDetails.cy.ts
@@ -2767,7 +2767,9 @@ describe('Stop details', { tags: [Tag.StopRegistry] }, () => {
       Toast.expectSuccessToast('Uusi versio luotu\nAvataan uusi versio');
       copyModal.modal().should('not.exist');
       StopDetailsPage.loadingStopDetails().should('not.exist');
-      StopDetailsPage.validityPeriod().shouldHaveText('20.3.2020-1.4.2020');
+      StopDetailsPage.validityPeriod().shouldHaveText(
+        'Luonnos|20.3.2020-1.4.2020',
+      );
 
       // Reopen Temp version
       cy.visit(

--- a/ui/src/components/routes-and-lines/line-details/LineDetailsByIdPage.tsx
+++ b/ui/src/components/routes-and-lines/line-details/LineDetailsByIdPage.tsx
@@ -52,16 +52,6 @@ export const LineDetailsByIdPage: FC = () => {
     selectIsTimingSettingsModalOpen,
   );
 
-  const getHeaderBorderClassName = () => {
-    if (line?.priority === Priority.Draft) {
-      return 'border-b-4 border-medium-grey border-dashed';
-    }
-    if (line?.priority === Priority.Temporary) {
-      return 'border-b-4 border-city-bicycle-yellow';
-    }
-    return '';
-  };
-
   const isRouteCreationAllowed = line && !isPastEntity(DateTime.now(), line);
   const onCreateRoute = isRouteCreationAllowed
     ? () => createRoute(line)
@@ -72,9 +62,14 @@ export const LineDetailsByIdPage: FC = () => {
       displayedRouteLabels?.includes(route.label),
     ) ?? [];
 
+  const isDraft = line?.priority === Priority.Draft;
+
   return (
     <div>
-      <PageHeader className={getHeaderBorderClassName()}>
+      <PageHeader
+        // Remove border because draft-divider handles separation in draft mode
+        className={isDraft ? 'border-0' : ''}
+      >
         <Row>
           {line?.primary_vehicle_mode && (
             <i
@@ -87,6 +82,7 @@ export const LineDetailsByIdPage: FC = () => {
           {line && <LineTitle line={line} onCreateRoute={onCreateRoute} />}
         </Row>
       </PageHeader>
+      {isDraft && <div className="draft-divider" />}
       <ActionsRow className="pt-4 pb-0" />
       <Container className="pt-10">
         {line ? (

--- a/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
+++ b/ui/src/components/stop-registry/stops/stop-details/StopDetailsPage.tsx
@@ -58,6 +58,12 @@ export const StopDetailsPage: FC = () => {
 
   const { stopDetails, loading, error, mirroredQuays } = useGetStopDetails();
 
+  const isDraft = stopDetails?.priority === Priority.Draft;
+
+  const headerDividerClassName = isDraft
+    ? 'my-4 draft-divider'
+    : 'my-4 h-px bg-light-grey opacity-30';
+
   return (
     <Container testId={testIds.page}>
       <StopTitleRow
@@ -67,7 +73,7 @@ export const StopDetailsPage: FC = () => {
       />
       <StopHeaderSummaryRow className="my-2" stopDetails={stopDetails} />
       <StopDetailsVersion label={label} />
-      <hr className="my-4" />
+      <div className={headerDividerClassName} />
       <div className="my-4 flex">
         <div className="flex items-center gap-2">
           <h2>{t(($) => $.stopDetails.stopDetails)}</h2>
@@ -82,6 +88,10 @@ export const StopDetailsPage: FC = () => {
                 title={t(($) => $.priority.temporary)}
               />
             )}
+            {isDraft && (
+              <span className="font-bold">{t(($) => $.priority.draft)}</span>
+            )}
+            {isDraft && <span className="mx-1">|</span>}
             {mapToShortDate(stopDetails?.validity_start)}
             <span className="mx-1">-</span>
             {mapToShortDate(stopDetails?.validity_end)}

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -115,6 +115,16 @@
   .border-l-dashed {
     border-left-style: dashed;
   }
+
+  .draft-divider {
+    height: 0.25rem;
+    color: #cccccc;
+    background-image: repeating-linear-gradient(
+      -65deg,
+      currentColor 0px 6px,
+      transparent 6px 9px
+    );
+  }
 }
 
 .maplibregl-ctrl-bottom-right {


### PR DESCRIPTION
Add a draft-divider to stop details page when viewing drafts.

Also remove the styled divider from temporary line details as it's not used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1459)
<!-- Reviewable:end -->
