### PR TITLE
Add a new base DateInput component

### DIFF
--- a/codegen/codegen.ts
+++ b/codegen/codegen.ts
@@ -29,6 +29,7 @@ const scalars = {
   date: 'luxon.DateTime',
   interval: 'luxon.Duration',
   stop_registry_DateTime: 'luxon.DateTime',
+  stop_registry_LocalDate: 'luxon.DateTime',
   stop_registry_Coordinates: 'GeoJSON.Position',
   float8: 'number',
   smallint: 'number',

--- a/test-db-manager/src/generated/graphql.ts
+++ b/test-db-manager/src/generated/graphql.ts
@@ -38,7 +38,7 @@ export type Scalars = {
   /** Date time using the format: yyyy-MM-dd'T'HH:mm:ss.SSSXXXX. Example: 2017-04-23T18:25:43.511+0100 */
   stop_registry_DateTime: { input: luxon.DateTime; output: luxon.DateTime; }
   /** Date using the format: yyyy-MM-dd. Example: 2025-04-23 */
-  stop_registry_LocalDate: { input: any; output: any; }
+  stop_registry_LocalDate: { input: luxon.DateTime; output: luxon.DateTime; }
   /** Legacy GeoJSON Coordinates */
   stop_registry_legacyCoordinates: { input: any; output: any; }
   timestamp: { input: any; output: any; }

--- a/ui/src/components/common/BaseDateInput.tsx
+++ b/ui/src/components/common/BaseDateInput.tsx
@@ -1,0 +1,257 @@
+import { DateTime } from 'luxon';
+import {
+  ChangeEventHandler,
+  ClipboardEventHandler,
+  FocusEventHandler,
+  ForwardRefRenderFunction,
+  InputHTMLAttributes,
+  KeyboardEventHandler,
+  forwardRef,
+  useEffect,
+  useState,
+} from 'react';
+import { DateLike, mapToShortDate, tryToParseDate } from '../../time';
+
+type ParsedNotNull = {
+  readonly parsed: true;
+  readonly nullable?: false | never;
+  readonly value: DateTime;
+  readonly onChange: (value: DateTime) => void;
+};
+
+type ParsedNullable = {
+  readonly parsed: true;
+  readonly nullable: true;
+  readonly value: DateTime | null | undefined;
+  readonly onChange: (value: DateTime | null) => void;
+};
+
+type RawNotNull = {
+  readonly parsed?: false | never;
+  readonly nullable?: false | never;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+};
+
+type RawNullable = {
+  readonly parsed?: false | never;
+  readonly nullable: true;
+  readonly value: string | null | undefined;
+  readonly onChange: (value: string | null) => void;
+};
+
+type GenericInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'onChange' | 'type' | 'value'
+>;
+
+type BaseDateInputProps = GenericInputProps &
+  (ParsedNotNull | ParsedNullable | RawNotNull | RawNullable);
+
+function valueToString(value: DateLike | null | undefined): string {
+  return tryToParseDate(value)?.toISODate() ?? '';
+}
+
+const typeISODate = 'hus/ISOData';
+const typePlainText = 'text/plain';
+
+const isoDateRegexp = /\d{4}-\d{2}-\d{2}/;
+const cleanIsoDateRegexp = /^\d{4}-\d{2}-\d{2}$/;
+const formattedDateRegexp = /(\d{1,2}).(\d{1,2}).(\d{4})/;
+
+type DateValuePair = {
+  readonly parsed: DateTime;
+  readonly str: string;
+};
+
+function getIsoDateData(data: DataTransfer) {
+  const isoDateData = data.getData(typeISODate);
+  if (isoDateData) {
+    return isoDateData;
+  }
+
+  const plainTextIsoDateData = data.getData(typePlainText);
+  const match = isoDateRegexp.exec(plainTextIsoDateData);
+  if (match) {
+    return match[0];
+  }
+
+  return null;
+}
+
+function tryToParseIsoDate(data: DataTransfer): DateValuePair | null {
+  const isoDateData = getIsoDateData(data);
+  const parsed = tryToParseDate(isoDateData);
+
+  if (isoDateData && parsed) {
+    return { parsed, str: isoDateData };
+  }
+
+  return null;
+}
+
+function tryToParseFormattedDate(data: DataTransfer): DateValuePair | null {
+  const plainTextData = data.getData(typePlainText);
+  const match = formattedDateRegexp.exec(plainTextData);
+
+  if (match) {
+    const [, day, month, year] = match;
+    const isoDateStr = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+    const parsed = tryToParseDate(isoDateStr);
+
+    if (parsed) {
+      return { parsed, str: isoDateStr };
+    }
+  }
+
+  return null;
+}
+
+function getDateFromClipboard(data: DataTransfer): DateValuePair | null {
+  return tryToParseIsoDate(data) ?? tryToParseFormattedDate(data);
+}
+
+const BaseDateInputImpl: ForwardRefRenderFunction<
+  HTMLInputElement,
+  BaseDateInputProps
+> = (
+  {
+    parsed,
+    nullable,
+    value,
+    onBlur,
+    onChange,
+    onCopy,
+    onKeyUp,
+    onPaste,
+    ...rest
+  },
+  ref,
+) => {
+  const [str, setStr] = useState(() => valueToString(value));
+
+  useEffect(() => setStr(() => valueToString(value)), [value]);
+
+  // Only expose full proper dates to the outside world.
+  const augmentedOnChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const newValue = e.target.value;
+    setStr(newValue);
+
+    const parsedValue = tryToParseDate(newValue);
+
+    if (parsedValue) {
+      if (parsed) {
+        onChange(parsedValue);
+      } else {
+        onChange(newValue);
+      }
+    }
+
+    if (nullable && !newValue) {
+      onChange(null);
+    }
+  };
+
+  // If we have partial input when losing focus. Clear out the whole input for
+  // nullable fields, or reset to the previous set value for non nullable.
+  const augmentedOnBlur: FocusEventHandler<HTMLInputElement> = (e) => {
+    const parsedValue = tryToParseDate(str);
+    if (!parsedValue) {
+      if (nullable) {
+        setStr('');
+        onChange(null);
+      } else {
+        setStr(typeof value === 'string' ? value : value.toISODate());
+      }
+    }
+    onBlur?.(e);
+  };
+
+  // Shortcut to set current date as the value.
+  const augmentedOnKeyUp: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    const normalizedKey = e.key.toLowerCase();
+    if (normalizedKey === 't' || normalizedKey === 'n') {
+      const today = DateTime.now().startOf('day');
+      const todayStr = today.toISODate();
+      setStr(todayStr);
+      if (parsed) {
+        onChange(today);
+      } else {
+        onChange(todayStr);
+      }
+    }
+
+    onKeyUp?.(e);
+  };
+
+  // Add handling for copying out current value.
+  const augmentedOnCopy: ClipboardEventHandler<HTMLInputElement> = (e) => {
+    if (str.match(cleanIsoDateRegexp)) {
+      e.clipboardData.setData(typeISODate, str);
+      e.clipboardData.setData(typePlainText, mapToShortDate(str) ?? '');
+      e.preventDefault();
+    }
+    onCopy?.(e);
+  };
+
+  // Add handling for pasting in dates.
+  const augmentedOnPaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
+    const date = getDateFromClipboard(e.clipboardData);
+    if (date) {
+      setStr(date.str);
+
+      if (parsed) {
+        onChange(date.parsed);
+      } else {
+        onChange(date.str);
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+    } else {
+      onPaste?.(e);
+    }
+  };
+
+  return (
+    <input
+      onBlur={augmentedOnBlur}
+      onChange={augmentedOnChange}
+      onCopy={augmentedOnCopy}
+      onKeyUp={augmentedOnKeyUp}
+      onPaste={augmentedOnPaste}
+      ref={ref}
+      type="date"
+      value={str}
+      {...rest}
+    />
+  );
+};
+
+export const BaseDateInput = forwardRef(BaseDateInputImpl);
+
+type CompatBaseDateInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'onChange'
+> & {
+  // Good enough shape for react hook forms
+  readonly onChange: (e: { target: { value: string }; type: 'change' }) => void;
+};
+
+const CompatBaseDateInputImpl: ForwardRefRenderFunction<
+  HTMLInputElement,
+  CompatBaseDateInputProps
+> = (props, ref) =>
+  BaseDateInputImpl(
+    {
+      ...props,
+      parsed: false,
+      nullable: true,
+      value: props.value ? String(props.value) : '',
+      onChange: (value) =>
+        props.onChange({ target: { value: value ?? '' }, type: 'change' }),
+    },
+    ref,
+  );
+
+export const CompatBaseDateInput = forwardRef(CompatBaseDateInputImpl);

--- a/ui/src/components/common/ChangeHistory/DateRangeFilter.tsx
+++ b/ui/src/components/common/ChangeHistory/DateRangeFilter.tsx
@@ -1,14 +1,7 @@
-import {
-  ChangeEventHandler,
-  Dispatch,
-  FC,
-  SetStateAction,
-  useEffect,
-  useId,
-  useState,
-} from 'react';
+import { DateTime } from 'luxon';
+import { Dispatch, FC, SetStateAction, useId } from 'react';
 import { useTranslation } from 'react-i18next';
-import { parseDate } from '../../../time';
+import { BaseDateInput } from '../BaseDateInput';
 import { ChangeHistoryFilters } from './types';
 
 const testIds = {
@@ -31,27 +24,8 @@ export const DateRangeFilter: FC<DateRangeFilterProps> = ({
 
   const id = useId();
 
-  const filterFromDateStr = from.toISODate();
-  const filterToDateStr = to.toISODate();
-
-  const [fromDateStr, setFromDateStr] = useState<string>(filterFromDateStr);
-  const [toDateStr, setToDateStr] = useState<string>(filterToDateStr);
-
-  useEffect(() => {
-    setFromDateStr(filterFromDateStr);
-    setToDateStr(filterToDateStr);
-  }, [filterFromDateStr, filterToDateStr]);
-
-  const onFromChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const str = e.target.value;
-    setFromDateStr(str);
-
-    const parsed = parseDate(str);
-    if (!parsed) {
-      return;
-    }
-
-    const newFromDate = parsed.startOf('day');
+  const onFromChange = (newDate: DateTime) => {
+    const newFromDate = newDate.startOf('day');
 
     setFilters((p) => {
       const currentToDate = p.to.startOf('day');
@@ -68,15 +42,8 @@ export const DateRangeFilter: FC<DateRangeFilterProps> = ({
     });
   };
 
-  const onToChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const str = e.target.value;
-    setToDateStr(str);
-
-    const parsed = parseDate(str);
-    if (!parsed) {
-      return;
-    }
-    const newToDate = parsed.endOf('day');
+  const onToChange = (newDate: DateTime) => {
+    const newToDate = newDate.endOf('day');
 
     setFilters((p) => {
       const currentFromDate = p.from.endOf('day');
@@ -99,20 +66,20 @@ export const DateRangeFilter: FC<DateRangeFilterProps> = ({
         {t(($) => $.changeHistory.tableHeaders.changed)}
       </label>
       <fieldset aria-labelledby={id} className="flex gap-4">
-        <input
+        <BaseDateInput
           data-testid={testIds.fromDate}
           id={`${id}from`}
+          parsed
+          value={from}
           onChange={onFromChange}
-          type="date"
-          value={fromDateStr}
         />
-        <input
+
+        <BaseDateInput
           data-testid={testIds.toDate}
           id={`${id}to`}
-          className="invalid:border-hsl-red"
+          parsed
+          value={to}
           onChange={onToChange}
-          type="date"
-          value={toDateStr}
         />
       </fieldset>
     </div>

--- a/ui/src/components/common/DateControl.tsx
+++ b/ui/src/components/common/DateControl.tsx
@@ -1,7 +1,6 @@
-import { DateTime } from 'luxon';
 import { FC } from 'react';
-import { QueryParameterName } from '../../hooks';
 import { useDateQueryParam } from '../../hooks/urlQuery/useDateQueryParam';
+import { QueryParameterName } from '../../hooks/urlQuery/useUrlQuery';
 import { DateInput } from './DateInput';
 
 type DateControlProps = {
@@ -31,20 +30,12 @@ export const DateControl: FC<DateControlProps> = ({
     queryParamName,
     initialize,
   });
-  const onDateChange = (newDate: DateTime) => {
-    // Do not allow setting empty value to date
-    if (!date.isValid) {
-      return;
-    }
-
-    setDateToUrl(newDate);
-  };
 
   return (
     <DateInput
       label={label}
       value={date}
-      onChange={onDateChange}
+      onChange={setDateToUrl}
       className={className}
       required
       disabled={disabled}

--- a/ui/src/components/common/DateInput.tsx
+++ b/ui/src/components/common/DateInput.tsx
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon';
 import { FC, MouseEventHandler } from 'react';
+import { BaseDateInput } from './BaseDateInput';
 import { Column } from './LayoutComponents';
 
 type DateInputProps = {
@@ -18,7 +19,6 @@ export const DateInput: FC<DateInputProps> = ({
   value,
   label,
   onChange,
-  // TODO: This prop is improperly used as input for multiple nested components (<Column> & <Input>). I do not know which one should actually get the the prop, as I am unable to open the use place due to lack of test data for Timetables. Thus cannot fix this.
   className,
   testId,
   required = false,
@@ -29,13 +29,12 @@ export const DateInput: FC<DateInputProps> = ({
   return (
     <Column className={className}>
       <label htmlFor={dateInputId}>{label}</label>
-      <input
-        type="date"
-        value={value.toISODate()}
-        onChange={(e) => onChange(DateTime.fromISO(e.target.value))}
+      <BaseDateInput
+        parsed
+        value={value}
+        onChange={onChange}
         onClick={onClick}
         id={dateInputId}
-        className={className}
         data-testid={testId}
         required={required}
         disabled={disabled}

--- a/ui/src/components/common/index.ts
+++ b/ui/src/components/common/index.ts
@@ -1,3 +1,4 @@
+export * from './BaseDateInput';
 export * from './DateControl';
 export * from './DateInput';
 export * from './FormInputTypes';

--- a/ui/src/components/forms/common/DateInputField.tsx
+++ b/ui/src/components/forms/common/DateInputField.tsx
@@ -3,7 +3,7 @@ import { DetailedHTMLProps, InputHTMLAttributes, ReactElement } from 'react';
 import { FieldPathByValue, FieldValues, useController } from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
 import { TranslationKey } from '../../../i18n';
-import { parseDate } from '../../../time';
+import { BaseDateInput } from '../../common/BaseDateInput';
 import { Column } from '../../common/LayoutComponents';
 import { inputErrorStyles } from './InputElement';
 import { InputLabel } from './InputLabel';
@@ -37,14 +37,17 @@ export const DateInputField = <FormState extends FieldValues>({
   return (
     <Column className={className}>
       <InputLabel fieldPath={fieldPath} translationPrefix={translationPrefix} />
-      <input
+      <BaseDateInput
+        parsed
+        nullable
         id={id}
         data-testid={testId}
         className={twMerge(inputClassName, invalid ? inputErrorStyles : '')}
-        onChange={(e) => onChange(parseDate(e.target.value))}
-        type="date"
-        value={value?.toISODate()}
+        onChange={onChange}
+        value={value}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...inputProps}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...fieldProps}
       />
     </Column>

--- a/ui/src/components/forms/common/InputElement.tsx
+++ b/ui/src/components/forms/common/InputElement.tsx
@@ -5,8 +5,14 @@ import {
   ReactElement,
   TextareaHTMLAttributes,
 } from 'react';
-import { FieldValues, Path, useFormContext } from 'react-hook-form';
+import {
+  FieldValues,
+  Path,
+  useController,
+  useFormContext,
+} from 'react-hook-form';
 import { twMerge } from 'tailwind-merge';
+import { CompatBaseDateInput } from '../../common';
 
 export type InputElementDefaultProps = InputHTMLAttributes<HTMLInputElement> & {
   readonly id: string;
@@ -34,7 +40,7 @@ type InputElementProps<FormState extends FieldValues> =
 
 export const inputErrorStyles = 'border-hsl-red bg-hsl-red/5 border-2';
 
-export const InputElement = <FormState extends FieldValues>({
+export const RawInputElement = <FormState extends FieldValues>({
   className,
   fieldPath,
   testId,
@@ -63,6 +69,7 @@ export const InputElement = <FormState extends FieldValues>({
   }
 
   const inputProps = elementProps as HTMLInputProps;
+
   return (
     <input
       {...inputProps}
@@ -72,4 +79,42 @@ export const InputElement = <FormState extends FieldValues>({
       type={type}
     />
   );
+};
+
+export const DateInputElement = <FormState extends FieldValues>({
+  className,
+  fieldPath,
+  testId,
+  ...elementProps
+}: InputElementProps<FormState>): ReactElement => {
+  const {
+    field,
+    fieldState: { error },
+  } = useController<FormState, typeof fieldPath>({ name: fieldPath });
+
+  const inputProps = elementProps as HTMLInputProps;
+
+  return (
+    <CompatBaseDateInput
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...inputProps}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...field}
+      className={twMerge(className, error ? inputErrorStyles : '')}
+      data-testid={testId}
+    />
+  );
+};
+
+export const InputElement = <FormState extends FieldValues>(
+  props: InputElementProps<FormState>,
+): ReactElement => {
+  // eslint-disable-next-line react/destructuring-assignment
+  if (props.type === 'date') {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <DateInputElement {...props} />;
+  }
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <RawInputElement {...props} />;
 };

--- a/ui/src/components/forms/common/ObservationDateInput.tsx
+++ b/ui/src/components/forms/common/ObservationDateInput.tsx
@@ -1,10 +1,11 @@
 import { DateTime } from 'luxon';
-import { FC, KeyboardEvent, useCallback, useEffect, useState } from 'react';
+import { FC, KeyboardEventHandler, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { mapToISODate, parseDate } from '../../../time';
+import { BaseDateInput } from '../../common/BaseDateInput';
 import { Column } from '../../common/LayoutComponents';
 
 type ObservationDateInputProps = {
+  readonly id?: string;
   readonly value: DateTime;
   readonly onChange: (value: DateTime) => void;
   readonly className?: string;
@@ -16,8 +17,10 @@ type ObservationDateInputProps = {
 };
 
 export const ObservationDateInput: FC<ObservationDateInputProps> = ({
+  id = 'observation-date-input',
   value,
   onChange,
+  // TODO: Check and fix this class bs
   className,
   containerClassName = className,
   inputClassName = className,
@@ -26,46 +29,32 @@ export const ObservationDateInput: FC<ObservationDateInputProps> = ({
   disabled = false,
 }) => {
   const { t } = useTranslation();
-  const dateInputId = 'observation-date-input';
 
-  const [localDateValue, setLocalDateValue] = useState(value);
+  const [localValue, setLocalValue] = useState(value);
+  useEffect(() => setLocalValue(value), [value]);
 
-  useEffect(() => {
-    if (value.isValid) {
-      setLocalDateValue(value);
+  const submitChangedValue = () => {
+    if (!value.equals(localValue)) {
+      onChange(localValue);
     }
-  }, [value]);
+  };
 
-  const updateUrlState = useCallback(() => {
-    if (!localDateValue.isValid) {
-      setLocalDateValue(value);
-      return;
+  const submitOnEnter: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === 'Enter') {
+      submitChangedValue();
     }
-
-    if (!localDateValue.equals(value)) {
-      onChange(localDateValue);
-    }
-  }, [localDateValue, value, onChange]);
-
-  const handleKeyUp = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        updateUrlState();
-      }
-    },
-    [updateUrlState],
-  );
+  };
 
   return (
     <Column className={containerClassName}>
-      <label htmlFor={dateInputId}>{t(($) => $.filters.observationDate)}</label>
-      <input
-        type="date"
-        value={mapToISODate(localDateValue)}
-        onChange={(e) => setLocalDateValue(parseDate(e.target.value))}
-        onBlur={updateUrlState}
-        onKeyUp={handleKeyUp}
-        id={dateInputId}
+      <label htmlFor={id}>{t(($) => $.filters.observationDate)}</label>
+      <BaseDateInput
+        parsed
+        value={value}
+        onBlur={submitChangedValue}
+        onChange={onChange}
+        onKeyUp={submitOnEnter}
+        id={id}
         className={inputClassName}
         data-testid={testId}
         required={required}

--- a/ui/src/components/map/MapObservationDateControl.tsx
+++ b/ui/src/components/map/MapObservationDateControl.tsx
@@ -1,9 +1,7 @@
-import { FC, KeyboardEvent, useCallback, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { FC } from 'react';
 import { useAppSelector } from '../../hooks';
 import { selectHasChangesInProgress } from '../../redux';
-import { mapToISODate, parseDate } from '../../time';
-import { Column } from '../common/LayoutComponents/Column';
+import { ObservationDateInput } from '../forms/common';
 import { useMapUrlStateContext } from './utils/mapUrlState';
 
 const testIds = {
@@ -19,11 +17,10 @@ type MapObservationDateControlProps = {
 
 export const MapObservationDateControl: FC<MapObservationDateControlProps> = ({
   className,
-  containerClassName = className,
-  inputClassName = className,
+  containerClassName,
+  inputClassName,
   disabled = false,
 }) => {
-  const { t } = useTranslation();
   const hasChangesInProgress = useAppSelector(selectHasChangesInProgress);
 
   const {
@@ -33,57 +30,22 @@ export const MapObservationDateControl: FC<MapObservationDateControlProps> = ({
     setFilters,
   } = useMapUrlStateContext();
 
-  const [localDateValue, setLocalDateValue] = useState(observationDate);
-
-  useEffect(() => {
-    if (observationDate.isValid) {
-      setLocalDateValue(observationDate);
-    }
-  }, [observationDate]);
-
-  const updateUrlState = useCallback(() => {
-    const newDate = parseDate(localDateValue);
-
-    if (!newDate.isValid) {
-      setLocalDateValue(observationDate);
-      return;
-    }
-
-    if (!newDate.equals(observationDate)) {
-      setFilters((prevFilters) => ({
-        ...prevFilters,
-        observationDate: newDate,
-      }));
-    }
-  }, [localDateValue, setFilters, observationDate]);
-
-  const handleKeyUp = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        updateUrlState();
-      }
-    },
-    [updateUrlState],
-  );
-
-  const dateInputId = 'map-observation-date-input';
-  const isDisabled = disabled || hasChangesInProgress;
-
   return (
-    <Column className={containerClassName}>
-      <label htmlFor={dateInputId}>{t(($) => $.filters.observationDate)}</label>
-      <input
-        type="date"
-        value={mapToISODate(localDateValue)}
-        onChange={(e) => setLocalDateValue(parseDate(e.target.value))}
-        onBlur={updateUrlState}
-        onKeyUp={handleKeyUp}
-        id={dateInputId}
-        className={inputClassName}
-        data-testid={testIds.observationDateInput}
-        required
-        disabled={isDisabled}
-      />
-    </Column>
+    <ObservationDateInput
+      id="map-observation-date-input"
+      className={className}
+      containerClassName={containerClassName}
+      inputClassName={inputClassName}
+      value={observationDate}
+      onChange={(newDate) =>
+        setFilters((prevFilters) => ({
+          ...prevFilters,
+          observationDate: newDate,
+        }))
+      }
+      testId={testIds.observationDateInput}
+      required
+      disabled={disabled || hasChangesInProgress}
+    />
   );
 };

--- a/ui/src/components/stop-registry/components/SelectMemberStops/common/useFindQuaysByQuery.ts
+++ b/ui/src/components/stop-registry/components/SelectMemberStops/common/useFindQuaysByQuery.ts
@@ -57,8 +57,8 @@ export function useFindQuaysByQuery(query: string) {
 
     const matchingStops = parsedStops.filter(
       (stop) =>
-        stop.publicCode?.toLowerCase().includes(query.toLowerCase()) ||
-        stop.name?.toLowerCase().includes(query.toLowerCase()),
+        !!stop.publicCode?.toLowerCase().includes(query.toLowerCase()) ||
+        !!stop.name?.toLowerCase().includes(query.toLowerCase()),
     );
 
     return { options: matchingStops, allQueryResults: parsedStops };

--- a/ui/src/components/stop-registry/search/types/StopSearchFilters.ts
+++ b/ui/src/components/stop-registry/search/types/StopSearchFilters.ts
@@ -12,7 +12,10 @@ import {
   StopPlaceState,
 } from '../../../../types/stop-registry';
 import { AllOptionEnum, NullOptionEnum, areEqual } from '../../../../utils';
-import { instanceOfDateTime, requiredString } from '../../../forms/common';
+import {
+  instanceOfDateTime,
+  requiredString,
+} from '../../../forms/common/customZodSchemas';
 import { SearchBy } from './SearchBy';
 import { SearchFor } from './SearchFor';
 import { knownMunicipalities } from './StringMunicipality';

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/MoveQuayToStopAreaModal.tsx
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/MoveQuayToStopAreaModal.tsx
@@ -1,9 +1,10 @@
 import { DateTime } from 'luxon';
-import { ChangeEventHandler, FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { showSuccessToast } from '../../../../../utils';
+import { DateInput } from '../../../../common';
 import { CloseIconButton, SimpleButton } from '../../../../common/Buttons';
-import { Column, Row } from '../../../../common/LayoutComponents';
+import { Row } from '../../../../common/LayoutComponents';
 import { Modal, ModalBody, NewModalFooter } from '../../../../common/Modals';
 import { SelectStopDropdown } from '../../../components/SelectMemberStops';
 import { SelectedStop } from '../../../components/SelectMemberStops/common/schema';
@@ -34,31 +35,30 @@ type MoveQuayToStopAreaModalProps = {
 
 type ModalState = {
   readonly selectedStop: SelectedStop | null;
-  readonly selectedDate: string;
+  readonly selectedDate: DateTime;
   readonly showVersions: boolean;
 };
 
 const initialState: ModalState = {
   selectedStop: null,
-  selectedDate: new Date().toISOString().split('T')[0],
+  selectedDate: DateTime.now().startOf('day'),
   showVersions: false,
 };
 
 const useFilteredStopVersions = (
   stopVersions: ReadonlyArray<StopVersion> | null | undefined,
-  selectedDate: Readonly<string>,
+  selectedDate: DateTime,
 ): ReadonlyArray<StopVersion> | null | undefined => {
   return useMemo(() => {
     if (!stopVersions || !selectedDate) {
       return stopVersions;
     }
 
-    const filterDate = DateTime.fromISO(selectedDate);
     return stopVersions.filter((version: StopVersion) => {
       const isValidOnDate =
-        version.validity_start <= filterDate &&
-        (version.validity_end === null || version.validity_end >= filterDate);
-      const isFutureVersion = version.validity_start > filterDate;
+        version.validity_start <= selectedDate &&
+        (version.validity_end === null || version.validity_end >= selectedDate);
+      const isFutureVersion = version.validity_start > selectedDate;
       return isValidOnDate ?? isFutureVersion;
     });
   }, [stopVersions, selectedDate]);
@@ -67,17 +67,16 @@ const useFilteredStopVersions = (
 // Remove versions that end before the selected date
 const useRemovePastStopAreaVersions = (
   stopAreaVersions: ReadonlyArray<StopAreaVersion> | null | undefined,
-  selectedDate: Readonly<string>,
+  selectedDate: DateTime,
 ): ReadonlyArray<StopAreaVersion> | null | undefined => {
   return useMemo(() => {
     if (!stopAreaVersions || !selectedDate) {
       return stopAreaVersions;
     }
 
-    const filterDate = DateTime.fromISO(selectedDate).startOf('day');
     return stopAreaVersions?.filter(
       (version) =>
-        version.validity_end === null || version.validity_end >= filterDate,
+        version.validity_end === null || version.validity_end >= selectedDate,
     );
   }, [selectedDate, stopAreaVersions]);
 };
@@ -177,9 +176,8 @@ export const MoveQuayToStopAreaModal: FC<MoveQuayToStopAreaModalProps> = ({
     [updateState],
   );
 
-  const handleDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    updateState({ selectedDate: event.target.value });
-  };
+  const onDateChange = (newDate: DateTime) =>
+    updateState({ selectedDate: newDate });
 
   const handleGetStopVersions = () => {
     if (selectedStop?.publicCode) {
@@ -232,18 +230,13 @@ export const MoveQuayToStopAreaModal: FC<MoveQuayToStopAreaModalProps> = ({
         {hasSelection && (
           <div className="items-center border-t border-light-grey bg-background px-8 py-8">
             <Row className="items-end gap-5">
-              <Column>
-                <label className="block" htmlFor="observation-date-input">
-                  {t(($) => $.stopAreaDetails.memberStops.transferDate)}
-                </label>
-                <input
-                  type="date"
-                  id="observation-date-input"
-                  data-testid={testIds.transferDateInput}
-                  value={selectedDate}
-                  onChange={handleDateChange}
-                />
-              </Column>
+              <DateInput
+                value={selectedDate}
+                label={t(($) => $.stopAreaDetails.memberStops.transferDate)}
+                onChange={onDateChange}
+                testId={testIds.transferDateInput}
+                dateInputId="observation-date-input"
+              />
 
               <SimpleButton
                 inverted

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/useMoveQuayToStopPlace.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/useMoveQuayToStopPlace.ts
@@ -14,8 +14,6 @@ import {
   extractQuayValidityEnd,
   extractStopPlaceQuays,
   fetchExistingStopPoints,
-  getPreviousDay,
-  isSameDate,
   updateStopPointValidity,
 } from './utils/helpers';
 import { MoveQuayParams, QuayInfo } from './utils/types';
@@ -63,7 +61,7 @@ export const useMoveQuayToStopPlace = () => {
     const stopPointNeedingUpdate = existingStopPoints.find((stopPoint) => {
       const isMovingFromValidityStart =
         stopPoint.validity_start &&
-        isSameDate(stopPoint.validity_start, params.moveQuayFromDate);
+        stopPoint.validity_start.equals(params.moveQuayFromDate);
       return !isMovingFromValidityStart;
     });
 
@@ -107,7 +105,7 @@ export const useMoveQuayToStopPlace = () => {
       );
 
       // Update the original stop point
-      const validityEndDate = getPreviousDay(params.moveQuayFromDate);
+      const validityEndDate = params.moveQuayFromDate.minus({ day: 1 });
       await updateStopPointValidity(
         stopPointNeedingUpdate.scheduled_stop_point_id,
         validityEndDate,

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/utils/helpers.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/utils/helpers.ts
@@ -7,24 +7,14 @@ import {
   useUpdateStopPointMutation,
 } from '../../../../../../generated/graphql';
 import { PartialScheduledStopPointSetInput } from '../../../../../../graphql';
-import { KnownValueKey, findKeyValue } from '../../../../../../utils';
+import { tryToParseDate } from '../../../../../../time';
+import { KnownValueKey, areEqual, findKeyValue } from '../../../../../../utils';
 import {
   MoveQuayParams,
   MoveStopPlace,
   QuayInfo,
   StopPointInfo,
 } from './types';
-
-export function getPreviousDay(dateString: string): string {
-  const date = new Date(dateString);
-  date.setDate(date.getDate() - 1);
-  return date.toISOString().split('T')[0];
-}
-
-export function isSameDate(date1: string | DateTime, date2: string): boolean {
-  const dateStr1 = typeof date1 === 'string' ? date1 : date1.toISODate();
-  return dateStr1 === date2;
-}
 
 export function extractStopPlaceQuays(
   stopPlace: MoveStopPlace | null | undefined,
@@ -43,8 +33,9 @@ export function extractStopPlaceQuays(
     .map((quay) => ({
       id: quay.id ?? '',
       publicCode: quay.publicCode ?? '',
-      validityStart:
-        findKeyValue(quay, KnownValueKey.ValidityStart) ?? undefined,
+      validityStart: tryToParseDate(
+        findKeyValue(quay, KnownValueKey.ValidityStart),
+      ),
     }))
     .filter((quay) => quay.id && quay.publicCode);
 }
@@ -52,7 +43,7 @@ export function extractStopPlaceQuays(
 export function extractQuayValidityEnd(
   stopPlace: MoveStopPlace | null | undefined,
   quayId: string,
-): string | null | undefined {
+): DateTime | null | undefined {
   // eslint-disable-next-line no-underscore-dangle
   if (stopPlace?.__typename !== 'stop_registry_StopPlace') {
     return undefined;
@@ -68,14 +59,14 @@ export function extractQuayValidityEnd(
   }
 
   const validityEnd = findKeyValue(quay, KnownValueKey.ValidityEnd);
-  return validityEnd ?? null;
+  return tryToParseDate(validityEnd);
 }
 
 export function createQuayMappingForCopiedQuay(
   originalQuays: ReadonlyArray<QuayInfo>,
   newQuays: ReadonlyArray<QuayInfo>,
-  moveQuayFromDate: string,
-): Map<string, string> {
+  moveQuayFromDate: DateTime,
+): ReadonlyMap<string, string> {
   const mapping = new Map<string, string>();
 
   originalQuays.forEach((originalQuay) => {
@@ -86,7 +77,7 @@ export function createQuayMappingForCopiedQuay(
     const matchingNewQuay = newQuays.find(
       (newQuay) =>
         newQuay.publicCode === originalQuay.publicCode &&
-        newQuay.validityStart === moveQuayFromDate,
+        areEqual(newQuay.validityStart, moveQuayFromDate),
     );
 
     if (matchingNewQuay?.id) {
@@ -132,11 +123,11 @@ export async function executeQuayMove(
 
 export async function updateStopPointValidity(
   stopPointId: string,
-  validityEnd: string,
+  validityEnd: DateTime,
   updateStopPointMutation: ReturnType<typeof useUpdateStopPointMutation>[0],
 ): Promise<void> {
   const updateChanges: PartialScheduledStopPointSetInput = {
-    validity_end: DateTime.fromISO(validityEnd),
+    validity_end: validityEnd,
   };
 
   const result = await updateStopPointMutation({
@@ -160,8 +151,8 @@ export async function updateStopPointValidity(
 export async function createAndInsertStopPoint(
   originalStopPoint: StopPointInfo,
   newQuayId: string,
-  moveFromDate: string,
-  validityEnd: string | null | undefined,
+  moveFromDate: DateTime,
+  validityEnd: DateTime | null | undefined,
   insertStopPointMutation: ReturnType<typeof useInsertStopPointMutation>[0],
 ) {
   const baseStopPoint: ServicePatternScheduledStopPointInsertInput = {
@@ -169,8 +160,8 @@ export async function createAndInsertStopPoint(
     direction: originalStopPoint.direction,
     label: originalStopPoint.label,
     timing_place_id: originalStopPoint.timing_place_id,
-    validity_start: DateTime.fromISO(moveFromDate),
-    validity_end: validityEnd ? DateTime.fromISO(validityEnd) : null,
+    validity_start: moveFromDate,
+    validity_end: validityEnd ?? null,
     located_on_infrastructure_link_id:
       originalStopPoint.located_on_infrastructure_link_id,
     stop_place_ref: newQuayId,

--- a/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/utils/types.ts
+++ b/ui/src/components/stop-registry/stop-areas/stop-area-details/MoveQuayToStopArea/utils/types.ts
@@ -1,15 +1,16 @@
+import { DateTime } from 'luxon';
 import { GetStopPointsByQuayIdQuery } from '../../../../../../generated/graphql';
 
 export type MoveQuayParams = {
   toStopPlaceId: string;
   quayIds: ReadonlyArray<string>;
-  moveQuayFromDate: string;
+  moveQuayFromDate: DateTime;
 };
 
 export type QuayInfo = {
   id: string;
   publicCode: string;
-  validityStart?: string;
+  validityStart?: DateTime;
 };
 
 export type StopPointInfo =

--- a/ui/src/graphql/client.ts
+++ b/ui/src/graphql/client.ts
@@ -33,6 +33,18 @@ function parseDateTime(raw: unknown) {
 }
 
 const buildScalarMappingLink = () => {
+  const dateMapper: ParsingFunctionsObject<DateTime, unknown> = {
+    serialize: (parsed: unknown) => {
+      if (DateTime.isDateTime(parsed)) {
+        return parsed.toISODate();
+      }
+
+      return parsed;
+    },
+
+    parseValue: parseDateTime,
+  };
+
   const dateTimeMapper: ParsingFunctionsObject<DateTime, unknown> = {
     serialize: (parsed: unknown) => {
       if (DateTime.isDateTime(parsed)) {
@@ -47,17 +59,7 @@ const buildScalarMappingLink = () => {
 
   const typesMap: FunctionsMap = {
     // automatically (de)serializing between graphql date <-> luxon.DateTime types
-    date: {
-      serialize: (parsed: unknown) => {
-        // if it's a luxon DateTime, serialize it to ISO date string
-        if (DateTime.isDateTime(parsed)) {
-          return parsed.toISODate();
-        }
-        // otherwise (string, null, undefined) just pass it on as is
-        return parsed;
-      },
-      parseValue: parseDateTime,
-    },
+    date: dateMapper,
     // automatically (de)serializing between graphql interval <-> luxon.Duration types
     interval: {
       serialize: (parsed: unknown) => {
@@ -77,6 +79,7 @@ const buildScalarMappingLink = () => {
       },
     },
     stop_registry_DateTime: dateTimeMapper,
+    stop_registry_LocalDate: dateMapper,
     timestamptz: dateTimeMapper,
   };
 

--- a/ui/src/time.ts
+++ b/ui/src/time.ts
@@ -14,14 +14,8 @@ import { Maybe, ValidityPeriod } from './generated/graphql';
 const helsinkiTimeZone = IANAZone.create('Europe/Helsinki');
 Settings.defaultZone = helsinkiTimeZone;
 
-// This is in fact false at the moment.
-// Previous versions of the luxon typings did not care about validity.
-// Currently, our code base can produce NPEs when working with Luxon classes.
-// Settings.throwOnInvalid = true; should be set next to defaultZone.
-// Setting this to true, breaks half of the code base as they rely on
-// parsing and creating invalid dates.
-// TODO: Set the throwOnInvalid setting or fix the codebase to deal with nulls produced by Luxon.
-Settings.throwOnInvalid = false;
+// Throw instead of returning invalid dates.
+Settings.throwOnInvalid = true;
 declare module 'luxon' {
   interface TSSettings {
     throwOnInvalid: true;
@@ -64,12 +58,17 @@ export function parseDate(date?: DateLike | null) {
   }
 
   // It is a date string
-  const dt = parseActualStringToDateTime(date);
-  if (dt.isValid) {
-    return dt;
-  }
+  return parseActualStringToDateTime(date);
+}
 
-  throw new Error(`Invalid date input: ${date}`);
+export function tryToParseDate(
+  date: DateLike | null | undefined,
+): DateTime | undefined {
+  try {
+    return parseDate(date);
+  } catch {
+    return undefined;
+  }
 }
 
 // date formats known by luxon: https://moment.github.io/luxon/#/formatting?id=presets


### PR DESCRIPTION
### GraphQL: Add type handling for stop_registry_LocalDate

### Add a new base DateInput component

All previous components implementing a Date Input of any sort, and any and all raw `<input type=date` elements now base their implementation on `<BaseDateInput \>` component.

BaseDateInput features:
- Can handle both nullable and not null values, either in parsed or raw string form.
- Support for copy pasting dates.
- A handy dandy shortcut(s) for resetting the date value to today: t: Tänään/Today === n: Nyt/Now

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1461)
<!-- Reviewable:end -->
