### PR TITLE
Improve contrast in simple button hover

### DIFF
--- a/ui/src/components/common/Buttons/SimpleButton.tsx
+++ b/ui/src/components/common/Buttons/SimpleButton.tsx
@@ -64,7 +64,7 @@ export function getHoverStyles(inverted: boolean, disabled: boolean) {
     return 'hover:outline-brand hover:border-brand';
   }
 
-  return 'hover:outline-tweaked-brand hover:border-tweaked-brand hover:bg-brand/50';
+  return 'hover:bg-tweaked-brand hover:border-tweaked-brand-darker30';
 }
 
 function getCommonClassNames(


### PR DESCRIPTION
Hovered state of blue buttons has insufficient contrast. The white text has 2.1:1 contrast ratio against the light blue background.

It should be at least 4.5:1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1466)
<!-- Reviewable:end -->
