### PR TITLE
Button accessibility

### DIFF
--- a/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/EditCloseButton.tsx
+++ b/ui/src/components/timetables/substitute-day-settings/CommonSubstitutePeriod/EditCloseButton.tsx
@@ -31,8 +31,8 @@ export const EditCloseButton: FC<EditCloseButtonProps> = ({
       <Visible visible={!showEdit}>
         <IconButton
           tooltip={titleClose}
-          className="text-base font-bold text-brand"
-          icon={<MdClose aria-hidden />}
+          className="inline-flex h-7.5 w-7.5 items-center justify-center rounded-full text-brand hover:bg-background-hover-grey"
+          icon={<MdClose size={18} aria-hidden />}
           onClick={onClose}
           testId={testId}
         />
@@ -40,8 +40,8 @@ export const EditCloseButton: FC<EditCloseButtonProps> = ({
       <Visible visible={showEdit}>
         <IconButton
           tooltip={titleEdit}
-          className="text-base font-bold text-brand"
-          icon={<MdEdit aria-hidden />}
+          className="inline-flex h-7.5 w-7.5 items-center justify-center rounded-full text-brand hover:bg-background-hover-grey"
+          icon={<MdEdit size={18} aria-hidden />}
           onClick={onEdit}
           testId={testId}
         />

--- a/ui/src/generated/theme.ts
+++ b/ui/src/generated/theme.ts
@@ -7,6 +7,7 @@ export const theme = {
     stop: "#004B7B",
     background: {
       grey: "#F2F5F7",
+      hoverGrey: "#D9D9D9",
       hslBlue: "#BFDEF1",
       hslCityBikeYellow: "#FFF3BF",
       hslCommuterTrainPurple: "#E2D1E5",

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -22,6 +22,7 @@ module.exports = {
         stop: colors.stop,
         background: {
           DEFAULT: colors.background.grey,
+          'hover-grey': colors.background.hoverGrey,
           'hsl-blue': colors.background.hslBlue,
           'hsl-city-bike-yellow': colors.background.hslCityBikeYellow,
           'hsl-commuter-train-purple': colors.background.hslCommuterTrainPurple,

--- a/ui/theme.js
+++ b/ui/theme.js
@@ -7,6 +7,7 @@ const theme = {
     stop: '#004B7B',
     background: {
       grey: '#F2F5F7',
+      hoverGrey: '#D9D9D9',
       hslBlue: '#BFDEF1',
       hslCityBikeYellow: '#FFF3BF',
       hslCommuterTrainPurple: '#E2D1E5',


### PR DESCRIPTION
The current clickable area for the edit and cancel icon in a reference day setting is 16x16px.
The clickable area for the icon should be at least 25 x 25 px: WCAG 2.2 2.5.8 Target size (Minimum)

Change the clickable area to 30 x 30 px and add a hover to them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-ui/1473)
<!-- Reviewable:end -->
