### PR TITLE
Fix redux spam in route drawing

### DIFF
--- a/ui/src/components/map/routes/DrawRouteLayer.tsx
+++ b/ui/src/components/map/routes/DrawRouteLayer.tsx
@@ -178,38 +178,36 @@ export const DrawRouteLayer: FC = () => {
   // Check that draw is ready before removing loader in new route draw phase and allowing user to start drawing
   useEffect(() => {
     const mapInstance = map?.getMap();
-    const handleDrawLoadingState = () => {
+
+    const isDrawReady = (): boolean => {
       const hasDrawRef = !!drawRef.current;
       const hasDrawHotSource = !!mapInstance?.getSource('mapbox-gl-draw-hot');
       const hasDrawColdSource = !!mapInstance?.getSource('mapbox-gl-draw-cold');
 
-      const isDrawReady = hasDrawRef && hasDrawHotSource && hasDrawColdSource;
-
-      setRouteDrawLoadingState(
-        isDrawReady ? LoadingState.NotLoading : LoadingState.HighPriority,
-      );
+      return hasDrawRef && hasDrawHotSource && hasDrawColdSource;
     };
 
-    if (isNewRouteDrawPhase) {
-      setRouteDrawLoadingState(LoadingState.HighPriority);
-      if (mapInstance) {
-        // Check if drawing is ready
-        handleDrawLoadingState();
-
-        // Re-check readiness when the map receives new data.
-        mapInstance.on('sourcedata', handleDrawLoadingState);
-
-        // Re-check readiness after the map has finished updating.
-        mapInstance.on('idle', handleDrawLoadingState);
+    const handleDrawLoadingState = () => {
+      if (isDrawReady()) {
+        setRouteDrawLoadingState(LoadingState.NotLoading);
+        mapInstance?.off('sourcedata', handleDrawLoadingState);
+        mapInstance?.off('idle', handleDrawLoadingState);
+      } else {
+        setRouteDrawLoadingState(LoadingState.HighPriority);
       }
+    };
+
+    if (isDrawReady()) {
+      return undefined;
     }
 
+    setRouteDrawLoadingState(LoadingState.HighPriority);
+    mapInstance?.on('sourcedata', handleDrawLoadingState);
+    mapInstance?.on('idle', handleDrawLoadingState);
+
     return () => {
-      if (mapInstance) {
-        mapInstance.off('sourcedata', handleDrawLoadingState);
-        mapInstance.off('idle', handleDrawLoadingState);
-      }
-      setRouteDrawLoadingState(LoadingState.NotLoading);
+      mapInstance?.off('sourcedata', handleDrawLoadingState);
+      mapInstance?.off('idle', handleDrawLoadingState);
     };
   }, [isNewRouteDrawPhase, map, setRouteDrawLoadingState]);
 


### PR DESCRIPTION
setRouteDrawLoadingState would be called after every action (for example, moving your mouse) on map even if the draw was ready.

This caused possibly thousands of state manipulations to be sent

Fixes:
- Unsubscribe from sourcedata and idle listeners immediately once draw is ready
- Only subscribe to listeners if the initial readiness check returns false

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1464)
<!-- Reviewable:end -->
